### PR TITLE
Release thundercrew-domain MVP 1차

### DIFF
--- a/components/dashboard/ControlMap.tsx
+++ b/components/dashboard/ControlMap.tsx
@@ -91,7 +91,7 @@ export function ControlMap() {
         {stationPins.map(({ station, region, left, top }) => (
           <button key={station.slug} className="map-object map-object-station" style={{ left, top }} aria-label={`${station.name} 배터리 스테이션 위치`} onClick={() => openRegionPanel(region)} type="button">
             <span className="map-object-dot">B</span>
-            <span className="map-object-label">{station.name} · {station.replaceableCount}개</span>
+            <span className="map-object-label">{station.name} {station.replaceableCount}/{station.batteryCount}</span>
           </button>
         ))}
       </div>

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,0 +1,30 @@
+# thundercrew-domain traceability
+
+This document records the CLEVER trace chain for the current MVP implementation.
+
+## Control-plane anchors
+
+- Project start: EVNSolution/clever-change-control#45
+- Change request: EVNSolution/clever-change-control#46
+
+## Target repository anchor
+
+- Target repository: EVNSolution/thundercrew-domain
+- Target issue: EVNSolution/thundercrew-domain#1
+- Scoped branch: `cc-46-mvp-implementation`
+
+## Deployment evidence
+
+- Production URL: https://thundercrew-domain.vercel.app
+- Latest deployment ID at trace correction: `dpl_FABtyJbsKCLyCD45vshmALCJcMfo`
+- Inspect URL: https://vercel.com/oziings-projects/thundercrew-domain/FABtyJbsKCLyCD45vshmALCJcMfo
+
+## Concurrent work decision
+
+Decision: `allowed-with-non-overlap`.
+
+Evidence: the target repository was newly created for this work item. At creation time there were no pre-existing open target issues or pull requests. The active branches `main`, `dev`, and `cc-46-mvp-implementation` all belong to this same trace chain.
+
+## Retrospective correction note
+
+Initial local implementation and Vercel deployment happened before the full CLEVER trace was established. The trace was corrected by creating the control-plane project-start and change-request issues, creating this target repository, creating the target issue, and linking the records bidirectionally.


### PR DESCRIPTION
## Summary

Promotes the completed 1차 MVP state of `thundercrew-domain` from `dev` to `main`.

## Included trace

- Project start: EVNSolution/clever-change-control#45
- Change request: EVNSolution/clever-change-control#46
- Target issue: EVNSolution/thundercrew-domain#1
- Implementation PRs:
  - EVNSolution/thundercrew-domain#2
  - EVNSolution/thundercrew-domain#3

## Completion state

- Production URL: https://thundercrew-domain.vercel.app
- Latest deployment ID: dpl_DTbBBwVMrfM1VcyGFQFDqTD1bxHn
- Vercel inspect: https://vercel.com/oziings-projects/thundercrew-domain/DTbBBwVMrfM1VcyGFQFDqTD1bxHn

## Validation evidence

- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm audit --audit-level=moderate`: pass, 0 vulnerabilities
- Production `/dashboard`: HTTP 200 confirmed

## Parallel work decision

Decision: `done`.

All scoped 1차 MVP implementation branches are merged or cleaned up. No open PR remains for the same target scope after this release PR is merged.

Closes EVNSolution/thundercrew-domain#1
