### PR TITLE
service-ops-api device registry command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,7 +4,7 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold, non-telemetry core persistence baseline, read-only API/DTO contract baseline, admin JWT login/access-token baseline, and first rider write-command slice:
+This module currently provides the backend scaffold, non-telemetry core persistence baseline, read-only API/DTO contract baseline, admin JWT login/access-token baseline, and initial operation command slices:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -37,19 +37,33 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `POST /api/v1/riders`
   - `PATCH /api/v1/riders/{id}`
   - `DELETE /api/v1/riders/{id}`
+- Bike command endpoints:
+  - `POST /api/v1/bikes`
+  - `PATCH /api/v1/bikes/{id}`
+  - `PATCH /api/v1/bikes/{id}/operation-status`
+  - `DELETE /api/v1/bikes/{id}`
+- Contract command endpoints:
+  - `POST /api/v1/contract-templates`
+  - `PATCH /api/v1/contract-templates/{id}`
+  - `DELETE /api/v1/contract-templates/{id}`
+  - `POST /api/v1/rider-bike-contracts`
+- Device registry command endpoints:
+  - `POST /api/v1/devices`
+  - `PATCH /api/v1/devices/{id}`
+  - `DELETE /api/v1/devices/{id}`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
 
 Out of scope for the current backend baseline:
 
-- Create/update/delete command endpoints and request DTOs outside the rider basic profile slice
+- Create/update/delete command endpoints and request DTOs outside delivered command slices
+- Bike-device installation create/replace/remove command endpoints
 - computed business DTOs that depend on telemetry, dashboard, map, or multi-table/time logic
 - telemetry tables and ingestion write paths
 - refresh token, logout/revocation, password reset, RBAC expansion, or admin-management UI
 - frontend relocation
 - TimescaleDB setup
-- contract overlap locking implementation
 - integrity scan/repair job
 
 ## Local environment
@@ -95,6 +109,19 @@ curl -X POST http://localhost:8080/api/v1/riders \
 
 Duplicate active phone numbers return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted phone numbers may be reused. Rider deletion is a soft delete and returns `409 INVALID_STATE_TRANSITION` when active bike-contract or rider-insurance references still exist.
 
