### PR TITLE
Add service-ops-api read-only API contract baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,7 +4,7 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold plus the non-telemetry core persistence baseline:
+This module currently provides the backend scaffold, non-telemetry core persistence baseline, and read-only API/DTO contract baseline:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -24,11 +24,20 @@ This module currently provides the backend scaffold plus the non-telemetry core 
   - devices and bike-device installation history
   - battery stations and station count logs
 
-Out of scope for the current persistence baseline:
+- Read-only `GET /api/v1/**` list/detail endpoints and response DTOs for:
+  - riders
+  - bikes and bike operation status histories
+  - contract templates and rider-bike contracts
+  - insurance items and rider-insurance links
+  - equipment types and bike equipment
+  - devices and bike-device installation history
+  - battery stations and station count logs
+- Shared `PageResponse` page contract and `RESOURCE_NOT_FOUND` error contract
 
-- REST CRUD controllers/endpoints
-- API request/response DTO contract layer
-- computed business DTOs that depend on multi-table or time logic
+Out of scope for the current read-only API baseline:
+
+- Create/update/delete command endpoints and request DTOs
+- computed business DTOs that depend on telemetry, dashboard, map, or multi-table/time logic
 - telemetry tables and ingestion write paths
 - JWT login/refresh/revocation implementation
 - frontend relocation
