### PR TITLE
Add rider-bike contract assignment overlap baseline

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
@@ -86,6 +86,47 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
     }
 
+    @ExceptionHandler(ReferenceNotFoundException.class)
+    ResponseEntity<ApiErrorResponse> handleReferenceNotFound(
+            ReferenceNotFoundException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.REFERENCE_NOT_FOUND,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(ReferenceDeletedException.class)
+    ResponseEntity<ApiErrorResponse> handleReferenceDeleted(
+            ReferenceDeletedException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.REFERENCE_DELETED,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler(PeriodOverlapException.class)
+    ResponseEntity<ApiErrorResponse> handlePeriodOverlap(
+            PeriodOverlapException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.PERIOD_OVERLAP,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     ResponseEntity<ApiErrorResponse> handleMessageNotReadable(

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/PeriodOverlapException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/PeriodOverlapException.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.common.api;
+
+public class PeriodOverlapException extends RuntimeException {
+
+    public PeriodOverlapException(String message) {
+        super(message);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ReferenceDeletedException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ReferenceDeletedException.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.common.api;
+
+import java.util.UUID;
+
+public class ReferenceDeletedException extends RuntimeException {
+
+    public ReferenceDeletedException(String resourceName, UUID id) {
+        super(resourceName + " reference is deleted: " + id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ReferenceNotFoundException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ReferenceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.common.api;
+
+import java.util.UUID;
+
+public class ReferenceNotFoundException extends RuntimeException {
+
+    public ReferenceNotFoundException(String resourceName, UUID id) {
+        super(resourceName + " reference not found: " + id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/RiderBikeContractCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/RiderBikeContractCommandController.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.contract.controller;
+
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractCreateRequest;
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
+import com.thundercrew.opsapi.contract.service.RiderBikeContractCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider-bike-contracts")
+public class RiderBikeContractCommandController {
+
+    private final RiderBikeContractCommandService riderBikeContractCommandService;
+
+    public RiderBikeContractCommandController(RiderBikeContractCommandService riderBikeContractCommandService) {
+        this.riderBikeContractCommandService = riderBikeContractCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<RiderBikeContractReadResponse> create(@Valid @RequestBody RiderBikeContractCreateRequest request) {
+        RiderBikeContractReadResponse response = riderBikeContractCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/rider-bike-contracts/" + response.id()))
+                .body(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/RiderBikeContract.java
@@ -31,28 +31,45 @@ public class RiderBikeContract extends DisplaySequencedEntity {
 
     private String memo;
 
+    public static RiderBikeContract create(
+            UUID riderId,
+            UUID bikeId,
+            UUID contractTemplateId,
+            Instant startAt,
+            Instant endAt,
+            String memo
+    ) {
+        RiderBikeContract contract = new RiderBikeContract();
+        contract.riderId = riderId;
+        contract.bikeId = bikeId;
+        contract.contractTemplateId = contractTemplateId;
+        contract.startAt = startAt;
+        contract.endAt = endAt;
+        contract.memo = memo;
+        return contract;
+    }
 
-    public java.util.UUID getRiderId() {
+    public UUID getRiderId() {
         return riderId;
     }
 
-    public java.util.UUID getBikeId() {
+    public UUID getBikeId() {
         return bikeId;
     }
 
-    public java.util.UUID getContractTemplateId() {
+    public UUID getContractTemplateId() {
         return contractTemplateId;
     }
 
-    public java.time.Instant getStartAt() {
+    public Instant getStartAt() {
         return startAt;
     }
 
-    public java.time.Instant getEndAt() {
+    public Instant getEndAt() {
         return endAt;
     }
 
-    public java.time.Instant getTerminatedAt() {
+    public Instant getTerminatedAt() {
         return terminatedAt;
     }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractCreateRequest.java
@@ -1,0 +1,16 @@
+package com.thundercrew.opsapi.contract.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RiderBikeContractCreateRequest(
+        @NotNull UUID riderId,
+        @NotNull UUID bikeId,
+        @NotNull UUID contractTemplateId,
+        @NotNull Instant startAt,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
@@ -11,6 +11,8 @@ public interface ContractTemplateRepository extends Repository<ContractTemplate,
 
     Page<ContractTemplate> findByDeletedAtIsNull(Pageable pageable);
 
+    Optional<ContractTemplate> findById(UUID id);
+
     Optional<ContractTemplate> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByNameAndDeletedAtIsNull(String name);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
@@ -1,15 +1,66 @@
 package com.thundercrew.opsapi.contract.repository;
 
 import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface RiderBikeContractRepository extends Repository<RiderBikeContract, UUID> {
 
     Page<RiderBikeContract> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<RiderBikeContract> findByIdAndDeletedAtIsNull(UUID id);
+
+    RiderBikeContract save(RiderBikeContract contract);
+
+    @Query(value = "select exists (select 1 from riders where id = :riderId)", nativeQuery = true)
+    boolean existsRiderById(@Param("riderId") UUID riderId);
+
+    @Query(value = "select exists (select 1 from riders where id = :riderId and deleted_at is null)", nativeQuery = true)
+    boolean existsActiveRiderById(@Param("riderId") UUID riderId);
+
+    @Query(value = "select exists (select 1 from bikes where id = :bikeId)", nativeQuery = true)
+    boolean existsBikeById(@Param("bikeId") UUID bikeId);
+
+    @Query(value = "select exists (select 1 from bikes where id = :bikeId and deleted_at is null)", nativeQuery = true)
+    boolean existsActiveBikeById(@Param("bikeId") UUID bikeId);
+
+    @Query(value = """
+            select exists (
+                select 1
+                from rider_bike_contracts
+                where rider_id = :riderId
+                  and deleted_at is null
+                  and terminated_at is null
+                  and start_at < :newEndAt
+                  and :newStartAt < coalesce(end_at, 'infinity'::timestamptz)
+            )
+            """, nativeQuery = true)
+    boolean existsOverlappingRiderPeriod(
+            @Param("riderId") UUID riderId,
+            @Param("newStartAt") Instant newStartAt,
+            @Param("newEndAt") Instant newEndAt
+    );
+
+    @Query(value = """
+            select exists (
+                select 1
+                from rider_bike_contracts
+                where bike_id = :bikeId
+                  and deleted_at is null
+                  and terminated_at is null
+                  and start_at < :newEndAt
+                  and :newStartAt < coalesce(end_at, 'infinity'::timestamptz)
+            )
+            """, nativeQuery = true)
+    boolean existsOverlappingBikePeriod(
+            @Param("bikeId") UUID bikeId,
+            @Param("newStartAt") Instant newStartAt,
+            @Param("newEndAt") Instant newEndAt
+    );
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/RiderBikeContractCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/RiderBikeContractCommandService.java
@@ -1,0 +1,128 @@
+package com.thundercrew.opsapi.contract.service;
+
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.PeriodOverlapException;
+import com.thundercrew.opsapi.common.api.ReferenceDeletedException;
+import com.thundercrew.opsapi.common.api.ReferenceNotFoundException;
+import com.thundercrew.opsapi.contract.domain.ContractTemplate;
+import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractCreateRequest;
+import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
+import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderBikeContractCommandService {
+
+    private static final Instant OPEN_ENDED_OVERLAP_BOUND = Instant.parse("9999-12-31T23:59:59Z");
+
+    private final RiderBikeContractRepository riderBikeContractRepository;
+    private final ContractTemplateRepository contractTemplateRepository;
+    private final EntityManager entityManager;
+
+    public RiderBikeContractCommandService(
+            RiderBikeContractRepository riderBikeContractRepository,
+            ContractTemplateRepository contractTemplateRepository,
+            EntityManager entityManager
+    ) {
+        this.riderBikeContractRepository = riderBikeContractRepository;
+        this.contractTemplateRepository = contractTemplateRepository;
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public RiderBikeContractReadResponse create(RiderBikeContractCreateRequest request) {
+        assertActiveRiderReference(request.riderId());
+        assertActiveBikeReference(request.bikeId());
+        ContractTemplate template = findEnabledTemplateReference(request.contractTemplateId());
+        Instant endAt = deriveEndAt(request.startAt(), template);
+        lockAssignmentReferences(request.riderId(), request.bikeId());
+        assertNoOverlap(request.riderId(), request.bikeId(), request.startAt(), endAt);
+
+        RiderBikeContract contract = RiderBikeContract.create(
+                request.riderId(),
+                request.bikeId(),
+                request.contractTemplateId(),
+                request.startAt(),
+                endAt,
+                request.memo()
+        );
+        RiderBikeContract saved = riderBikeContractRepository.save(contract);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return RiderBikeContractReadResponse.from(saved);
+    }
+
+    private void assertActiveRiderReference(UUID riderId) {
+        if (riderBikeContractRepository.existsActiveRiderById(riderId)) {
+            return;
+        }
+        if (riderBikeContractRepository.existsRiderById(riderId)) {
+            throw new ReferenceDeletedException("Rider", riderId);
+        }
+        throw new ReferenceNotFoundException("Rider", riderId);
+    }
+
+    private void assertActiveBikeReference(UUID bikeId) {
+        if (riderBikeContractRepository.existsActiveBikeById(bikeId)) {
+            return;
+        }
+        if (riderBikeContractRepository.existsBikeById(bikeId)) {
+            throw new ReferenceDeletedException("Bike", bikeId);
+        }
+        throw new ReferenceNotFoundException("Bike", bikeId);
+    }
+
+    private ContractTemplate findEnabledTemplateReference(UUID templateId) {
+        ContractTemplate template = contractTemplateRepository.findById(templateId)
+                .orElseThrow(() -> new ReferenceNotFoundException("ContractTemplate", templateId));
+        if (template.isDeleted()) {
+            throw new ReferenceDeletedException("ContractTemplate", templateId);
+        }
+        if (!template.isEnabled()) {
+            throw new InvalidStateTransitionException("Contract template is disabled and cannot be assigned.");
+        }
+        return template;
+    }
+
+    private Instant deriveEndAt(Instant startAt, ContractTemplate template) {
+        Integer durationMinutes = template.getDurationMinutes();
+        if (durationMinutes == null) {
+            return null;
+        }
+        return startAt.plus(Duration.ofMinutes(durationMinutes));
+    }
+
+    private void lockAssignmentReferences(UUID riderId, UUID bikeId) {
+        List.of(
+                        "rider-bike-contract:bike:" + bikeId,
+                        "rider-bike-contract:rider:" + riderId
+                )
+                .stream()
+                .sorted()
+                .forEach(this::lockByKey);
+    }
+
+    private void lockByKey(String lockKey) {
+        entityManager.createNativeQuery("select pg_advisory_xact_lock(hashtextextended(?1, 0))")
+                .setParameter(1, lockKey)
+                .getSingleResult();
+    }
+
+    private void assertNoOverlap(UUID riderId, UUID bikeId, Instant startAt, Instant endAt) {
+        Instant effectiveEndAt = endAt == null ? OPEN_ENDED_OVERLAP_BOUND : endAt;
+        if (riderBikeContractRepository.existsOverlappingRiderPeriod(riderId, startAt, effectiveEndAt)) {
+            throw new PeriodOverlapException("Rider already has an overlapping bike contract.");
+        }
+        if (riderBikeContractRepository.existsOverlappingBikePeriod(bikeId, startAt, effectiveEndAt)) {
+            throw new PeriodOverlapException("Bike already has an overlapping rider contract.");
+        }
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -76,7 +76,8 @@ class ArchitectureBoundaryTests {
                         || isAuthLogin(method)
                         || isRiderCommand(method)
                         || isBikeCommand(method)
-                        || isContractTemplateCommand(method)) {
+                        || isContractTemplateCommand(method)
+                        || isRiderBikeContractCommand(method)) {
                     return;
                 }
 
@@ -101,7 +102,8 @@ class ArchitectureBoundaryTests {
                 if (!isAuthLogin(method)
                         && !isRiderCommand(method)
                         && !isBikeCommand(method)
-                        && !isContractTemplateCommand(method)) {
+                        && !isContractTemplateCommand(method)
+                        && !isRiderBikeContractCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -136,6 +138,11 @@ class ArchitectureBoundaryTests {
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isRiderBikeContractCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.contract.controller.RiderBikeContractCommandController")
+                && method.getName().equals("create");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -230,11 +230,10 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
     }
 
     @Test
-    void nonBikeNonRiderAndNonContractTemplateWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
+    void remainingWriteRoutesAreNotPartOfTheCurrentCommandBaseline() throws Exception {
         UUID id = RIDER_ID;
         for (String endpoint : List.of(
                 "/api/v1/bike-operation-status-histories",
-                "/api/v1/rider-bike-contracts",
                 "/api/v1/insurance-items",
                 "/api/v1/rider-insurances",
                 "/api/v1/equipment-types",

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderBikeContractCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderBikeContractCommandApiContractTests.java
@@ -1,0 +1,335 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderBikeContractCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID BIKE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID TEMPLATE_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID SYSTEM_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final Instant CONTRACT_START = Instant.parse("2030-01-01T00:00:00Z");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from contract_templates where system_template = false");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        seedRider(RIDER_ID, "계약 라이더", "010-1000-2000", null);
+        seedBike(BIKE_ID, "서울A-1001", "VIN-CONTRACT-001", null);
+        seedTemplate(TEMPLATE_ID, "12일 계약", 17280, true, null);
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createFiniteContractGeneratesIdentifiersComputesEndAtAndIgnoresClientSystemFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "riderId":"%s",
+                                  "bikeId":"%s",
+                                  "contractTemplateId":"%s",
+                                  "startAt":"%s",
+                                  "endAt":"2099-01-01T00:00:00Z",
+                                  "terminatedAt":"2030-01-01T01:00:00Z",
+                                  "terminatedReason":"client ignored",
+                                  "deletedAt":"2030-01-02T00:00:00Z",
+                                  "memo":"강남 구역 12일 배정"
+                                }
+                                """.formatted(clientSuppliedId, RIDER_ID, BIKE_ID, TEMPLATE_ID, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/rider-bike-contracts/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.riderId").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.contractTemplateId").value(TEMPLATE_ID.toString()))
+                .andExpect(jsonPath("$.startAt").value(CONTRACT_START.toString()))
+                .andExpect(jsonPath("$.endAt").value("2030-01-13T00:00:00Z"))
+                .andExpect(jsonPath("$.terminatedAt").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.terminatedReason").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.memo").value("강남 구역 12일 배정"))
+                .andReturn();
+
+        UUID createdId = UUID.fromString(extractId(result));
+        Integer createdRows = jdbcTemplate.queryForObject("""
+                select count(*) from rider_bike_contracts
+                where id = ? and end_at = '2030-01-13T00:00:00Z'::timestamptz
+                  and terminated_at is null and deleted_at is null
+                """, Integer.class, createdId);
+        assertThat(createdRows).isEqualTo(1);
+    }
+
+    @Test
+    void createUnlimitedContractKeepsEndAtNull() throws Exception {
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, SYSTEM_TEMPLATE_ID, CONTRACT_START))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.endAt").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    void createContractRejectsMissingRequiredReferencesAndStartAt() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.path").value("/api/v1/rider-bike-contracts"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void createContractRejectsMissingDeletedOrDisabledReferences() throws Exception {
+        UUID missingRiderId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockMvc.perform(postContract(missingRiderId, BIKE_ID, TEMPLATE_ID, CONTRACT_START))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+
+        jdbcTemplate.update("update bikes set deleted_at = now() where id = ?", BIKE_ID);
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, CONTRACT_START))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+        jdbcTemplate.update("update bikes set deleted_at = null where id = ?", BIKE_ID);
+
+        jdbcTemplate.update("update contract_templates set enabled = false where id = ?", TEMPLATE_ID);
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, CONTRACT_START))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void createContractRejectsOverlappingRiderOrBikeIntervals() throws Exception {
+        UUID otherRiderId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID otherBikeId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        seedRider(otherRiderId, "다른 라이더", "010-2000-3000", null);
+        seedBike(otherBikeId, "서울B-2002", "VIN-CONTRACT-002", null);
+
+        seedContract(UUID.fromString("33333333-3333-3333-3333-333333333333"), RIDER_ID, otherBikeId,
+                TEMPLATE_ID, CONTRACT_START, Instant.parse("2030-01-13T00:00:00Z"), null, null);
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, Instant.parse("2030-01-12T00:00:00Z")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PERIOD_OVERLAP"));
+
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        seedContract(UUID.fromString("44444444-4444-4444-4444-444444444444"), otherRiderId, BIKE_ID,
+                TEMPLATE_ID, CONTRACT_START, Instant.parse("2030-01-13T00:00:00Z"), null, null);
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, Instant.parse("2030-01-12T00:00:00Z")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PERIOD_OVERLAP"));
+    }
+
+    @Test
+    void createContractAllowsBackToBackFutureReservationAndIgnoresTerminatedOrSoftDeletedRows() throws Exception {
+        seedContract(UUID.fromString("11111111-1111-1111-1111-111111111111"), RIDER_ID, BIKE_ID,
+                TEMPLATE_ID, CONTRACT_START, Instant.parse("2030-01-13T00:00:00Z"), null, null);
+        seedContract(UUID.fromString("22222222-2222-2222-2222-222222222222"), RIDER_ID, BIKE_ID,
+                TEMPLATE_ID, Instant.parse("2030-01-05T00:00:00Z"), Instant.parse("2030-01-17T00:00:00Z"),
+                Instant.parse("2030-01-06T00:00:00Z"), null);
+        seedContract(UUID.fromString("33333333-3333-3333-3333-333333333333"), RIDER_ID, BIKE_ID,
+                TEMPLATE_ID, Instant.parse("2030-01-07T00:00:00Z"), Instant.parse("2030-01-19T00:00:00Z"),
+                null, "now()");
+
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, Instant.parse("2030-01-13T00:00:00Z")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.startAt").value("2030-01-13T00:00:00Z"))
+                .andExpect(jsonPath("$.endAt").value("2030-01-25T00:00:00Z"));
+    }
+
+    @Test
+    void createContractRejectsLaterAssignmentWhenExistingUnlimitedContractIsOpen() throws Exception {
+        UUID otherBikeId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        seedBike(otherBikeId, "서울B-2002", "VIN-CONTRACT-002", null);
+        seedContract(UUID.fromString("33333333-3333-3333-3333-333333333333"), RIDER_ID, otherBikeId,
+                SYSTEM_TEMPLATE_ID, CONTRACT_START, null, null, null);
+
+        mockMvc.perform(postContract(RIDER_ID, BIKE_ID, TEMPLATE_ID, Instant.parse("2030-02-01T00:00:00Z")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PERIOD_OVERLAP"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthenticationAndOnlyCreateIsInThisBaseline() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "bikeId":"%s",
+                                  "contractTemplateId":"%s",
+                                  "startAt":"%s"
+                                }
+                                """.formatted(RIDER_ID, BIKE_ID, TEMPLATE_ID, CONTRACT_START)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(put("/api/v1/rider-bike-contracts/{id}", UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(patch("/api/v1/rider-bike-contracts/{id}", UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(delete("/api/v1/rider-bike-contracts/{id}", UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    private org.springframework.test.web.servlet.RequestBuilder postContract(
+            UUID riderId,
+            UUID bikeId,
+            UUID contractTemplateId,
+            Instant startAt
+    ) {
+        return post("/api/v1/rider-bike-contracts")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "riderId":"%s",
+                          "bikeId":"%s",
+                          "contractTemplateId":"%s",
+                          "startAt":"%s"
+                        }
+                        """.formatted(riderId, bikeId, contractTemplateId, startAt));
+    }
+
+    private void seedRider(UUID id, String name, String phoneNumber, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked, deleted_at)
+                values (?, ?, ?, false, %s)
+                """.formatted(deletedAtExpression), id, name, phoneNumber);
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, operation_status, deleted_at)
+                values (?, ?, ?, 'READY', %s)
+                """.formatted(deletedAtExpression), id, plateNumber, vin);
+    }
+
+    private void seedTemplate(UUID id, String name, Integer durationMinutes, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into contract_templates (id, name, duration_minutes, description, enabled, system_template, deleted_at)
+                values (?, ?, ?, 'fixture template', ?, false, %s)
+                """.formatted(deletedAtExpression), id, name, durationMinutes, enabled);
+    }
+
+    private void seedContract(
+            UUID id,
+            UUID riderId,
+            UUID bikeId,
+            UUID templateId,
+            Instant startAt,
+            Instant endAt,
+            Instant terminatedAt,
+            String deletedAtSql
+    ) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (
+                    id, rider_id, bike_id, contract_template_id, start_at, end_at, terminated_at, deleted_at
+                ) values (?, ?, ?, ?, ?, ?, ?, %s)
+                """.formatted(deletedAtExpression),
+                id,
+                riderId,
+                bikeId,
+                templateId,
+                Timestamp.from(startAt),
+                endAt == null ? null : Timestamp.from(endAt),
+                terminatedAt == null ? null : Timestamp.from(terminatedAt)
+        );
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -215,3 +215,29 @@ Boundary decision:
 - Seeded system templates such as `무제한 계약` are protected from update, disable, and delete.
 - Duplicate active names are blocked by service precheck plus the database partial unique index.
 - Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, and contract-template commands at this stage.
+
+## Rider-bike contract assignment / overlap baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#57
+- Target issue: EVNSolution/thundercrew-domain#26
+- Branch: `cc-57-rider-bike-contract-command`
+
+Issue-size decision:
+
+- This slice adds only create-time rider-bike contract assignment because the contract is the rider-bike relationship source of truth.
+- Included operation is authenticated `POST /api/v1/rider-bike-contracts` with selected rider, bike, contract-template references, `startAt`, and optional memo.
+- Contract update/reassignment, termination, delete/soft-delete, billing, e-signature, documents, rider app integration, frontend selectors, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- UI must not expose raw ID text inputs, but this backend command accepts UUID references produced by selector/search choices.
+- `endAt` is derived from the selected contract template: fixed `durationMinutes` adds minutes to `startAt`; `durationMinutes = null` keeps an open-ended contract.
+- Contract status remains computed from period and termination data; no stored status enum is introduced in this slice.
+- Rider and bike references are validated by service-layer table checks rather than DB foreign keys, preserving the no cross-domain FK policy.
+- Contract template references are validated as existing, not soft-deleted, and enabled.
+- Overlap uses half-open intervals `[startAt, endAt)`: adjacent reservations are valid, but overlapping non-deleted and non-terminated contracts are rejected for both rider and bike.
+- Open-ended contracts use the same overlap rule with an operational far-future bound, so they block later assignments until a future termination lifecycle issue exists.
+- Concurrency strategy is deterministic PostgreSQL advisory transaction locks on the rider/bike assignment keys before overlap checks and insert; exclusion constraints are deferred.
+- Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, contract-template commands, and rider-bike contract create at this stage.

--- a/docs/backend/04-open-questions.md
+++ b/docs/backend/04-open-questions.md
@@ -11,7 +11,6 @@
 7. Initial Flyway migration granularity and whether to use PostgreSQL extensions such as `pgcrypto`.
 8. Whether root `WORKSPACE.md` and `repo-map.md` should be introduced before or with scaffold.
 9. Existing frontend relocation plan: keep current app structure for now or move under `development/front-admin-web` in a separate PR.
-10. Implementation strategy for contract overlap under concurrency: service lock only, PostgreSQL advisory lock, or exclusion constraint.
 
 ## Resolved in this design branch
 
@@ -25,6 +24,7 @@
 8. `duration_minutes = null` is the unlimited/open-ended contract template signal.
 9. Station `current_battery_count` and `available_battery_count` are stored operator-managed data; logs are audit.
 10. Telemetry current state updates only when incoming telemetry is newer.
+11. Contract overlap concurrency uses deterministic PostgreSQL advisory transaction locks on rider/bike assignment keys plus service overlap queries; PostgreSQL exclusion constraints are deferred.
 
 ## Can resolve during implementation
 


### PR DESCRIPTION
## Summary
- Add create-only `POST /api/v1/rider-bike-contracts` command baseline for rider-bike assignment.
- Derive contract `endAt` from the selected contract template duration; keep `endAt = null` for unlimited templates.
- Validate rider, bike, and contract template references in the service layer while preserving no cross-domain FK policy.
- Reject overlapping non-deleted/non-terminated rider or bike intervals using half-open interval rules and deterministic PostgreSQL advisory transaction locks.
- Update command/read architecture gates, backend change ledger, and open-question resolution.

## Traceability
- Change-control anchor: EVNSolution/clever-change-control#57
- Target issue: EVNSolution/thundercrew-domain#26
- Branch: `cc-57-rider-bike-contract-command`

## Concurrent work gate
Decision: `allowed-with-non-overlap`

Evidence:
- Target repo open PRs before PR creation: none.
- Target repo open issues affecting this repo before PR creation: EVNSolution/thundercrew-domain#26 only.
- Target remote branches before PR creation: `main`, `dev`, `cc-57-rider-bike-contract-command`.

Non-overlap reason:
- This PR is limited to create-only rider-bike contract assignment / overlap baseline in `service-ops-api`.
- Device installation, equipment commands, frontend, telemetry, deployment, billing/e-signature, and broader contract lifecycle remain outside this branch.

## Validation
- `git diff --check`
- `cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.RiderBikeContractCommandApiContractTests --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew test --rerun-tasks --no-daemon`
- `cd development/service-ops-api && ./gradlew build --rerun-tasks --no-daemon`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review notes
- Architect subagent scoped this issue to create-only assignment + overlap/concurrency baseline.
- Code-reviewer subagent approved with no blocking findings.
