### PR TITLE
Add equipment type registry command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -54,6 +54,10 @@ This module currently provides the backend scaffold, non-telemetry core persiste
 - Bike-device installation command endpoints:
   - `POST /api/v1/bike-device-installations`
   - `PATCH /api/v1/bike-device-installations/{id}/remove`
+- Equipment type registry command endpoints:
+  - `POST /api/v1/equipment-types`
+  - `PATCH /api/v1/equipment-types/{id}`
+  - `DELETE /api/v1/equipment-types/{id}`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -124,6 +128,19 @@ curl -X POST http://localhost:8080/api/v1/devices \
 
 Duplicate active device UIDs return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted UIDs may be reused. Device deletion is a soft delete and returns `409 INVALID_STATE_TRANSITION` when an active bike-device installation still references the device.
 
+## Equipment type registry command API
+
+The equipment type registry slice is limited to operator-managed type fields. The server owns IDs, display sequence, audit columns, deleted state, and bike-equipment relationships. UI forms should collect a human-readable type name/description and enabled state only; operators must not type raw database IDs.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/equipment-types \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"브레이크 패드","description":"소모품","enabled":true}'
+```
+
+Duplicate active equipment type names return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted names may be reused. Equipment type deletion is a soft delete that disables the type and returns `409 INVALID_STATE_TRANSITION` while active bike-equipment rows still reference it. Removed historical bike-equipment rows do not block the registry type soft delete.
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -175,7 +192,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Create/update/delete service/controller slices for insurance, equipment, and station resources
+- Create/update/delete service/controller slices for insurance, bike equipment lifecycle, and station resources
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/EquipmentTypeCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/EquipmentTypeCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.equipment.controller;
+
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeCreateRequest;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeReadResponse;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeUpdateRequest;
+import com.thundercrew.opsapi.equipment.service.EquipmentTypeCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/equipment-types")
+public class EquipmentTypeCommandController {
+
+    private final EquipmentTypeCommandService equipmentTypeCommandService;
+
+    public EquipmentTypeCommandController(EquipmentTypeCommandService equipmentTypeCommandService) {
+        this.equipmentTypeCommandService = equipmentTypeCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<EquipmentTypeReadResponse> create(@Valid @RequestBody EquipmentTypeCreateRequest request) {
+        EquipmentTypeReadResponse response = equipmentTypeCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/equipment-types/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    EquipmentTypeReadResponse update(@PathVariable UUID id, @Valid @RequestBody EquipmentTypeUpdateRequest request) {
+        return equipmentTypeCommandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        equipmentTypeCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/EquipmentType.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "equipment_types")
@@ -17,6 +19,39 @@ public class EquipmentType extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+
+    public static EquipmentType create(
+            String name,
+            String description,
+            Boolean enabled
+    ) {
+        EquipmentType type = new EquipmentType();
+        type.name = name;
+        type.description = description;
+        type.enabled = enabled == null || enabled;
+        return type;
+    }
+
+    public void updateOperatorManagedFields(
+            String name,
+            String description,
+            Boolean enabled
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+    }
+
+    public void disableAndMarkDeleted(UUID actorId, Instant deletedAt) {
+        this.enabled = false;
+        markDeleted(actorId, deletedAt);
+    }
 
     public String getName() {
         return name;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeCreateRequest.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EquipmentTypeCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        String description,
+        Boolean enabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/EquipmentTypeUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EquipmentTypeUpdateRequest {
+
+    @Size(max = 100)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String name;
+
+    private String description;
+
+    private Boolean enabled;
+
+    public String name() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
@@ -12,4 +12,6 @@ public interface BikeEquipmentRepository extends Repository<BikeEquipment, UUID>
     Page<BikeEquipment> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<BikeEquipment> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByEquipmentTypeIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID equipmentTypeId);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
@@ -12,4 +12,10 @@ public interface EquipmentTypeRepository extends Repository<EquipmentType, UUID>
     Page<EquipmentType> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<EquipmentType> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
+
+    boolean existsByNameAndIdNotAndDeletedAtIsNull(String name, UUID id);
+
+    EquipmentType save(EquipmentType equipmentType);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/EquipmentTypeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/EquipmentTypeCommandService.java
@@ -1,0 +1,96 @@
+package com.thundercrew.opsapi.equipment.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.equipment.domain.EquipmentType;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeCreateRequest;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeReadResponse;
+import com.thundercrew.opsapi.equipment.dto.EquipmentTypeUpdateRequest;
+import com.thundercrew.opsapi.equipment.repository.BikeEquipmentRepository;
+import com.thundercrew.opsapi.equipment.repository.EquipmentTypeRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class EquipmentTypeCommandService {
+
+    private final EquipmentTypeRepository equipmentTypeRepository;
+    private final BikeEquipmentRepository bikeEquipmentRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public EquipmentTypeCommandService(
+            EquipmentTypeRepository equipmentTypeRepository,
+            BikeEquipmentRepository bikeEquipmentRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.equipmentTypeRepository = equipmentTypeRepository;
+        this.bikeEquipmentRepository = bikeEquipmentRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public EquipmentTypeReadResponse create(EquipmentTypeCreateRequest request) {
+        assertNameIsNotDuplicated(request.name());
+        EquipmentType type = EquipmentType.create(
+                request.name(),
+                request.description(),
+                request.enabled()
+        );
+        try {
+            EquipmentType saved = equipmentTypeRepository.save(type);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return EquipmentTypeReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("EquipmentType", "name");
+        }
+    }
+
+    @Transactional
+    public EquipmentTypeReadResponse update(UUID id, EquipmentTypeUpdateRequest request) {
+        EquipmentType type = equipmentTypeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("EquipmentType", id));
+        if (StringUtils.hasText(request.name())
+                && equipmentTypeRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
+            throw new DuplicateActiveResourceException("EquipmentType", "name");
+        }
+        try {
+            type.updateOperatorManagedFields(
+                    request.name(),
+                    request.description(),
+                    request.enabled()
+            );
+            entityManager.flush();
+            return EquipmentTypeReadResponse.from(type);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("EquipmentType", "name");
+        }
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        EquipmentType type = equipmentTypeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("EquipmentType", id));
+        if (bikeEquipmentRepository.existsByEquipmentTypeIdAndRemovedAtIsNullAndDeletedAtIsNull(id)) {
+            throw new InvalidStateTransitionException(
+                    "Equipment type cannot be deleted while active bike equipment references it."
+            );
+        }
+        type.disableAndMarkDeleted(null, clock.instant());
+    }
+
+    private void assertNameIsNotDuplicated(String name) {
+        if (equipmentTypeRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new DuplicateActiveResourceException("EquipmentType", "name");
+        }
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V3__add_bike_equipment_type_active_index.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V3__add_bike_equipment_type_active_index.sql
@@ -1,0 +1,3 @@
+create index ix_bike_equipments_equipment_type_active
+    on bike_equipments(equipment_type_id)
+    where removed_at is null and deleted_at is null;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -79,7 +79,8 @@ class ArchitectureBoundaryTests {
                         || isContractTemplateCommand(method)
                         || isRiderBikeContractCommand(method)
                         || isDeviceCommand(method)
-                        || isBikeDeviceInstallationCommand(method)) {
+                        || isBikeDeviceInstallationCommand(method)
+                        || isEquipmentTypeCommand(method)) {
                     return;
                 }
 
@@ -107,7 +108,8 @@ class ArchitectureBoundaryTests {
                         && !isContractTemplateCommand(method)
                         && !isRiderBikeContractCommand(method)
                         && !isDeviceCommand(method)
-                        && !isBikeDeviceInstallationCommand(method)) {
+                        && !isBikeDeviceInstallationCommand(method)
+                        && !isEquipmentTypeCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -160,6 +162,13 @@ class ArchitectureBoundaryTests {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.device.controller.BikeDeviceInstallationCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("remove"));
+    }
+
+    private static boolean isEquipmentTypeCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.equipment.controller.EquipmentTypeCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("delete"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/EquipmentTypeCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/EquipmentTypeCommandApiContractTests.java
@@ -1,0 +1,312 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EquipmentTypeCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID EQUIPMENT_TYPE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID BIKE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID BIKE_EQUIPMENT_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_equipments");
+        jdbcTemplate.update("delete from equipment_types");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createEquipmentTypeGeneratesIdentifiersAndIgnoresClientSuppliedSystemFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/equipment-types")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "name":"브레이크 패드",
+                                  "description":"소모품",
+                                  "enabled":true,
+                                  "deletedAt":"2026-01-01T00:00:00Z",
+                                  "bikeId":"11111111-1111-1111-1111-111111111111"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/equipment-types/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.name").value("브레이크 패드"))
+                .andExpect(jsonPath("$.description").value("소모품"))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andReturn();
+
+        mockMvc.perform(get("/api/v1/equipment-types/{id}", extractId(result))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("브레이크 패드"));
+    }
+
+    @Test
+    void createEquipmentTypeRejectsMissingNameAndDuplicateActiveName() throws Exception {
+        mockMvc.perform(post("/api/v1/equipment-types")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "타이어", true, null);
+        mockMvc.perform(post("/api/v1/equipment-types")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"타이어"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateEquipmentTypeChangesOperatorFieldsAndRejectsMissingOrDuplicateTargets() throws Exception {
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "타이어", true, null);
+        UUID otherId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        seedEquipmentType(otherId, "브레이크", true, null);
+        Long originalIdx = jdbcTemplate.queryForObject(
+                "select idx from equipment_types where id = ?",
+                Long.class,
+                EQUIPMENT_TYPE_ID
+        );
+
+        mockMvc.perform(patch("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"11111111-1111-1111-1111-111111111111",
+                                  "idx":999,
+                                  "name":"타이어 세트",
+                                  "description":"교체 대상",
+                                  "enabled":false,
+                                  "deletedAt":"2026-01-01T00:00:00Z",
+                                  "bikeId":"22222222-2222-2222-2222-222222222222"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(EQUIPMENT_TYPE_ID.toString()))
+                .andExpect(jsonPath("$.idx").value(originalIdx))
+                .andExpect(jsonPath("$.name").value("타이어 세트"))
+                .andExpect(jsonPath("$.description").value("교체 대상"))
+                .andExpect(jsonPath("$.enabled").value(false));
+
+        Long updatedIdx = jdbcTemplate.queryForObject(
+                "select idx from equipment_types where id = ?",
+                Long.class,
+                EQUIPMENT_TYPE_ID
+        );
+        Boolean stillNotDeleted = jdbcTemplate.queryForObject(
+                "select deleted_at is null from equipment_types where id = ?",
+                Boolean.class,
+                EQUIPMENT_TYPE_ID
+        );
+        assertThat(updatedIdx).isEqualTo(originalIdx);
+        assertThat(stillNotDeleted).isTrue();
+
+        UUID missingId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockMvc.perform(patch("/api/v1/equipment-types/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"없는 장비"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"브레이크"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void deleteEquipmentTypeSoftDeletesDisablesAndAllowsNameReuse() throws Exception {
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "배터리 커넥터", true, null);
+
+        mockMvc.perform(delete("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        Boolean enabled = jdbcTemplate.queryForObject(
+                "select enabled from equipment_types where id = ?",
+                Boolean.class,
+                EQUIPMENT_TYPE_ID
+        );
+        assertThat(enabled).isFalse();
+
+        mockMvc.perform(get("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/equipment-types")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(0));
+
+        mockMvc.perform(post("/api/v1/equipment-types")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"배터리 커넥터"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("배터리 커넥터"));
+    }
+
+    @Test
+    void deleteEquipmentTypeRejectsActiveBikeEquipmentButAllowsRemovedHistory() throws Exception {
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        seedBike(BIKE_ID);
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, null);
+
+        mockMvc.perform(delete("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        jdbcTemplate.update("update bike_equipments set removed_at = now() where id = ?", BIKE_EQUIPMENT_ID);
+
+        mockMvc.perform(delete("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/equipment-types")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(delete("/api/v1/equipment-types/{id}", EQUIPMENT_TYPE_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedBike(UUID id) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, ?, ?, 'Thunder M1', 'READY')
+                """, id, "서울E-" + id.toString().substring(0, 4), "VIN-EQ-" + id);
+    }
+
+    private void seedEquipmentType(UUID id, String name, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name, description, enabled, deleted_at)
+                values (?, ?, 'fixture type', ?, %s)
+                """.formatted(deletedAtExpression), id, name, enabled);
+    }
+
+    private void seedBikeEquipment(UUID id, UUID bikeId, UUID equipmentTypeId, String removedAtSql) {
+        String removedAtExpression = removedAtSql == null ? "null" : removedAtSql;
+        jdbcTemplate.update("""
+                insert into bike_equipments (
+                    id, bike_id, equipment_type_id, equipment_label, model_name, serial_number,
+                    installed_at, removed_at, management_due_date, management_note, memo
+                ) values (?, ?, ?, 'fixture equipment', 'EQ-100', 'SER-TYPE-GUARD', now(), %s, current_date + interval '30 day', 'fixture note', 'fixture memo')
+                """.formatted(removedAtExpression), id, bikeId, equipmentTypeId);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -236,7 +236,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
                 "/api/v1/bike-operation-status-histories",
                 "/api/v1/insurance-items",
                 "/api/v1/rider-insurances",
-                "/api/v1/equipment-types",
                 "/api/v1/bike-equipments",
                 "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"
@@ -259,6 +258,12 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
             mockMvc.perform(delete(endpoint + "/{id}", id).with(user("ops-admin")))
                     .andExpect(status().isMethodNotAllowed());
         }
+
+        mockMvc.perform(put("/api/v1/equipment-types/{id}", id)
+                        .with(user("ops-admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
 
         mockMvc.perform(put("/api/v1/bike-device-installations/{id}", id)
                         .with(user("ops-admin"))

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -288,3 +288,26 @@ Boundary decision:
 - Install/replace uses deterministic PostgreSQL advisory transaction locks on bike/device keys, closes existing active bike/device rows, flushes, then inserts the replacement row in one transaction.
 - Remove sets `removedAt` and preserves history; it does not soft-delete the installation row.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and bike-device installation create/remove at this stage.
+
+## Equipment type registry command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#60
+- Target issue: EVNSolution/thundercrew-domain#32
+- Branch: `cc-60-equipment-type-command`
+
+Issue-size decision:
+
+- This slice adds only the equipment type registry command baseline after the device and bike-device command slices.
+- Included operations are authenticated `POST /api/v1/equipment-types`, `PATCH /api/v1/equipment-types/{id}`, and `DELETE /api/v1/equipment-types/{id}` as soft-delete.
+- Bike equipment attach/update/remove lifecycle commands, computed equipment due-status, frontend selectors, dashboard/map APIs, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only operator-managed registry fields: `name`, `description`, and `enabled`.
+- Server-generated id, idx, audit/deleted fields, bike-equipment relationships, and lifecycle/system fields remain non-client inputs and are ignored when sent.
+- `name` is unique among active, non-deleted equipment types; soft-deleted names may be reused through the existing active partial unique index.
+- Equipment type soft-delete disables the type and blocks deletion while active `bike_equipments` rows reference it.
+- Removed/historical bike-equipment rows do not block type soft-delete, preserving history by UUID reference without JPA relationships.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and equipment type registry commands at this stage.


### PR DESCRIPTION
## Summary

- Adds authenticated equipment type registry command endpoints:
  - `POST /api/v1/equipment-types`
  - `PATCH /api/v1/equipment-types/{id}`
  - `DELETE /api/v1/equipment-types/{id}`
- Keeps request DTOs limited to operator-managed fields: `name`, `description`, `enabled`.
- Preserves server-owned IDs/idx/audit/deleted fields and ignores unknown/system fields in create/update payloads.
- Blocks equipment type soft-delete while active `bike_equipments` rows reference the type; removed historical rows do not block deletion.
- Adds an active equipment-type reference index for the delete guard.
- Updates architecture/read-only contract tests and backend docs/ledger.

## Trace

- Change-control issue: EVNSolution/clever-change-control#60
- Target issue: EVNSolution/thundercrew-domain#32
- Branch: `cc-60-equipment-type-command`

## Concurrent work gate

Decision: `allowed-with-non-overlap`

Evidence:
- Target repo open PRs checked before PR creation: none.
- Target repo open issues checked before PR creation: only EVNSolution/thundercrew-domain#32 for this equipment type registry slice.
- Active target branches checked: `main`, `dev`, `cc-60-equipment-type-command`.
- Change-control open issues checked: #60 plus unrelated historical/project-start/control issues.

Non-overlap reason:
- This PR only touches `service-ops-api` equipment type registry commands, tests, schema index, and docs.
- Bike equipment lifecycle commands, frontend relocation, telemetry/current status, dashboard/map, station/insurance commands, and deployment work remain outside this PR.

## Verification

- `git diff --check`
- `(cd development/service-ops-api && ./gradlew test --tests '*EquipmentTypeCommandApiContractTests' --tests '*ReadOnlyApiContractTests' --tests '*ArchitectureBoundaryTests')`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review evidence

- Code-reviewer subagent: PASS; medium coverage/index findings were addressed before PR.
- Verifier subagent: PASS; confirmed equipment list coverage, partial index, PATCH ignored system fields, and PR readiness.