@@ -75,7 +84,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- CRUD service/controller for rider, bike, contract, insurance, equipment, device, and station slices
+- Create/update/delete service/controller slices for rider, bike, contract, insurance, equipment, device, and station resources
 - JWT login/refresh/revocation
 - Telemetry schema and raw/recent/current ingestion
 - Dashboard/map read API

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeReadController.java
@@ -1,0 +1,44 @@
+package com.thundercrew.opsapi.bike.controller;
+
+import com.thundercrew.opsapi.bike.dto.BikeOperationStatusHistoryReadResponse;
+import com.thundercrew.opsapi.bike.dto.BikeReadResponse;
+import com.thundercrew.opsapi.bike.service.BikeReadService;
+import com.thundercrew.opsapi.common.api.PageResponse;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class BikeReadController {
+
+    private final BikeReadService bikeReadService;
+
+    public BikeReadController(BikeReadService bikeReadService) {
+        this.bikeReadService = bikeReadService;
+    }
+
+    @GetMapping("/api/v1/bikes")
+    PageResponse<BikeReadResponse> listBikes(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return bikeReadService.listBikes(pageable);
+    }
+
+    @GetMapping("/api/v1/bikes/{id}")
+    BikeReadResponse getBike(@PathVariable UUID id) {
+        return bikeReadService.getBike(id);
+    }
+
+    @GetMapping("/api/v1/bike-operation-status-histories")
+    PageResponse<BikeOperationStatusHistoryReadResponse> listStatusHistories(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return bikeReadService.listStatusHistories(pageable);
+    }
+
+    @GetMapping("/api/v1/bike-operation-status-histories/{id}")
+    BikeOperationStatusHistoryReadResponse getStatusHistory(@PathVariable UUID id) {
+        return bikeReadService.getStatusHistory(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -26,6 +26,27 @@ public class Bike extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public String getPlateNumber() {
+        return plateNumber;
+    }
+
+    public String getVin() {
+        return vin;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public BikeOperationStatus getOperationStatus() {
+        return operationStatus;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected Bike() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
@@ -31,6 +31,35 @@ public class BikeOperationStatusHistory extends DisplaySequencedEntity {
 
     private UUID changedBy;
 
+
+    public java.util.UUID getBikeId() {
+        return bikeId;
+    }
+
+    public BikeOperationStatus getOperationStatus() {
+        return operationStatus;
+    }
+
+    public java.time.Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public java.time.Instant getEndedAt() {
+        return endedAt;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public java.util.UUID getChangedBy() {
+        return changedBy;
+    }
+
     protected BikeOperationStatusHistory() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeOperationStatusHistoryReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeOperationStatusHistoryReadResponse.java
@@ -1,0 +1,36 @@
+package com.thundercrew.opsapi.bike.dto;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BikeOperationStatusHistoryReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        BikeOperationStatus operationStatus,
+        Instant startedAt,
+        Instant endedAt,
+        String reason,
+        String memo,
+        UUID changedBy,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BikeOperationStatusHistoryReadResponse from(BikeOperationStatusHistory history) {
+        return new BikeOperationStatusHistoryReadResponse(
+                history.getId(),
+                history.getIdx(),
+                history.getBikeId(),
+                history.getOperationStatus(),
+                history.getStartedAt(),
+                history.getEndedAt(),
+                history.getReason(),
+                history.getMemo(),
+                history.getChangedBy(),
+                history.getCreatedAt(),
+                history.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
@@ -1,0 +1,32 @@
+package com.thundercrew.opsapi.bike.dto;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BikeReadResponse(
+        UUID id,
+        Long idx,
+        String plateNumber,
+        String vin,
+        String modelName,
+        BikeOperationStatus operationStatus,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BikeReadResponse from(Bike bike) {
+        return new BikeReadResponse(
+                bike.getId(),
+                bike.getIdx(),
+                bike.getPlateNumber(),
+                bike.getVin(),
+                bike.getModelName(),
+                bike.getOperationStatus(),
+                bike.getMemo(),
+                bike.getCreatedAt(),
+                bike.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeOperationStatusHistoryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeOperationStatusHistoryRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.bike.repository;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeOperationStatusHistoryRepository extends Repository<BikeOperationStatusHistory, UUID> {
+
+    Page<BikeOperationStatusHistory> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<BikeOperationStatusHistory> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.bike.repository;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeRepository extends Repository<Bike, UUID> {
+
+    Page<Bike> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<Bike> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.bike.service;
+
+import com.thundercrew.opsapi.bike.dto.BikeOperationStatusHistoryReadResponse;
+import com.thundercrew.opsapi.bike.dto.BikeReadResponse;
+import com.thundercrew.opsapi.bike.repository.BikeOperationStatusHistoryRepository;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class BikeReadService {
+
+    private final BikeRepository bikeRepository;
+    private final BikeOperationStatusHistoryRepository historyRepository;
+
+    public BikeReadService(BikeRepository bikeRepository, BikeOperationStatusHistoryRepository historyRepository) {
+        this.bikeRepository = bikeRepository;
+        this.historyRepository = historyRepository;
+    }
+
+    public PageResponse<BikeReadResponse> listBikes(Pageable pageable) {
+        return PageResponse.of(bikeRepository.findByDeletedAtIsNull(pageable).map(BikeReadResponse::from));
+    }
+
+    public BikeReadResponse getBike(UUID id) {
+        return bikeRepository.findByIdAndDeletedAtIsNull(id)
+                .map(BikeReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", id));
+    }
+
+    public PageResponse<BikeOperationStatusHistoryReadResponse> listStatusHistories(Pageable pageable) {
+        return PageResponse.of(historyRepository.findByDeletedAtIsNull(pageable).map(BikeOperationStatusHistoryReadResponse::from));
+    }
+
+    public BikeOperationStatusHistoryReadResponse getStatusHistory(UUID id) {
+        return historyRepository.findByIdAndDeletedAtIsNull(id)
+                .map(BikeOperationStatusHistoryReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeOperationStatusHistory", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.common.api;
 
 public enum ErrorCode {
     VALIDATION_FAILED,
+    RESOURCE_NOT_FOUND,
     REFERENCE_NOT_FOUND,
     REFERENCE_DELETED,
     DUPLICATE_ACTIVE_RELATION,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -39,6 +41,48 @@ public class GlobalExceptionHandler {
                 violations
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    ResponseEntity<ApiErrorResponse> handleResourceNotFound(
+            ResourceNotFoundException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    ResponseEntity<ApiErrorResponse> handleTypeMismatch(
+            MethodArgumentTypeMismatchException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.VALIDATION_FAILED,
+                "Request parameter or path value has an invalid type.",
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    ResponseEntity<ApiErrorResponse> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.VALIDATION_FAILED,
+                "HTTP method is not allowed for this resource.",
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(body);
     }
 
     @ExceptionHandler(Exception.class)

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/PageResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/PageResponse.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.common.api;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+        List<T> items,
+        PageMetadata page
+) {
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                new PageMetadata(
+                        page.getNumber(),
+                        page.getSize(),
+                        page.getTotalElements(),
+                        page.getTotalPages(),
+                        page.hasNext(),
+                        page.hasPrevious()
+                )
+        );
+    }
+
+    public record PageMetadata(
+            int number,
+            int size,
+            long totalItems,
+            int totalPages,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ResourceNotFoundException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.common.api;
+
+import java.util.UUID;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String resourceName, UUID id) {
+        super(resourceName + " not found: " + id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractReadController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.contract.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
+import com.thundercrew.opsapi.contract.service.ContractReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ContractReadController {
+
+    private final ContractReadService contractReadService;
+
+    public ContractReadController(ContractReadService contractReadService) {
+        this.contractReadService = contractReadService;
+    }
+
+    @GetMapping("/api/v1/contract-templates")
+    PageResponse<ContractTemplateReadResponse> listTemplates(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return contractReadService.listTemplates(pageable);
+    }
+
+    @GetMapping("/api/v1/contract-templates/{id}")
+    ContractTemplateReadResponse getTemplate(@PathVariable UUID id) {
+        return contractReadService.getTemplate(id);
+    }
+
+    @GetMapping("/api/v1/rider-bike-contracts")
+    PageResponse<RiderBikeContractReadResponse> listRiderBikeContracts(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return contractReadService.listRiderBikeContracts(pageable);
+    }
+
+    @GetMapping("/api/v1/rider-bike-contracts/{id}")
+    RiderBikeContractReadResponse getRiderBikeContract(@PathVariable UUID id) {
+        return contractReadService.getRiderBikeContract(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
@@ -1,0 +1,47 @@
+package com.thundercrew.opsapi.contract.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "contract_templates")
+public class ContractTemplate extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    private Integer durationMinutes;
+
+    private String description;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @Column(nullable = false)
+    private boolean systemTemplate;
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getDurationMinutes() {
+        return durationMinutes;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isSystemTemplate() {
+        return systemTemplate;
+    }
+
+    protected ContractTemplate() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
@@ -31,6 +31,39 @@ public class RiderBikeContract extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public java.util.UUID getRiderId() {
+        return riderId;
+    }
+
+    public java.util.UUID getBikeId() {
+        return bikeId;
+    }
+
+    public java.util.UUID getContractTemplateId() {
+        return contractTemplateId;
+    }
+
+    public java.time.Instant getStartAt() {
+        return startAt;
+    }
+
+    public java.time.Instant getEndAt() {
+        return endAt;
+    }
+
+    public java.time.Instant getTerminatedAt() {
+        return terminatedAt;
+    }
+
+    public String getTerminatedReason() {
+        return terminatedReason;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected RiderBikeContract() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateReadResponse.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.contract.dto;
+
+import com.thundercrew.opsapi.contract.domain.ContractTemplate;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ContractTemplateReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        Integer durationMinutes,
+        boolean unlimited,
+        String description,
+        boolean enabled,
+        boolean systemTemplate,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static ContractTemplateReadResponse from(ContractTemplate template) {
+        return new ContractTemplateReadResponse(
+                template.getId(),
+                template.getIdx(),
+                template.getName(),
+                template.getDurationMinutes(),
+                template.getDurationMinutes() == null,
+                template.getDescription(),
+                template.isEnabled(),
+                template.isSystemTemplate(),
+                template.getCreatedAt(),
+                template.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
@@ -1,0 +1,37 @@
+package com.thundercrew.opsapi.contract.dto;
+
+import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderBikeContractReadResponse(
+        UUID id,
+        Long idx,
+        UUID riderId,
+        UUID bikeId,
+        UUID contractTemplateId,
+        Instant startAt,
+        Instant endAt,
+        Instant terminatedAt,
+        String terminatedReason,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static RiderBikeContractReadResponse from(RiderBikeContract contract) {
+        return new RiderBikeContractReadResponse(
+                contract.getId(),
+                contract.getIdx(),
+                contract.getRiderId(),
+                contract.getBikeId(),
+                contract.getContractTemplateId(),
+                contract.getStartAt(),
+                contract.getEndAt(),
+                contract.getTerminatedAt(),
+                contract.getTerminatedReason(),
+                contract.getMemo(),
+                contract.getCreatedAt(),
+                contract.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.contract.repository;
+
+import com.thundercrew.opsapi.contract.domain.ContractTemplate;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface ContractTemplateRepository extends Repository<ContractTemplate, UUID> {
+
+    Page<ContractTemplate> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<ContractTemplate> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.contract.repository;
+
+import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface RiderBikeContractRepository extends Repository<RiderBikeContract, UUID> {
+
+    Page<RiderBikeContract> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<RiderBikeContract> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.contract.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
+import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ContractReadService {
+
+    private final ContractTemplateRepository contractTemplateRepository;
+    private final RiderBikeContractRepository riderBikeContractRepository;
+
+    public ContractReadService(ContractTemplateRepository contractTemplateRepository, RiderBikeContractRepository riderBikeContractRepository) {
+        this.contractTemplateRepository = contractTemplateRepository;
+        this.riderBikeContractRepository = riderBikeContractRepository;
+    }
+
+    public PageResponse<ContractTemplateReadResponse> listTemplates(Pageable pageable) {
+        return PageResponse.of(contractTemplateRepository.findByDeletedAtIsNull(pageable).map(ContractTemplateReadResponse::from));
+    }
+
+    public ContractTemplateReadResponse getTemplate(UUID id) {
+        return contractTemplateRepository.findByIdAndDeletedAtIsNull(id)
+                .map(ContractTemplateReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("ContractTemplate", id));
+    }
+
+    public PageResponse<RiderBikeContractReadResponse> listRiderBikeContracts(Pageable pageable) {
+        return PageResponse.of(riderBikeContractRepository.findByDeletedAtIsNull(pageable).map(RiderBikeContractReadResponse::from));
+    }
+
+    public RiderBikeContractReadResponse getRiderBikeContract(UUID id) {
+        return riderBikeContractRepository.findByIdAndDeletedAtIsNull(id)
+                .map(RiderBikeContractReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderBikeContract", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/DeviceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/DeviceReadController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.device.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationReadResponse;
+import com.thundercrew.opsapi.device.dto.DeviceReadResponse;
+import com.thundercrew.opsapi.device.service.DeviceReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DeviceReadController {
+
+    private final DeviceReadService deviceReadService;
+
+    public DeviceReadController(DeviceReadService deviceReadService) {
+        this.deviceReadService = deviceReadService;
+    }
+
+    @GetMapping("/api/v1/devices")
+    PageResponse<DeviceReadResponse> listDevices(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return deviceReadService.listDevices(pageable);
+    }
+
+    @GetMapping("/api/v1/devices/{id}")
+    DeviceReadResponse getDevice(@PathVariable UUID id) {
+        return deviceReadService.getDevice(id);
+    }
+
+    @GetMapping("/api/v1/bike-device-installations")
+    PageResponse<BikeDeviceInstallationReadResponse> listInstallations(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return deviceReadService.listInstallations(pageable);
+    }
+
+    @GetMapping("/api/v1/bike-device-installations/{id}")
+    BikeDeviceInstallationReadResponse getInstallation(@PathVariable UUID id) {
+        return deviceReadService.getInstallation(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
@@ -24,6 +24,27 @@ public class BikeDeviceInstallation extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public java.util.UUID getBikeId() {
+        return bikeId;
+    }
+
+    public java.util.UUID getDeviceId() {
+        return deviceId;
+    }
+
+    public java.time.Instant getInstalledAt() {
+        return installedAt;
+    }
+
+    public java.time.Instant getRemovedAt() {
+        return removedAt;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected BikeDeviceInstallation() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
@@ -23,6 +23,27 @@ public class Device extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public String getDeviceUid() {
+        return deviceUid;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected Device() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationReadResponse.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.thundercrew.opsapi.device.domain.BikeDeviceInstallation;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BikeDeviceInstallationReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        UUID deviceId,
+        Instant installedAt,
+        Instant removedAt,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BikeDeviceInstallationReadResponse from(BikeDeviceInstallation installation) {
+        return new BikeDeviceInstallationReadResponse(
+                installation.getId(),
+                installation.getIdx(),
+                installation.getBikeId(),
+                installation.getDeviceId(),
+                installation.getInstalledAt(),
+                installation.getRemovedAt(),
+                installation.getMemo(),
+                installation.getCreatedAt(),
+                installation.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceReadResponse.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.thundercrew.opsapi.device.domain.Device;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DeviceReadResponse(
+        UUID id,
+        Long idx,
+        String deviceUid,
+        String manufacturer,
+        String modelName,
+        boolean enabled,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static DeviceReadResponse from(Device device) {
+        return new DeviceReadResponse(
+                device.getId(),
+                device.getIdx(),
+                device.getDeviceUid(),
+                device.getManufacturer(),
+                device.getModelName(),
+                device.isEnabled(),
+                device.getMemo(),
+                device.getCreatedAt(),
+                device.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.device.repository;
+
+import com.thundercrew.opsapi.device.domain.BikeDeviceInstallation;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeDeviceInstallationRepository extends Repository<BikeDeviceInstallation, UUID> {
+
+    Page<BikeDeviceInstallation> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<BikeDeviceInstallation> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.device.repository;
+
+import com.thundercrew.opsapi.device.domain.Device;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface DeviceRepository extends Repository<Device, UUID> {
+
+    Page<Device> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<Device> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/DeviceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/DeviceReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.device.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationReadResponse;
+import com.thundercrew.opsapi.device.dto.DeviceReadResponse;
+import com.thundercrew.opsapi.device.repository.BikeDeviceInstallationRepository;
+import com.thundercrew.opsapi.device.repository.DeviceRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DeviceReadService {
+
+    private final DeviceRepository deviceRepository;
+    private final BikeDeviceInstallationRepository installationRepository;
+
+    public DeviceReadService(DeviceRepository deviceRepository, BikeDeviceInstallationRepository installationRepository) {
+        this.deviceRepository = deviceRepository;
+        this.installationRepository = installationRepository;
+    }
+
+    public PageResponse<DeviceReadResponse> listDevices(Pageable pageable) {
+        return PageResponse.of(deviceRepository.findByDeletedAtIsNull(pageable).map(DeviceReadResponse::from));
+    }
+
+    public DeviceReadResponse getDevice(UUID id) {
+        return deviceRepository.findByIdAndDeletedAtIsNull(id)
+                .map(DeviceReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("Device", id));
+    }
+
+    public PageResponse<BikeDeviceInstallationReadResponse> listInstallations(Pageable pageable) {
+        return PageResponse.of(installationRepository.findByDeletedAtIsNull(pageable).map(BikeDeviceInstallationReadResponse::from));
+    }
+
+    public BikeDeviceInstallationReadResponse getInstallation(UUID id) {
+        return installationRepository.findByIdAndDeletedAtIsNull(id)
+                .map(BikeDeviceInstallationReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeDeviceInstallation", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/EquipmentReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/EquipmentReadController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.equipment.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentReadResponse;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeReadResponse;
+import com.thundercrew.opsapi.equipment.service.EquipmentReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class EquipmentReadController {
+
+    private final EquipmentReadService equipmentReadService;
+
+    public EquipmentReadController(EquipmentReadService equipmentReadService) {
+        this.equipmentReadService = equipmentReadService;
+    }
+
+    @GetMapping("/api/v1/equipment-types")
+    PageResponse<EquipmentTypeReadResponse> listTypes(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return equipmentReadService.listTypes(pageable);
+    }
+
+    @GetMapping("/api/v1/equipment-types/{id}")
+    EquipmentTypeReadResponse getType(@PathVariable UUID id) {
+        return equipmentReadService.getType(id);
+    }
+
+    @GetMapping("/api/v1/bike-equipments")
+    PageResponse<BikeEquipmentReadResponse> listBikeEquipments(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return equipmentReadService.listBikeEquipments(pageable);
+    }
+
+    @GetMapping("/api/v1/bike-equipments/{id}")
+    BikeEquipmentReadResponse getBikeEquipment(@PathVariable UUID id) {
+        return equipmentReadService.getBikeEquipment(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
@@ -39,6 +39,47 @@ public class BikeEquipment extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public java.util.UUID getBikeId() {
+        return bikeId;
+    }
+
+    public java.util.UUID getEquipmentTypeId() {
+        return equipmentTypeId;
+    }
+
+    public String getEquipmentLabel() {
+        return equipmentLabel;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public java.time.Instant getInstalledAt() {
+        return installedAt;
+    }
+
+    public java.time.Instant getRemovedAt() {
+        return removedAt;
+    }
+
+    public java.time.LocalDate getManagementDueDate() {
+        return managementDueDate;
+    }
+
+    public String getManagementNote() {
+        return managementNote;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected BikeEquipment() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
@@ -17,6 +17,19 @@ public class EquipmentType extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
     protected EquipmentType() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentReadResponse.java
@@ -1,0 +1,42 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.thundercrew.opsapi.equipment.domain.BikeEquipment;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record BikeEquipmentReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        UUID equipmentTypeId,
+        String equipmentLabel,
+        String modelName,
+        String serialNumber,
+        Instant installedAt,
+        Instant removedAt,
+        LocalDate managementDueDate,
+        String managementNote,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BikeEquipmentReadResponse from(BikeEquipment equipment) {
+        return new BikeEquipmentReadResponse(
+                equipment.getId(),
+                equipment.getIdx(),
+                equipment.getBikeId(),
+                equipment.getEquipmentTypeId(),
+                equipment.getEquipmentLabel(),
+                equipment.getModelName(),
+                equipment.getSerialNumber(),
+                equipment.getInstalledAt(),
+                equipment.getRemovedAt(),
+                equipment.getManagementDueDate(),
+                equipment.getManagementNote(),
+                equipment.getMemo(),
+                equipment.getCreatedAt(),
+                equipment.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeReadResponse.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.thundercrew.opsapi.equipment.domain.EquipmentType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record EquipmentTypeReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        String description,
+        boolean enabled,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static EquipmentTypeReadResponse from(EquipmentType type) {
+        return new EquipmentTypeReadResponse(
+                type.getId(),
+                type.getIdx(),
+                type.getName(),
+                type.getDescription(),
+                type.isEnabled(),
+                type.getCreatedAt(),
+                type.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.equipment.repository;
+
+import com.thundercrew.opsapi.equipment.domain.BikeEquipment;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeEquipmentRepository extends Repository<BikeEquipment, UUID> {
+
+    Page<BikeEquipment> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<BikeEquipment> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.equipment.repository;
+
+import com.thundercrew.opsapi.equipment.domain.EquipmentType;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface EquipmentTypeRepository extends Repository<EquipmentType, UUID> {
+
+    Page<EquipmentType> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<EquipmentType> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/EquipmentReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/EquipmentReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.equipment.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentReadResponse;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeReadResponse;
+import com.thundercrew.opsapi.equipment.repository.BikeEquipmentRepository;
+import com.thundercrew.opsapi.equipment.repository.EquipmentTypeRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class EquipmentReadService {
+
+    private final EquipmentTypeRepository equipmentTypeRepository;
+    private final BikeEquipmentRepository bikeEquipmentRepository;
+
+    public EquipmentReadService(EquipmentTypeRepository equipmentTypeRepository, BikeEquipmentRepository bikeEquipmentRepository) {
+        this.equipmentTypeRepository = equipmentTypeRepository;
+        this.bikeEquipmentRepository = bikeEquipmentRepository;
+    }
+
+    public PageResponse<EquipmentTypeReadResponse> listTypes(Pageable pageable) {
+        return PageResponse.of(equipmentTypeRepository.findByDeletedAtIsNull(pageable).map(EquipmentTypeReadResponse::from));
+    }
+
+    public EquipmentTypeReadResponse getType(UUID id) {
+        return equipmentTypeRepository.findByIdAndDeletedAtIsNull(id)
+                .map(EquipmentTypeReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("EquipmentType", id));
+    }
+
+    public PageResponse<BikeEquipmentReadResponse> listBikeEquipments(Pageable pageable) {
+        return PageResponse.of(bikeEquipmentRepository.findByDeletedAtIsNull(pageable).map(BikeEquipmentReadResponse::from));
+    }
+
+    public BikeEquipmentReadResponse getBikeEquipment(UUID id) {
+        return bikeEquipmentRepository.findByIdAndDeletedAtIsNull(id)
+                .map(BikeEquipmentReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeEquipment", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/InsuranceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/InsuranceReadController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.insurance.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemReadResponse;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceReadResponse;
+import com.thundercrew.opsapi.insurance.service.InsuranceReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class InsuranceReadController {
+
+    private final InsuranceReadService insuranceReadService;
+
+    public InsuranceReadController(InsuranceReadService insuranceReadService) {
+        this.insuranceReadService = insuranceReadService;
+    }
+
+    @GetMapping("/api/v1/insurance-items")
+    PageResponse<InsuranceItemReadResponse> listItems(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return insuranceReadService.listItems(pageable);
+    }
+
+    @GetMapping("/api/v1/insurance-items/{id}")
+    InsuranceItemReadResponse getItem(@PathVariable UUID id) {
+        return insuranceReadService.getItem(id);
+    }
+
+    @GetMapping("/api/v1/rider-insurances")
+    PageResponse<RiderInsuranceReadResponse> listRiderInsurances(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return insuranceReadService.listRiderInsurances(pageable);
+    }
+
+    @GetMapping("/api/v1/rider-insurances/{id}")
+    RiderInsuranceReadResponse getRiderInsurance(@PathVariable UUID id) {
+        return insuranceReadService.getRiderInsurance(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
@@ -17,6 +17,19 @@ public class InsuranceItem extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
     protected InsuranceItem() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
@@ -21,6 +21,23 @@ public class RiderInsurance extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+
+    public java.util.UUID getRiderId() {
+        return riderId;
+    }
+
+    public java.util.UUID getInsuranceItemId() {
+        return insuranceItemId;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
     protected RiderInsurance() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemReadResponse.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
+import java.time.Instant;
+import java.util.UUID;
+
+public record InsuranceItemReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        String description,
+        boolean enabled,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static InsuranceItemReadResponse from(InsuranceItem item) {
+        return new InsuranceItemReadResponse(
+                item.getId(),
+                item.getIdx(),
+                item.getName(),
+                item.getDescription(),
+                item.isEnabled(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceReadResponse.java
@@ -1,0 +1,29 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.thundercrew.opsapi.insurance.domain.RiderInsurance;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderInsuranceReadResponse(
+        UUID id,
+        Long idx,
+        UUID riderId,
+        UUID insuranceItemId,
+        String memo,
+        boolean enabled,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static RiderInsuranceReadResponse from(RiderInsurance riderInsurance) {
+        return new RiderInsuranceReadResponse(
+                riderInsurance.getId(),
+                riderInsurance.getIdx(),
+                riderInsurance.getRiderId(),
+                riderInsurance.getInsuranceItemId(),
+                riderInsurance.getMemo(),
+                riderInsurance.isEnabled(),
+                riderInsurance.getCreatedAt(),
+                riderInsurance.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/InsuranceItemRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/InsuranceItemRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.insurance.repository;
+
+import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface InsuranceItemRepository extends Repository<InsuranceItem, UUID> {
+
+    Page<InsuranceItem> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<InsuranceItem> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/RiderInsuranceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/RiderInsuranceRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.insurance.repository;
+
+import com.thundercrew.opsapi.insurance.domain.RiderInsurance;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface RiderInsuranceRepository extends Repository<RiderInsurance, UUID> {
+
+    Page<RiderInsurance> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<RiderInsurance> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.insurance.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemReadResponse;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceReadResponse;
+import com.thundercrew.opsapi.insurance.repository.InsuranceItemRepository;
+import com.thundercrew.opsapi.insurance.repository.RiderInsuranceRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class InsuranceReadService {
+
+    private final InsuranceItemRepository insuranceItemRepository;
+    private final RiderInsuranceRepository riderInsuranceRepository;
+
+    public InsuranceReadService(InsuranceItemRepository insuranceItemRepository, RiderInsuranceRepository riderInsuranceRepository) {
+        this.insuranceItemRepository = insuranceItemRepository;
+        this.riderInsuranceRepository = riderInsuranceRepository;
+    }
+
+    public PageResponse<InsuranceItemReadResponse> listItems(Pageable pageable) {
+        return PageResponse.of(insuranceItemRepository.findByDeletedAtIsNull(pageable).map(InsuranceItemReadResponse::from));
+    }
+
+    public InsuranceItemReadResponse getItem(UUID id) {
+        return insuranceItemRepository.findByIdAndDeletedAtIsNull(id)
+                .map(InsuranceItemReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("InsuranceItem", id));
+    }
+
+    public PageResponse<RiderInsuranceReadResponse> listRiderInsurances(Pageable pageable) {
+        return PageResponse.of(riderInsuranceRepository.findByDeletedAtIsNull(pageable).map(RiderInsuranceReadResponse::from));
+    }
+
+    public RiderInsuranceReadResponse getRiderInsurance(UUID id) {
+        return riderInsuranceRepository.findByIdAndDeletedAtIsNull(id)
+                .map(RiderInsuranceReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderInsurance", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderReadController.java
@@ -1,0 +1,34 @@
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.rider.dto.RiderReadResponse;
+import com.thundercrew.opsapi.rider.service.RiderReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/riders")
+public class RiderReadController {
+
+    private final RiderReadService riderReadService;
+
+    public RiderReadController(RiderReadService riderReadService) {
+        this.riderReadService = riderReadService;
+    }
+
+    @GetMapping
+    PageResponse<RiderReadResponse> list(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return riderReadService.list(pageable);
+    }
+
+    @GetMapping("/{id}")
+    RiderReadResponse get(@PathVariable UUID id) {
+        return riderReadService.get(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
@@ -32,6 +32,39 @@ public class Rider extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public String getAreaName() {
+        return areaName;
+    }
+
+    public boolean isAppAccountLinked() {
+        return appAccountLinked;
+    }
+
+    public java.util.UUID getAppAccountId() {
+        return appAccountId;
+    }
+
+    public java.time.Instant getAppLinkedAt() {
+        return appLinkedAt;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected Rider() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
@@ -1,0 +1,39 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.thundercrew.opsapi.rider.domain.Rider;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        String phoneNumber,
+        String teamName,
+        String areaName,
+        boolean appAccountLinked,
+        UUID appAccountId,
+        Instant appLinkedAt,
+        String appLinkStatus,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static RiderReadResponse from(Rider rider) {
+        return new RiderReadResponse(
+                rider.getId(),
+                rider.getIdx(),
+                rider.getName(),
+                rider.getPhoneNumber(),
+                rider.getTeamName(),
+                rider.getAreaName(),
+                rider.isAppAccountLinked(),
+                rider.getAppAccountId(),
+                rider.getAppLinkedAt(),
+                rider.isAppAccountLinked() ? "LINKED" : "NOT_LINKED",
+                rider.getMemo(),
+                rider.getCreatedAt(),
+                rider.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.rider.repository;
+
+import com.thundercrew.opsapi.rider.domain.Rider;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface RiderRepository extends Repository<Rider, UUID> {
+
+    Page<Rider> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<Rider> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderReadService.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.rider.dto.RiderReadResponse;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class RiderReadService {
+
+    private final RiderRepository riderRepository;
+
+    public RiderReadService(RiderRepository riderRepository) {
+        this.riderRepository = riderRepository;
+    }
+
+    public PageResponse<RiderReadResponse> list(Pageable pageable) {
+        return PageResponse.of(riderRepository.findByDeletedAtIsNull(pageable).map(RiderReadResponse::from));
+    }
+
+    public RiderReadResponse get(UUID id) {
+        return riderRepository.findByIdAndDeletedAtIsNull(id)
+                .map(RiderReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/controller/StationReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/controller/StationReadController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.station.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
+import com.thundercrew.opsapi.station.dto.StationBatteryCountLogReadResponse;
+import com.thundercrew.opsapi.station.service.StationReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StationReadController {
+
+    private final StationReadService stationReadService;
+
+    public StationReadController(StationReadService stationReadService) {
+        this.stationReadService = stationReadService;
+    }
+
+    @GetMapping("/api/v1/battery-stations")
+    PageResponse<BatteryStationReadResponse> listStations(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return stationReadService.listStations(pageable);
+    }
+
+    @GetMapping("/api/v1/battery-stations/{id}")
+    BatteryStationReadResponse getStation(@PathVariable UUID id) {
+        return stationReadService.getStation(id);
+    }
+
+    @GetMapping("/api/v1/station-battery-count-logs")
+    PageResponse<StationBatteryCountLogReadResponse> listCountLogs(@PageableDefault(size = 20, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable) {
+        return stationReadService.listCountLogs(pageable);
+    }
+
+    @GetMapping("/api/v1/station-battery-count-logs/{id}")
+    StationBatteryCountLogReadResponse getCountLog(@PathVariable UUID id) {
+        return stationReadService.getCountLog(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
@@ -39,6 +39,43 @@ public class BatteryStation extends DisplaySequencedEntity {
 
     private String memo;
 
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public java.math.BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public java.math.BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BatteryStationStatus getStatus() {
+        return status;
+    }
+
+    public int getMaxBatteryCapacity() {
+        return maxBatteryCapacity;
+    }
+
+    public int getCurrentBatteryCount() {
+        return currentBatteryCount;
+    }
+
+    public int getAvailableBatteryCount() {
+        return availableBatteryCount;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
     protected BatteryStation() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
@@ -42,6 +42,51 @@ public class StationBatteryCountLog extends DisplaySequencedEntity {
 
     private UUID changedBy;
 
+
+    public java.util.UUID getStationId() {
+        return stationId;
+    }
+
+    public int getBeforeMaxBatteryCapacity() {
+        return beforeMaxBatteryCapacity;
+    }
+
+    public int getAfterMaxBatteryCapacity() {
+        return afterMaxBatteryCapacity;
+    }
+
+    public int getBeforeCurrentBatteryCount() {
+        return beforeCurrentBatteryCount;
+    }
+
+    public int getAfterCurrentBatteryCount() {
+        return afterCurrentBatteryCount;
+    }
+
+    public int getBeforeAvailableBatteryCount() {
+        return beforeAvailableBatteryCount;
+    }
+
+    public int getAfterAvailableBatteryCount() {
+        return afterAvailableBatteryCount;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public java.time.Instant getChangedAt() {
+        return changedAt;
+    }
+
+    public java.util.UUID getChangedBy() {
+        return changedBy;
+    }
+
     protected StationBatteryCountLog() {
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationReadResponse.java
@@ -1,0 +1,52 @@
+package com.thundercrew.opsapi.station.dto;
+
+import com.thundercrew.opsapi.station.domain.BatteryStation;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BatteryStationReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        String address,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        BatteryStationStatus status,
+        int maxBatteryCapacity,
+        int currentBatteryCount,
+        int availableBatteryCount,
+        String availableBatteryLabel,
+        int capacityPercentage,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BatteryStationReadResponse from(BatteryStation station) {
+        return new BatteryStationReadResponse(
+                station.getId(),
+                station.getIdx(),
+                station.getName(),
+                station.getAddress(),
+                station.getLatitude(),
+                station.getLongitude(),
+                station.getStatus(),
+                station.getMaxBatteryCapacity(),
+                station.getCurrentBatteryCount(),
+                station.getAvailableBatteryCount(),
+                station.getAvailableBatteryCount() + "/" + station.getMaxBatteryCapacity(),
+                calculateCapacityPercentage(station),
+                station.getMemo(),
+                station.getCreatedAt(),
+                station.getUpdatedAt()
+        );
+    }
+
+    private static int calculateCapacityPercentage(BatteryStation station) {
+        if (station.getMaxBatteryCapacity() == 0) {
+            return 0;
+        }
+        return Math.round((station.getCurrentBatteryCount() * 100.0f) / station.getMaxBatteryCapacity());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/StationBatteryCountLogReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/StationBatteryCountLogReadResponse.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.station.dto;
+
+import com.thundercrew.opsapi.station.domain.StationBatteryCountLog;
+import java.time.Instant;
+import java.util.UUID;
+
+public record StationBatteryCountLogReadResponse(
+        UUID id,
+        Long idx,
+        UUID stationId,
+        int beforeMaxBatteryCapacity,
+        int afterMaxBatteryCapacity,
+        int beforeCurrentBatteryCount,
+        int afterCurrentBatteryCount,
+        int beforeAvailableBatteryCount,
+        int afterAvailableBatteryCount,
+        String reason,
+        String memo,
+        Instant changedAt,
+        UUID changedBy,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static StationBatteryCountLogReadResponse from(StationBatteryCountLog log) {
+        return new StationBatteryCountLogReadResponse(
+                log.getId(),
+                log.getIdx(),
+                log.getStationId(),
+                log.getBeforeMaxBatteryCapacity(),
+                log.getAfterMaxBatteryCapacity(),
+                log.getBeforeCurrentBatteryCount(),
+                log.getAfterCurrentBatteryCount(),
+                log.getBeforeAvailableBatteryCount(),
+                log.getAfterAvailableBatteryCount(),
+                log.getReason(),
+                log.getMemo(),
+                log.getChangedAt(),
+                log.getChangedBy(),
+                log.getCreatedAt(),
+                log.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.station.repository;
+
+import com.thundercrew.opsapi.station.domain.BatteryStation;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BatteryStationRepository extends Repository<BatteryStation, UUID> {
+
+    Page<BatteryStation> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<BatteryStation> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/StationBatteryCountLogRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/StationBatteryCountLogRepository.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.station.repository;
+
+import com.thundercrew.opsapi.station.domain.StationBatteryCountLog;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface StationBatteryCountLogRepository extends Repository<StationBatteryCountLog, UUID> {
+
+    Page<StationBatteryCountLog> findByDeletedAtIsNull(Pageable pageable);
+
+    Optional<StationBatteryCountLog> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationReadService.java
@@ -1,0 +1,45 @@
+package com.thundercrew.opsapi.station.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
+import com.thundercrew.opsapi.station.dto.StationBatteryCountLogReadResponse;
+import com.thundercrew.opsapi.station.repository.BatteryStationRepository;
+import com.thundercrew.opsapi.station.repository.StationBatteryCountLogRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class StationReadService {
+
+    private final BatteryStationRepository batteryStationRepository;
+    private final StationBatteryCountLogRepository countLogRepository;
+
+    public StationReadService(BatteryStationRepository batteryStationRepository, StationBatteryCountLogRepository countLogRepository) {
+        this.batteryStationRepository = batteryStationRepository;
+        this.countLogRepository = countLogRepository;
+    }
+
+    public PageResponse<BatteryStationReadResponse> listStations(Pageable pageable) {
+        return PageResponse.of(batteryStationRepository.findByDeletedAtIsNull(pageable).map(BatteryStationReadResponse::from));
+    }
+
+    public BatteryStationReadResponse getStation(UUID id) {
+        return batteryStationRepository.findByIdAndDeletedAtIsNull(id)
+                .map(BatteryStationReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("BatteryStation", id));
+    }
+
+    public PageResponse<StationBatteryCountLogReadResponse> listCountLogs(Pageable pageable) {
+        return PageResponse.of(countLogRepository.findByDeletedAtIsNull(pageable).map(StationBatteryCountLogReadResponse::from));
+    }
+
+    public StationBatteryCountLogReadResponse getCountLog(UUID id) {
+        return countLogRepository.findByIdAndDeletedAtIsNull(id)
+                .map(StationBatteryCountLogReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("StationBatteryCountLog", id));
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -1,19 +1,29 @@
 package com.thundercrew.opsapi;
 
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 
 @AnalyzeClasses(packages = "com.thundercrew.opsapi", importOptions = ImportOption.DoNotIncludeTests.class)
 class ArchitectureBoundaryTests {
@@ -34,14 +44,43 @@ class ArchitectureBoundaryTests {
                     "..dashboard..");
 
     @ArchTest
-    static final ArchRule issue_12_must_not_add_rest_controllers = noClasses()
-            .should().beAnnotatedWith(RestController.class)
-            .orShould().beAnnotatedWith(Controller.class);
+    static final ArchRule issue_14_read_api_allows_get_only_route_methods = noMethods()
+            .should().beAnnotatedWith(PostMapping.class)
+            .orShould().beAnnotatedWith(PutMapping.class)
+            .orShould().beAnnotatedWith(PatchMapping.class)
+            .orShould().beAnnotatedWith(DeleteMapping.class);
 
     @ArchTest
-    static final ArchRule issue_12_persistence_baseline_must_not_use_jpa_relationship_annotations = noFields()
+    static final ArchRule issue_14_read_api_must_not_accept_request_bodies = methods()
+            .that().areDeclaredInClassesThat().resideInAPackage("..controller..")
+            .should(notHaveRequestBodyParameters());
+
+    @ArchTest
+    static final ArchRule issue_14_must_not_add_telemetry_or_dashboard_controllers = noClasses()
+            .that().resideInAnyPackage("..telemetry..", "..dashboard..")
+            .should().beAnnotatedWith(RestController.class);
+
+    @ArchTest
+    static final ArchRule persistence_baseline_must_not_use_jpa_relationship_annotations = noFields()
             .should().beAnnotatedWith(ManyToOne.class)
             .orShould().beAnnotatedWith(OneToMany.class)
             .orShould().beAnnotatedWith(OneToOne.class)
             .orShould().beAnnotatedWith(ManyToMany.class);
+
+    private static ArchCondition<JavaMethod> notHaveRequestBodyParameters() {
+        return new ArchCondition<>("not have @RequestBody parameters") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                boolean hasRequestBodyParameter = method.getParameters().stream()
+                        .anyMatch(parameter -> parameter.isAnnotatedWith(RequestBody.class));
+                if (hasRequestBodyParameter) {
+                    events.add(SimpleConditionEvent.violated(
+                            method,
+                            method.getFullName() + " must not declare @RequestBody parameters in the read-only API baseline"
+                    ));
+                }
+            }
+        };
+    }
+
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -1,0 +1,291 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ReadOnlyApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID RIDER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID BIKE_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID STATION_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID HISTORY_ID = UUID.fromString("44444444-4444-4444-4444-444444444444");
+    private static final UUID CONTRACT_ID = UUID.fromString("55555555-5555-5555-5555-555555555555");
+    private static final UUID INSURANCE_ITEM_ID = UUID.fromString("66666666-6666-6666-6666-666666666666");
+    private static final UUID RIDER_INSURANCE_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+    private static final UUID EQUIPMENT_TYPE_ID = UUID.fromString("88888888-8888-8888-8888-888888888888");
+    private static final UUID BIKE_EQUIPMENT_ID = UUID.fromString("99999999-9999-9999-9999-999999999991");
+    private static final UUID DEVICE_ID = UUID.fromString("99999999-9999-9999-9999-999999999992");
+    private static final UUID INSTALLATION_ID = UUID.fromString("99999999-9999-9999-9999-999999999993");
+    private static final UUID COUNT_LOG_ID = UUID.fromString("99999999-9999-9999-9999-999999999994");
+    private static final UUID CONTRACT_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() {
+        List.of(
+                "station_battery_count_logs",
+                "battery_stations",
+                "bike_device_installations",
+                "devices",
+                "bike_equipments",
+                "equipment_types",
+                "rider_insurances",
+                "insurance_items",
+                "rider_bike_contracts",
+                "bike_operation_status_histories",
+                "bikes",
+                "riders"
+        ).forEach(table -> jdbcTemplate.update("delete from " + table));
+
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, app_account_id, app_linked_at, memo)
+                values (?, '김라이더', '010-1000-2000', '강남팀', '서울 강남', false, null, null, '대표 라이더')
+                """, RIDER_ID);
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, memo)
+                values (?, 'TH-100', 'VIN-READ-001', 'Thunder M1', 'READY', '대표 바이크')
+                """, BIKE_ID);
+        jdbcTemplate.update("""
+                insert into battery_stations (id, name, address, latitude, longitude, status, max_battery_capacity, current_battery_count, available_battery_count, memo)
+                values (?, '강남 스테이션', '서울 강남구 테헤란로', 37.5010000, 127.0396000, 'ACTIVE', 5, 4, 2, '지도 핀 기준')
+                """, STATION_ID);
+        jdbcTemplate.update("""
+                insert into bike_operation_status_histories (id, bike_id, operation_status, started_at, reason)
+                values (?, ?, 'READY', now(), 'read api fixture')
+                """, HISTORY_ID, BIKE_ID);
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, memo)
+                values (?, ?, ?, ?, now(), 'read api contract')
+                """, CONTRACT_ID, RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID);
+        jdbcTemplate.update("""
+                insert into insurance_items (id, name, description, enabled)
+                values (?, '기본 보험', 'read api fixture', true)
+                """, INSURANCE_ITEM_ID);
+        jdbcTemplate.update("""
+                insert into rider_insurances (id, rider_id, insurance_item_id, memo, enabled)
+                values (?, ?, ?, 'read api rider insurance', true)
+                """, RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID);
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name, description, enabled)
+                values (?, '브레이크 패드', 'read api fixture', true)
+                """, EQUIPMENT_TYPE_ID);
+        jdbcTemplate.update("""
+                insert into bike_equipments (id, bike_id, equipment_type_id, equipment_label, model_name, serial_number, installed_at, management_due_date)
+                values (?, ?, ?, '전륜 브레이크', 'Brake V1', 'SERIAL-READ-001', now(), current_date)
+                """, BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID);
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled, memo)
+                values (?, 'DEVICE-READ-001', 'Thunder', 'Tracker V1', true, 'read api device')
+                """, DEVICE_ID);
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at, memo)
+                values (?, ?, ?, now(), 'read api installation')
+                """, INSTALLATION_ID, BIKE_ID, DEVICE_ID);
+        jdbcTemplate.update("""
+                insert into station_battery_count_logs (
+                    id, station_id,
+                    before_max_battery_capacity, after_max_battery_capacity,
+                    before_current_battery_count, after_current_battery_count,
+                    before_available_battery_count, after_available_battery_count,
+                    reason, changed_at
+                ) values (?, ?, 5, 5, 3, 4, 1, 2, 'read api count update', now())
+                """, COUNT_LOG_ID, STATION_ID);
+    }
+
+    @Test
+    void readListsExposeSharedPageContractForEveryCoreResource() throws Exception {
+        for (String endpoint : List.of(
+                "/api/v1/riders",
+                "/api/v1/bikes",
+                "/api/v1/bike-operation-status-histories",
+                "/api/v1/contract-templates",
+                "/api/v1/rider-bike-contracts",
+                "/api/v1/insurance-items",
+                "/api/v1/rider-insurances",
+                "/api/v1/equipment-types",
+                "/api/v1/bike-equipments",
+                "/api/v1/devices",
+                "/api/v1/bike-device-installations",
+                "/api/v1/battery-stations",
+                "/api/v1/station-battery-count-logs"
+        )) {
+            mockMvc.perform(get(endpoint).with(user("ops-admin")).param("size", "5"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.items").isArray())
+                    .andExpect(jsonPath("$.page.size").value(5))
+                    .andExpect(jsonPath("$.page.totalItems").exists());
+        }
+    }
+
+    @Test
+    void representativeDetailsExposeHumanReadableReadDtos() throws Exception {
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID).with(user("ops-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.name").value("김라이더"))
+                .andExpect(jsonPath("$.phoneNumber").value("010-1000-2000"))
+                .andExpect(jsonPath("$.appLinkStatus").value("NOT_LINKED"));
+
+        mockMvc.perform(get("/api/v1/bikes/{id}", BIKE_ID).with(user("ops-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plateNumber").value("TH-100"))
+                .andExpect(jsonPath("$.operationStatus").value("READY"));
+
+        mockMvc.perform(get("/api/v1/battery-stations/{id}", STATION_ID).with(user("ops-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("강남 스테이션"))
+                .andExpect(jsonPath("$.availableBatteryLabel").value("2/5"))
+                .andExpect(jsonPath("$.capacityPercentage").value(80));
+
+        mockMvc.perform(get("/api/v1/contract-templates/{id}", CONTRACT_TEMPLATE_ID).with(user("ops-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("무제한 계약"))
+                .andExpect(jsonPath("$.unlimited").value(true));
+    }
+
+
+    @Test
+    void everyDetailEndpointReturnsItsSeededResourceId() throws Exception {
+        for (DetailEndpoint endpoint : detailEndpoints()) {
+            mockMvc.perform(get(endpoint.path() + "/{id}", endpoint.id()).with(user("ops-admin")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(endpoint.id().toString()));
+        }
+    }
+
+    @Test
+    void missingDetailReturnsNotFoundErrorContract() throws Exception {
+        UUID missingId = UUID.fromString("99999999-9999-9999-9999-999999999999");
+
+        for (DetailEndpoint endpoint : detailEndpoints()) {
+            mockMvc.perform(get(endpoint.path() + "/{id}", missingId).with(user("ops-admin")))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.path").value(endpoint.path() + "/" + missingId));
+        }
+    }
+
+
+    @Test
+    void softDeletedRowsAreHiddenFromReadLists() throws Exception {
+        UUID deletedRiderId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked, deleted_at)
+                values (?, '삭제라이더', '010-9999-0000', false, now())
+                """, deletedRiderId);
+
+        mockMvc.perform(get("/api/v1/riders").with(user("ops-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].name").value("김라이더"));
+    }
+
+    @Test
+    void malformedDetailIdReturnsValidationErrorContract() throws Exception {
+        mockMvc.perform(get("/api/v1/riders/not-a-uuid").with(user("ops-admin")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/riders/not-a-uuid"));
+    }
+
+    @Test
+    void operationReadEndpointsStillRequireAuthenticatedScaffoldPrincipal() throws Exception {
+        mockMvc.perform(get("/api/v1/riders"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void writeRoutesAreNotPartOfThisReadOnlyBaseline() throws Exception {
+        UUID id = RIDER_ID;
+        for (String endpoint : List.of(
+                "/api/v1/riders",
+                "/api/v1/bikes",
+                "/api/v1/bike-operation-status-histories",
+                "/api/v1/contract-templates",
+                "/api/v1/rider-bike-contracts",
+                "/api/v1/insurance-items",
+                "/api/v1/rider-insurances",
+                "/api/v1/equipment-types",
+                "/api/v1/bike-equipments",
+                "/api/v1/devices",
+                "/api/v1/bike-device-installations",
+                "/api/v1/battery-stations",
+                "/api/v1/station-battery-count-logs"
+        )) {
+            mockMvc.perform(post(endpoint)
+                            .with(user("ops-admin"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isMethodNotAllowed());
+            mockMvc.perform(put(endpoint + "/{id}", id)
+                            .with(user("ops-admin"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isMethodNotAllowed());
+            mockMvc.perform(patch(endpoint + "/{id}", id)
+                            .with(user("ops-admin"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isMethodNotAllowed());
+            mockMvc.perform(delete(endpoint + "/{id}", id).with(user("ops-admin")))
+                    .andExpect(status().isMethodNotAllowed());
+        }
+    }
+
+    private List<DetailEndpoint> detailEndpoints() {
+        return List.of(
+                new DetailEndpoint("/api/v1/riders", RIDER_ID),
+                new DetailEndpoint("/api/v1/bikes", BIKE_ID),
+                new DetailEndpoint("/api/v1/bike-operation-status-histories", HISTORY_ID),
+                new DetailEndpoint("/api/v1/contract-templates", CONTRACT_TEMPLATE_ID),
+                new DetailEndpoint("/api/v1/rider-bike-contracts", CONTRACT_ID),
+                new DetailEndpoint("/api/v1/insurance-items", INSURANCE_ITEM_ID),
+                new DetailEndpoint("/api/v1/rider-insurances", RIDER_INSURANCE_ID),
+                new DetailEndpoint("/api/v1/equipment-types", EQUIPMENT_TYPE_ID),
+                new DetailEndpoint("/api/v1/bike-equipments", BIKE_EQUIPMENT_ID),
+                new DetailEndpoint("/api/v1/devices", DEVICE_ID),
+                new DetailEndpoint("/api/v1/bike-device-installations", INSTALLATION_ID),
+                new DetailEndpoint("/api/v1/battery-stations", STATION_ID),
+                new DetailEndpoint("/api/v1/station-battery-count-logs", COUNT_LOG_ID)
+        );
+    }
+
+    private record DetailEndpoint(String path, UUID id) {
+    }
+
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -86,3 +86,25 @@ Scope decision:
 - Keep CRUD controllers, API DTO contracts, JWT, telemetry tables/write path, dashboard/map API, and frontend relocation out of this issue.
 - Cross-domain references remain UUID scalar columns without DB foreign-key constraints.
 - JPA mappings intentionally avoid cross-domain relationship annotations such as `@ManyToOne`.
+
+
+## Read-only API contract baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#51
+- Target issue: EVNSolution/thundercrew-domain#14
+- Branch: `cc-51-api-read-contracts`
+
+Issue-size decision:
+
+- Full CRUD plus API DTOs across all domains is too broad for one review unit.
+- This slice only adds read-only `GET` API contracts, DTOs, read services, and read repositories for the non-telemetry core resources.
+- Contract templates are included as a selector/read dependency for rider-bike contracts because they already exist in the V1 backend schema.
+- Write commands, JWT/auth endpoints, telemetry, dashboard/map APIs, and frontend relocation remain follow-up issue scopes.
+
+Boundary decision:
+
+- Controllers are allowed from this issue forward, but `POST`, `PUT`, `PATCH`, `DELETE`, and `@RequestBody` remain forbidden by architecture tests for this baseline.
+- Operation data remains protected by the existing authenticated scaffold; JWT implementation is still deferred.
+- Read repositories intentionally expose only derived read methods rather than `save`/`delete` repository methods.


### PR DESCRIPTION
## Summary
- Add a GET-only `service-ops-api` read API contract baseline for non-telemetry core resources.
- Add response DTOs, read services, and read-only Spring Data repositories for riders, bikes, contracts/templates, insurance, equipment, devices, and stations.
- Add shared `PageResponse` and `RESOURCE_NOT_FOUND` error handling for stable list/detail contracts.
- Update architecture tests to allow controllers while still forbidding write mappings, `@RequestBody` parameters, telemetry/dashboard controllers, and JPA relationship annotations.
- Update backend ledger and service README with the issue-size decision and exclusions.

## Traceability
- Change-control anchor: EVNSolution/clever-change-control#51
- Target work issue: EVNSolution/thundercrew-domain#14
- Project start: EVNSolution/clever-change-control#45
- Previous persistence baseline: EVNSolution/clever-change-control#50 / EVNSolution/thundercrew-domain#12
- Branch: `cc-51-api-read-contracts`

## Issue-size review
Full CRUD/API across all domains is too broad for one issue. This PR intentionally limits the slice to read-only API/DTO contracts so response shape, pagination, not-found behavior, auth boundary, and package structure can be reviewed before write workflows.

Included:
- GET list/detail endpoints under `/api/v1/**`.
- Contract templates included as a read/selector dependency for rider-bike contracts.
- DTOs expose UUID + table-local `idx` identifiers and human-readable fields for selection/display.
- Existing authenticated scaffold remains in place; tests use mock authenticated principals.

Excluded:
- POST/PUT/PATCH/DELETE APIs and request DTOs.
- JWT login/refresh/revocation or auth redesign.
- Telemetry/time-series ingestion, dashboard/map APIs, TimescaleDB, frontend relocation/app restructure.

## Concurrent work gate
Decision: `allowed-with-non-overlap`

Evidence checked before PR creation:
- Target open PRs: none.
- Target active branches: `main`, `dev`, `cc-51-api-read-contracts`.
- Target open issues: only #14 for `thundercrew-domain`.
- Change-control open issues reviewed: #51 plus unrelated #44, #40, #35, #24, #23.

Non-overlap reason: this branch only changes `development/service-ops-api` read API contracts and backend ledger docs; no open PR overlaps the same service/API/data/deploy/file scope.

## Review evidence
- Architect review: confirmed the slice is issue-sized only as a GET-only contract baseline.
- Test-engineer checklist: applied MockMvc/Testcontainers/ArchUnit acceptance coverage.
- Code-reviewer: PASS; two non-blocking test-hardening comments were addressed before PR:
  - ArchUnit now checks `@RequestBody` method parameters.
  - Detail/missing/write-route contract coverage now spans every read endpoint family.

## Validation
- `git diff --check`
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Context/docs update
- Updated `docs/backend/00-change-ledger.md` with #51/#14 scope and boundary decisions.
- Updated `development/service-ops-api/README.md` with the read-only API baseline and follow-up exclusions.
