### PR TITLE
Document Spring Boot backend domain design

### DIFF
--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -1,0 +1,73 @@
+# Backend redesign change ledger
+
+## Trace
+
+- Project start: EVNSolution/clever-change-control#45
+- Change request: EVNSolution/clever-change-control#48
+- Target issue: EVNSolution/thundercrew-domain#8
+- Branch: `cc-48-backend-domain-design`
+- Phase: backend PRD/domain/DB design only; Spring Boot scaffold is a follow-up scope.
+
+## Intent
+
+`thundercrew-domain` 백엔드는 기존 mock/front-first 구현을 전제로 이어가지 않고,
+Spring Boot 기반 운영 API를 처음부터 다시 설계한다.
+
+이번 변경은 구현보다 변화관리와 설계 검토가 핵심이다. PRD, domain, DB, DTO,
+scaffold 계획을 먼저 문서화하고, implementation은 별도 후속 issue/branch에서 진행한다.
+
+## Confirmed decisions
+
+- MSA umbrella monorepo template은 참고하되 맹신하지 않는다.
+- 1차 backend runtime은 `development/service-ops-api` modular monolith로 시작한다.
+- 미래 MSA 분리를 고려해 bounded context와 문서 경계를 먼저 잡는다.
+- Spring Boot 3.x, Java 21, Gradle.
+- PostgreSQL, Spring Data JPA/Hibernate, Flyway.
+- Spring Security + 자체 관리자 JWT.
+- 운영자는 1차에서 단일 관리자 권한이다.
+- DB는 data를 저장하고, DTO/API에서 information을 계산한다.
+- 주요 테이블은 UUID PK와 테이블별 표시 순번 `idx`를 가진다.
+- 주요 테이블은 soft delete와 full audit columns를 가진다.
+- cross-domain DB FK constraint는 기본 사용하지 않는다.
+- 같은 table 내부 invariant는 DB check/unique/partial unique index로 보강한다.
+- 도메인 간 참조 존재 여부, soft delete 참조 차단, overlap 검증은 service layer와 테스트로 보상한다.
+
+## Review model and outcome
+
+- PRD/scope review: architect subagent `Copernicus`.
+- Domain/DB draft review: architect subagent `Confucius`.
+- Risk critique: critic subagent `Laplace`.
+
+Review result:
+
+- PRD/scope 방향은 accepted.
+- Domain/DB 초안 방향은 accepted with required clarifications.
+- Critic review initially returned **REJECT before commit** because no-FK compensation,
+  telemetry write path, invariant matrix, and module-boundary enforcement were not concrete enough.
+
+Integrated fixes in this branch:
+
+- Added same-domain vs cross-domain reference policy.
+- Added soft delete + unique/reference policy.
+- Added invariant matrix and required DB constraints.
+- Added telemetry raw/recent/current write-path rules, idempotency, out-of-order handling, and fallback.
+- Added package-boundary enforcement plan with ArchUnit/module facade rules.
+- Added Supabase MVP schema transition policy.
+- Added review integration notes.
+
+## Existing Supabase MVP schema transition
+
+The existing Supabase frontend-first migration remains historical MVP evidence only.
+It is not the canonical backend schema for the Spring Boot redesign.
+
+Decision for the backend design phase:
+
+- Treat the Spring Boot schema as a new backend baseline.
+- Do not mutate production Supabase data or assume data migration in this issue.
+- If a real backend database already contains MVP data later, create a separate migration/reset issue before applying Flyway.
+- Keep old Supabase migration files untouched in this design branch to avoid mixing frontend MVP cleanup with backend design.
+
+## Branch/merge policy
+
+The user authorized branch-of-branch work and internal merges for this change-management-heavy phase.
+This branch remains the trace branch for #48/#8 until a PR is opened into `dev`.

