### PR TITLE
service-ops-api bike-device installation command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -51,6 +51,9 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `POST /api/v1/devices`
   - `PATCH /api/v1/devices/{id}`
   - `DELETE /api/v1/devices/{id}`
+- Bike-device installation command endpoints:
+  - `POST /api/v1/bike-device-installations`
+  - `PATCH /api/v1/bike-device-installations/{id}/remove`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -58,7 +61,6 @@ This module currently provides the backend scaffold, non-telemetry core persiste
 Out of scope for the current backend baseline:
 
 - Create/update/delete command endpoints and request DTOs outside delivered command slices
-- Bike-device installation create/replace/remove command endpoints
 - computed business DTOs that depend on telemetry, dashboard, map, or multi-table/time logic
 - telemetry tables and ingestion write paths
 - refresh token, logout/revocation, password reset, RBAC expansion, or admin-management UI
@@ -122,6 +124,26 @@ curl -X POST http://localhost:8080/api/v1/devices \
 
 Duplicate active device UIDs return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted UIDs may be reused. Device deletion is a soft delete and returns `409 INVALID_STATE_TRANSITION` when an active bike-device installation still references the device.
 
+## Bike-device installation command API
+
+The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/bike-device-installations \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"bikeId":"<selected-bike-id>","deviceId":"<selected-device-id>","installedAt":"2026-04-30T00:00:00Z","memo":"차량 단말 설치"}'
+```
+
+Installing closes any previous active row for the selected bike and/or selected device, then inserts the new active row in the same transaction. Disabled/deleted/missing devices and deleted/missing bikes are rejected. Removal preserves history by setting `removedAt`:
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/bike-device-installations/<installation-id>/remove \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"removedAt":"2026-05-01T00:00:00Z","memo":"현장 탈거"}'
+```
+
 ## Auth API
 
 Login with a seeded/enabled admin user:
@@ -154,7 +176,6 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 ## Follow-up implementation issues
 
 - Create/update/delete service/controller slices for insurance, equipment, and station resources
