### PR TITLE
Add service-ops-api core operations persistence baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -1,10 +1,10 @@
 # service-ops-api
 
-Spring Boot scaffold baseline for ThunderCrew operations API.
+Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module is intentionally narrow. It provides the backend scaffold only:
+This module currently provides the backend scaffold plus the non-telemetry core persistence baseline:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -12,18 +12,29 @@ This module is intentionally narrow. It provides the backend scaffold only:
 - Spring Data JPA baseline
 - Spring Security + BCrypt password hashing
 - bounded package skeleton
-- ArchUnit boundary smoke test
+- ArchUnit boundary tests
 - common API error/audit/soft-delete/time baseline
-- minimal Flyway baseline for `admin_users`, `contract_templates`, and the system `무제한 계약` seed
+- Flyway baseline for `admin_users`, `contract_templates`, and the system `무제한 계약` seed
+- Flyway + JPA entity mappings for non-telemetry core operations:
+  - riders
+  - bikes and operation status history
+  - rider-bike contracts
+  - insurance items and rider-insurance links
+  - equipment types and bike equipment
+  - devices and bike-device installation history
+  - battery stations and station count logs
 
-Out of scope for this scaffold issue:
+Out of scope for the current persistence baseline:
 
-- full domain CRUD
-- telemetry ingestion
+- REST CRUD controllers/endpoints
+- API request/response DTO contract layer
+- computed business DTOs that depend on multi-table or time logic
+- telemetry tables and ingestion write paths
 - JWT login/refresh/revocation implementation
 - frontend relocation
 - TimescaleDB setup
-- contract overlap implementation
+- contract overlap locking implementation
+- integrity scan/repair job
 
 ## Local environment
 
@@ -64,8 +75,9 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Domain CRUD/schema beyond admin/template baseline
+- CRUD service/controller for rider, bike, contract, insurance, equipment, device, and station slices
 - JWT login/refresh/revocation