--- a/docs/backend/01-prd-scope.md
+++ b/docs/backend/01-prd-scope.md
@@ -1,0 +1,218 @@
+# Spring Boot backend PRD / scope
+
+## Purpose
+
+`thundercrew-domain` backend is the Spring Boot operating API for an electric two-wheeler
+control and operations management service.
+
+The first backend goal is not a physically split MSA. The goal is to build a modular
+monolith slice that can later be separated into MSA runtime slices when ownership,
+workload, and deployment boundaries become real.
+
+Initial runtime slice:
+
+```text
+development/service-ops-api
+```
+
+The API lets an admin/operator manage riders, bikes, devices, contracts, insurance,
+equipment, telemetry-derived control state, and battery stations.
+
+## Non-goals for this backend phase
+
+- Do not create multiple independently deployed Spring Boot services yet.
+- Do not implement the full Rider app backend.
+- Do not implement social login, OIDC, or external IAM integration.
+- Do not implement multi-role admin/RBAC beyond one admin/operator role.
+- Do not implement contract document generation, e-signature, billing, or settlement.
+- Do not expand insurance into insurer, policy number, period, claim, or coverage management.
+- Do not implement manual telemetry correction.
+- Do not finalize actual device vendor payload fields.
+- Do not require cross-domain DB FK constraints as the coupling mechanism.
+- Do not create a rider-bike assignment table separate from contracts.
+- Do not relocate the existing frontend into `development/front-admin-web` in this issue.
+
+## Target repository shape
+
+Long-term target shape follows the workspace/umbrella direction, but only as a guide.
+The template must not be treated as more authoritative than the current domain needs.
+
+```text
+thundercrew-domain/
+├── WORKSPACE.md
+├── repo-map.md
+├── docs/
+│   ├── goals/
+│   ├── boundaries/
+│   ├── mappings/
+│   ├── contracts/
+│   ├── decisions/
+│   └── backend/
+├── development/
+│   ├── front-admin-web/
+│   └── service-ops-api/
+└── clever-agent-workspace/
+```
+
+This issue documents the backend design. Actual directory relocation/scaffold is a
+follow-up implementation issue.
+
+## Runtime slice choice
+
+1차 backend는 `development/service-ops-api` 하나로 둔다.
+
+Reasons:
+
+- Current requirements form one admin operations responsibility group.
+- Domain count is high, but separate deployment ownership and failure isolation are not yet proven.
+- Early physical MSA would add operational complexity before the business boundary is stable.
+- Future separation remains possible by keeping package boundaries, API contracts, data ownership, and no cross-domain FK coupling.
+
+## Actors
+
+### Admin / Operator
+
+Initial only user role.
+
+Responsibilities:
+
+- rider CRUD and app-account link review
+- bike CRUD and operation status management
+- rider-bike contract management
+- contract template management
+- insurance item and rider-insurance link management
+- equipment type and bike equipment management
+- device registration and bike installation management
+- telemetry/control-state lookup
+- battery station location, status, and count management
+
+### Rider
+
+Operational target, not an admin user.
+
+- Has name and phone number.
+- May be linked to a rider app account.
+- Has no separate rider status enum in backend phase 1.
+- Bike connection state is derived from contracts.
+
+### External Device / Telemetry Source
+
+System input source, not a manual user.
+
+- Polling can fetch device state.
+- Webhook can receive device state.
+- Raw telemetry creates raw log data.
+- Raw telemetry also feeds recent state and current map/dashboard state.
+
+## Main capabilities
+
+### 1. Admin auth
+
+- Spring Security.
+- Own admin JWT.
+- One admin/operator role in MVP.
+- Token expiry, refresh, revocation, bootstrap admin creation, and password hashing must be fixed before implementation.
+
+### 2. Rider management
+
+- Internal UUID PK.
+- Table-local `idx` display sequence.
+- Phone number active-unique.
+- App-account linkage fields.
+- No rider status enum.
+- Soft delete and audit columns.
+
+### 3. Bike management
+
+- Internal UUID PK.
+- Table-local `idx` display sequence.
+- `plate_number` and `vin` active-unique.
+- `operation_status` is stored DB data entered/changed by the operator.
+- Operation status history is retained.
+- Telemetry-driven `drivingStatus`, `connectionStatus`, and `batteryStatus` are DTO/API information, not bike table data.
+
+### 4. Rider-bike contracts
+
+- Rider-bike connection is represented by contract.
+- No separate assignment table.
+- Contract template is admin-managed.
+- Seeded `무제한 계약` is protected.
+- `duration_minutes = null` means unlimited/open-ended template.
+- Concrete rider-bike contract stores `start_at`, nullable `end_at`, and nullable `terminated_at`.
+- Contract status is computed, not stored.
+- A rider cannot have overlapping bike contracts.
+- A bike cannot have overlapping rider contracts.
+- Future reservations are allowed if they do not overlap.
+
+### 5. Insurance
+
+- Admin-managed insurance item name list.
+- Rider-insurance link table.
+- No period/policy/provider details in phase 1.
+- Duplicate active rider-insurance link is blocked.
+
+### 6. Equipment
+
+- Admin-managed equipment type.
+- Bike-specific attached equipment object is the operational object.
+- Attached equipment has one `management_due_date`.
+- Equipment status is computed: `NORMAL`, `DUE_SOON`, `OVERDUE`.
+- Multiple equipment objects of the same type on one bike are allowed unless the implementation issue later narrows this.
+
+### 7. Device and telemetry
+
+- Device has unique `device_uid` supplied by the device itself.
+- Device and bike current installation is 1:1.
+- Installation history is preserved.
+- Telemetry source is only `POLLING` or `WEBHOOK`; no manual source in phase 1.
+- Raw telemetry, recent state, and current state are separated by responsibility.
+- API sync log records device API interactions without storing sensitive full payloads.
+
+### 8. Battery station
+
+- Stores name, address, latitude, longitude.
+- Stores max/current/available battery counts as operator-maintained data.
+- Count changes are logged.
+- DTO may compute availability labels and capacity percentage.
+- Map API is expected later, so pin-ready coordinates are phase-1 data.
+
+## Accepted design principles
+
+- DB stores source data.
+- API/DTO derives information from source data.
+- `operation_status` is stored because it is operator-entered operation data.
+- telemetry-derived statuses are not stored because they are information calculated from latest observed telemetry.
+- Cross-domain FK constraints are avoided to preserve future slice separation.
+- Same-table and local invariants use DB constraints/indexes where useful.
+- Service layer validates reference existence, soft-delete eligibility, overlap, and authorization.
+- Spring tests must cover validation that DB FKs intentionally do not enforce.
+- Current-value tables are caches/read models, not the canonical raw source.
+
+## Risks and controls
+
+| Risk | Control |
+|---|---|
+| No-FK design can create orphan references | service validation, repository tests, integrity scan job, and explicit error contract |
+| `service-ops-api` can become too broad | package boundaries, module facades, ArchUnit dependency tests |
+| Contract-as-assignment can drift | overlap validation and transaction/lock strategy |
+| Telemetry raw/recent/current can diverge | idempotency key, current upsert rule, retry/rebuild policy |
+| Soft delete + unique can conflict | active partial unique indexes per table |
+| Station count current/log can become dual truth | current count is source data; log is audit only |
+| Existing Supabase schema differs | treat existing Supabase migration as legacy MVP evidence; new backend Flyway baseline is separate |
+
+## Open questions
+
+Implementation-blocking:
+
+- Gradle Kotlin DSL or Groovy DSL.
+- JWT library, expiry, refresh, revocation.
+- Admin bootstrap account and secret handling.
+- TimescaleDB availability; if unavailable, native partition/retention fallback.
+- Estimated telemetry device count and write volume.
+
+Not blocking this design PR:
+
+- Exact vendor payload shape.
+- Exact frontend relocation timing.
+- Long-term analytics/read-model tables.
+- Insurance period expansion.

