### PR TITLE
Add contract template command baseline

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractTemplateCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractTemplateCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.contract.controller;
+
+import com.thundercrew.opsapi.contract.dto.ContractTemplateCreateRequest;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateUpdateRequest;
+import com.thundercrew.opsapi.contract.service.ContractTemplateCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/contract-templates")
+public class ContractTemplateCommandController {
+
+    private final ContractTemplateCommandService contractTemplateCommandService;
+
+    public ContractTemplateCommandController(ContractTemplateCommandService contractTemplateCommandService) {
+        this.contractTemplateCommandService = contractTemplateCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<ContractTemplateReadResponse> create(@Valid @RequestBody ContractTemplateCreateRequest request) {
+        ContractTemplateReadResponse response = contractTemplateCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/contract-templates/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    ContractTemplateReadResponse update(@PathVariable UUID id, @Valid @RequestBody ContractTemplateUpdateRequest request) {
+        return contractTemplateCommandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        contractTemplateCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "contract_templates")
@@ -21,6 +23,47 @@ public class ContractTemplate extends DisplaySequencedEntity {
 
     @Column(nullable = false)
     private boolean systemTemplate;
+
+    public static ContractTemplate create(
+            String name,
+            Integer durationMinutes,
+            String description,
+            Boolean enabled
+    ) {
+        ContractTemplate template = new ContractTemplate();
+        template.name = name;
+        template.durationMinutes = durationMinutes;
+        template.description = description;
+        template.enabled = enabled == null || enabled;
+        template.systemTemplate = false;
+        return template;
+    }
+
+    public void updateAdminManagedFields(
+            String name,
+            boolean durationMinutesProvided,
+            Integer durationMinutes,
+            String description,
+            Boolean enabled
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (durationMinutesProvided) {
+            this.durationMinutes = durationMinutes;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+    }
+
+    public void disableAndMarkDeleted(UUID actorId, Instant deletedAt) {
+        this.enabled = false;
+        markDeleted(actorId, deletedAt);
+    }
 
     public String getName() {
         return name;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateCreateRequest.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.contract.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ContractTemplateCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        @Positive Integer durationMinutes,
+        String description,
+        Boolean enabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateUpdateRequest.java
@@ -1,0 +1,60 @@
+package com.thundercrew.opsapi.contract.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContractTemplateUpdateRequest {
+
+    @Size(max = 100)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String name;
+
+    @Positive
+    private Integer durationMinutes;
+
+    private boolean durationMinutesProvided;
+
+    private String description;
+
+    private Boolean enabled;
+
+    public String name() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer durationMinutes() {
+        return durationMinutes;
+    }
+
+    public boolean durationMinutesProvided() {
+        return durationMinutesProvided;
+    }
+
+    public void setDurationMinutes(Integer durationMinutes) {
+        this.durationMinutes = durationMinutes;
+        this.durationMinutesProvided = true;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
@@ -12,4 +12,10 @@ public interface ContractTemplateRepository extends Repository<ContractTemplate,
     Page<ContractTemplate> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<ContractTemplate> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
+
+    boolean existsByNameAndIdNotAndDeletedAtIsNull(String name, UUID id);
+
+    ContractTemplate save(ContractTemplate template);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractTemplateCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractTemplateCommandService.java
@@ -1,0 +1,98 @@
+package com.thundercrew.opsapi.contract.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.domain.ContractTemplate;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateCreateRequest;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
+import com.thundercrew.opsapi.contract.dto.ContractTemplateUpdateRequest;
+import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ContractTemplateCommandService {
+
+    private final ContractTemplateRepository contractTemplateRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public ContractTemplateCommandService(
+            ContractTemplateRepository contractTemplateRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.contractTemplateRepository = contractTemplateRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public ContractTemplateReadResponse create(ContractTemplateCreateRequest request) {
+        assertNameIsNotDuplicated(request.name());
+        ContractTemplate template = ContractTemplate.create(
+                request.name(),
+                request.durationMinutes(),
+                request.description(),
+                request.enabled()
+        );
+        try {
+            ContractTemplate saved = contractTemplateRepository.save(template);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return ContractTemplateReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("ContractTemplate", "name");
+        }
+    }
+
+    @Transactional
+    public ContractTemplateReadResponse update(UUID id, ContractTemplateUpdateRequest request) {
+        ContractTemplate template = contractTemplateRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("ContractTemplate", id));
+        assertTemplateIsMutable(template);
+        if (StringUtils.hasText(request.name())
+                && contractTemplateRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
+            throw new DuplicateActiveResourceException("ContractTemplate", "name");
+        }
+        try {
+            template.updateAdminManagedFields(
+                    request.name(),
+                    request.durationMinutesProvided(),
+                    request.durationMinutes(),
+                    request.description(),
+                    request.enabled()
+            );
+            entityManager.flush();
+            return ContractTemplateReadResponse.from(template);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("ContractTemplate", "name");
+        }
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        ContractTemplate template = contractTemplateRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("ContractTemplate", id));
+        assertTemplateIsMutable(template);
+        template.disableAndMarkDeleted(null, clock.instant());
+    }
+
+    private void assertNameIsNotDuplicated(String name) {
+        if (contractTemplateRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new DuplicateActiveResourceException("ContractTemplate", "name");
+        }
+    }
+
+    private void assertTemplateIsMutable(ContractTemplate template) {
+        if (template.isSystemTemplate()) {
+            throw new InvalidStateTransitionException("System contract template cannot be modified or deleted.");
+        }
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -72,7 +72,11 @@ class ArchitectureBoundaryTests {
                         || method.isAnnotatedWith(PutMapping.class)
                         || method.isAnnotatedWith(PatchMapping.class)
                         || method.isAnnotatedWith(DeleteMapping.class);
-                if (!hasWriteRouteMapping || isAuthLogin(method) || isRiderCommand(method) || isBikeCommand(method)) {
+                if (!hasWriteRouteMapping
+                        || isAuthLogin(method)
+                        || isRiderCommand(method)
+                        || isBikeCommand(method)
+                        || isContractTemplateCommand(method)) {
                     return;
                 }
 
@@ -94,7 +98,10 @@ class ArchitectureBoundaryTests {
                     return;
                 }
 
-                if (!isAuthLogin(method) && !isRiderCommand(method) && !isBikeCommand(method)) {
+                if (!isAuthLogin(method)
+                        && !isRiderCommand(method)
+                        && !isBikeCommand(method)
+                        && !isContractTemplateCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -121,6 +128,13 @@ class ArchitectureBoundaryTests {
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
                 || method.getName().equals("changeOperationStatus")
+                || method.getName().equals("delete"));
+    }
+
+    private static boolean isContractTemplateCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.contract.controller.ContractTemplateCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
                 || method.getName().equals("delete"));
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractTemplateCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractTemplateCommandApiContractTests.java
@@ -1,0 +1,320 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ContractTemplateCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID SYSTEM_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID TEMPLATE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from contract_templates where system_template = false");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createTemplateGeneratesIdentifiersAndIgnoresClientSuppliedSystemFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "name":"12일 계약",
+                                  "durationMinutes":17280,
+                                  "description":"12일 운영 계약",
+                                  "enabled":true,
+                                  "systemTemplate":true,
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/contract-templates/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.name").value("12일 계약"))
+                .andExpect(jsonPath("$.durationMinutes").value(17280))
+                .andExpect(jsonPath("$.unlimited").value(false))
+                .andExpect(jsonPath("$.description").value("12일 운영 계약"))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.systemTemplate").value(false))
+                .andReturn();
+
+        String createdId = extractId(result);
+        mockMvc.perform(get("/api/v1/contract-templates/{id}", createdId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("12일 계약"));
+    }
+
+    @Test
+    void createTemplateAllowsUnlimitedDurationWhenDurationMinutesIsNull() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"무제한 현장 계약","durationMinutes":null,"description":"기간 제한 없음"}
+                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.durationMinutes").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.unlimited").value(true))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.systemTemplate").value(false));
+    }
+
+    @Test
+    void createTemplateRejectsMissingNameOrInvalidDuration() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"","durationMinutes":0}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void createTemplateRejectsDuplicateActiveName() throws Exception {
+        seedTemplate(TEMPLATE_ID, "표준 12일", 17280, false, true, null);
+
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"표준 12일","durationMinutes":17280}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateTemplateChangesHumanManagedFieldsAndIgnoresSystemFields() throws Exception {
+        seedTemplate(TEMPLATE_ID, "표준 12일", 17280, false, true, null);
+
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "idx":999,
+                                  "name":"표준 13일",
+                                  "durationMinutes":18720,
+                                  "description":"13일 계약",
+                                  "enabled":false,
+                                  "systemTemplate":true,
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(TEMPLATE_ID.toString()))
+                .andExpect(jsonPath("$.name").value("표준 13일"))
+                .andExpect(jsonPath("$.durationMinutes").value(18720))
+                .andExpect(jsonPath("$.description").value("13일 계약"))
+                .andExpect(jsonPath("$.enabled").value(false))
+                .andExpect(jsonPath("$.systemTemplate").value(false));
+    }
+
+    @Test
+    void updateTemplateCanExplicitlySetDurationToUnlimited() throws Exception {
+        seedTemplate(TEMPLATE_ID, "표준 12일", 17280, false, true, null);
+
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"durationMinutes":null}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(TEMPLATE_ID.toString()))
+                .andExpect(jsonPath("$.name").value("표준 12일"))
+                .andExpect(jsonPath("$.durationMinutes").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.unlimited").value(true));
+    }
+
+    @Test
+    void updateTemplateRejectsMissingOrDuplicateTargets() throws Exception {
+        seedTemplate(TEMPLATE_ID, "표준 12일", 17280, false, true, null);
+        UUID otherId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        seedTemplate(otherId, "표준 13일", 18720, false, true, null);
+
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"없음"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"표준 13일"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void systemTemplateCannotBeUpdatedOrDeleted() throws Exception {
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", SYSTEM_TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"시스템 변경 시도","enabled":false}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        mockMvc.perform(delete("/api/v1/contract-templates/{id}", SYSTEM_TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void deleteTemplateSoftDeletesAndAllowsNameReuse() throws Exception {
+        seedTemplate(TEMPLATE_ID, "표준 12일", 17280, false, true, null);
+
+        mockMvc.perform(delete("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"표준 12일","durationMinutes":17280}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("표준 12일"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"무인증 계약","durationMinutes":1440}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", TEMPLATE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"무인증 수정"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(delete("/api/v1/contract-templates/{id}", TEMPLATE_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedTemplate(
+            UUID id,
+            String name,
+            Integer durationMinutes,
+            boolean systemTemplate,
+            boolean enabled,
+            String deletedAtSql
+    ) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into contract_templates (id, name, duration_minutes, description, enabled, system_template, deleted_at)
+                values (?, ?, ?, 'fixture template', ?, ?, %s)
+                """.formatted(deletedAtExpression), id, name, durationMinutes, enabled, systemTemplate);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -230,11 +230,10 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
     }
 
     @Test
-    void nonBikeAndNonRiderWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
+    void nonBikeNonRiderAndNonContractTemplateWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
         UUID id = RIDER_ID;
         for (String endpoint : List.of(
                 "/api/v1/bike-operation-status-histories",
-                "/api/v1/contract-templates",
                 "/api/v1/rider-bike-contracts",
                 "/api/v1/insurance-items",
                 "/api/v1/rider-insurances",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -191,3 +191,27 @@ Boundary decision:
 - Client request DTOs ignore IDs, idx, audit/deleted fields, telemetry/system values, and FK-like relationship fields.
 - Soft delete blocks active rider-bike contract, active bike equipment, and active device installation references.
 - Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, and bike commands at this stage.
+
+## Contract template write-command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#56
+- Target issue: EVNSolution/thundercrew-domain#24
+- Branch: `cc-56-contract-template-command`
+
+Issue-size decision:
+
+- This slice adds only the ContractTemplate aggregate command baseline after the Rider and Bike command baselines.
+- Included operations are authenticated contract-template create/update/soft-delete for operator-managed templates.
+- Rider-bike contract assignment, overlap locking, termination, billing, e-signature, frontend integration, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only operator-managed fields: name, durationMinutes, description, enabled.
+- Server-generated id, idx, audit/deleted fields, and systemTemplate remain non-client inputs and are ignored when sent.
+- `durationMinutes = null` means an unlimited template; positive integer values represent fixed durations; zero/negative values are invalid.
+- `PATCH enabled=false` disables selection while keeping the template readable; `DELETE` soft-deletes and removes the template from active read APIs.
+- Seeded system templates such as `무제한 계약` are protected from update, disable, and delete.
+- Duplicate active names are blocked by service precheck plus the database partial unique index.
+- Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, and contract-template commands at this stage.


### PR DESCRIPTION
## Summary
- Add authenticated ContractTemplate command routes for `POST`, `PATCH`, and `DELETE /api/v1/contract-templates`.
- Add create/update request DTOs that expose only operator-managed fields and ignore client-supplied system/id/audit/deleted fields.
- Protect seeded system templates from update/delete, block duplicate active names, preserve soft-delete semantics, and support explicit `durationMinutes: null` as unlimited.
- Update architecture/read-only contract tests and backend change ledger for the new command baseline.

## Traceability
- Change-control anchor: EVNSolution/clever-change-control#56
- Target issue: EVNSolution/thundercrew-domain#24
- Branch: `cc-56-contract-template-command`

## Concurrent work gate
Decision: `allowed-with-non-overlap`

Evidence:
- Target repo open PRs before PR creation: none.
- Target repo open issues affecting this repo before PR creation: EVNSolution/thundercrew-domain#24 only.
- Target remote branches before PR creation: `main`, `dev`, `cc-56-contract-template-command`.
- Other open change-control issues did not target this repo's `service-ops-api` ContractTemplate command aggregate.

Non-overlap reason:
- This PR is limited to the ContractTemplate aggregate command baseline.
- Rider-bike contract assignment/overlap, device installation, equipment commands, frontend, telemetry, and deployment remain follow-up scopes.

## Validation
- `git diff --check`
- `cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.ContractTemplateCommandApiContractTests --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review notes
- Subagent review caught explicit `PATCH {"durationMinutes": null}` semantics; fixed with presence-aware update DTO and regression coverage.