-- Bike-device installation create/replace/remove command API
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
@@ -13,6 +13,8 @@ public interface BikeRepository extends Repository<Bike, UUID> {
 
     Page<Bike> findByDeletedAtIsNull(Pageable pageable);
 
+    boolean existsById(UUID id);
+
     Optional<Bike> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByPlateNumberAndDeletedAtIsNull(String plateNumber);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/BikeDeviceInstallationCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/controller/BikeDeviceInstallationCommandController.java
@@ -1,0 +1,42 @@
+package com.thundercrew.opsapi.device.controller;
+
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationCreateRequest;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationReadResponse;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationRemoveRequest;
+import com.thundercrew.opsapi.device.service.BikeDeviceInstallationCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/bike-device-installations")
+public class BikeDeviceInstallationCommandController {
+
+    private final BikeDeviceInstallationCommandService commandService;
+
+    public BikeDeviceInstallationCommandController(BikeDeviceInstallationCommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    @PostMapping
+    ResponseEntity<BikeDeviceInstallationReadResponse> create(@Valid @RequestBody BikeDeviceInstallationCreateRequest request) {
+        BikeDeviceInstallationReadResponse response = commandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/bike-device-installations/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}/remove")
+    BikeDeviceInstallationReadResponse remove(
+            @PathVariable UUID id,
+            @Valid @RequestBody(required = false) BikeDeviceInstallationRemoveRequest request
+    ) {
+        return commandService.remove(id, request == null ? new BikeDeviceInstallationRemoveRequest(null, null) : request);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/domain/BikeDeviceInstallation.java
@@ -24,6 +24,26 @@ public class BikeDeviceInstallation extends DisplaySequencedEntity {
 
     private String memo;
 
+    public static BikeDeviceInstallation create(
+            UUID bikeId,
+            UUID deviceId,
+            Instant installedAt,
+            String memo
+    ) {
+        BikeDeviceInstallation installation = new BikeDeviceInstallation();
+        installation.bikeId = bikeId;
+        installation.deviceId = deviceId;
+        installation.installedAt = installedAt;
+        installation.memo = memo;
+        return installation;
+    }
+
+    public void remove(Instant removedAt, String memo) {
+        this.removedAt = removedAt;
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
 
     public java.util.UUID getBikeId() {
         return bikeId;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationCreateRequest.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeDeviceInstallationCreateRequest(
+        @NotNull UUID bikeId,
+        @NotNull UUID deviceId,
+        @NotNull Instant installedAt,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationRemoveRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/dto/BikeDeviceInstallationRemoveRequest.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.device.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeDeviceInstallationRemoveRequest(
+        Instant removedAt,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
@@ -14,4 +14,10 @@ public interface BikeDeviceInstallationRepository extends Repository<BikeDeviceI
     Optional<BikeDeviceInstallation> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID deviceId);
+
+    Optional<BikeDeviceInstallation> findByBikeIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID bikeId);
+
+    Optional<BikeDeviceInstallation> findByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID deviceId);
+
+    BikeDeviceInstallation save(BikeDeviceInstallation installation);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
@@ -11,6 +11,8 @@ public interface DeviceRepository extends Repository<Device, UUID> {
 
     Page<Device> findByDeletedAtIsNull(Pageable pageable);
 
+    Optional<Device> findById(UUID id);
+
     Optional<Device> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByDeviceUidAndDeletedAtIsNull(String deviceUid);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/BikeDeviceInstallationCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/service/BikeDeviceInstallationCommandService.java
@@ -1,0 +1,140 @@
+package com.thundercrew.opsapi.device.service;
+
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ReferenceDeletedException;
+import com.thundercrew.opsapi.common.api.ReferenceNotFoundException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.device.domain.BikeDeviceInstallation;
+import com.thundercrew.opsapi.device.domain.Device;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationCreateRequest;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationReadResponse;
+import com.thundercrew.opsapi.device.dto.BikeDeviceInstallationRemoveRequest;
+import com.thundercrew.opsapi.device.repository.BikeDeviceInstallationRepository;
+import com.thundercrew.opsapi.device.repository.DeviceRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BikeDeviceInstallationCommandService {
+
+    private final BikeDeviceInstallationRepository installationRepository;
+    private final BikeRepository bikeRepository;
+    private final DeviceRepository deviceRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public BikeDeviceInstallationCommandService(
+            BikeDeviceInstallationRepository installationRepository,
+            BikeRepository bikeRepository,
+            DeviceRepository deviceRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.installationRepository = installationRepository;
+        this.bikeRepository = bikeRepository;
+        this.deviceRepository = deviceRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public BikeDeviceInstallationReadResponse create(BikeDeviceInstallationCreateRequest request) {
+        assertActiveBikeReference(request.bikeId());
+        Device device = findEnabledDeviceReference(request.deviceId());
+        lockInstallationReferences(request.bikeId(), request.deviceId());
+        closeConflictingActiveInstallations(request.bikeId(), device.getId(), request.installedAt());
+
+        BikeDeviceInstallation installation = BikeDeviceInstallation.create(
+                request.bikeId(),
+                request.deviceId(),
+                request.installedAt(),
+                request.memo()
+        );
+        BikeDeviceInstallation saved = installationRepository.save(installation);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return BikeDeviceInstallationReadResponse.from(saved);
+    }
+
+    @Transactional
+    public BikeDeviceInstallationReadResponse remove(UUID id, BikeDeviceInstallationRemoveRequest request) {
+        BikeDeviceInstallation installation = installationRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeDeviceInstallation", id));
+        if (installation.getRemovedAt() != null) {
+            throw new InvalidStateTransitionException("Bike-device installation is already removed.");
+        }
+        Instant removedAt = request.removedAt() == null ? Instant.now(clock) : request.removedAt();
+        assertRemovalTimeIsValid(installation, removedAt);
+        installation.remove(removedAt, request.memo());
+        entityManager.flush();
+        return BikeDeviceInstallationReadResponse.from(installation);
+    }
+
+    private void assertActiveBikeReference(UUID bikeId) {
+        if (bikeRepository.findByIdAndDeletedAtIsNull(bikeId).isPresent()) {
+            return;
+        }
+        if (bikeRepository.existsById(bikeId)) {
+            throw new ReferenceDeletedException("Bike", bikeId);
+        }
+        throw new ReferenceNotFoundException("Bike", bikeId);
+    }
+
+    private Device findEnabledDeviceReference(UUID deviceId) {
+        Device device = deviceRepository.findById(deviceId)
+                .orElseThrow(() -> new ReferenceNotFoundException("Device", deviceId));
+        if (device.isDeleted()) {
+            throw new ReferenceDeletedException("Device", deviceId);
+        }
+        if (!device.isEnabled()) {
+            throw new InvalidStateTransitionException("Device is disabled and cannot be installed.");
+        }
+        return device;
+    }
+
+    private void closeConflictingActiveInstallations(UUID bikeId, UUID deviceId, Instant replacementInstalledAt) {
+        Map<UUID, BikeDeviceInstallation> installationsById = new LinkedHashMap<>();
+        installationRepository.findByBikeIdAndRemovedAtIsNullAndDeletedAtIsNull(bikeId)
+                .ifPresent(installation -> installationsById.put(installation.getId(), installation));
+        installationRepository.findByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(deviceId)
+                .ifPresent(installation -> installationsById.put(installation.getId(), installation));
+
+        installationsById.values().forEach(installation -> {
+            assertRemovalTimeIsValid(installation, replacementInstalledAt);
+            installation.remove(replacementInstalledAt, installation.getMemo());
+        });
+        if (!installationsById.isEmpty()) {
+            entityManager.flush();
+        }
+    }
+
+    private void assertRemovalTimeIsValid(BikeDeviceInstallation installation, Instant removedAt) {
+        if (removedAt.isBefore(installation.getInstalledAt())) {
+            throw new InvalidStateTransitionException("Bike-device installation removal time cannot be before installed time.");
+        }
+    }
+
+    private void lockInstallationReferences(UUID bikeId, UUID deviceId) {
+        List.of(
+                        "bike-device-installation:bike:" + bikeId,
+                        "bike-device-installation:device:" + deviceId
+                )
+                .stream()
+                .sorted()
+                .forEach(this::lockByKey);
+    }
+
+    private void lockByKey(String lockKey) {
+        entityManager.createNativeQuery("select pg_advisory_xact_lock(hashtextextended(?1, 0))")
+                .setParameter(1, lockKey)
+                .getSingleResult();
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -78,7 +78,8 @@ class ArchitectureBoundaryTests {
                         || isBikeCommand(method)
                         || isContractTemplateCommand(method)
                         || isRiderBikeContractCommand(method)
-                        || isDeviceCommand(method)) {
+                        || isDeviceCommand(method)
+                        || isBikeDeviceInstallationCommand(method)) {
                     return;
                 }
 
@@ -105,7 +106,8 @@ class ArchitectureBoundaryTests {
                         && !isBikeCommand(method)
                         && !isContractTemplateCommand(method)
                         && !isRiderBikeContractCommand(method)
-                        && !isDeviceCommand(method)) {
+                        && !isDeviceCommand(method)
+                        && !isBikeDeviceInstallationCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -152,6 +154,12 @@ class ArchitectureBoundaryTests {
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isBikeDeviceInstallationCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.device.controller.BikeDeviceInstallationCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("remove"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeDeviceInstallationCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeDeviceInstallationCommandApiContractTests.java
@@ -1,0 +1,385 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BikeDeviceInstallationCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID DEVICE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID INSTALLATION_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final String INSTALLED_AT = "2026-04-30T00:00:00Z";
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_device_installations");
+        jdbcTemplate.update("delete from devices");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void installDeviceGeneratesIdentifiersAndIgnoresClientSuppliedSystemFields() throws Exception {
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(DEVICE_ID, "DEV-INSTALL-001", true, null);
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/bike-device-installations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "bikeId":"%s",
+                                  "deviceId":"%s",
+                                  "installedAt":"%s",
+                                  "removedAt":"2026-05-01T00:00:00Z",
+                                  "memo":"차량 단말 설치",
+                                  "deviceUid":"IGNORED-UID",
+                                  "telemetryStatus":"ONLINE",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId, BIKE_ID, DEVICE_ID, INSTALLED_AT)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/bike-device-installations/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.deviceId").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.installedAt").value(INSTALLED_AT))
+                .andExpect(jsonPath("$.removedAt").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.memo").value("차량 단말 설치"))
+                .andReturn();
+
+        String createdId = extractId(result);
+        mockMvc.perform(get("/api/v1/bike-device-installations/{id}", createdId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()));
+    }
+
+    @Test
+    void installDeviceRejectsMissingRequiredFields() throws Exception {
+        mockMvc.perform(post("/api/v1/bike-device-installations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void installDeviceRejectsMissingDeletedOrDisabledReferences() throws Exception {
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(DEVICE_ID, "DEV-INSTALL-001", true, null);
+
+        UUID missingBikeId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockMvc.perform(postInstall(missingBikeId, DEVICE_ID, INSTALLED_AT))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+
+        UUID deletedBikeId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        seedBike(deletedBikeId, "서울I-2002", "VIN-INSTALL-002", "now()");
+        mockMvc.perform(postInstall(deletedBikeId, DEVICE_ID, INSTALLED_AT))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        UUID missingDeviceId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        mockMvc.perform(postInstall(BIKE_ID, missingDeviceId, INSTALLED_AT))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+
+        UUID deletedDeviceId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        seedDevice(deletedDeviceId, "DEV-INSTALL-DELETED", true, "now()");
+        mockMvc.perform(postInstall(BIKE_ID, deletedDeviceId, INSTALLED_AT))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        UUID disabledDeviceId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        seedDevice(disabledDeviceId, "DEV-INSTALL-DISABLED", false, null);
+        mockMvc.perform(postInstall(BIKE_ID, disabledDeviceId, INSTALLED_AT))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void installDeviceReplacesActiveBikeAndDeviceInstallationsTransactionally() throws Exception {
+        UUID bikeA = BIKE_ID;
+        UUID bikeB = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID oldDevice = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        UUID newDevice = DEVICE_ID;
+        seedBike(bikeA, "서울I-1001", "VIN-INSTALL-001", null);
+        seedBike(bikeB, "서울I-2002", "VIN-INSTALL-002", null);
+        seedDevice(oldDevice, "DEV-OLD-001", true, null);
+        seedDevice(newDevice, "DEV-NEW-001", true, null);
+        seedInstallation(UUID.fromString("33333333-3333-3333-3333-333333333333"), bikeA, oldDevice, "2026-04-29T00:00:00Z", null, "old bike device", null);
+        seedInstallation(UUID.fromString("44444444-4444-4444-4444-444444444444"), bikeB, newDevice, "2026-04-29T00:00:00Z", null, "old device bike", null);
+
+        mockMvc.perform(postInstall(bikeA, newDevice, INSTALLED_AT))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bikeId").value(bikeA.toString()))
+                .andExpect(jsonPath("$.deviceId").value(newDevice.toString()))
+                .andExpect(jsonPath("$.removedAt").value(org.hamcrest.Matchers.nullValue()));
+
+        Integer activeBikeACount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_device_installations
+                where bike_id = ? and removed_at is null and deleted_at is null
+                """, Integer.class, bikeA);
+        Integer activeNewDeviceCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_device_installations
+                where device_id = ? and removed_at is null and deleted_at is null
+                """, Integer.class, newDevice);
+        Integer closedOldRows = jdbcTemplate.queryForObject("""
+                select count(*) from bike_device_installations
+                where id in ('33333333-3333-3333-3333-333333333333', '44444444-4444-4444-4444-444444444444')
+                  and removed_at = ?::timestamptz
+                  and deleted_at is null
+                """, Integer.class, INSTALLED_AT);
+
+        assertThat(activeBikeACount).isEqualTo(1);
+        assertThat(activeNewDeviceCount).isEqualTo(1);
+        assertThat(closedOldRows).isEqualTo(2);
+    }
+
+    @Test
+    void installDeviceLeavesExistingInstallationOpenWhenReplacementDeviceIsDisabled() throws Exception {
+        UUID oldDevice = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        UUID disabledDevice = DEVICE_ID;
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(oldDevice, "DEV-OLD-001", true, null);
+        seedDevice(disabledDevice, "DEV-DISABLED-001", false, null);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, oldDevice, "2026-04-29T00:00:00Z", null, "old active", null);
+
+        mockMvc.perform(postInstall(BIKE_ID, disabledDevice, INSTALLED_AT))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        Integer oldActiveCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_device_installations
+                where id = ? and removed_at is null and deleted_at is null
+                """, Integer.class, INSTALLATION_ID);
+        Integer disabledInsertedCount = jdbcTemplate.queryForObject("""
+                select count(*) from bike_device_installations
+                where bike_id = ? and device_id = ?
+                """, Integer.class, BIKE_ID, disabledDevice);
+
+        assertThat(oldActiveCount).isEqualTo(1);
+        assertThat(disabledInsertedCount).isZero();
+    }
+
+    @Test
+    void removeInstallationSetsRemovedAtPreservesHistoryAndAllowsReinstall() throws Exception {
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(DEVICE_ID, "DEV-INSTALL-001", true, null);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, INSTALLED_AT, null, "installed", null);
+        String removedAt = "2026-05-01T00:00:00Z";
+
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", INSTALLATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"removedAt":"%s","memo":"현장 탈거"}
+                                """.formatted(removedAt)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(INSTALLATION_ID.toString()))
+                .andExpect(jsonPath("$.removedAt").value(removedAt))
+                .andExpect(jsonPath("$.memo").value("현장 탈거"));
+
+        mockMvc.perform(get("/api/v1/bike-device-installations/{id}", INSTALLATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.removedAt").value(removedAt));
+
+        mockMvc.perform(postInstall(BIKE_ID, DEVICE_ID, "2026-05-02T00:00:00Z"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.deviceId").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.removedAt").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    void removeInstallationRejectsAlreadyRemovedOrDeletedRows() throws Exception {
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(DEVICE_ID, "DEV-INSTALL-001", true, null);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, INSTALLED_AT, "2026-05-01T00:00:00Z", "removed", null);
+
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", INSTALLATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        UUID deletedInstallationId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        seedInstallation(deletedInstallationId, BIKE_ID, DEVICE_ID, "2026-05-02T00:00:00Z", "2026-05-03T00:00:00Z", "deleted", "now()");
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", deletedInstallationId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void removeInstallationRejectsMissingAndBeforeInstallRemovalTime() throws Exception {
+        UUID missingInstallationId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", missingInstallationId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        seedBike(BIKE_ID, "서울I-1001", "VIN-INSTALL-001", null);
+        seedDevice(DEVICE_ID, "DEV-INSTALL-001", true, null);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, "2026-04-30T00:00:00Z", null, "installed", null);
+
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", INSTALLATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"removedAt":"2026-04-29T00:00:00Z"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/bike-device-installations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}/remove", INSTALLATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private org.springframework.test.web.servlet.RequestBuilder postInstall(
+            UUID bikeId,
+            UUID deviceId,
+            String installedAt
+    ) {
+        return post("/api/v1/bike-device-installations")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"bikeId":"%s","deviceId":"%s","installedAt":"%s","memo":"install"}
+                        """.formatted(bikeId, deviceId, installedAt));
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, deleted_at)
+                values (?, ?, ?, 'Thunder M1', 'READY', %s)
+                """.formatted(deletedAtExpression), id, plateNumber, vin);
+    }
+
+    private void seedDevice(UUID id, String deviceUid, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled, deleted_at)
+                values (?, ?, 'ThunderDevice', 'TD-100', ?, %s)
+                """.formatted(deletedAtExpression), id, deviceUid, enabled);
+    }
+
+    private void seedInstallation(
+            UUID id,
+            UUID bikeId,
+            UUID deviceId,
+            String installedAt,
+            String removedAt,
+            String memo,
+            String deletedAtSql
+    ) {
+        String removedAtExpression = removedAt == null ? "null" : "'%s'::timestamptz".formatted(removedAt);
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at, removed_at, memo, deleted_at)
+                values (?, ?, ?, ?::timestamptz, %s, ?, %s)
+                """.formatted(removedAtExpression, deletedAtExpression), id, bikeId, deviceId, installedAt, memo);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -238,7 +238,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
                 "/api/v1/rider-insurances",
                 "/api/v1/equipment-types",
                 "/api/v1/bike-equipments",
-                "/api/v1/bike-device-installations",
                 "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"
         )) {
@@ -260,6 +259,19 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
             mockMvc.perform(delete(endpoint + "/{id}", id).with(user("ops-admin")))
                     .andExpect(status().isMethodNotAllowed());
         }
+
+        mockMvc.perform(put("/api/v1/bike-device-installations/{id}", id)
+                        .with(user("ops-admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(patch("/api/v1/bike-device-installations/{id}", id)
+                        .with(user("ops-admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(delete("/api/v1/bike-device-installations/{id}", id).with(user("ops-admin")))
+                .andExpect(status().isMethodNotAllowed());
     }
 
     private List<DetailEndpoint> detailEndpoints() {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -264,3 +264,27 @@ Boundary decision:
 - Soft-deleted device UIDs may be reused through the existing active partial unique index.
 - Device soft-delete disables the device and blocks deletion while an active `bike_device_installations` row references it.
 - Architecture tests allow operation write mappings/request bodies only for auth login, rider commands, bike commands, contract-template commands, rider-bike contract create, and device registry commands at this stage.
+
+## Bike-device installation command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#59
+- Target issue: EVNSolution/thundercrew-domain#30
+- Branch: `cc-59-bike-device-installation-command`
+
+Issue-size decision:
+
+- This slice adds only the bike-device installation lifecycle command baseline after the device registry command baseline.
+- Included operations are authenticated `POST /api/v1/bike-device-installations` for install/replace and `PATCH /api/v1/bike-device-installations/{id}/remove` for lifecycle removal.
+- Device registry commands, telemetry ingestion/current state, device API sync logs, dashboard/map APIs, frontend selectors, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only selector-produced references and operator lifecycle fields: `bikeId`, `deviceId`, `installedAt`, optional `memo`, and remove `removedAt`/`memo`.
+- Server-generated id, idx, audit/deleted fields, telemetry fields, and relationship/system state outside the lifecycle endpoints remain non-client inputs and are ignored when sent.
+- Bike and device references are validated in the service layer without DB foreign keys or JPA relationships.
+- Disabled devices cannot be installed.
+- Install/replace uses deterministic PostgreSQL advisory transaction locks on bike/device keys, closes existing active bike/device rows, flushes, then inserts the replacement row in one transaction.
+- Remove sets `removedAt` and preserves history; it does not soft-delete the installation row.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and bike-device installation create/remove at this stage.


### PR DESCRIPTION
## Summary

- Add authenticated bike-device installation lifecycle endpoints: `POST /api/v1/bike-device-installations` and `PATCH /api/v1/bike-device-installations/{id}/remove`.
- Validate selected bike/device references in service layer without DB FKs/JPA relationships; reject deleted/missing refs and disabled devices.
- Replace active installation rows by locking bike/device keys, closing existing active bike/device rows, flushing, and inserting the new active row in one transaction.
- Preserve installation history on remove by setting `removedAt` rather than soft-deleting.
- Update API boundary/architecture tests and backend docs for the new command slice.

## Trace

- Change-control issue: EVNSolution/clever-change-control#59
- Target issue: EVNSolution/thundercrew-domain#30
- Root project-start: EVNSolution/clever-change-control#45
- Branch: `cc-59-bike-device-installation-command`

## Concurrent work decision

`allowed-with-non-overlap`

Evidence checked before implementation and again before this PR:
- No open PRs in EVNSolution/thundercrew-domain.
- Open target issue scope is this bike-device installation issue only.
- Remote branches are `main`, `dev`, and this task branch.
- Other open clever-change-control issues are unrelated historical/control-plane scopes.

Non-overlap reason: this PR only touches service-ops-api bike-device installation lifecycle commands/docs/tests and explicitly excludes device registry changes, telemetry/current-state, dashboard/map APIs, and frontend work.

## Validation

- `git diff --check`
- `(cd development/service-ops-api && ./gradlew test --tests '*BikeDeviceInstallationCommandApiContractTests')`
- `(cd development/service-ops-api && ./gradlew test --tests '*BikeDeviceInstallationCommandApiContractTests' --tests '*ReadOnlyApiContractTests' --tests '*ArchitectureBoundaryTests')`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review

- Subagent test-engineer produced acceptance plan.
- Subagent code-reviewer PASS.

## Watch item

If deterministic history under concurrent cross-replacements becomes release-critical, consider adding row-level locking for active conflict rows in a follow-up issue.
