### PR TITLE
Add service-ops-api admin JWT auth baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,15 @@ SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:54
 # Local/test-only admin seed placeholders. Do not commit real passwords.
 SEED_ADMIN_EMAIL=admin@thundercrew-domain.local
 SEED_ADMIN_PASSWORD=<local-test-admin-password>
+
+# Spring Boot service-ops-api local backend config. Place real values in .env.local only.
+SERVICE_OPS_DB_URL=jdbc:postgresql://localhost:5432/service_ops_api
+SERVICE_OPS_DB_USERNAME=service_ops
+SERVICE_OPS_DB_PASSWORD=<local-db-password>
+THUNDERCREW_AUTH_JWT_SECRET=<at-least-32-byte-jwt-secret>
+THUNDERCREW_AUTH_JWT_ISSUER=thundercrew-domain
+THUNDERCREW_AUTH_JWT_ACCESS_TOKEN_TTL=PT30M
+THUNDERCREW_ADMIN_SEED_LOGIN_ID=<admin-login-id>
+THUNDERCREW_ADMIN_SEED_PASSWORD=<admin-password>
+THUNDERCREW_ADMIN_SEED_DISPLAY_NAME=<admin-display-name>
+THUNDERCREW_ADMIN_SEED_EMAIL=<admin-email>

--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,13 +4,13 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold, non-telemetry core persistence baseline, and read-only API/DTO contract baseline:
+This module currently provides the backend scaffold, non-telemetry core persistence baseline, read-only API/DTO contract baseline, and admin JWT login/access-token baseline:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
 - PostgreSQL + Flyway
 - Spring Data JPA baseline
-- Spring Security + BCrypt password hashing
+- Spring Security + BCrypt password hashing + stateless Bearer JWT access tokens
 - bounded package skeleton
 - ArchUnit boundary tests
 - common API error/audit/soft-delete/time baseline
@@ -33,13 +33,16 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - devices and bike-device installation history
   - battery stations and station count logs
 - Shared `PageResponse` page contract and `RESOURCE_NOT_FOUND` error contract
+- `POST /api/v1/auth/login` for admin access-token issuance
+- Existing protected read APIs accept `Authorization: Bearer <token>`
+- `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
 
-Out of scope for the current read-only API baseline:
+Out of scope for the current auth/read API baseline:
 
 - Create/update/delete command endpoints and request DTOs
 - computed business DTOs that depend on telemetry, dashboard, map, or multi-table/time logic
 - telemetry tables and ingestion write paths
-- JWT login/refresh/revocation implementation
+- refresh token, logout/revocation, password reset, RBAC expansion, or admin-management UI
 - frontend relocation
 - TimescaleDB setup
 - contract overlap locking implementation
@@ -53,12 +56,15 @@ Copy placeholders and provide local secrets outside git:
 cp .env.example .env.local
 ```
 
-Required DB variables for local runtime:
+Required DB and JWT variables for local runtime:
 
 ```bash
 SERVICE_OPS_DB_URL=jdbc:postgresql://localhost:5432/service_ops_api
 SERVICE_OPS_DB_USERNAME=service_ops
 SERVICE_OPS_DB_PASSWORD=<local-db-password>
+THUNDERCREW_AUTH_JWT_SECRET=<at-least-32-byte-jwt-secret>
+THUNDERCREW_AUTH_JWT_ISSUER=thundercrew-domain
+THUNDERCREW_AUTH_JWT_ACCESS_TOKEN_TTL=PT30M
 ```
 
 Optional admin seed variables. If any required value is missing, seeding is skipped.
@@ -71,6 +77,25 @@ THUNDERCREW_ADMIN_SEED_EMAIL=<admin-email>
 ```
 
 Do not commit real passwords, JWT secrets, or service credentials.
+
+## Auth API
+
+Login with a seeded/enabled admin user:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"loginId":"<admin-login-id>","password":"<admin-password>"}'
+```
+
+Use the returned access token for protected read APIs:
+
+```bash
+curl http://localhost:8080/api/v1/riders \
+  -H "Authorization: Bearer <access-token>"
+```
+
+Do not commit real JWT secrets or admin passwords.
 
 ## Commands
 
@@ -85,7 +110,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 ## Follow-up implementation issues
 
 - Create/update/delete service/controller slices for rider, bike, contract, insurance, equipment, device, and station resources
-- JWT login/refresh/revocation
+- Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion
 - Dashboard/map read API
 - Contract overlap locking implementation