-- Telemetry raw/recent/current ingestion
+- Telemetry schema and raw/recent/current ingestion
+- Dashboard/map read API
 - Contract overlap locking implementation
 - Integrity scan implementation

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.bike.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "bikes")
+public class Bike extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 50)
+    private String plateNumber;
+
+    @Column(nullable = false, length = 100)
+    private String vin;
+
+    @Column(length = 100)
+    private String modelName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private BikeOperationStatus operationStatus;
+
+    private String memo;
+
+    protected Bike() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatus.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.bike.domain;
+
+public enum BikeOperationStatus {
+    READY,
+    IN_SERVICE,
+    REPAIRING,
+    INSPECTION_REQUIRED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
@@ -1,0 +1,36 @@
+package com.thundercrew.opsapi.bike.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "bike_operation_status_histories")
+public class BikeOperationStatusHistory extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private BikeOperationStatus operationStatus;
+
+    @Column(nullable = false)
+    private Instant startedAt;
+
+    private Instant endedAt;
+
+    private String reason;
+
+    private String memo;
+
+    private UUID changedBy;
+
+    protected BikeOperationStatusHistory() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/domain/DisplaySequencedEntity.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/domain/DisplaySequencedEntity.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class DisplaySequencedEntity extends SoftDeletableEntity {
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Long idx;
+
+    public Long getIdx() {
+        return idx;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
@@ -1,0 +1,36 @@
+package com.thundercrew.opsapi.contract.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "rider_bike_contracts")
+public class RiderBikeContract extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID riderId;
+
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    @Column(nullable = false)
+    private UUID contractTemplateId;
+
+    @Column(nullable = false)
+    private Instant startAt;
+
+    private Instant endAt;
+
+    private Instant terminatedAt;
+
+    private String terminatedReason;
+
+    private String memo;
+
+    protected RiderBikeContract() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
@@ -1,0 +1,29 @@
+package com.thundercrew.opsapi.device.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "bike_device_installations")
+public class BikeDeviceInstallation extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    @Column(nullable = false)
+    private UUID deviceId;
+
+    @Column(nullable = false)
+    private Instant installedAt;
+
+    private Instant removedAt;
+
+    private String memo;
+
+    protected BikeDeviceInstallation() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
@@ -1,0 +1,28 @@
+package com.thundercrew.opsapi.device.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "devices")
+public class Device extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String deviceUid;
+
+    @Column(length = 100)
+    private String manufacturer;
+
+    @Column(length = 100)
+    private String modelName;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    private String memo;
+
+    protected Device() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
@@ -1,0 +1,44 @@
+package com.thundercrew.opsapi.equipment.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "bike_equipments")
+public class BikeEquipment extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    @Column(nullable = false)
+    private UUID equipmentTypeId;
+
+    @Column(length = 100)
+    private String equipmentLabel;
+
+    @Column(length = 100)
+    private String modelName;
+
+    @Column(length = 100)
+    private String serialNumber;
+
+    @Column(nullable = false)
+    private Instant installedAt;
+
+    private Instant removedAt;
+
+    @Column(nullable = false)
+    private LocalDate managementDueDate;
+
+    private String managementNote;
+
+    private String memo;
+
+    protected BikeEquipment() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.equipment.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "equipment_types")
+public class EquipmentType extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    private String description;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    protected EquipmentType() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.insurance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "insurance_items")
+public class InsuranceItem extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    private String description;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    protected InsuranceItem() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
@@ -1,0 +1,26 @@
+package com.thundercrew.opsapi.insurance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "rider_insurances")
+public class RiderInsurance extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID riderId;
+
+    @Column(nullable = false)
+    private UUID insuranceItemId;
+
+    private String memo;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    protected RiderInsurance() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
@@ -1,0 +1,37 @@
+package com.thundercrew.opsapi.rider.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "riders")
+public class Rider extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 30)
+    private String phoneNumber;
+
+    @Column(length = 100)
+    private String teamName;
+
+    @Column(length = 100)
+    private String areaName;
+
+    @Column(nullable = false)
+    private boolean appAccountLinked;
+
+    private UUID appAccountId;
+
+    private Instant appLinkedAt;
+
+    private String memo;
+
+    protected Rider() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
@@ -1,0 +1,44 @@
+package com.thundercrew.opsapi.station.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "battery_stations")
+public class BatteryStation extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private BatteryStationStatus status;
+
+    @Column(nullable = false)
+    private int maxBatteryCapacity;
+
+    @Column(nullable = false)
+    private int currentBatteryCount;
+
+    @Column(nullable = false)
+    private int availableBatteryCount;
+
+    private String memo;
+
+    protected BatteryStation() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStationStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStationStatus.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.station.domain;
+
+public enum BatteryStationStatus {
+    ACTIVE,
+    MAINTENANCE,
+    INACTIVE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
@@ -1,0 +1,47 @@
+package com.thundercrew.opsapi.station.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "station_battery_count_logs")
+public class StationBatteryCountLog extends DisplaySequencedEntity {
+
+    @Column(nullable = false)
+    private UUID stationId;
+
+    @Column(nullable = false)
+    private int beforeMaxBatteryCapacity;
+
+    @Column(nullable = false)
+    private int afterMaxBatteryCapacity;
+
+    @Column(nullable = false)
+    private int beforeCurrentBatteryCount;
+
+    @Column(nullable = false)
+    private int afterCurrentBatteryCount;
+
+    @Column(nullable = false)
+    private int beforeAvailableBatteryCount;
+
+    @Column(nullable = false)
+    private int afterAvailableBatteryCount;
+
+    @Column(length = 100)
+    private String reason;
+
+    private String memo;
+
+    @Column(nullable = false)
+    private Instant changedAt;
+
+    private UUID changedBy;
+
+    protected StationBatteryCountLog() {
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V2__init_core_operations_persistence.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V2__init_core_operations_persistence.sql
@@ -1,0 +1,344 @@
+create table riders (
+    id uuid primary key,
+    idx bigserial not null unique,
+    name varchar(100) not null,
+    phone_number varchar(30) not null,
+    team_name varchar(100),
+    area_name varchar(100),
+    app_account_linked boolean not null default false,
+    app_account_id uuid,
+    app_linked_at timestamptz,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_riders_app_link_consistency check (
+        (app_account_linked = false and app_account_id is null and app_linked_at is null)
+        or
+        (app_account_linked = true and app_account_id is not null and app_linked_at is not null)
+    )
+);
+
+create unique index ux_riders_phone_number_active
+    on riders(phone_number)
+    where deleted_at is null;
+
+create unique index ux_riders_app_account_id_active
+    on riders(app_account_id)
+    where app_account_id is not null and deleted_at is null;
+
+create index ix_riders_team_area_active
+    on riders(team_name, area_name)
+    where deleted_at is null;
+
+create table bikes (
+    id uuid primary key,
+    idx bigserial not null unique,
+    plate_number varchar(50) not null,
+    vin varchar(100) not null,
+    model_name varchar(100),
+    operation_status varchar(40) not null,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_bikes_operation_status check (
+        operation_status in ('READY', 'IN_SERVICE', 'REPAIRING', 'INSPECTION_REQUIRED')
+    )
+);
+
+create unique index ux_bikes_plate_number_active
+    on bikes(plate_number)
+    where deleted_at is null;
+
+create unique index ux_bikes_vin_active
+    on bikes(vin)
+    where deleted_at is null;
+
+create index ix_bikes_operation_status_active
+    on bikes(operation_status)
+    where deleted_at is null;
+
+create table bike_operation_status_histories (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    operation_status varchar(40) not null,
+    started_at timestamptz not null,
+    ended_at timestamptz,
+    reason text,
+    memo text,
+    changed_by uuid,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_bike_status_histories_operation_status check (
+        operation_status in ('READY', 'IN_SERVICE', 'REPAIRING', 'INSPECTION_REQUIRED')
+    ),
+    constraint ck_bike_status_histories_ended_after_started check (
+        ended_at is null or ended_at >= started_at
+    )
+);
+
+create unique index ux_bike_operation_status_histories_open_bike
+    on bike_operation_status_histories(bike_id)
+    where ended_at is null and deleted_at is null;
+
+create index ix_bike_operation_status_histories_bike_started
+    on bike_operation_status_histories(bike_id, started_at desc)
+    where deleted_at is null;
+
+create table rider_bike_contracts (
+    id uuid primary key,
+    idx bigserial not null unique,
+    rider_id uuid not null,
+    bike_id uuid not null,
+    contract_template_id uuid not null,
+    start_at timestamptz not null,
+    end_at timestamptz,
+    terminated_at timestamptz,
+    terminated_reason text,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_contracts_end_after_start check (end_at is null or end_at > start_at),
+    constraint ck_contracts_terminated_after_start check (terminated_at is null or terminated_at >= start_at)
+);
+
+create index ix_contracts_rider_period_active
+    on rider_bike_contracts(rider_id, start_at, end_at)
+    where deleted_at is null;
+
+create index ix_contracts_bike_period_active
+    on rider_bike_contracts(bike_id, start_at, end_at)
+    where deleted_at is null;
+
+create table insurance_items (
+    id uuid primary key,
+    idx bigserial not null unique,
+    name varchar(100) not null,
+    description text,
+    enabled boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+
+create unique index ux_insurance_items_name_active
+    on insurance_items(name)
+    where deleted_at is null;
+
+create table rider_insurances (
+    id uuid primary key,
+    idx bigserial not null unique,
+    rider_id uuid not null,
+    insurance_item_id uuid not null,
+    memo text,
+    enabled boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+
+create unique index ux_rider_insurances_active_pair
+    on rider_insurances(rider_id, insurance_item_id)
+    where deleted_at is null;
+
+create index ix_rider_insurances_item_active
+    on rider_insurances(insurance_item_id)
+    where deleted_at is null;
+
+create table equipment_types (
+    id uuid primary key,
+    idx bigserial not null unique,
+    name varchar(100) not null,
+    description text,
+    enabled boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+
+create unique index ux_equipment_types_name_active
+    on equipment_types(name)
+    where deleted_at is null;
+
+create table bike_equipments (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    equipment_type_id uuid not null,
+    equipment_label varchar(100),
+    model_name varchar(100),
+    serial_number varchar(100),
+    installed_at timestamptz not null,
+    removed_at timestamptz,
+    management_due_date date not null,
+    management_note text,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_bike_equipments_removed_after_install check (removed_at is null or removed_at >= installed_at)
+);
+
+create index ix_bike_equipments_bike_active
+    on bike_equipments(bike_id)
+    where removed_at is null and deleted_at is null;
+
+create index ix_bike_equipments_due_active
+    on bike_equipments(management_due_date)
+    where removed_at is null and deleted_at is null;
+
+create unique index ux_bike_equipments_serial_active
+    on bike_equipments(serial_number)
+    where serial_number is not null and removed_at is null and deleted_at is null;
+
+create table devices (
+    id uuid primary key,
+    idx bigserial not null unique,
+    device_uid varchar(100) not null,
+    manufacturer varchar(100),
+    model_name varchar(100),
+    enabled boolean not null default true,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+
+create unique index ux_devices_device_uid_active
+    on devices(device_uid)
+    where deleted_at is null;
+
+create table bike_device_installations (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    device_id uuid not null,
+    installed_at timestamptz not null,
+    removed_at timestamptz,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_device_install_removed_after_install check (removed_at is null or removed_at >= installed_at)
+);
+
+create unique index ux_bike_device_installations_active_bike
+    on bike_device_installations(bike_id)
+    where removed_at is null and deleted_at is null;
+
+create unique index ux_bike_device_installations_active_device
+    on bike_device_installations(device_id)
+    where removed_at is null and deleted_at is null;
+
+create index ix_bike_device_installations_bike_history
+    on bike_device_installations(bike_id, installed_at desc)
+    where deleted_at is null;
+
+create index ix_bike_device_installations_device_history
+    on bike_device_installations(device_id, installed_at desc)
+    where deleted_at is null;
+
+create table battery_stations (
+    id uuid primary key,
+    idx bigserial not null unique,
+    name varchar(100) not null,
+    address varchar(255) not null,
+    latitude numeric(10,7) not null,
+    longitude numeric(10,7) not null,
+    status varchar(30) not null,
+    max_battery_capacity integer not null,
+    current_battery_count integer not null,
+    available_battery_count integer not null,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_battery_stations_status check (status in ('ACTIVE', 'MAINTENANCE', 'INACTIVE')),
+    constraint ck_battery_stations_latitude check (latitude >= -90 and latitude <= 90),
+    constraint ck_battery_stations_longitude check (longitude >= -180 and longitude <= 180),
+    constraint ck_battery_stations_max_capacity check (max_battery_capacity >= 0),
+    constraint ck_battery_stations_current_count check (current_battery_count >= 0),
+    constraint ck_battery_stations_available_count check (available_battery_count >= 0),
+    constraint ck_battery_stations_current_within_max check (current_battery_count <= max_battery_capacity),
+    constraint ck_battery_stations_available_within_current check (available_battery_count <= current_battery_count)
+);
+
+create unique index ux_battery_stations_name_active
+    on battery_stations(name)
+    where deleted_at is null;
+
+create index ix_battery_stations_location_active
+    on battery_stations(latitude, longitude)
+    where deleted_at is null;
+
+create table station_battery_count_logs (
+    id uuid primary key,
+    idx bigserial not null unique,
+    station_id uuid not null,
+    before_max_battery_capacity integer not null,
+    after_max_battery_capacity integer not null,
+    before_current_battery_count integer not null,
+    after_current_battery_count integer not null,
+    before_available_battery_count integer not null,
+    after_available_battery_count integer not null,
+    reason varchar(100),
+    memo text,
+    changed_at timestamptz not null,
+    changed_by uuid,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_station_count_logs_before_max_nonnegative check (before_max_battery_capacity >= 0),
+    constraint ck_station_count_logs_after_max_nonnegative check (after_max_battery_capacity >= 0),
+    constraint ck_station_count_logs_before_current_nonnegative check (before_current_battery_count >= 0),
+    constraint ck_station_count_logs_after_current_nonnegative check (after_current_battery_count >= 0),
+    constraint ck_station_count_logs_before_available_nonnegative check (before_available_battery_count >= 0),
+    constraint ck_station_count_logs_after_available_nonnegative check (after_available_battery_count >= 0),
+    constraint ck_station_count_logs_before_current_within_max check (before_current_battery_count <= before_max_battery_capacity),
+    constraint ck_station_count_logs_after_current_within_max check (after_current_battery_count <= after_max_battery_capacity),
+    constraint ck_station_count_logs_before_available_within_current check (before_available_battery_count <= before_current_battery_count),
+    constraint ck_station_count_logs_after_available_within_current check (after_available_battery_count <= after_current_battery_count)
+);
+
+create index ix_station_battery_count_logs_station_changed
+    on station_battery_count_logs(station_id, changed_at desc);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -4,8 +4,16 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
 @AnalyzeClasses(packages = "com.thundercrew.opsapi", importOptions = ImportOption.DoNotIncludeTests.class)
 class ArchitectureBoundaryTests {
@@ -24,4 +32,16 @@ class ArchitectureBoundaryTests {
                     "..telemetry..",
                     "..station..",
                     "..dashboard..");
+
+    @ArchTest
+    static final ArchRule issue_12_must_not_add_rest_controllers = noClasses()
+            .should().beAnnotatedWith(RestController.class)
+            .orShould().beAnnotatedWith(Controller.class);
+
+    @ArchTest
+    static final ArchRule issue_12_persistence_baseline_must_not_use_jpa_relationship_annotations = noFields()
+            .should().beAnnotatedWith(ManyToOne.class)
+            .orShould().beAnnotatedWith(OneToMany.class)
+            .orShould().beAnnotatedWith(OneToOne.class)
+            .orShould().beAnnotatedWith(ManyToMany.class);
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
@@ -1,0 +1,260 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CorePersistenceBaselineTests extends PostgresContainerSupport {
+
+    private static final List<String> CORE_TABLES = List.of(
+            "riders",
+            "bikes",
+            "bike_operation_status_histories",
+            "rider_bike_contracts",
+            "insurance_items",
+            "rider_insurances",
+            "equipment_types",
+            "bike_equipments",
+            "devices",
+            "bike_device_installations",
+            "battery_stations",
+            "station_battery_count_logs");
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @Test
+    void flywayCreatesEveryNonTelemetryCoreOperationsTable() {
+        List<String> tables = jdbcTemplate.queryForList("""
+                select table_name
+                from information_schema.tables
+                where table_schema = current_schema()
+                order by table_name
+                """, String.class);
+
+        assertThat(tables).containsAll(CORE_TABLES);
+    }
+
+    @Test
+    void coreSchemaDoesNotCreateCrossDomainForeignKeys() {
+        Integer foreignKeyCount = jdbcTemplate.queryForObject("""
+                select count(*)
+                from information_schema.table_constraints
+                where table_schema = current_schema()
+                  and constraint_type = 'FOREIGN KEY'
+                  and table_name in (
+                    'riders',
+                    'bikes',
+                    'bike_operation_status_histories',
+                    'rider_bike_contracts',
+                    'insurance_items',
+                    'rider_insurances',
+                    'equipment_types',
+                    'bike_equipments',
+                    'devices',
+                    'bike_device_installations',
+                    'battery_stations',
+                    'station_battery_count_logs'
+                  )
+                """, Integer.class);
+
+        assertThat(foreignKeyCount).isZero();
+    }
+
+
+    @Test
+    void schemaExposesRequiredPartialIndexesAndOmitsTelemetryTables() {
+        List<String> indexNames = jdbcTemplate.queryForList("""
+                select indexname
+                from pg_indexes
+                where schemaname = current_schema()
+                order by indexname
+                """, String.class);
+
+        assertThat(indexNames).contains(
+                "ux_riders_phone_number_active",
+                "ux_bikes_plate_number_active",
+                "ux_bikes_vin_active",
+                "ux_bike_operation_status_histories_open_bike",
+                "ux_insurance_items_name_active",
+                "ux_rider_insurances_active_pair",
+                "ux_equipment_types_name_active",
+                "ux_bike_equipments_serial_active",
+                "ux_devices_device_uid_active",
+                "ux_bike_device_installations_active_bike",
+                "ux_bike_device_installations_active_device",
+                "ux_battery_stations_name_active");
+
+        List<String> telemetryTables = jdbcTemplate.queryForList("""
+                select table_name
+                from information_schema.tables
+                where table_schema = current_schema()
+                  and table_name in (
+                    'device_telemetry_logs',
+                    'bike_recent_states',
+                    'bike_current_states',
+                    'device_api_sync_logs',
+                    'telemetry_ingestion_error_logs'
+                  )
+                """, String.class);
+
+        assertThat(telemetryTables).isEmpty();
+    }
+
+    @Test
+    void mutableCoreTablesHaveUuidIdDisplayIdxAndAuditColumns() {
+        for (String tableName : CORE_TABLES) {
+            List<String> columns = jdbcTemplate.queryForList("""
+                    select column_name
+                    from information_schema.columns
+                    where table_schema = current_schema()
+                      and table_name = ?
+                    """, String.class, tableName);
+
+            assertThat(columns)
+                    .as("%s should follow the core table column convention", tableName)
+                    .contains("id", "idx", "created_at", "updated_at", "deleted_at", "created_by", "updated_by", "deleted_by");
+        }
+    }
+
+    @Test
+    void activeUniqueIndexesAllowBusinessIdentifierReuseAfterSoftDelete() {
+        UUID deletedRiderId = UUID.randomUUID();
+        UUID replacementRiderId = UUID.randomUUID();
+
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, deleted_at)
+                values (?, 'Deleted Rider', '010-9999-0000', now())
+                """, deletedRiderId);
+
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number)
+                values (?, 'Replacement Rider', '010-9999-0000')
+                """, replacementRiderId);
+
+        Integer activeCount = jdbcTemplate.queryForObject("""
+                select count(*) from riders
+                where phone_number = '010-9999-0000'
+                  and deleted_at is null
+                """, Integer.class);
+
+        assertThat(activeCount).isEqualTo(1);
+    }
+
+    @Test
+    void activeUniqueIndexesProtectHumanBusinessIdentifiers() {
+        UUID rider1 = UUID.randomUUID();
+        UUID rider2 = UUID.randomUUID();
+        jdbcTemplate.update("insert into riders (id, name, phone_number) values (?, 'Kim Rider', '010-1111-2222')", rider1);
+        assertThatThrownBy(() -> jdbcTemplate.update(
+                "insert into riders (id, name, phone_number) values (?, 'Park Rider', '010-1111-2222')", rider2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        UUID bike1 = UUID.randomUUID();
+        UUID bike2 = UUID.randomUUID();
+        UUID bike3 = UUID.randomUUID();
+        jdbcTemplate.update("insert into bikes (id, plate_number, vin, operation_status) values (?, '서울A-001', 'VIN-001', 'READY')", bike1);
+        assertThatThrownBy(() -> jdbcTemplate.update(
+                "insert into bikes (id, plate_number, vin, operation_status) values (?, '서울A-001', 'VIN-002', 'READY')", bike2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbcTemplate.update(
+                "insert into bikes (id, plate_number, vin, operation_status) values (?, '서울A-003', 'VIN-001', 'READY')", bike3))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        UUID device1 = UUID.randomUUID();
+        UUID device2 = UUID.randomUUID();
+        jdbcTemplate.update("insert into devices (id, device_uid) values (?, 'DEVICE-001')", device1);
+        assertThatThrownBy(() -> jdbcTemplate.update("insert into devices (id, device_uid) values (?, 'DEVICE-001')", device2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        UUID station1 = UUID.randomUUID();
+        UUID station2 = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into battery_stations
+                    (id, name, address, latitude, longitude, status, max_battery_capacity, current_battery_count, available_battery_count)
+                values (?, '강남 스테이션', '서울 강남구', 37.5000000, 127.0300000, 'ACTIVE', 20, 10, 5)
+                """, station1);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into battery_stations
+                    (id, name, address, latitude, longitude, status, max_battery_capacity, current_battery_count, available_battery_count)
+                values (?, '강남 스테이션', '서울 강남구', 37.5000000, 127.0300000, 'ACTIVE', 20, 10, 5)
+                """, station2)).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void coreCheckConstraintsAndPartialUniqueIndexesProtectRepresentativeInvariants() {
+        UUID bikeId = UUID.randomUUID();
+        UUID otherBikeId = UUID.randomUUID();
+        UUID deviceId = UUID.randomUUID();
+        UUID otherDeviceId = UUID.randomUUID();
+
+        jdbcTemplate.update("insert into bikes (id, plate_number, vin, operation_status) values (?, '서울B-001', 'VIN-B-001', 'IN_SERVICE')", bikeId);
+        jdbcTemplate.update("insert into bikes (id, plate_number, vin, operation_status) values (?, '서울B-002', 'VIN-B-002', 'IN_SERVICE')", otherBikeId);
+        jdbcTemplate.update("insert into devices (id, device_uid) values (?, 'DEVICE-B-001')", deviceId);
+        jdbcTemplate.update("insert into devices (id, device_uid) values (?, 'DEVICE-B-002')", otherDeviceId);
+
+        jdbcTemplate.update("""
+                insert into bike_operation_status_histories (id, bike_id, operation_status, started_at)
+                values (?, ?, 'IN_SERVICE', now())
+                """, UUID.randomUUID(), bikeId);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into bike_operation_status_histories (id, bike_id, operation_status, started_at)
+                values (?, ?, 'READY', now())
+                """, UUID.randomUUID(), bikeId)).isInstanceOf(DataIntegrityViolationException.class);
+
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at)
+                values (?, ?, ?, now())
+                """, UUID.randomUUID(), bikeId, deviceId);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at)
+                values (?, ?, ?, now())
+                """, UUID.randomUUID(), bikeId, otherDeviceId)).isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at)
+                values (?, ?, ?, now())
+                """, UUID.randomUUID(), otherBikeId, deviceId)).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into battery_stations
+                    (id, name, address, latitude, longitude, status, max_battery_capacity, current_battery_count, available_battery_count)
+                values (?, '카운트 오류 스테이션', '서울', 37.5000000, 127.0300000, 'ACTIVE', 5, 10, 1)
+                """, UUID.randomUUID())).isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into battery_stations
+                    (id, name, address, latitude, longitude, status, max_battery_capacity, current_battery_count, available_battery_count)
+                values (?, '사용가능수 오류 스테이션', '서울', 37.5000000, 127.0300000, 'ACTIVE', 10, 3, 4)
+                """, UUID.randomUUID())).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into rider_bike_contracts
+                    (id, rider_id, bike_id, contract_template_id, start_at, end_at)
+                values (?, ?, ?, ?, '2026-05-02T00:00:00Z', '2026-05-01T00:00:00Z')
+                """, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                insert into rider_bike_contracts
+                    (id, rider_id, bike_id, contract_template_id, start_at, terminated_at)
+                values (?, ?, ?, ?, '2026-05-02T00:00:00Z', '2026-05-01T00:00:00Z')
+                """, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -71,3 +71,18 @@ Decision for the backend design phase:
 
 The user authorized branch-of-branch work and internal merges for this change-management-heavy phase.
 This branch remains the trace branch for #48/#8 until a PR is opened into `dev`.
+
+## Core persistence baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#50
+- Target issue: EVNSolution/thundercrew-domain#12
+- Branch: `cc-50-core-persistence-baseline`
+
+Scope decision:
+
+- Implement the non-telemetry core relational schema and JPA entity/enums only.
+- Keep CRUD controllers, API DTO contracts, JWT, telemetry tables/write path, dashboard/map API, and frontend relocation out of this issue.
+- Cross-domain references remain UUID scalar columns without DB foreign-key constraints.
+- JPA mappings intentionally avoid cross-domain relationship annotations such as `@ManyToOne`.


### PR DESCRIPTION
## Summary
- Add the non-telemetry `service-ops-api` core operations persistence baseline for riders, bikes, rider-bike contracts, insurance items, bike equipment, devices, battery stations, and station inventory count logs.
- Add JPA entity/enums with UUID scalar references only, preserving the current no-FK/no-JPA-relationship boundary for MSA-oriented slices.
- Add regression tests for schema shape, no foreign keys, partial uniqueness, soft-delete reuse, active assignment constraints, and status/count/date checks.
- Update backend ledger and service README with the scope guard and next-step boundaries.

## Traceability
- Change-control anchor: EVNSolution/clever-change-control#50
- Target work issue: EVNSolution/thundercrew-domain#12
- Prior context: EVNSolution/clever-change-control#45, EVNSolution/clever-change-control#49, EVNSolution/thundercrew-domain#10, EVNSolution/thundercrew-domain#11
- Branch: `cc-50-core-persistence-baseline`

## Scope guard
Included:
- Flyway V2 migration for 12 core non-telemetry tables.
- JPA entity mappings and enum types.
- Persistence/schema tests and architecture guardrails.

Explicitly excluded for follow-up issues:
- REST CRUD, API DTO contracts, JWT/auth endpoints.
- Telemetry/time-series ingestion tables, TimescaleDB setup, retention/partitioning.
- Dashboard/map API and frontend relocation.
- Full contract-overlap locking service or integrity scan/repair jobs.

## Concurrent work gate
Decision: `allowed-with-non-overlap`

Evidence checked before PR creation:
- Target open PRs: none.
- Target active branches: `main`, `dev`, `cc-50-core-persistence-baseline`.
- Target open issues: only #12 for `thundercrew-domain`.
- Change-control open issues reviewed: #50 plus unrelated #44, #40, #35, #24, #23.

Non-overlap reason: this branch only changes the service-ops-api persistence baseline and backend ledger docs; no open PR currently overlaps the same service/API/data/deploy/file scope.

## Review evidence
- Test-engineer checklist applied to schema invariants and no-FK/no-ID-entry principles.
- Code-reviewer pass after implementation; one LOW architecture-test naming issue was fixed before PR.

## Validation
- `git diff --check`
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Context/docs update
- Updated `docs/backend/00-change-ledger.md` with the issue #12/#50 scope decision and validation path.
- Updated `development/service-ops-api/README.md` with persistence baseline details and exclusions.