--- a/docs/backend/02-domain-db-draft.md
+++ b/docs/backend/02-domain-db-draft.md
@@ -1,0 +1,734 @@
+# Domain and DB draft
+
+## 0. Design frame
+
+### Stored data vs computed information
+
+DB stores source data:
+
+- admin-entered operation data
+- timestamps
+- coordinates
+- speed
+- battery percentage
+- ignition status
+- device identifiers
+- battery station current counts
+- raw telemetry payload summaries
+
+API/DTO computes information:
+
+- rider app link display state
+- rider-bike connection state
+- contract status
+- equipment status
+- driving status
+- connection status
+- battery status
+- station availability label and capacity percentage
+
+Important distinction:
+
+- `bikes.operation_status` is stored because it is operator-entered operation data.
+- `driving_status`, `connection_status`, and `battery_status` are not stored because they are derived from telemetry and time.
+
+### Reference and FK policy
+
+Default rule:
+
+- Cross-domain references store UUID values without DB FK constraints.
+- Same-table and local aggregate invariants use DB checks/partial unique indexes.
+- Service layer validates reference existence and soft-delete eligibility before write.
+
+Reference categories:
+
+| Reference | Category | DB FK? | Required compensation |
+|---|---|---:|---|
+| audit `created_by/updated_by/deleted_by` → admin | cross-domain audit ref | No | actor existence best-effort; keep historical UUID even if admin is deleted |
+| `rider_bike_contracts.rider_id` → rider | cross-domain business ref | No | service existence + active/not-deleted validation; integrity scan |
+| `rider_bike_contracts.bike_id` → bike | cross-domain business ref | No | service existence + active/not-deleted validation; overlap validation |
+| `rider_bike_contracts.contract_template_id` → template | same bounded area but separate aggregate | No in MVP | service validation; system template protected |
+| `rider_insurances.rider_id` → rider | cross-domain business ref | No | service validation; duplicate active link partial unique |
+| `rider_insurances.insurance_item_id` → insurance item | same bounded area | No in MVP | service validation |
+| `bike_equipments.bike_id` → bike | cross-domain business ref | No | service validation; active equipment indexes |
+| `bike_equipments.equipment_type_id` → equipment type | same bounded area | No in MVP | service validation |
+| `bike_device_installations.bike_id` → bike | cross-domain business ref | No | service validation; active 1:1 partial unique |
+| `bike_device_installations.device_id` → device | same device bounded area | No in MVP | service validation; active 1:1 partial unique |
+| telemetry `device_id/bike_id` | historical observation ref | No | resolve at ingestion time; keep historical association |
+| station log → station | same bounded area | No in MVP | service validation; append-only audit |
+
+Soft-delete reference policy:
+
+- New writes must not reference `deleted_at is not null` rows.
+- Historical rows retain UUID references after the target is soft-deleted.
+- List/detail APIs should render historical references as snapshot/unknown/deleted labels rather than hiding history.
+- Regular integrity scan reports missing or deleted references for operational repair.
+
+### Global table conventions
+
+Major mutable business tables use:
+
+- `id uuid primary key`
+- `idx bigserial not null unique` or equivalent table-local sequence
+- `created_at timestamptz not null`
+- `updated_at timestamptz not null`
+- `deleted_at timestamptz null`
+- `created_by uuid null`
+- `updated_by uuid null`
+- `deleted_by uuid null`
+
+Unique policy:
+
+- Human/business identifiers use active partial unique indexes with `WHERE deleted_at IS NULL`.
+- This permits reuse after soft delete unless a table explicitly states otherwise.
+- Historical references still use UUID, not display `idx`.
+
+Timezone:
+
+- Store timestamps as `timestamptz`.
+- API/business calculation baseline is Asia/Seoul unless an implementation issue explicitly changes it.
+
+## 1. Auth
+
+### `admin_users`
+
+- `id`, `idx`, audit columns
+- `login_id varchar(100) not null`
+- `email varchar(255) null`
+- `password_hash varchar(255) not null`
+- `display_name varchar(100) not null`
+- `enabled boolean not null default true`
+- `last_login_at timestamptz null`
+
+Indexes/checks:
+
+```sql
+CREATE UNIQUE INDEX ux_admin_users_login_id_active
+ON admin_users(login_id)
+WHERE deleted_at IS NULL;
+```
+
+Policy:
+
+- No role table in phase 1.
+- JWT claim can include `adminUserId`, `loginId`, `role=ADMIN`.
+- Password hashing must be BCrypt/Argon2 class; no plaintext or reversible encryption.
+- Bootstrap admin secret must come from environment/ops secret, not committed seed data.
+
+## 2. Rider
+
+### `riders`
+
+- `id`, `idx`, audit columns
+- `name varchar(100) not null`
+- `phone_number varchar(30) not null`
+- `team_name varchar(100) null`
+- `area_name varchar(100) null`
+- `app_account_linked boolean not null default false`
+- `app_account_id uuid null`
+- `app_linked_at timestamptz null`
+- `memo text null`
+
+Indexes/checks:
+
+```sql
+CREATE UNIQUE INDEX ux_riders_phone_number_active
+ON riders(phone_number)
+WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX ux_riders_app_account_id_active
+ON riders(app_account_id)
+WHERE app_account_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX ix_riders_team_area_active
+ON riders(team_name, area_name)
+WHERE deleted_at IS NULL;
+
+ALTER TABLE riders ADD CONSTRAINT ck_riders_app_link_consistency CHECK (
+  (app_account_linked = false AND app_account_id IS NULL AND app_linked_at IS NULL)
+  OR
+  (app_account_linked = true AND app_account_id IS NOT NULL AND app_linked_at IS NOT NULL)
+);
+```
+
+Computed DTO information:
+
+- `appLinkStatus`: `LINKED` / `NOT_LINKED`.
+- `bikeConnectionStatus`: from active contract query.
+
+No rider status enum is stored.
+
+## 3. Bike
+
+### `bikes`
+
+- `id`, `idx`, audit columns
+- `plate_number varchar(50) not null`
+- `vin varchar(100) not null`
+- `model_name varchar(100) null`
+- `operation_status varchar(40) not null`
+- `memo text null`
+
+Allowed `operation_status` values:
+
+- `READY`
+- `IN_SERVICE`
+- `REPAIRING`
+- `INSPECTION_REQUIRED`
+
+Indexes/checks:
+
+```sql
+ALTER TABLE bikes ADD CONSTRAINT ck_bikes_operation_status
+CHECK (operation_status IN ('READY', 'IN_SERVICE', 'REPAIRING', 'INSPECTION_REQUIRED'));
+
+CREATE UNIQUE INDEX ux_bikes_plate_number_active
+ON bikes(plate_number)
+WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX ux_bikes_vin_active
+ON bikes(vin)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_bikes_operation_status_active
+ON bikes(operation_status)
+WHERE deleted_at IS NULL;
+```
+
+### `bike_operation_status_histories`
+
+- `id`, `idx`, audit columns
+- `bike_id uuid not null`
+- `operation_status varchar(40) not null`
+- `started_at timestamptz not null`
+- `ended_at timestamptz null`
+- `reason text null`
+- `memo text null`
+- `changed_by uuid null`
+
+Invariant:
+
+- Service closes previous open history row before opening a new one.
+- DB enforces at most one open status history per bike.
+
+```sql
+CREATE UNIQUE INDEX ux_bike_operation_status_histories_open_bike
+ON bike_operation_status_histories(bike_id)
+WHERE ended_at IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX ix_bike_operation_status_histories_bike_started
+ON bike_operation_status_histories(bike_id, started_at DESC)
+WHERE deleted_at IS NULL;
+```
+
+## 4. Contract
+
+### `contract_templates`
+
+- `id`, `idx`, audit columns
+- `name varchar(100) not null`
+- `duration_minutes integer null`
+- `description text null`
+- `enabled boolean not null default true`
+- `system_template boolean not null default false`
+
+Seed:
+
+- `무제한 계약`
+- `duration_minutes = null`
+- `system_template = true`
+
+Rules:
+
+- `duration_minutes IS NULL` is the single source for unlimited/open-ended template.
+- `system_template = true` rows cannot be deleted or core-edited by normal admin APIs.
+- Name is active-unique.
+
+```sql
+ALTER TABLE contract_templates ADD CONSTRAINT ck_contract_templates_duration
+CHECK (duration_minutes IS NULL OR duration_minutes > 0);
+
+CREATE UNIQUE INDEX ux_contract_templates_name_active
+ON contract_templates(name)
+WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX ux_contract_templates_single_system_default
+ON contract_templates(system_template)
+WHERE system_template = true AND deleted_at IS NULL;
+```
+
+### `rider_bike_contracts`
+
+- `id`, `idx`, audit columns
+- `rider_id uuid not null`
+- `bike_id uuid not null`
+- `contract_template_id uuid not null`
+- `start_at timestamptz not null`
+- `end_at timestamptz null`
+- `terminated_at timestamptz null`
+- `terminated_reason text null`
+- `memo text null`
+
+Computed status:
+
+| Status | Rule |
+|---|---|
+| `TERMINATED` | `terminated_at` exists |
+| `SCHEDULED` | not terminated and `now < start_at` |
+| `ACTIVE` | not terminated and `start_at <= now` and (`end_at is null` or `now < end_at`) |
+| `EXPIRED` | not terminated and `end_at is not null` and `now >= end_at` |
+
+Checks/indexes:
+
+```sql
+ALTER TABLE rider_bike_contracts ADD CONSTRAINT ck_contracts_end_after_start
+CHECK (end_at IS NULL OR end_at > start_at);
+
+ALTER TABLE rider_bike_contracts ADD CONSTRAINT ck_contracts_terminated_after_start
+CHECK (terminated_at IS NULL OR terminated_at >= start_at);
+
+CREATE INDEX ix_contracts_rider_period_active
+ON rider_bike_contracts(rider_id, start_at, end_at)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_contracts_bike_period_active
+ON rider_bike_contracts(bike_id, start_at, end_at)
+WHERE deleted_at IS NULL;
+```
+
+Overlap invariant:
+
+- Same rider cannot have overlapping non-deleted, non-terminated scheduled/active intervals.
+- Same bike cannot have overlapping non-deleted, non-terminated scheduled/active intervals.
+- Service layer must validate overlap inside a transaction.
+- Implementation should use transaction + lock strategy; if PostgreSQL exclusion constraints are adopted later, document why they do not violate the no cross-domain FK policy.
+
+## 5. Insurance
+
+### `insurance_items`
+
+- `id`, `idx`, audit columns
+- `name varchar(100) not null`
+- `description text null`
+- `enabled boolean not null default true`
+
+```sql
+CREATE UNIQUE INDEX ux_insurance_items_name_active
+ON insurance_items(name)
+WHERE deleted_at IS NULL;
+```
+
+### `rider_insurances`
+
+- `id`, `idx`, audit columns
+- `rider_id uuid not null`
+- `insurance_item_id uuid not null`
+- `memo text null`
+- `enabled boolean not null default true`
+
+```sql
+CREATE UNIQUE INDEX ux_rider_insurances_active_pair
+ON rider_insurances(rider_id, insurance_item_id)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_rider_insurances_item_active
+ON rider_insurances(insurance_item_id)
+WHERE deleted_at IS NULL;
+```
+
+Phase 1 excludes period, policy number, provider details, claim, and expiration.
+
+## 6. Equipment
+
+### `equipment_types`
+
+- `id`, `idx`, audit columns
+- `name varchar(100) not null`
+- `description text null`
+- `enabled boolean not null default true`
+
+```sql
+CREATE UNIQUE INDEX ux_equipment_types_name_active
+ON equipment_types(name)
+WHERE deleted_at IS NULL;
+```
+
+### `bike_equipments`
+
+- `id`, `idx`, audit columns
+- `bike_id uuid not null`
+- `equipment_type_id uuid not null`
+- `equipment_label varchar(100) null`
+- `model_name varchar(100) null`
+- `serial_number varchar(100) null`
+- `installed_at timestamptz not null`
+- `removed_at timestamptz null`
+- `management_due_date date not null`
+- `management_note text null`
+- `memo text null`
+
+```sql
+ALTER TABLE bike_equipments ADD CONSTRAINT ck_bike_equipments_removed_after_install
+CHECK (removed_at IS NULL OR removed_at >= installed_at);
+
+CREATE INDEX ix_bike_equipments_bike_active
+ON bike_equipments(bike_id)
+WHERE removed_at IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX ix_bike_equipments_due_active
+ON bike_equipments(management_due_date)
+WHERE removed_at IS NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX ux_bike_equipments_serial_active
+ON bike_equipments(serial_number)
+WHERE serial_number IS NOT NULL AND removed_at IS NULL AND deleted_at IS NULL;
+```
+
+Computed equipment status, Asia/Seoul local date:
+
+- `OVERDUE`: `management_due_date < today`
+- `DUE_SOON`: `today <= management_due_date <= today + 7 days`
+- `NORMAL`: otherwise
+
+No active unique constraint on `(bike_id, equipment_type_id)` in phase 1 because one bike may have multiple objects of the same equipment type.
+
+## 7. Device
+
+### `devices`
+
+- `id`, `idx`, audit columns
+- `device_uid varchar(100) not null`
+- `manufacturer varchar(100) null`
+- `model_name varchar(100) null`
+- `enabled boolean not null default true`
+- `memo text null`
+
+```sql
+CREATE UNIQUE INDEX ux_devices_device_uid_active
+ON devices(device_uid)
+WHERE deleted_at IS NULL;
+```
+
+Policy:
+
+- `devices` does not store `bike_id`; current installation is derived from `bike_device_installations`.
+- Reinstalling the same device later is allowed after the previous active installation is closed.
+
+### `bike_device_installations`
+
+- `id`, `idx`, audit columns
+- `bike_id uuid not null`
+- `device_id uuid not null`
+- `installed_at timestamptz not null`
+- `removed_at timestamptz null`
+- `memo text null`
+
+```sql
+ALTER TABLE bike_device_installations ADD CONSTRAINT ck_device_install_removed_after_install
+CHECK (removed_at IS NULL OR removed_at >= installed_at);
+
+CREATE UNIQUE INDEX ux_bike_device_installations_active_bike
+ON bike_device_installations(bike_id)
+WHERE removed_at IS NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX ux_bike_device_installations_active_device
+ON bike_device_installations(device_id)
+WHERE removed_at IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX ix_bike_device_installations_bike_history
+ON bike_device_installations(bike_id, installed_at DESC)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_bike_device_installations_device_history
+ON bike_device_installations(device_id, installed_at DESC)
+WHERE deleted_at IS NULL;
+```
+
+API transaction rule:
+
+- Install/replace closes existing active row first, then inserts the new row in the same transaction.
+- Service validates both bike and device are active/not deleted.
+
+## 8. Telemetry
+
+### `device_telemetry_logs`
+
+Raw time-series log; TimescaleDB hypertable candidate.
+
+- `id uuid not null`
+- `idx bigserial`
+- `device_id uuid null`
+- `device_uid varchar(100) not null`
+- `bike_id uuid null`
+- `vendor_event_id varchar(200) null`
+- `payload_hash varchar(128) null`
+- `received_at timestamptz not null`
+- `device_reported_at timestamptz null`
+- `latitude numeric(10,7) null`
+- `longitude numeric(10,7) null`
+- `speed_kph numeric(8,2) null`
+- `battery_percent numeric(5,2) null`
+- `ignition_status varchar(20) not null`
+- `telemetry_source varchar(20) not null`
+- `raw_payload jsonb null`
+- `created_at timestamptz not null`
+
+No `driving_status`, `connection_status`, or `battery_status` stored.
+
+Checks:
+
+```sql
+CHECK (latitude IS NULL OR (latitude >= -90 AND latitude <= 90));
+CHECK (longitude IS NULL OR (longitude >= -180 AND longitude <= 180));
+CHECK (battery_percent IS NULL OR (battery_percent >= 0 AND battery_percent <= 100));
+CHECK (ignition_status IN ('UNKNOWN', 'ON', 'OFF'));
+CHECK (telemetry_source IN ('POLLING', 'WEBHOOK'));
+```
+
+Idempotency:
+
+- Preferred key: `device_uid + vendor_event_id` when vendor event ID exists.
+- Fallback key: `device_uid + received_at + telemetry_source + payload_hash`.
+- TimescaleDB implementation must ensure unique indexes include the time partition column if required.
+
+### `bike_recent_states`
+
+Recent normalized state history retained for about 7 days.
+
+- `id`, `idx`
+- `bike_id uuid not null`
+- `device_id uuid null`
+- `telemetry_log_id uuid null`
+- `received_at timestamptz not null`
+- `latitude numeric(10,7) null`
+- `longitude numeric(10,7) null`
+- `speed_kph numeric(8,2) null`
+- `battery_percent numeric(5,2) null`
+- `ignition_status varchar(20) not null`
+- `telemetry_source varchar(20) not null`
+- `created_at timestamptz not null`
+
+Indexes:
+
+```sql
+CREATE INDEX ix_bike_recent_states_bike_received
+ON bike_recent_states(bike_id, received_at DESC);
+
+CREATE INDEX ix_bike_recent_states_cleanup
+ON bike_recent_states(received_at);
+```
+
+Retention:
+
+- Keep short operational window, default 7 days.
+- Purge by scheduled job.
+- If scheduler fails, cleanup can be rerun idempotently.
+
+### `bike_current_states`
+
+Latest cache for map/dashboard. Bike has at most one row.
+
+- `bike_id uuid not null primary key`
+- `device_id uuid null`
+- `telemetry_log_id uuid null`
+- `last_received_at timestamptz not null`
+- `latitude numeric(10,7) null`
+- `longitude numeric(10,7) null`
+- `speed_kph numeric(8,2) null`
+- `battery_percent numeric(5,2) null`
+- `ignition_status varchar(20) not null`
+- `telemetry_source varchar(20) not null`
+- `updated_at timestamptz not null`
+
+Update rule:
+
+- Upsert only when `incoming.received_at > current.last_received_at`.
+- Out-of-order telemetry remains in raw/recent history but does not replace current state.
+- Current state is rebuildable from recent/raw logs if needed.
+
+### Telemetry write path
+
+1. Resolve `device_uid` to active device.
+2. Resolve active bike installation at the telemetry time where possible.
+3. Insert raw `device_telemetry_logs` with idempotency protection.
+4. Insert normalized `bike_recent_states` when bike association exists.
+5. Upsert `bike_current_states` only if newer than current state.
+6. Record failure in `device_api_sync_logs` or ingestion error log if any downstream step fails.
+
+Failure policy:
+
+- Raw log is the primary durable input.
+- Recent/current can be rebuilt from raw log and installation history.
+- Partial failures must be retryable by idempotency key.
+- If TimescaleDB is unavailable, start with PostgreSQL native partitioning/indexes and keep the same logical model.
+
+Computed DTO information:
+
+| Value | Rule |
+|---|---|
+| `driving_status = UNKNOWN` | `ignition_status = UNKNOWN` |
+| `driving_status = PARKED` | `ignition_status = OFF` |
+| `driving_status = DRIVING` | `ignition_status = ON` and `speed_kph >= 3` |
+| `driving_status = STOPPED` | `ignition_status = ON` and `speed_kph < 3` |
+| `connection_status = ONLINE` | `now - last_received_at <= 10 minutes` |
+| `connection_status = SIGNAL_LOST` | stale over 10 minutes and `ignition_status = ON` |
+| `connection_status = PARKED_OFFLINE_NORMAL` | stale over 10 minutes and `ignition_status = OFF` |
+| `connection_status = STALE_UNKNOWN` | stale over 10 minutes and `ignition_status = UNKNOWN` |
+| `battery_status = UNKNOWN` | battery is null |
+| `battery_status = CRITICAL` | battery < 20 |
+| `battery_status = LOW` | battery >= 20 and battery < 50 |
+| `battery_status = NORMAL` | battery >= 50 |
+
+### `device_api_sync_logs`
+
+External device API polling/webhook request-response evidence. This is for API call/sync trace,
+not for every normalized telemetry processing failure.
+
+- `id`, `idx`
+- `device_id uuid null`
+- `device_uid varchar(100) null`
+- `sync_type varchar(50) not null`
+- `request_started_at timestamptz not null`
+- `request_finished_at timestamptz null`
+- `success boolean not null`
+- `http_status integer null`
+- `external_trace_id varchar(200) null`
+- `error_code varchar(100) null`
+- `error_message text null`
+- `request_summary jsonb null`
+- `response_summary jsonb null`
+- `created_at timestamptz not null`
+
+Payload policy:
+
+- Store summaries/redacted payload only.
+- Never store credentials or full secret-bearing payloads.
+
+### `telemetry_ingestion_error_logs`
+
+Telemetry processing failure evidence for retry/repair. This table records failures after or
+around raw ingest, especially when recent/current state updates fail or telemetry cannot be
+associated with a valid bike/device.
+
+- `id`, `idx`
+- `telemetry_log_id uuid null`
+- `device_uid varchar(100) null`
+- `bike_id uuid null`
+- `received_at timestamptz null`
+- `ingestion_stage varchar(50) not null`
+- `retryable boolean not null default true`
+- `resolved_at timestamptz null`
+- `error_code varchar(100) not null`
+- `error_message text null`
+- `context_summary jsonb null`
+- `created_at timestamptz not null`
+
+Rules:
+
+- Store redacted context only.
+- Retry jobs use idempotency keys from raw telemetry; retries must not duplicate raw/recent/current rows.
+- If the error is caused by missing device/bike installation, resolution can be manual data repair plus replay.
+
+## 9. Battery station
+
+### `battery_stations`
+
+- `id`, `idx`, audit columns
+- `name varchar(100) not null`
+- `address varchar(255) not null`
+- `latitude numeric(10,7) not null`
+- `longitude numeric(10,7) not null`
+- `status varchar(30) not null`
+- `max_battery_capacity integer not null`
+- `current_battery_count integer not null`
+- `available_battery_count integer not null`
+- `memo text null`
+
+Policy:
+
+- `current_battery_count` and `available_battery_count` are operator-maintained stored data.
+- Change logs are audit, not the source of truth.
+- API computes `isAvailable` and `capacityUsagePercent`.
+
+Checks/indexes:
+
+```sql
+CHECK (status IN ('ACTIVE', 'MAINTENANCE', 'INACTIVE'));
+CHECK (latitude >= -90 AND latitude <= 90);
+CHECK (longitude >= -180 AND longitude <= 180);
+CHECK (max_battery_capacity >= 0);
+CHECK (current_battery_count >= 0);
+CHECK (available_battery_count >= 0);
+CHECK (current_battery_count <= max_battery_capacity);
+CHECK (available_battery_count <= current_battery_count);
+
+CREATE UNIQUE INDEX ux_battery_stations_name_active
+ON battery_stations(name)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_battery_stations_location_active
+ON battery_stations(latitude, longitude)
+WHERE deleted_at IS NULL;
+```
+
+### `station_battery_count_logs`
+
+- `id`, `idx`, audit columns
+- `station_id uuid not null`
+- `before_max_battery_capacity integer not null`
+- `after_max_battery_capacity integer not null`
+- `before_current_battery_count integer not null`
+- `after_current_battery_count integer not null`
+- `before_available_battery_count integer not null`
+- `after_available_battery_count integer not null`
+- `reason varchar(100) null`
+- `memo text null`
+- `changed_at timestamptz not null`
+- `changed_by uuid null`
+
+```sql
+CREATE INDEX ix_station_battery_count_logs_station_changed
+ON station_battery_count_logs(station_id, changed_at DESC);
+```
+
+## 10. Invariant matrix
+
+| Area | Invariant | DB control | Service/test control |
+|---|---|---|---|
+| Common | `idx` table-local display sequence only | unique sequence | never accept user-supplied `idx` as identity |
+| Soft delete unique | active phone/plate/vin/device_uid/name unique | partial unique indexes | restore/reuse behavior tests |
+| Rider app link | linked fields consistent | check constraint | link/unlink service tests |
+| Bike status | one open status row per bike | partial unique open-row index | status-change transaction tests |
+| Contract | no rider interval overlap | indexes for lookup | transaction + overlap validation tests |
+| Contract | no bike interval overlap | indexes for lookup | transaction + overlap validation tests |
+| Insurance | no duplicate active rider-insurance pair | partial unique pair | service validation |
+| Equipment | removed after installed | check constraint | install/remove tests |
+| Device install | one active device per bike | partial unique active bike | replace transaction test |
+| Device install | one active bike per device | partial unique active device | replace transaction test |
+| Telemetry | duplicate event ignored/retried safely | unique/idempotency index | ingestion idempotency tests |
+| Telemetry | current state only moves forward | bike PK/unique | newer-only upsert tests |
+| Telemetry | processing failure is replayable | ingestion error log | retry/rebuild tests |
+| Station | count bounds | check constraints | update transaction/log tests |
+
+## 11. Integrity scan and error contract
+
+Because cross-domain FK is intentionally avoided, the backend must include an integrity check path before production hardening.
+
+Minimum integrity scan targets:
+
+- contracts referencing missing/deleted rider, bike, or template
+- rider insurance links referencing missing/deleted rider or insurance item
+- bike equipment referencing missing/deleted bike or equipment type
+- device installation referencing missing/deleted bike or device
+- telemetry current/recent states referencing missing bike/device
+- station logs referencing missing/deleted station
+
+Minimum API error categories:
+
+- `REFERENCE_NOT_FOUND`
+- `REFERENCE_DELETED`
+- `DUPLICATE_ACTIVE_RELATION`
+- `PERIOD_OVERLAP`
+- `INVALID_STATE_TRANSITION`
+- `STALE_TELEMETRY_IGNORED`
+- `IDEMPOTENT_REPLAY`