--- a/development/service-ops-api/build.gradle.kts
+++ b/development/service-ops-api/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.flywaydb:flyway-core")

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
@@ -1,14 +1,40 @@
 package com.thundercrew.opsapi.auth.config;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.thundercrew.opsapi.common.api.ApiErrorResponse;
+import com.thundercrew.opsapi.common.api.ErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.util.StringUtils;
 
 @Configuration
 public class SecurityConfig {
@@ -21,18 +47,75 @@ public class SecurityConfig {
     @Bean
     UserDetailsService userDetailsService() {
         return username -> {
-            throw new UsernameNotFoundException("Admin authentication is deferred to the follow-up JWT implementation.");
+            throw new UsernameNotFoundException("Admin authentication uses bearer JWT tokens.");
         };
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            AuthenticationEntryPoint authenticationEntryPoint
+    ) throws Exception {
         return http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/actuator/health", "/api/v1/auth/login").permitAll()
                         .anyRequest().authenticated())
-                .httpBasic(Customizer.withDefaults())
+                .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .jwt(jwt -> { }))
                 .build();
+    }
+
+    @Bean
+    JwtEncoder jwtEncoder(SecretKey jwtSecretKey) {
+        return new NimbusJwtEncoder(new ImmutableSecret<>(jwtSecretKey));
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(
+            SecretKey jwtSecretKey,
+            @Value("${thundercrew.auth.jwt.issuer:thundercrew-domain}") String issuer
+    ) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+        OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
+                JwtValidators.createDefaultWithIssuer(issuer),
+                new JwtClaimValidator<String>("adminUserId", StringUtils::hasText),
+                new JwtClaimValidator<String>("loginId", StringUtils::hasText),
+                new JwtClaimValidator<String>("role", "ADMIN"::equals)
+        );
+        decoder.setJwtValidator(validator);
+        return decoder;
+    }
+
+    @Bean
+    SecretKey jwtSecretKey(@Value("${thundercrew.auth.jwt.secret:}") String secret) {
+        if (secret == null || secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+            throw new IllegalStateException(
+                    "thundercrew.auth.jwt.secret must be provided with at least 32 bytes; use environment variables, not committed secrets."
+            );
+        }
+        return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    @Bean
+    AuthenticationEntryPoint authenticationEntryPoint(ObjectMapper objectMapper, Clock clock) {
+        return (request, response, authException) -> {
+            ApiErrorResponse body = ApiErrorResponse.of(
+                    ErrorCode.AUTHENTICATION_FAILED,
+                    "Authentication is required or the provided token is invalid.",
+                    request.getRequestURI(),
+                    clock.instant()
+            );
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            objectMapper.writeValue(response.getOutputStream(), body);
+        };
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.thundercrew.opsapi.auth.controller;
+
+import com.thundercrew.opsapi.auth.dto.AdminLoginRequest;
+import com.thundercrew.opsapi.auth.dto.AdminLoginResponse;
+import com.thundercrew.opsapi.auth.service.AdminAuthService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AdminAuthService adminAuthService;
+
+    public AuthController(AdminAuthService adminAuthService) {
+        this.adminAuthService = adminAuthService;
+    }
+
+    @PostMapping("/login")
+    AdminLoginResponse login(@Valid @RequestBody AdminLoginRequest request) {
+        return adminAuthService.login(request);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.thundercrew.opsapi.auth.controller;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import com.thundercrew.opsapi.auth.service.AdminAuthenticationException;
+import com.thundercrew.opsapi.common.api.ApiErrorResponse;
+import com.thundercrew.opsapi.common.api.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+    private final Clock clock;
+
+    public AuthExceptionHandler(Clock clock) {
+        this.clock = clock;
+    }
+
+    @ExceptionHandler(AdminAuthenticationException.class)
+    ResponseEntity<ApiErrorResponse> handleAdminAuthentication(
+            AdminAuthenticationException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.AUTHENTICATION_FAILED,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminIdentityResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminIdentityResponse.java
@@ -1,0 +1,23 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import java.util.UUID;
+
+import com.thundercrew.opsapi.auth.repository.AdminUserAccount;
+
+public record AdminIdentityResponse(
+        UUID id,
+        String loginId,
+        String email,
+        String displayName,
+        String role
+) {
+    public static AdminIdentityResponse from(AdminUserAccount account) {
+        return new AdminIdentityResponse(
+                account.id(),
+                account.loginId(),
+                account.email(),
+                account.displayName(),
+                "ADMIN"
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminLoginRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminLoginRequest.java
@@ -1,0 +1,9 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @NotBlank String loginId,
+        @NotBlank String password
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminLoginResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminLoginResponse.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import java.time.Instant;
+
+public record AdminLoginResponse(
+        String tokenType,
+        String accessToken,
+        Instant expiresAt,
+        AdminIdentityResponse admin
+) {
+    public static AdminLoginResponse bearer(String accessToken, Instant expiresAt, AdminIdentityResponse admin) {
+        return new AdminLoginResponse("Bearer", accessToken, expiresAt, admin);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccount.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccount.java
@@ -1,0 +1,12 @@
+package com.thundercrew.opsapi.auth.repository;
+
+import java.util.UUID;
+
+public record AdminUserAccount(
+        UUID id,
+        String loginId,
+        String email,
+        String passwordHash,
+        String displayName
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
@@ -1,0 +1,41 @@
+package com.thundercrew.opsapi.auth.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminUserAccountRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public AdminUserAccountRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public Optional<AdminUserAccount> findEnabledActiveByLoginId(String loginId) {
+        return jdbcTemplate.query("""
+                        select id, login_id, email, password_hash, display_name
+                        from admin_users
+                        where login_id = ?
+                          and enabled = true
+                          and deleted_at is null
+                        """,
+                this::mapRow,
+                loginId
+        ).stream().findFirst();
+    }
+
+    private AdminUserAccount mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+        return new AdminUserAccount(
+                resultSet.getObject("id", UUID.class),
+                resultSet.getString("login_id"),
+                resultSet.getString("email"),
+                resultSet.getString("password_hash"),
+                resultSet.getString("display_name")
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthService.java
@@ -1,0 +1,39 @@
+package com.thundercrew.opsapi.auth.service;
+
+import com.thundercrew.opsapi.auth.dto.AdminIdentityResponse;
+import com.thundercrew.opsapi.auth.dto.AdminLoginRequest;
+import com.thundercrew.opsapi.auth.dto.AdminLoginResponse;
+import com.thundercrew.opsapi.auth.repository.AdminUserAccount;
+import com.thundercrew.opsapi.auth.repository.AdminUserAccountRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AdminAuthService {
+
+    private final AdminUserAccountRepository adminUserAccountRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenService jwtTokenService;
+
+    public AdminAuthService(
+            AdminUserAccountRepository adminUserAccountRepository,
+            PasswordEncoder passwordEncoder,
+            JwtTokenService jwtTokenService
+    ) {
+        this.adminUserAccountRepository = adminUserAccountRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Transactional(readOnly = true)
+    public AdminLoginResponse login(AdminLoginRequest request) {
+        AdminUserAccount account = adminUserAccountRepository.findEnabledActiveByLoginId(request.loginId())
+                .filter(candidate -> passwordEncoder.matches(request.password(), candidate.passwordHash()))
+                .orElseThrow(AdminAuthenticationException::new);
+
+        AdminIdentityResponse admin = AdminIdentityResponse.from(account);
+        JwtTokenService.IssuedToken token = jwtTokenService.issueAccessToken(account);
+        return AdminLoginResponse.bearer(token.value(), token.expiresAt(), admin);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthenticationException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthenticationException.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.auth.service;
+
+public class AdminAuthenticationException extends RuntimeException {
+
+    public AdminAuthenticationException() {
+        super("Admin login id or password is invalid.");
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/JwtTokenService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/JwtTokenService.java
@@ -1,0 +1,55 @@
+package com.thundercrew.opsapi.auth.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.thundercrew.opsapi.auth.repository.AdminUserAccount;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtTokenService {
+
+    private final JwtEncoder jwtEncoder;
+    private final Clock clock;
+    private final String issuer;
+    private final Duration accessTokenTtl;
+
+    public JwtTokenService(
+            JwtEncoder jwtEncoder,
+            Clock clock,
+            @Value("${thundercrew.auth.jwt.issuer:thundercrew-domain}") String issuer,
+            @Value("${thundercrew.auth.jwt.access-token-ttl:PT30M}") Duration accessTokenTtl
+    ) {
+        this.jwtEncoder = jwtEncoder;
+        this.clock = clock;
+        this.issuer = issuer;
+        this.accessTokenTtl = accessTokenTtl;
+    }
+
+    public IssuedToken issueAccessToken(AdminUserAccount account) {
+        Instant issuedAt = Instant.now(clock);
+        Instant expiresAt = issuedAt.plus(accessTokenTtl);
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(issuer)
+                .subject(account.id().toString())
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("adminUserId", account.id().toString())
+                .claim("loginId", account.loginId())
+                .claim("role", "ADMIN")
+                .build();
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+        String token = jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+        return new IssuedToken(token, expiresAt);
+    }
+
+    public record IssuedToken(String value, Instant expiresAt) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.common.api;
 
 public enum ErrorCode {
     VALIDATION_FAILED,
+    AUTHENTICATION_FAILED,
     RESOURCE_NOT_FOUND,
     REFERENCE_NOT_FOUND,
     REFERENCE_DELETED,

--- a/development/service-ops-api/src/main/resources/application.properties
+++ b/development/service-ops-api/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.datasource.password=${SERVICE_OPS_DB_PASSWORD:}
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.flyway.enabled=true
+# Admin JWT auth. Provide the secret through environment variables or local .env only.
+thundercrew.auth.jwt.secret=${THUNDERCREW_AUTH_JWT_SECRET:}
+thundercrew.auth.jwt.issuer=${THUNDERCREW_AUTH_JWT_ISSUER:thundercrew-domain}
+thundercrew.auth.jwt.access-token-ttl=${THUNDERCREW_AUTH_JWT_ACCESS_TOKEN_TTL:PT30M}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -23,7 +23,6 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 
 @AnalyzeClasses(packages = "com.thundercrew.opsapi", importOptions = ImportOption.DoNotIncludeTests.class)
 class ArchitectureBoundaryTests {
@@ -44,16 +43,14 @@ class ArchitectureBoundaryTests {
                     "..dashboard..");
 
     @ArchTest
-    static final ArchRule issue_14_read_api_allows_get_only_route_methods = noMethods()
-            .should().beAnnotatedWith(PostMapping.class)
-            .orShould().beAnnotatedWith(PutMapping.class)
-            .orShould().beAnnotatedWith(PatchMapping.class)
-            .orShould().beAnnotatedWith(DeleteMapping.class);
+    static final ArchRule issue_52_auth_login_is_the_only_write_route_exception = methods()
+            .that().areDeclaredInClassesThat().resideInAPackage("..controller..")
+            .should(onlyAuthLoginMayUseWriteRouteMappings());
 
     @ArchTest
-    static final ArchRule issue_14_read_api_must_not_accept_request_bodies = methods()
+    static final ArchRule issue_52_auth_login_is_the_only_request_body_exception = methods()
             .that().areDeclaredInClassesThat().resideInAPackage("..controller..")
-            .should(notHaveRequestBodyParameters());
+            .should(onlyAuthLoginMayHaveRequestBodyParameters());
 
     @ArchTest
     static final ArchRule issue_14_must_not_add_telemetry_or_dashboard_controllers = noClasses()
@@ -67,20 +64,49 @@ class ArchitectureBoundaryTests {
             .orShould().beAnnotatedWith(OneToOne.class)
             .orShould().beAnnotatedWith(ManyToMany.class);
 
-    private static ArchCondition<JavaMethod> notHaveRequestBodyParameters() {
-        return new ArchCondition<>("not have @RequestBody parameters") {
+    private static ArchCondition<JavaMethod> onlyAuthLoginMayUseWriteRouteMappings() {
+        return new ArchCondition<>("use write route mappings only on AuthController.login") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                boolean hasWriteRouteMapping = method.isAnnotatedWith(PostMapping.class)
+                        || method.isAnnotatedWith(PutMapping.class)
+                        || method.isAnnotatedWith(PatchMapping.class)
+                        || method.isAnnotatedWith(DeleteMapping.class);
+                if (!hasWriteRouteMapping || isAuthLogin(method)) {
+                    return;
+                }
+
+                events.add(SimpleConditionEvent.violated(
+                        method,
+                        method.getFullName() + " must not declare write route mappings outside auth login"
+                ));
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> onlyAuthLoginMayHaveRequestBodyParameters() {
+        return new ArchCondition<>("have @RequestBody parameters only on AuthController.login") {
             @Override
             public void check(JavaMethod method, ConditionEvents events) {
                 boolean hasRequestBodyParameter = method.getParameters().stream()
                         .anyMatch(parameter -> parameter.isAnnotatedWith(RequestBody.class));
-                if (hasRequestBodyParameter) {
+                if (!hasRequestBodyParameter) {
+                    return;
+                }
+
+                if (!isAuthLogin(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
-                            method.getFullName() + " must not declare @RequestBody parameters in the read-only API baseline"
+                            method.getFullName() + " must not declare @RequestBody parameters outside auth login"
                     ));
                 }
             }
         };
+    }
+
+    private static boolean isAuthLogin(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.auth.controller.AuthController")
+                && method.getName().equals("login");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AuthApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AuthApiContractTests.java
@@ -1,0 +1,272 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtDecoder jwtDecoder;
+
+    @Autowired
+    private JwtEncoder jwtEncoder;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() {
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo)
+                values (?, '김라이더', '010-1000-2000', '강남팀', '서울 강남', false, 'auth api fixture')
+                """, RIDER_ID);
+    }
+
+    @Test
+    void adminLoginReturnsBearerAccessTokenAndAdminSummary() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.expiresAt").isString())
+                .andExpect(jsonPath("$.admin.id").value(ADMIN_ID.toString()))
+                .andExpect(jsonPath("$.admin.loginId").value("ops-admin"))
+                .andExpect(jsonPath("$.admin.displayName").value("Ops Admin"))
+                .andExpect(jsonPath("$.admin.role").value("ADMIN"))
+                .andReturn();
+
+        String token = extractAccessToken(result);
+        assertThat(jwtDecoder.decode(token).getClaimAsString("adminUserId")).isEqualTo(ADMIN_ID.toString());
+        assertThat(jwtDecoder.decode(token).getClaimAsString("loginId")).isEqualTo("ops-admin");
+        assertThat(jwtDecoder.decode(token).getClaimAsString("role")).isEqualTo("ADMIN");
+    }
+
+    @Test
+    void existingReadApisAcceptValidBearerToken() throws Exception {
+        String token = loginAndExtractToken("ops-admin", "correct-password");
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.name").value("김라이더"));
+    }
+
+    @Test
+    void loginRejectsWrongPasswordWithStableUnauthorizedErrorContract() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"wrong-password"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/auth/login"));
+    }
+
+    @Test
+    void loginRejectsDisabledOrSoftDeletedAdmins() throws Exception {
+        jdbcTemplate.update("update admin_users set enabled = false where id = ?", ADMIN_ID);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        jdbcTemplate.update("update admin_users set enabled = true, deleted_at = now() where id = ?", ADMIN_ID);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void loginRequestValidationUsesSharedErrorContract() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"","password":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void protectedApisRejectMissingOrInvalidBearerTokenWithStableUnauthorizedErrorContract() throws Exception {
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/riders/" + RIDER_ID));
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer not-a-valid-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"))
+                .andExpect(header().doesNotExist(HttpHeaders.WWW_AUTHENTICATE));
+    }
+
+    @Test
+    void protectedApisRejectExpiredBearerTokenWithStableUnauthorizedErrorContract() throws Exception {
+        Instant issuedAt = Instant.now().minusSeconds(3600);
+        String expiredToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).build(),
+                JwtClaimsSet.builder()
+                        .issuer("thundercrew-domain-test")
+                        .subject(ADMIN_ID.toString())
+                        .issuedAt(issuedAt)
+                        .expiresAt(issuedAt.plusSeconds(60))
+                        .claim("adminUserId", ADMIN_ID.toString())
+                        .claim("loginId", "ops-admin")
+                        .claim("role", "ADMIN")
+                        .build()
+        )).getTokenValue();
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/riders/" + RIDER_ID));
+    }
+
+
+    @Test
+    void protectedApisRejectTokensWithoutRequiredAdminClaims() throws Exception {
+        String missingAdminClaimsToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).build(),
+                JwtClaimsSet.builder()
+                        .issuer("thundercrew-domain-test")
+                        .subject(ADMIN_ID.toString())
+                        .issuedAt(Instant.now())
+                        .expiresAt(Instant.now().plusSeconds(1800))
+                        .build()
+        )).getTokenValue();
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + missingAdminClaimsToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void protectedApisRejectTokensWithWrongIssuerOrNonAdminRole() throws Exception {
+        String wrongIssuerToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).build(),
+                JwtClaimsSet.builder()
+                        .issuer("wrong-issuer")
+                        .subject(ADMIN_ID.toString())
+                        .issuedAt(Instant.now())
+                        .expiresAt(Instant.now().plusSeconds(1800))
+                        .claim("adminUserId", ADMIN_ID.toString())
+                        .claim("loginId", "ops-admin")
+                        .claim("role", "ADMIN")
+                        .build()
+        )).getTokenValue();
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + wrongIssuerToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        String nonAdminToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).build(),
+                JwtClaimsSet.builder()
+                        .issuer("thundercrew-domain-test")
+                        .subject(ADMIN_ID.toString())
+                        .issuedAt(Instant.now())
+                        .expiresAt(Instant.now().plusSeconds(1800))
+                        .claim("adminUserId", ADMIN_ID.toString())
+                        .claim("loginId", "ops-admin")
+                        .claim("role", "VIEWER")
+                        .build()
+        )).getTokenValue();
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + nonAdminToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private String loginAndExtractToken(String loginId, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"loginId\":\"" + loginId + "\",\"password\":\"" + password + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        if (!matcher.find()) {
+            throw new AssertionError("accessToken was not present in login response: "
+                    + result.getResponse().getContentAsString());
+        }
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/resources/application-test.properties
+++ b/development/service-ops-api/src/test/resources/application-test.properties
@@ -2,3 +2,6 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.flyway.enabled=true
 logging.level.org.testcontainers=INFO
+thundercrew.auth.jwt.secret=test-secret-at-least-32-bytes-long-for-hs256-signing-0001
+thundercrew.auth.jwt.issuer=thundercrew-domain-test
+thundercrew.auth.jwt.access-token-ttl=PT30M

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -108,3 +108,23 @@ Boundary decision:
 - Controllers are allowed from this issue forward, but `POST`, `PUT`, `PATCH`, `DELETE`, and `@RequestBody` remain forbidden by architecture tests for this baseline.
 - Operation data remains protected by the existing authenticated scaffold; JWT implementation is still deferred.
 - Read repositories intentionally expose only derived read methods rather than `save`/`delete` repository methods.
+
+## Admin JWT auth baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#52
+- Target issue: EVNSolution/thundercrew-domain#16
+- Branch: `cc-52-admin-jwt-auth-baseline`
+
+Issue-size decision:
+
+- Write-command APIs are intentionally deferred until a real admin principal/authentication baseline exists.
+- This slice only adds admin login/access-token issuance and Bearer authentication for the existing read APIs.
+- Operation `POST`, `PUT`, `PATCH`, `DELETE`, refresh/revocation, RBAC expansion, admin UI, telemetry, dashboard/map APIs, TimescaleDB, and frontend relocation remain follow-up issue scopes.
+
+Boundary decision:
+
+- `POST` and `@RequestBody` are allowed only for `AuthController.login`.
+- Operation controllers remain read-only and architecture tests continue to block write mappings outside auth.
+- JWT secret is environment/config driven and must not be committed.


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/auth/login` for seeded/enabled admin login.
- Issue stateless Bearer JWT access tokens with issuer/admin claims and `role=ADMIN`.
- Protect existing read APIs with Bearer JWT validation and stable `AUTHENTICATION_FAILED` 401 JSON errors.
- Keep operation write routes blocked; allow `POST`/`@RequestBody` only for `AuthController.login`.
- Update service docs, env placeholders, and backend ledger.

## Trace

- Change-control: EVNSolution/clever-change-control#52
- Target issue: EVNSolution/thundercrew-domain#16
- Branch: `cc-52-admin-jwt-auth-baseline`

## Concurrent work decision

`allowed-with-non-overlap` — before starting and before PR open, the target repo had no open PRs and no active target issues/branches for the same backend auth slice. Remote target branches were `main`, `dev`, and this scoped branch only.

## Scope boundary

Included:

- Admin login/access-token baseline.
- Bearer authentication for existing protected read APIs.
- JWT issuer/admin claim/role validation.
- Auth-specific tests and architecture guard updates.

Excluded:

- Write CRUD commands.
- Refresh token, logout/revocation, password reset, RBAC expansion, admin-management UI.
- Telemetry/dashboard/map APIs.
- Frontend relocation/app restructure.
- Supabase login replacement.
- TimescaleDB/retention work.

## Review

- Initial code-reviewer verdict: BLOCK on broad JWT validation and broad auth write-route exception.
- Fixed by adding issuer/adminUserId/loginId/role validators, negative tests for missing claims/wrong issuer/non-admin role, and an ArchUnit rule that allows write mapping/request body only on `AuthController.login`.
- Follow-up code-reviewer verdict: PASS.

## Verification

- `git diff --check` PASS
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon` PASS
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon` PASS
- `npm run lint` PASS
- `npm run typecheck` PASS after rerun; first parallel run raced with `next build` generated `.next/types/routes.js`
- `npm run build` PASS
