### PR TITLE
Add bike write-command baseline

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeCommandController.java
@@ -1,0 +1,55 @@
+package com.thundercrew.opsapi.bike.controller;
+
+import com.thundercrew.opsapi.bike.dto.BikeCreateRequest;
+import com.thundercrew.opsapi.bike.dto.BikeOperationStatusChangeRequest;
+import com.thundercrew.opsapi.bike.dto.BikeReadResponse;
+import com.thundercrew.opsapi.bike.dto.BikeUpdateRequest;
+import com.thundercrew.opsapi.bike.service.BikeCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/bikes")
+public class BikeCommandController {
+
+    private final BikeCommandService bikeCommandService;
+
+    public BikeCommandController(BikeCommandService bikeCommandService) {
+        this.bikeCommandService = bikeCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<BikeReadResponse> create(@Valid @RequestBody BikeCreateRequest request) {
+        BikeReadResponse response = bikeCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/bikes/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    BikeReadResponse update(@PathVariable UUID id, @Valid @RequestBody BikeUpdateRequest request) {
+        return bikeCommandService.update(id, request);
+    }
+
+    @PatchMapping("/{id}/operation-status")
+    BikeReadResponse changeOperationStatus(
+            @PathVariable UUID id,
+            @Valid @RequestBody BikeOperationStatusChangeRequest request
+    ) {
+        return bikeCommandService.changeOperationStatus(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        bikeCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -26,6 +26,46 @@ public class Bike extends DisplaySequencedEntity {
 
     private String memo;
 
+    public static Bike create(
+            String plateNumber,
+            String vin,
+            String modelName,
+            BikeOperationStatus operationStatus,
+            String memo
+    ) {
+        Bike bike = new Bike();
+        bike.plateNumber = plateNumber;
+        bike.vin = vin;
+        bike.modelName = modelName;
+        bike.operationStatus = operationStatus;
+        bike.memo = memo;
+        return bike;
+    }
+
+    public void updateBasicProfile(
+            String plateNumber,
+            String vin,
+            String modelName,
+            String memo
+    ) {
+        if (plateNumber != null) {
+            this.plateNumber = plateNumber;
+        }
+        if (vin != null) {
+            this.vin = vin;
+        }
+        if (modelName != null) {
+            this.modelName = modelName;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public void changeOperationStatus(BikeOperationStatus operationStatus) {
+        this.operationStatus = operationStatus;
+    }
+
 
     public String getPlateNumber() {
         return plateNumber;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeOperationStatusHistory.java
@@ -31,6 +31,28 @@ public class BikeOperationStatusHistory extends DisplaySequencedEntity {
 
     private UUID changedBy;
 
+    public static BikeOperationStatusHistory open(
+            UUID bikeId,
+            BikeOperationStatus operationStatus,
+            Instant startedAt,
+            String reason,
+            String memo,
+            UUID changedBy
+    ) {
+        BikeOperationStatusHistory history = new BikeOperationStatusHistory();
+        history.bikeId = bikeId;
+        history.operationStatus = operationStatus;
+        history.startedAt = startedAt;
+        history.reason = reason;
+        history.memo = memo;
+        history.changedBy = changedBy;
+        return history;
+    }
+
+    public void closeAt(Instant endedAt) {
+        this.endedAt = endedAt;
+    }
+
 
     public java.util.UUID getBikeId() {
         return bikeId;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.bike.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeCreateRequest(
+        @NotBlank @Size(max = 50) String plateNumber,
+        @NotBlank @Size(max = 100) String vin,
+        @Size(max = 100) String modelName,
+        @NotNull BikeOperationStatus operationStatus,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeOperationStatusChangeRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeOperationStatusChangeRequest.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.bike.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeOperationStatusChangeRequest(
+        @NotNull BikeOperationStatus operationStatus,
+        @Size(max = 200) String reason,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.bike.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeUpdateRequest(
+        @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String plateNumber,
+        @Size(max = 100) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String vin,
+        @Size(max = 100) String modelName,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeOperationStatusHistoryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeOperationStatusHistoryRepository.java
@@ -12,4 +12,8 @@ public interface BikeOperationStatusHistoryRepository extends Repository<BikeOpe
     Page<BikeOperationStatusHistory> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<BikeOperationStatusHistory> findByIdAndDeletedAtIsNull(UUID id);
+
+    Optional<BikeOperationStatusHistory> findFirstByBikeIdAndEndedAtIsNullAndDeletedAtIsNull(UUID bikeId);
+
+    BikeOperationStatusHistory save(BikeOperationStatusHistory history);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
@@ -5,11 +5,56 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface BikeRepository extends Repository<Bike, UUID> {
 
     Page<Bike> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<Bike> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByPlateNumberAndDeletedAtIsNull(String plateNumber);
+
+    boolean existsByPlateNumberAndIdNotAndDeletedAtIsNull(String plateNumber, UUID id);
+
+    boolean existsByVinAndDeletedAtIsNull(String vin);
+
+    boolean existsByVinAndIdNotAndDeletedAtIsNull(String vin, UUID id);
+
+    Bike save(Bike bike);
+
+    @Query(value = """
+            select exists (
+                select 1
+                from rider_bike_contracts
+                where bike_id = :bikeId
+                  and deleted_at is null
+                  and terminated_at is null
+            )
+            """, nativeQuery = true)
+    boolean existsActiveContractReference(@Param("bikeId") UUID bikeId);
+
+    @Query(value = """
+            select exists (
+                select 1
+                from bike_equipments
+                where bike_id = :bikeId
+                  and deleted_at is null
+                  and removed_at is null
+            )
+            """, nativeQuery = true)
+    boolean existsActiveEquipmentReference(@Param("bikeId") UUID bikeId);
+
+    @Query(value = """
+            select exists (
+                select 1
+                from bike_device_installations
+                where bike_id = :bikeId
+                  and deleted_at is null
+                  and removed_at is null
+            )
+            """, nativeQuery = true)
+    boolean existsActiveDeviceInstallationReference(@Param("bikeId") UUID bikeId);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
@@ -1,0 +1,163 @@
+package com.thundercrew.opsapi.bike.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
+import com.thundercrew.opsapi.bike.dto.BikeCreateRequest;
+import com.thundercrew.opsapi.bike.dto.BikeOperationStatusChangeRequest;
+import com.thundercrew.opsapi.bike.dto.BikeReadResponse;
+import com.thundercrew.opsapi.bike.dto.BikeUpdateRequest;
+import com.thundercrew.opsapi.bike.repository.BikeOperationStatusHistoryRepository;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class BikeCommandService {
+
+    private final BikeRepository bikeRepository;
+    private final BikeOperationStatusHistoryRepository historyRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public BikeCommandService(
+            BikeRepository bikeRepository,
+            BikeOperationStatusHistoryRepository historyRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.bikeRepository = bikeRepository;
+        this.historyRepository = historyRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public BikeReadResponse create(BikeCreateRequest request) {
+        assertPlateNumberIsNotDuplicated(request.plateNumber());
+        assertVinIsNotDuplicated(request.vin());
+        Bike bike = Bike.create(
+                request.plateNumber(),
+                request.vin(),
+                request.modelName(),
+                request.operationStatus(),
+                request.memo()
+        );
+        try {
+            Bike saved = bikeRepository.save(bike);
+            historyRepository.save(BikeOperationStatusHistory.open(
+                    saved.getId(),
+                    request.operationStatus(),
+                    Instant.now(clock),
+                    "INITIAL_STATUS",
+                    "Bike created with initial operation status.",
+                    null
+            ));
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return BikeReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("Bike", "plateNumberOrVin");
+        }
+    }
+
+    @Transactional
+    public BikeReadResponse update(UUID id, BikeUpdateRequest request) {
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", id));
+        if (StringUtils.hasText(request.plateNumber())
+                && bikeRepository.existsByPlateNumberAndIdNotAndDeletedAtIsNull(request.plateNumber(), id)) {
+            throw new DuplicateActiveResourceException("Bike", "plateNumber");
+        }
+        if (StringUtils.hasText(request.vin())
+                && bikeRepository.existsByVinAndIdNotAndDeletedAtIsNull(request.vin(), id)) {
+            throw new DuplicateActiveResourceException("Bike", "vin");
+        }
+        try {
+            bike.updateBasicProfile(
+                    request.plateNumber(),
+                    request.vin(),
+                    request.modelName(),
+                    request.memo()
+            );
+            entityManager.flush();
+            return BikeReadResponse.from(bike);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("Bike", "plateNumberOrVin");
+        }
+    }
+
+    @Transactional
+    public BikeReadResponse changeOperationStatus(UUID id, BikeOperationStatusChangeRequest request) {
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", id));
+        if (bike.getOperationStatus() == request.operationStatus()) {
+            return BikeReadResponse.from(bike);
+        }
+        Instant changedAt = Instant.now(clock);
+        historyRepository.findFirstByBikeIdAndEndedAtIsNullAndDeletedAtIsNull(id)
+                .ifPresent(history -> {
+                    history.closeAt(changedAt);
+                    entityManager.flush();
+                });
+        bike.changeOperationStatus(request.operationStatus());
+        historyRepository.save(BikeOperationStatusHistory.open(
+                id,
+                request.operationStatus(),
+                changedAt,
+                request.reason(),
+                request.memo(),
+                null
+        ));
+        entityManager.flush();
+        return BikeReadResponse.from(bike);
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", id));
+        assertNoActiveDependentRecords(id);
+        bike.markDeleted(null, clock.instant());
+        historyRepository.findFirstByBikeIdAndEndedAtIsNullAndDeletedAtIsNull(id)
+                .ifPresent(history -> history.closeAt(clock.instant()));
+    }
+
+    private void assertPlateNumberIsNotDuplicated(String plateNumber) {
+        if (bikeRepository.existsByPlateNumberAndDeletedAtIsNull(plateNumber)) {
+            throw new DuplicateActiveResourceException("Bike", "plateNumber");
+        }
+    }
+
+    private void assertVinIsNotDuplicated(String vin) {
+        if (bikeRepository.existsByVinAndDeletedAtIsNull(vin)) {
+            throw new DuplicateActiveResourceException("Bike", "vin");
+        }
+    }
+
+    private void assertNoActiveDependentRecords(UUID id) {
+        if (bikeRepository.existsActiveContractReference(id)) {
+            throw new InvalidStateTransitionException(
+                    "Bike has an active rider-bike contract and cannot be deleted."
+            );
+        }
+        if (bikeRepository.existsActiveEquipmentReference(id)) {
+            throw new InvalidStateTransitionException(
+                    "Bike has active equipment and cannot be deleted."
+            );
+        }
+        if (bikeRepository.existsActiveDeviceInstallationReference(id)) {
+            throw new InvalidStateTransitionException(
+                    "Bike has an active device installation and cannot be deleted."
+            );
+        }
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -83,6 +84,21 @@ public class GlobalExceptionHandler {
                 Instant.now(clock)
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ResponseEntity<ApiErrorResponse> handleMessageNotReadable(
+            HttpMessageNotReadableException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.VALIDATION_FAILED,
+                "Request body is malformed or contains an unsupported value.",
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -72,7 +72,7 @@ class ArchitectureBoundaryTests {
                         || method.isAnnotatedWith(PutMapping.class)
                         || method.isAnnotatedWith(PatchMapping.class)
                         || method.isAnnotatedWith(DeleteMapping.class);
-                if (!hasWriteRouteMapping || isAuthLogin(method) || isRiderCommand(method)) {
+                if (!hasWriteRouteMapping || isAuthLogin(method) || isRiderCommand(method) || isBikeCommand(method)) {
                     return;
                 }
 
@@ -94,7 +94,7 @@ class ArchitectureBoundaryTests {
                     return;
                 }
 
-                if (!isAuthLogin(method) && !isRiderCommand(method)) {
+                if (!isAuthLogin(method) && !isRiderCommand(method) && !isBikeCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -113,6 +113,14 @@ class ArchitectureBoundaryTests {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.rider.controller.RiderCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
+                || method.getName().equals("delete"));
+    }
+
+    private static boolean isBikeCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.bike.controller.BikeCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("changeOperationStatus")
                 || method.getName().equals("delete"));
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
@@ -1,0 +1,387 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BikeCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_device_installations");
+        jdbcTemplate.update("delete from devices");
+        jdbcTemplate.update("delete from bike_equipments");
+        jdbcTemplate.update("delete from equipment_types");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from bike_operation_status_histories");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createBikeGeneratesIdentifiersIgnoresSystemFieldsAndCreatesInitialOpenHistory() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "plateNumber":"서울A-1001",
+                                  "vin":"VIN-BIKE-CREATE-001",
+                                  "modelName":"Thunder M1",
+                                  "operationStatus":"READY",
+                                  "memo":"초기 등록",
+                                  "riderId":"11111111-1111-1111-1111-111111111111",
+                                  "deviceId":"22222222-2222-2222-2222-222222222222",
+                                  "contractId":"33333333-3333-3333-3333-333333333333",
+                                  "telemetryStatus":"ONLINE",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/bikes/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.plateNumber").value("서울A-1001"))
+                .andExpect(jsonPath("$.vin").value("VIN-BIKE-CREATE-001"))
+                .andExpect(jsonPath("$.modelName").value("Thunder M1"))
+                .andExpect(jsonPath("$.operationStatus").value("READY"))
+                .andExpect(jsonPath("$.memo").value("초기 등록"))
+                .andReturn();
+
+        UUID createdId = UUID.fromString(extractId(result));
+        Integer openHistoryCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_operation_status_histories
+                where bike_id = ? and operation_status = 'READY' and ended_at is null and deleted_at is null
+                """, Integer.class, createdId);
+        assertThat(openHistoryCount).isEqualTo(1);
+    }
+
+    @Test
+    void createBikeRejectsMissingHumanRequiredFields() throws Exception {
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"","vin":"","operationStatus":null}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+
+    @Test
+    void createBikeRejectsUnknownOperationStatusAsValidationError() throws Exception {
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울Z-9999","vin":"VIN-INVALID-STATUS-001","operationStatus":"BROKEN"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/bikes"));
+    }
+
+    @Test
+    void createBikeRejectsDuplicateActivePlateNumberOrVin() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-DUP-001", "READY", null);
+
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울A-1001","vin":"VIN-NEW-001","operationStatus":"READY"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울A-2002","vin":"VIN-DUP-001","operationStatus":"READY"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateBikeChangesOnlyBasicProfileAndDoesNotChangeOperationStatus() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-UPDATE-001", "READY", null);
+
+        mockMvc.perform(patch("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "plateNumber":"서울B-2002",
+                                  "vin":"VIN-BIKE-UPDATE-002",
+                                  "modelName":"Thunder M2",
+                                  "memo":"기본 정보 수정",
+                                  "operationStatus":"IN_SERVICE",
+                                  "riderId":"11111111-1111-1111-1111-111111111111",
+                                  "deviceId":"22222222-2222-2222-2222-222222222222"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.plateNumber").value("서울B-2002"))
+                .andExpect(jsonPath("$.vin").value("VIN-BIKE-UPDATE-002"))
+                .andExpect(jsonPath("$.modelName").value("Thunder M2"))
+                .andExpect(jsonPath("$.memo").value("기본 정보 수정"))
+                .andExpect(jsonPath("$.operationStatus").value("READY"));
+    }
+
+    @Test
+    void updateBikeRejectsMissingOrDuplicateTargets() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-UPDATE-001", "READY", null);
+        UUID otherId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        seedBike(otherId, "서울C-3003", "VIN-BIKE-UPDATE-003", "READY", null);
+
+        UUID missingId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        mockMvc.perform(patch("/api/v1/bikes/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울X-9999"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울C-3003"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        mockMvc.perform(patch("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"vin":"VIN-BIKE-UPDATE-003"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void changeOperationStatusUpdatesBikeAndClosesPreviousOpenHistory() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-STATUS-001", "READY", null);
+        seedOpenStatusHistory(BIKE_ID, "READY");
+
+        mockMvc.perform(patch("/api/v1/bikes/{id}/operation-status", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "operationStatus":"IN_SERVICE",
+                                  "reason":"운영 투입",
+                                  "memo":"강남 구역",
+                                  "plateNumber":"무시-9999",
+                                  "deviceId":"22222222-2222-2222-2222-222222222222"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.operationStatus").value("IN_SERVICE"))
+                .andExpect(jsonPath("$.plateNumber").value("서울A-1001"));
+
+        Integer closedReadyCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_operation_status_histories
+                where bike_id = ? and operation_status = 'READY' and ended_at is not null and deleted_at is null
+                """, Integer.class, BIKE_ID);
+        Integer openInServiceCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_operation_status_histories
+                where bike_id = ? and operation_status = 'IN_SERVICE' and ended_at is null
+                  and reason = '운영 투입' and memo = '강남 구역' and deleted_at is null
+                """, Integer.class, BIKE_ID);
+
+        assertThat(closedReadyCount).isEqualTo(1);
+        assertThat(openInServiceCount).isEqualTo(1);
+    }
+
+    @Test
+    void deleteBikeSoftDeletesAndAllowsPlateAndVinReuse() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-DELETE-001", "READY", null);
+
+        mockMvc.perform(delete("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"서울A-1001","vin":"VIN-BIKE-DELETE-001","operationStatus":"READY"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.plateNumber").value("서울A-1001"))
+                .andExpect(jsonPath("$.vin").value("VIN-BIKE-DELETE-001"));
+    }
+
+    @Test
+    void deleteBikeRejectsActiveContractEquipmentOrDeviceReferences() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-REF-001", "READY", null);
+        UUID riderId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '참조 라이더', '010-1000-2000', false)
+                """, riderId);
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at)
+                values (?, ?, ?, '00000000-0000-0000-0000-000000000001', now())
+                """, UUID.fromString("22222222-2222-2222-2222-222222222222"), riderId, BIKE_ID);
+
+        mockMvc.perform(delete("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        UUID equipmentTypeId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name, enabled)
+                values (?, '브레이크 패드', true)
+                """, equipmentTypeId);
+        jdbcTemplate.update("""
+                insert into bike_equipments (id, bike_id, equipment_type_id, installed_at, management_due_date)
+                values (?, ?, ?, now(), current_date + interval '30 day')
+                """, UUID.fromString("44444444-4444-4444-4444-444444444444"), BIKE_ID, equipmentTypeId);
+
+        mockMvc.perform(delete("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        jdbcTemplate.update("delete from bike_equipments");
+        UUID deviceId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, enabled)
+                values (?, 'DEVICE-REF-001', true)
+                """, deviceId);
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at)
+                values (?, ?, ?, now())
+                """, UUID.fromString("66666666-6666-6666-6666-666666666666"), BIKE_ID, deviceId);
+
+        mockMvc.perform(delete("/api/v1/bikes/{id}", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/bikes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"plateNumber":"무인증-1","vin":"VIN-NO-AUTH-001","operationStatus":"READY"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String operationStatus, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, memo, deleted_at)
+                values (?, ?, ?, 'Thunder M1', ?, 'fixture bike', %s)
+                """.formatted(deletedAtExpression), id, plateNumber, vin, operationStatus);
+    }
+
+    private void seedOpenStatusHistory(UUID bikeId, String operationStatus) {
+        jdbcTemplate.update("""
+                insert into bike_operation_status_histories (id, bike_id, operation_status, started_at, reason, memo)
+                values (?, ?, ?, now() - interval '1 hour', 'fixture', 'fixture history')
+                """, UUID.randomUUID(), bikeId, operationStatus);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -230,10 +230,9 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
     }
 
     @Test
-    void nonRiderWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
+    void nonBikeAndNonRiderWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
         UUID id = RIDER_ID;
         for (String endpoint : List.of(
-                "/api/v1/bikes",
                 "/api/v1/bike-operation-status-histories",
                 "/api/v1/contract-templates",
                 "/api/v1/rider-bike-contracts",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -168,3 +168,26 @@ Boundary decision:
 - Repository root becomes the workspace orchestration layer.
 - Product runtime source lives under `development/front-admin-web` and `development/service-ops-api`.
 - Root npm scripts delegate to the frontend workspace so existing local verification commands remain stable.
+
+## Bike write-command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#55
+- Target issue: EVNSolution/thundercrew-domain#22
+- Branch: `cc-55-bike-command-baseline`
+
+Issue-size decision:
+
+- This slice adds only the Bike aggregate command baseline after the Rider command baseline.
+- Included operations are bike create/update/soft-delete and a dedicated operation-status change endpoint that closes/appends status history.
+- The current schema fields are `plateNumber`, `vin`, `modelName`, `operationStatus`, and `memo`; `manufacturer` and `manufacturedYear` are deferred to a future schema extension issue.
+- Rider-bike contract assignment, device installation commands, equipment commands, telemetry, dashboard/map APIs, frontend integration, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Generic bike PATCH is profile-only and does not accept `operationStatus` as a mutable field.
+- Operation status remains operator-entered DB data and changes only through `/api/v1/bikes/{id}/operation-status` so history transitions are transactional.
+- Client request DTOs ignore IDs, idx, audit/deleted fields, telemetry/system values, and FK-like relationship fields.
+- Soft delete blocks active rider-bike contract, active bike equipment, and active device installation references.
+- Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, and bike commands at this stage.


### PR DESCRIPTION
## Summary
- Adds authenticated bike command APIs for create, profile update, soft delete, and dedicated operation-status transitions.
- Keeps generic bike PATCH profile-only; status changes close the previous open history row and append a new open history row transactionally.
- Preserves no direct client ID/FK/system input policy with request DTOs that ignore unknown/system fields and generate DB UUID/idx server-side.
- Adds bike command contract tests, restores bike read-list contract coverage, and narrows architecture-test write exceptions to `BikeCommandController` only.

## Traceability
- Change-control anchor: EVNSolution/clever-change-control#55
- Target issue: EVNSolution/thundercrew-domain#22
- Branch: `cc-55-bike-command-baseline`
- Commit: `21301e0a8930c2b6e545a159105bea46eaa7401f`

## Concurrent work gate
- Target open issues before PR: EVNSolution/thundercrew-domain#22 only for this branch.
- Target open PRs before PR: none.
- Active target branches before PR: `main`, `dev`, `cc-55-bike-command-baseline`.
- Decision: `allowed-with-non-overlap`; no other active work overlaps this service/API/domain/file surface.

## Scope boundaries
Included:
- `POST /api/v1/bikes`
- `PATCH /api/v1/bikes/{id}` for profile fields only
- `PATCH /api/v1/bikes/{id}/operation-status`
- `DELETE /api/v1/bikes/{id}` soft delete with active contract/equipment/device-installation guards

Excluded:
- rider-bike contract assignment
- device installation commands
- equipment commands
- telemetry/dashboard/map APIs
- frontend integration
- hard delete/restore, bulk import/export, advanced search
- schema expansion for `manufacturer` / `manufacturedYear`

## Verification
- TDD RED: `BikeCommandApiContractTests` initially failed for missing bike commands.
- `cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.BikeCommandApiContractTests --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.BikeCommandApiContractTests.createBikeRejectsUnknownOperationStatusAsValidationError --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.ReadOnlyApiContractTests.readListsExposeSharedPageContractForEveryCoreResource --rerun-tasks --no-daemon`
- `git diff --check`
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review notes
- Architect review PASS after narrowing the issue to current bike schema fields.
- Code-review first pass BLOCK was addressed by committing previously untracked implementation files and restoring `/api/v1/bikes` read-list contract coverage.