--- a/docs/backend/03-scaffold-plan.md
+++ b/docs/backend/03-scaffold-plan.md
@@ -1,0 +1,139 @@
+# Spring Boot scaffold plan
+
+## Target path
+
+```text
+development/service-ops-api/
+```
+
+This issue documents the plan only. Scaffold generation should happen in a follow-up
+implementation issue/branch unless explicitly approved.
+
+## Build/runtime stack
+
+- Java 21
+- Spring Boot 3.x
+- Gradle; DSL choice still open
+- Spring Web
+- Spring Validation
+- Spring Data JPA for CRUD domains
+- JDBC batch/native SQL path for telemetry ingestion if volume requires it
+- PostgreSQL Driver
+- Flyway
+- Spring Security
+- JWT library to be selected during implementation
+- Testcontainers for repository/integration tests where feasible
+- ArchUnit for package dependency rules
+
+## Package boundary draft
+
+```text
+com.thundercrew.opsapi
+├── auth
+├── rider
+├── bike
+├── contract
+├── insurance
+├── equipment
+├── device
+├── telemetry
+├── station
+├── dashboard
+└── common
+```
+
+## Boundary enforcement
+
+Package names alone are not enough. Implementation must add boundary checks.
+
+Rules:
+
+- Controllers call only their own package service/facade or an explicit cross-domain facade.
+- Repositories are private to their bounded package.
+- Direct repository import across bounded packages is forbidden.
+- Cross-domain writes go through the owning package service/facade.
+- DTO calculation helpers that are cross-domain neutral live in `common`; business rules stay in owner packages.
+- Telemetry ingestion can remain in the same app, but its write path must be isolated behind `telemetry` services/adapters.
+- Dashboard can read through package facades/read services, not direct arbitrary repositories.
+
+Verification:
+
+- Add ArchUnit tests for forbidden imports.
+- Add service tests for no-FK compensation rules.
+- Add repository/integration tests for DB check/partial unique constraints.
+
+## Layer convention
+
+Each bounded package may contain:
+
+```text
+controller
+service
+domain
+repository
+dto
+```
+
+`common` owns:
+
+- audit base entity
+- soft delete helpers
+- exception handling
+- API response/error model
+- time/clock utilities
+- neutral calculated-status helpers only when not domain-owned
+
+## Flyway migration plan
+
+Draft split:
+
+- `V1__init_admin_and_common.sql`
+- `V2__init_rider_bike_contract.sql`
+- `V3__init_insurance_equipment_device.sql`
+- `V4__init_telemetry_station.sql`
+- `V5__seed_system_contract_template.sql`
+
+Implementation may adjust split, but must keep these review gates:
+
+- all active unique indexes are present
+- all status check constraints are present
+- all active installation/status-history partial unique indexes are present
+- station count checks are present
+- telemetry ingestion error evidence exists
+- seed for `무제한 계약` is protected by service policy
+
+## Telemetry implementation path
+
+Minimum safe path:
+
+1. Resolve device and active bike installation.
+2. Insert raw telemetry idempotently.
+3. Insert recent state if bike association exists.
+4. Upsert current state only for newer telemetry.
+5. Record API sync evidence in `device_api_sync_logs`.
+6. Record telemetry processing failures in `telemetry_ingestion_error_logs` with redacted context and retryability.
+
+Fallback if TimescaleDB is unavailable:
+
+- Use normal PostgreSQL table first.
+- Add indexes matching query patterns.
+- Add scheduled retention cleanup for recent states.
+- Introduce native partitioning or TimescaleDB in a later performance issue.
+
+## Implementation guardrails
+
+- Do not expose UUID/FK text inputs directly in user-facing forms.
+- API may accept selected resource IDs from UI selection results, but UI should present labels/search/idx/phone/plate/device UID.
+- Validate cross-domain references in service layer.
+- Keep DTO calculated information separate from DB stored data.
+- Keep telemetry ingestion idempotent and retryable.
+- Record any intentional partial failure/rebuild behavior in code comments and tests.
+- Do not hardcode secrets in code, migrations, docs, or seed files.
+
+## Review gates before coding
+
+- Domain/DB draft reviewed by architect and critic.
+- Critic REJECT items resolved or explicitly deferred.
+- Open-question ledger acknowledged.
+- Target issue updated with accepted scope.
+- Implementation issue/branch created for scaffold work.

