### PR TITLE
Show battery station availability on map pins

### DIFF
--- a/components/dashboard/ControlMap.tsx
+++ b/components/dashboard/ControlMap.tsx
@@ -91,7 +91,7 @@ export function ControlMap() {
         {stationPins.map(({ station, region, left, top }) => (
           <button key={station.slug} className="map-object map-object-station" style={{ left, top }} aria-label={`${station.name} 배터리 스테이션 위치`} onClick={() => openRegionPanel(region)} type="button">
             <span className="map-object-dot">B</span>
-            <span className="map-object-label">{station.name} · {station.replaceableCount}개</span>
+            <span className="map-object-label">{station.name} {station.replaceableCount}/{station.batteryCount}</span>
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary

Updates battery station map markers so each station label shows available battery count out of total capacity.

Example format:
- `강남 교체 스테이션 31/48`
- `서초 물류 스테이션 19/35`

## Trace

- Project start: EVNSolution/clever-change-control#45
- Change request: EVNSolution/clever-change-control#46
- Target issue: EVNSolution/thundercrew-domain#1

## Parallel work decision

Decision: `allowed-with-non-overlap`.

Reason: this is a narrow dashboard map label-only change in `components/dashboard/ControlMap.tsx`; open PR #2 is documentation-only (`docs/traceability.md`), so file scope does not overlap.

## Validation

- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm audit --audit-level=moderate`: pass, 0 vulnerabilities