+## Device registry command API
+
+The device registry slice is limited to operator-managed registry fields. The server owns IDs, display sequence, audit columns, deleted state, installation relationships, and telemetry/system state. Clients should present human-readable device UID choices rather than asking operators to type raw database IDs.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"deviceUid":"DEV-SEOUL-001","manufacturer":"ThunderDevice","modelName":"TD-100","enabled":true}'
+```
+
+Duplicate active device UIDs return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted UIDs may be reused. Device deletion is a soft delete and returns `409 INVALID_STATE_TRANSITION` when an active bike-device installation still references the device.
+
 ## Auth API
 
 Login with a seeded/enabled admin user:
@@ -126,7 +153,8 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Create/update/delete service/controller slices for bike, contract, insurance, equipment, device, and station resources
+- Create/update/delete service/controller slices for insurance, equipment, and station resources
+- Bike-device installation create/replace/remove command API
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/DeviceCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/DeviceCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.device.controller;
+
+import com.thundercrew.opsapi.device.dto.DeviceCreateRequest;
+import com.thundercrew.opsapi.device.dto.DeviceReadResponse;
+import com.thundercrew.opsapi.device.dto.DeviceUpdateRequest;
+import com.thundercrew.opsapi.device.service.DeviceCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/devices")
+public class DeviceCommandController {
+
+    private final DeviceCommandService deviceCommandService;
+
+    public DeviceCommandController(DeviceCommandService deviceCommandService) {
+        this.deviceCommandService = deviceCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<DeviceReadResponse> create(@Valid @RequestBody DeviceCreateRequest request) {
+        DeviceReadResponse response = deviceCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/devices/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    DeviceReadResponse update(@PathVariable UUID id, @Valid @RequestBody DeviceUpdateRequest request) {
+        return deviceCommandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        deviceCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/Device.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "devices")
@@ -23,6 +25,50 @@ public class Device extends DisplaySequencedEntity {
 
     private String memo;
 
+    public static Device create(
+            String deviceUid,
+            String manufacturer,
+            String modelName,
+            Boolean enabled,
+            String memo
+    ) {
+        Device device = new Device();
+        device.deviceUid = deviceUid;
+        device.manufacturer = manufacturer;
+        device.modelName = modelName;
+        device.enabled = enabled == null || enabled;
+        device.memo = memo;
+        return device;
+    }
+
+    public void updateOperatorManagedFields(
+            String deviceUid,
+            String manufacturer,
+            String modelName,
+            Boolean enabled,
+            String memo
+    ) {
+        if (deviceUid != null) {
+            this.deviceUid = deviceUid;
+        }
+        if (manufacturer != null) {
+            this.manufacturer = manufacturer;
+        }
+        if (modelName != null) {
+            this.modelName = modelName;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public void disableAndMarkDeleted(UUID actorId, Instant deletedAt) {
+        this.enabled = false;
+        markDeleted(actorId, deletedAt);
+    }
 
     public String getDeviceUid() {
         return deviceUid;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceCreateRequest.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeviceCreateRequest(
+        @NotBlank @Size(max = 100) String deviceUid,
+        @Size(max = 100) String manufacturer,
+        @Size(max = 100) String modelName,
+        Boolean enabled,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/DeviceUpdateRequest.java
@@ -1,0 +1,63 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeviceUpdateRequest {
+
+    @Size(max = 100)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String deviceUid;
+
+    @Size(max = 100)
+    private String manufacturer;
+
+    @Size(max = 100)
+    private String modelName;
+
+    private Boolean enabled;
+
+    private String memo;
+
+    public String deviceUid() {
+        return deviceUid;
+    }
+
+    public void setDeviceUid(String deviceUid) {
+        this.deviceUid = deviceUid;
+    }
+
+    public String manufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public Boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String memo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
@@ -12,4 +12,6 @@ public interface BikeDeviceInstallationRepository extends Repository<BikeDeviceI
     Page<BikeDeviceInstallation> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<BikeDeviceInstallation> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID deviceId);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
@@ -12,4 +12,10 @@ public interface DeviceRepository extends Repository<Device, UUID> {
     Page<Device> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<Device> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByDeviceUidAndDeletedAtIsNull(String deviceUid);
+
+    boolean existsByDeviceUidAndIdNotAndDeletedAtIsNull(String deviceUid, UUID id);
+
+    Device save(Device device);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/DeviceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/DeviceCommandService.java
@@ -1,0 +1,98 @@
+package com.thundercrew.opsapi.device.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.device.domain.Device;
+import com.thundercrew.opsapi.device.dto.DeviceCreateRequest;
+import com.thundercrew.opsapi.device.dto.DeviceReadResponse;
+import com.thundercrew.opsapi.device.dto.DeviceUpdateRequest;
+import com.thundercrew.opsapi.device.repository.BikeDeviceInstallationRepository;
+import com.thundercrew.opsapi.device.repository.DeviceRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class DeviceCommandService {
+
+    private final DeviceRepository deviceRepository;
+    private final BikeDeviceInstallationRepository installationRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public DeviceCommandService(
+            DeviceRepository deviceRepository,
+            BikeDeviceInstallationRepository installationRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.deviceRepository = deviceRepository;
+        this.installationRepository = installationRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public DeviceReadResponse create(DeviceCreateRequest request) {
+        assertDeviceUidIsNotDuplicated(request.deviceUid());
+        Device device = Device.create(
+                request.deviceUid(),
+                request.manufacturer(),
+                request.modelName(),
+                request.enabled(),
+                request.memo()
+        );
+        try {
+            Device saved = deviceRepository.save(device);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return DeviceReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("Device", "deviceUid");
+        }
+    }
+
+    @Transactional
+    public DeviceReadResponse update(UUID id, DeviceUpdateRequest request) {
+        Device device = deviceRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Device", id));
+        if (StringUtils.hasText(request.deviceUid())
+                && deviceRepository.existsByDeviceUidAndIdNotAndDeletedAtIsNull(request.deviceUid(), id)) {
+            throw new DuplicateActiveResourceException("Device", "deviceUid");
+        }
+        try {
+            device.updateOperatorManagedFields(
+                    request.deviceUid(),
+                    request.manufacturer(),
+                    request.modelName(),
+                    request.enabled(),
+                    request.memo()
+            );
+            entityManager.flush();
+            return DeviceReadResponse.from(device);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("Device", "deviceUid");
+        }
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        Device device = deviceRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Device", id));
+        if (installationRepository.existsByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(id)) {
+            throw new InvalidStateTransitionException("Device cannot be deleted while it has an active bike installation.");
+        }
+        device.disableAndMarkDeleted(null, clock.instant());
+    }
+
+    private void assertDeviceUidIsNotDuplicated(String deviceUid) {
+        if (deviceRepository.existsByDeviceUidAndDeletedAtIsNull(deviceUid)) {
+            throw new DuplicateActiveResourceException("Device", "deviceUid");
+        }
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -77,7 +77,8 @@ class ArchitectureBoundaryTests {
                         || isRiderCommand(method)
                         || isBikeCommand(method)
                         || isContractTemplateCommand(method)
-                        || isRiderBikeContractCommand(method)) {
+                        || isRiderBikeContractCommand(method)
+                        || isDeviceCommand(method)) {
                     return;
                 }
 
@@ -103,7 +104,8 @@ class ArchitectureBoundaryTests {
                         && !isRiderCommand(method)
                         && !isBikeCommand(method)
                         && !isContractTemplateCommand(method)
-                        && !isRiderBikeContractCommand(method)) {
+                        && !isRiderBikeContractCommand(method)
+                        && !isDeviceCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -143,6 +145,13 @@ class ArchitectureBoundaryTests {
     private static boolean isRiderBikeContractCommand(JavaMethod method) {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.contract.controller.RiderBikeContractCommandController")
                 && method.getName().equals("create");
+    }
+
+    private static boolean isDeviceCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.device.controller.DeviceCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("delete"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeviceCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeviceCommandApiContractTests.java
@@ -1,0 +1,329 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DeviceCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID DEVICE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_device_installations");
+        jdbcTemplate.update("delete from devices");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createDeviceGeneratesIdentifiersAndIgnoresClientSuppliedSystemAndRelationshipFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/devices")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "deviceUid":"DEV-CREATE-001",
+                                  "manufacturer":"ThunderDevice",
+                                  "modelName":"TD-100",
+                                  "enabled":true,
+                                  "memo":"초기 단말 등록",
+                                  "bikeId":"11111111-1111-1111-1111-111111111111",
+                                  "installationId":"22222222-2222-2222-2222-222222222222",
+                                  "telemetryStatus":"ONLINE",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/devices/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.deviceUid").value("DEV-CREATE-001"))
+                .andExpect(jsonPath("$.manufacturer").value("ThunderDevice"))
+                .andExpect(jsonPath("$.modelName").value("TD-100"))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.memo").value("초기 단말 등록"))
+                .andReturn();
+
+        String createdId = extractId(result);
+        mockMvc.perform(get("/api/v1/devices/{id}", createdId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deviceUid").value("DEV-CREATE-001"));
+    }
+
+    @Test
+    void createDeviceRejectsMissingHumanRequiredFields() throws Exception {
+        mockMvc.perform(post("/api/v1/devices")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void createDeviceRejectsDuplicateActiveDeviceUid() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-DUP-001", "ThunderDevice", "TD-100", true, null);
+
+        mockMvc.perform(post("/api/v1/devices")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":"DEV-DUP-001","manufacturer":"Other"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateDeviceChangesOnlyOperatorManagedFieldsAndIgnoresRelationshipFields() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-UPDATE-001", "ThunderDevice", "TD-100", true, null);
+
+        mockMvc.perform(patch("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "idx":999,
+                                  "deviceUid":"DEV-UPDATE-002",
+                                  "manufacturer":"UpdatedMaker",
+                                  "modelName":"TD-200",
+                                  "enabled":false,
+                                  "memo":"단말 정보 수정",
+                                  "bikeId":"11111111-1111-1111-1111-111111111111",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.deviceUid").value("DEV-UPDATE-002"))
+                .andExpect(jsonPath("$.manufacturer").value("UpdatedMaker"))
+                .andExpect(jsonPath("$.modelName").value("TD-200"))
+                .andExpect(jsonPath("$.enabled").value(false))
+                .andExpect(jsonPath("$.memo").value("단말 정보 수정"));
+    }
+
+    @Test
+    void updateDeviceRejectsMissingOrDuplicateTargets() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-UPDATE-001", "ThunderDevice", "TD-100", true, null);
+        UUID otherId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        seedDevice(otherId, "DEV-UPDATE-002", "ThunderDevice", "TD-100", true, null);
+
+        UUID missingId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        mockMvc.perform(patch("/api/v1/devices/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":"DEV-MISSING-001"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":"DEV-UPDATE-002"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void deleteDeviceSoftDeletesAndAllowsDeviceUidReuse() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-DELETE-001", "ThunderDevice", "TD-100", true, null);
+
+        mockMvc.perform(delete("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        Boolean enabled = jdbcTemplate.queryForObject(
+                "select enabled from devices where id = ?",
+                Boolean.class,
+                DEVICE_ID
+        );
+        assertThat(enabled).isFalse();
+
+        mockMvc.perform(get("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(post("/api/v1/devices")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":"DEV-DELETE-001","manufacturer":"ReusedMaker"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceUid").value("DEV-DELETE-001"))
+                .andExpect(jsonPath("$.manufacturer").value("ReusedMaker"));
+    }
+
+    @Test
+    void deleteDeviceAllowsRemovedInstallationHistory() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-REMOVED-INSTALL-001", "ThunderDevice", "TD-100", true, null);
+        UUID bikeId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, '서울D-2002', 'VIN-DEVICE-REMOVED-001', 'Thunder M1', 'READY')
+                """, bikeId);
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at, removed_at)
+                values (?, ?, ?, now() - interval '1 day', now())
+                """, UUID.fromString("22222222-2222-2222-2222-222222222222"), bikeId, DEVICE_ID);
+
+        mockMvc.perform(delete("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteDeviceRejectsActiveBikeInstallationReferences() throws Exception {
+        seedDevice(DEVICE_ID, "DEV-INSTALLED-001", "ThunderDevice", "TD-100", true, null);
+        UUID bikeId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, '서울D-1001', 'VIN-DEVICE-REF-001', 'Thunder M1', 'READY')
+                """, bikeId);
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at)
+                values (?, ?, ?, now())
+                """, UUID.fromString("22222222-2222-2222-2222-222222222222"), bikeId, DEVICE_ID);
+
+        mockMvc.perform(delete("/api/v1/devices/{id}", DEVICE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        Integer activeDeviceCount = jdbcTemplate.queryForObject("""
+                select count(*) from devices where id = ? and deleted_at is null
+                """, Integer.class, DEVICE_ID);
+        assertThat(activeDeviceCount).isEqualTo(1);
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"deviceUid":"DEV-NO-AUTH-001"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/devices/{id}", DEVICE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"manufacturer":"NoAuth"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(delete("/api/v1/devices/{id}", DEVICE_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedDevice(
+            UUID id,
+            String deviceUid,
+            String manufacturer,
+            String modelName,
+            boolean enabled,
+            String deletedAtSql
+    ) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled, memo, deleted_at)
+                values (?, ?, ?, ?, ?, 'fixture device', %s)
+                """.formatted(deletedAtExpression), id, deviceUid, manufacturer, modelName, enabled);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -238,7 +238,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
                 "/api/v1/rider-insurances",
                 "/api/v1/equipment-types",
                 "/api/v1/bike-equipments",
-                "/api/v1/devices",
                 "/api/v1/bike-device-installations",
                 "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -241,3 +241,26 @@ Boundary decision:
 - Open-ended contracts use the same overlap rule with an operational far-future bound, so they block later assignments until a future termination lifecycle issue exists.
 - Concurrency strategy is deterministic PostgreSQL advisory transaction locks on the rider/bike assignment keys before overlap checks and insert; exclusion constraints are deferred.
 - Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, contract-template commands, and rider-bike contract create at this stage.
+
+## Device registry command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#58
+- Target issue: EVNSolution/thundercrew-domain#28
+- Branch: `cc-58-device-registry-command`
+
+Issue-size decision:
+
+- This slice adds only the Device registry command baseline before bike-device installation commands.
+- Included operations are authenticated `POST /api/v1/devices`, `PATCH /api/v1/devices/{id}`, and `DELETE /api/v1/devices/{id}` as soft-delete.
+- Bike-device installation create/replace/remove, telemetry ingestion/current state, device API sync logs, dashboard/map APIs, frontend selectors, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only operator-managed registry fields: `deviceUid`, `manufacturer`, `modelName`, `enabled`, and `memo`.
+- Server-generated id, idx, audit/deleted fields, relationship fields such as bike/installation IDs, and telemetry/system fields remain non-client inputs and are ignored when sent.
+- `deviceUid` is the device-supplied business identifier and is unique among active, non-deleted devices.
+- Soft-deleted device UIDs may be reused through the existing active partial unique index.
+- Device soft-delete disables the device and blocks deletion while an active `bike_device_installations` row references it.
+- Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, contract-template commands, rider-bike contract create, and device registry commands at this stage.


### PR DESCRIPTION
## Summary

- Add authenticated service-ops-api device registry command endpoints: `POST/PATCH/DELETE /api/v1/devices`.
- Keep request inputs to operator-managed fields only: `deviceUid`, `manufacturer`, `modelName`, `enabled`, `memo`.
- Enforce active `deviceUid` uniqueness, soft-delete with `enabled=false`, reuse after soft-delete, and active installation delete guard.
- Update API boundary/architecture tests and backend docs for the new command slice.

## Trace

- Change-control issue: EVNSolution/clever-change-control#58
- Target issue: EVNSolution/thundercrew-domain#28
- Root project-start: EVNSolution/clever-change-control#45
- Branch: `cc-58-device-registry-command`

## Concurrent work decision

`allowed-with-non-overlap`

Evidence checked before implementation and again before this PR:
- No open PRs in EVNSolution/thundercrew-domain.
- Open target issue scope is this device registry issue only.
- Remote branches are `main`, `dev`, and this task branch.
- Other open clever-change-control issues are unrelated historical/control-plane scopes.

Non-overlap reason: this PR only touches service-ops-api device registry commands/docs/tests and explicitly excludes bike-device installation lifecycle, telemetry/current-state, dashboard/map APIs, and frontend work.

## Validation

- `git diff --check`
- `(cd development/service-ops-api && ./gradlew test --tests '*DeviceCommandApiContractTests')`
- `(cd development/service-ops-api && ./gradlew test --tests '*DeviceCommandApiContractTests' --tests '*ReadOnlyApiContractTests' --tests '*ArchitectureBoundaryTests')`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review

- Subagent code-reviewer PASS; non-blocking suggestions were applied by adding delete-disabled and removed-installation-history tests.