--- a/docs/backend/04-open-questions.md
+++ b/docs/backend/04-open-questions.md
@@ -1,0 +1,44 @@
+# Backend open questions ledger
+
+## Must resolve before scaffold implementation
+
+1. Gradle DSL preference: Kotlin DSL or Groovy DSL.
+2. JWT library choice, token expiry, refresh token, and revocation strategy.
+3. Admin seed account creation method and secret handling.
+4. Password hashing choice: BCrypt vs Argon2.
+5. Whether TimescaleDB extension is available in the target Postgres environment.
+6. Expected telemetry device count, polling cadence, webhook volume, and daily write volume.
+7. Initial Flyway migration granularity and whether to use PostgreSQL extensions such as `pgcrypto`.
+8. Whether root `WORKSPACE.md` and `repo-map.md` should be introduced before or with scaffold.
+9. Existing frontend relocation plan: keep current app structure for now or move under `development/front-admin-web` in a separate PR.
+10. Implementation strategy for contract overlap under concurrency: service lock only, PostgreSQL advisory lock, or exclusion constraint.
+
+## Resolved in this design branch
+
+1. Runtime slice starts as `development/service-ops-api` modular monolith.
+2. DB FK policy: no cross-domain FK by default; compensate with service validation, tests, and integrity scan.
+3. Same-table/local invariants can use DB checks and partial unique indexes.
+4. Soft-deleted business identifiers can be reused through active partial unique indexes unless a later issue narrows a specific table.
+5. Historical rows keep UUID references even if the target is later soft-deleted.
+6. `bikes.operation_status` is stored data; telemetry statuses are computed information.
+7. Contract is the rider-bike relationship source of truth; no assignment table.
+8. `duration_minutes = null` is the unlimited/open-ended contract template signal.
+9. Station `current_battery_count` and `available_battery_count` are stored operator-managed data; logs are audit.
+10. Telemetry current state updates only when incoming telemetry is newer.
+
+## Can resolve during implementation
+
+1. Exact numeric precision changes for coordinates and speed if vendor requires.
+2. Whether audit `*_by` stores admin UUID only or also system actor strings.
+3. Exact common API error response JSON shape.
+4. Pagination/sorting/filtering request conventions.
+5. Whether `bike_current_states` is rebuilt by explicit admin job or background job.
+6. Exact ArchUnit package rule syntax.
+
+## Deferred until vendor/API details
+
+1. Actual device payload schema.
+2. Polling authentication and webhook signature verification.
+3. Timescale compression and raw telemetry long-term retention periods.
+4. Long-term analytics or daily summary tables.
+5. Whether telemetry ingestion becomes a separate worker/runtime slice.

--- a/docs/backend/05-review-integration.md
+++ b/docs/backend/05-review-integration.md
@@ -1,0 +1,44 @@
+# Backend review integration notes
+
+## Review participants
+
+- `Copernicus` / architect: PRD and scope review.
+- `Confucius` / architect: domain and DB table draft review.
+- `Laplace` / critic: risk and contradiction review.
+
+## Main review conclusions
+
+### Accepted
+
+- Start with modular monolith `development/service-ops-api`.
+- Keep future MSA separation possible through data ownership and package boundaries.
+- Use UUID PK plus table-local `idx` display sequence.
+- Avoid direct user-entered IDs/FKs in UI.
+- Contract is the rider-bike relationship source of truth.
+- Device installation history is the device-bike relationship source of truth.
+- Raw/recent/current telemetry split is directionally correct.
+- Station count current values plus audit logs are acceptable if current values are declared source data.
+
+### Rejected until fixed
+
+The critic rejected the initial docs before commit for these reasons:
+
+1. No-FK strategy lacked concrete compensation.
+2. Telemetry raw/recent/current write path lacked idempotency and out-of-order rules.
+3. Core invariants were partly deferred to implementation.
+4. `service-ops-api` boundary enforcement was too weak for a broad modular monolith.
+
+## Integrated fixes
+
+| Review issue | Fix |
+|---|---|
+| No-FK compensation unclear | Added reference/FK policy, soft-delete reference policy, integrity scan, and error categories in `02-domain-db-draft.md`. |
+| Telemetry write path risky | Added idempotency keys, raw-first rule, current newer-only upsert, rebuild/retry policy, and Timescale fallback. |
+| Invariants too implicit | Added invariant matrix with DB and service/test controls. |
+| `service-ops-api` too broad | Added package boundary, facade, no cross-repository import, and ArchUnit test plan in `03-scaffold-plan.md`. |
+| Existing Supabase schema transition missing | Added transition policy in `00-change-ledger.md`. |
+| Stored data vs computed information blurry | Added explicit data/information split in `01-prd-scope.md` and `02-domain-db-draft.md`. |
+
+## Remaining implementation gate
+
+The design branch can be reviewed/merged as a backend design artifact. Spring Boot scaffold should wait until the open questions marked “Must resolve before scaffold implementation” are answered or explicitly accepted as implementation-time decisions.


### PR DESCRIPTION
## Summary

- Adds backend change ledger for `clever-change-control#48` / target issue `#8`.
- Documents Spring Boot modular-monolith scope for `development/service-ops-api`.
- Drafts domain/DB model for admin, riders, bikes, contracts, insurance, equipment, devices, telemetry, and battery stations.
- Adds no-FK compensation policy, invariant matrix, telemetry write-path/idempotency rules, and scaffold guardrails.
- Records subagent architecture/critic/verifier review integration.

## Trace

- Project start: EVNSolution/clever-change-control#45
- Change request: EVNSolution/clever-change-control#48
- Target issue: EVNSolution/thundercrew-domain#8
- Branch: `cc-48-backend-domain-design`

## Concurrent work decision

Decision: `allowed-with-non-overlap`.

Evidence checked before PR:

- Target repo open issues: only EVNSolution/thundercrew-domain#8.
- Target repo open PRs: none.
- Target repo remote branches: `main`, `dev`, `cc-48-backend-domain-design`.
- Open change-control issues outside #48 are different projects/control-plane tasks or non-target scopes and do not overlap this backend design documentation branch.

## Review evidence

- Architect PRD/scope review: accepted direction.
- Architect domain/DB review: accepted with required clarifications.
- Critic review: initial REJECT until no-FK compensation, telemetry write path, invariants, and module boundaries were made concrete.
- Final verifier review: PASS, no must-fix.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Notes

This PR is design/change-management only. It does not scaffold Spring Boot code and does not mutate Supabase/Vercel production state.
