### PR TITLE
Add bike equipment lifecycle command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -58,6 +58,10 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `POST /api/v1/equipment-types`
   - `PATCH /api/v1/equipment-types/{id}`
   - `DELETE /api/v1/equipment-types/{id}`
+- Bike equipment lifecycle command endpoints:
+  - `POST /api/v1/bike-equipments`
+  - `PATCH /api/v1/bike-equipments/{id}`
+  - `PATCH /api/v1/bike-equipments/{id}/remove`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -141,6 +145,26 @@ curl -X POST http://localhost:8080/api/v1/equipment-types \
 
 Duplicate active equipment type names return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted names may be reused. Equipment type deletion is a soft delete that disables the type and returns `409 INVALID_STATE_TRANSITION` while active bike-equipment rows still reference it. Removed historical bike-equipment rows do not block the registry type soft delete.
 
+## Bike equipment lifecycle command API
+
+The bike equipment lifecycle slice manages equipment objects attached to a bike. UI forms should choose bikes by plate/VIN and equipment types by name; operators must not type raw database IDs. Transfer to another bike or type reclassification is out of scope for generic update and should be modeled as remove + create or a future dedicated correction workflow.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/bike-equipments \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"bikeId":"<selected-bike-id>","equipmentTypeId":"<selected-type-id>","equipmentLabel":"전륜 브레이크","serialNumber":"SER-001","installedAt":"2026-04-30T00:00:00Z","managementDueDate":"2026-05-30"}'
+```
+
+Multiple active equipment rows of the same type may exist on one bike. Active `serialNumber` values are unique and may be reused after removal. The read DTO computes `managementStatus` from the Asia/Seoul local date and `managementDueDate`: `OVERDUE`, `DUE_SOON`, or `NORMAL`. Removal preserves history by setting `removedAt`:
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/bike-equipments/<equipment-id>/remove \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"removedAt":"2026-05-01T00:00:00Z","memo":"장비 탈거"}'
+```
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -192,7 +216,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Create/update/delete service/controller slices for insurance, bike equipment lifecycle, and station resources
+- Create/update/delete service/controller slices for insurance and station resources
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/BikeEquipmentCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/controller/BikeEquipmentCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.equipment.controller;
+
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentCreateRequest;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentReadResponse;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentRemoveRequest;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentUpdateRequest;
+import com.thundercrew.opsapi.equipment.service.BikeEquipmentCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/bike-equipments")
+public class BikeEquipmentCommandController {
+
+    private final BikeEquipmentCommandService bikeEquipmentCommandService;
+
+    public BikeEquipmentCommandController(BikeEquipmentCommandService bikeEquipmentCommandService) {
+        this.bikeEquipmentCommandService = bikeEquipmentCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<BikeEquipmentReadResponse> create(@Valid @RequestBody BikeEquipmentCreateRequest request) {
+        BikeEquipmentReadResponse response = bikeEquipmentCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/bike-equipments/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    BikeEquipmentReadResponse update(@PathVariable UUID id, @Valid @RequestBody BikeEquipmentUpdateRequest request) {
+        return bikeEquipmentCommandService.update(id, request);
+    }
+
+    @PatchMapping("/{id}/remove")
+    BikeEquipmentReadResponse remove(@PathVariable UUID id, @RequestBody(required = false) BikeEquipmentRemoveRequest request) {
+        BikeEquipmentRemoveRequest effectiveRequest = request == null ? new BikeEquipmentRemoveRequest(null, null) : request;
+        return bikeEquipmentCommandService.remove(id, effectiveRequest);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipment.java
@@ -40,6 +40,65 @@ public class BikeEquipment extends DisplaySequencedEntity {
     private String memo;
 
 
+    public static BikeEquipment create(
+            UUID bikeId,
+            UUID equipmentTypeId,
+            String equipmentLabel,
+            String modelName,
+            String serialNumber,
+            Instant installedAt,
+            LocalDate managementDueDate,
+            String managementNote,
+            String memo
+    ) {
+        BikeEquipment equipment = new BikeEquipment();
+        equipment.bikeId = bikeId;
+        equipment.equipmentTypeId = equipmentTypeId;
+        equipment.equipmentLabel = equipmentLabel;
+        equipment.modelName = modelName;
+        equipment.serialNumber = serialNumber;
+        equipment.installedAt = installedAt;
+        equipment.managementDueDate = managementDueDate;
+        equipment.managementNote = managementNote;
+        equipment.memo = memo;
+        return equipment;
+    }
+
+    public void updateOperatorManagedFields(
+            String equipmentLabel,
+            String modelName,
+            String serialNumber,
+            LocalDate managementDueDate,
+            String managementNote,
+            String memo
+    ) {
+        if (equipmentLabel != null) {
+            this.equipmentLabel = equipmentLabel;
+        }
+        if (modelName != null) {
+            this.modelName = modelName;
+        }
+        if (serialNumber != null) {
+            this.serialNumber = serialNumber;
+        }
+        if (managementDueDate != null) {
+            this.managementDueDate = managementDueDate;
+        }
+        if (managementNote != null) {
+            this.managementNote = managementNote;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public void remove(Instant removedAt, String memo) {
+        this.removedAt = removedAt;
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
     public java.util.UUID getBikeId() {
         return bikeId;
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipmentManagementStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/domain/BikeEquipmentManagementStatus.java
@@ -1,0 +1,19 @@
+package com.thundercrew.opsapi.equipment.domain;
+
+import java.time.LocalDate;
+
+public enum BikeEquipmentManagementStatus {
+    NORMAL,
+    DUE_SOON,
+    OVERDUE;
+
+    public static BikeEquipmentManagementStatus from(LocalDate managementDueDate, LocalDate today) {
+        if (managementDueDate.isBefore(today)) {
+            return OVERDUE;
+        }
+        if (!managementDueDate.isAfter(today.plusDays(7))) {
+            return DUE_SOON;
+        }
+        return NORMAL;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentCreateRequest.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeEquipmentCreateRequest(
+        @NotNull UUID bikeId,
+        @NotNull UUID equipmentTypeId,
+        @Size(max = 100) String equipmentLabel,
+        @Size(max = 100) String modelName,
+        @Size(max = 100) String serialNumber,
+        @NotNull Instant installedAt,
+        @NotNull LocalDate managementDueDate,
+        String managementNote,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentReadResponse.java
@@ -1,6 +1,8 @@
 package com.thundercrew.opsapi.equipment.dto;
 
+import com.thundercrew.opsapi.common.time.ApplicationClock;
 import com.thundercrew.opsapi.equipment.domain.BikeEquipment;
+import com.thundercrew.opsapi.equipment.domain.BikeEquipmentManagementStatus;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -16,12 +18,17 @@ public record BikeEquipmentReadResponse(
         Instant installedAt,
         Instant removedAt,
         LocalDate managementDueDate,
+        BikeEquipmentManagementStatus managementStatus,
         String managementNote,
         String memo,
         Instant createdAt,
         Instant updatedAt
 ) {
     public static BikeEquipmentReadResponse from(BikeEquipment equipment) {
+        return from(equipment, LocalDate.now(ApplicationClock.OPERATION_ZONE));
+    }
+
+    public static BikeEquipmentReadResponse from(BikeEquipment equipment, LocalDate today) {
         return new BikeEquipmentReadResponse(
                 equipment.getId(),
                 equipment.getIdx(),
@@ -33,6 +40,7 @@ public record BikeEquipmentReadResponse(
                 equipment.getInstalledAt(),
                 equipment.getRemovedAt(),
                 equipment.getManagementDueDate(),
+                BikeEquipmentManagementStatus.from(equipment.getManagementDueDate(), today),
                 equipment.getManagementNote(),
                 equipment.getMemo(),
                 equipment.getCreatedAt(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentRemoveRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentRemoveRequest.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BikeEquipmentRemoveRequest(
+        Instant removedAt,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/dto/BikeEquipmentUpdateRequest.java
@@ -1,0 +1,74 @@
+package com.thundercrew.opsapi.equipment.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BikeEquipmentUpdateRequest {
+
+    @Size(max = 100)
+    private String equipmentLabel;
+
+    @Size(max = 100)
+    private String modelName;
+
+    @Size(max = 100)
+    @Pattern(regexp = "^$|.*\\S.*", message = "must not be blank when provided")
+    private String serialNumber;
+
+    private LocalDate managementDueDate;
+
+    private String managementNote;
+
+    private String memo;
+
+    public String equipmentLabel() {
+        return equipmentLabel;
+    }
+
+    public void setEquipmentLabel(String equipmentLabel) {
+        this.equipmentLabel = equipmentLabel;
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public String serialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    public LocalDate managementDueDate() {
+        return managementDueDate;
+    }
+
+    public void setManagementDueDate(LocalDate managementDueDate) {
+        this.managementDueDate = managementDueDate;
+    }
+
+    public String managementNote() {
+        return managementNote;
+    }
+
+    public void setManagementNote(String managementNote) {
+        this.managementNote = managementNote;
+    }
+
+    public String memo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/BikeEquipmentRepository.java
@@ -14,4 +14,10 @@ public interface BikeEquipmentRepository extends Repository<BikeEquipment, UUID>
     Optional<BikeEquipment> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByEquipmentTypeIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID equipmentTypeId);
+
+    boolean existsBySerialNumberAndRemovedAtIsNullAndDeletedAtIsNull(String serialNumber);
+
+    boolean existsBySerialNumberAndIdNotAndRemovedAtIsNullAndDeletedAtIsNull(String serialNumber, UUID id);
+
+    BikeEquipment save(BikeEquipment equipment);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/repository/EquipmentTypeRepository.java
@@ -11,6 +11,8 @@ public interface EquipmentTypeRepository extends Repository<EquipmentType, UUID>
 
     Page<EquipmentType> findByDeletedAtIsNull(Pageable pageable);
 
+    Optional<EquipmentType> findById(UUID id);
+
     Optional<EquipmentType> findByIdAndDeletedAtIsNull(UUID id);
 
     boolean existsByNameAndDeletedAtIsNull(String name);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/BikeEquipmentCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/equipment/service/BikeEquipmentCommandService.java
@@ -1,0 +1,152 @@
+package com.thundercrew.opsapi.equipment.service;
+
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ReferenceDeletedException;
+import com.thundercrew.opsapi.common.api.ReferenceNotFoundException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.equipment.domain.BikeEquipment;
+import com.thundercrew.opsapi.equipment.domain.EquipmentType;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentCreateRequest;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentReadResponse;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentRemoveRequest;
+import com.thundercrew.opsapi.equipment.dto.BikeEquipmentUpdateRequest;
+import com.thundercrew.opsapi.equipment.repository.BikeEquipmentRepository;
+import com.thundercrew.opsapi.equipment.repository.EquipmentTypeRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class BikeEquipmentCommandService {
+
+    private final BikeEquipmentRepository bikeEquipmentRepository;
+    private final BikeRepository bikeRepository;
+    private final EquipmentTypeRepository equipmentTypeRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public BikeEquipmentCommandService(
+            BikeEquipmentRepository bikeEquipmentRepository,
+            BikeRepository bikeRepository,
+            EquipmentTypeRepository equipmentTypeRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.bikeEquipmentRepository = bikeEquipmentRepository;
+        this.bikeRepository = bikeRepository;
+        this.equipmentTypeRepository = equipmentTypeRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public BikeEquipmentReadResponse create(BikeEquipmentCreateRequest request) {
+        assertActiveBikeReference(request.bikeId());
+        findEnabledEquipmentTypeReference(request.equipmentTypeId());
+        assertSerialNumberIsNotDuplicated(request.serialNumber());
+
+        BikeEquipment equipment = BikeEquipment.create(
+                request.bikeId(),
+                request.equipmentTypeId(),
+                request.equipmentLabel(),
+                request.modelName(),
+                request.serialNumber(),
+                request.installedAt(),
+                request.managementDueDate(),
+                request.managementNote(),
+                request.memo()
+        );
+        try {
+            BikeEquipment saved = bikeEquipmentRepository.save(equipment);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return BikeEquipmentReadResponse.from(saved, LocalDate.now(clock));
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("BikeEquipment", "serialNumber");
+        }
+    }
+
+    @Transactional
+    public BikeEquipmentReadResponse update(UUID id, BikeEquipmentUpdateRequest request) {
+        BikeEquipment equipment = bikeEquipmentRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeEquipment", id));
+        if (equipment.getRemovedAt() != null) {
+            throw new InvalidStateTransitionException("Bike equipment is already removed.");
+        }
+        if (StringUtils.hasText(request.serialNumber())
+                && bikeEquipmentRepository.existsBySerialNumberAndIdNotAndRemovedAtIsNullAndDeletedAtIsNull(request.serialNumber(), id)) {
+            throw new DuplicateActiveResourceException("BikeEquipment", "serialNumber");
+        }
+        try {
+            equipment.updateOperatorManagedFields(
+                    request.equipmentLabel(),
+                    request.modelName(),
+                    request.serialNumber(),
+                    request.managementDueDate(),
+                    request.managementNote(),
+                    request.memo()
+            );
+            entityManager.flush();
+            return BikeEquipmentReadResponse.from(equipment, LocalDate.now(clock));
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("BikeEquipment", "serialNumber");
+        }
+    }
+
+    @Transactional
+    public BikeEquipmentReadResponse remove(UUID id, BikeEquipmentRemoveRequest request) {
+        BikeEquipment equipment = bikeEquipmentRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("BikeEquipment", id));
+        if (equipment.getRemovedAt() != null) {
+            throw new InvalidStateTransitionException("Bike equipment is already removed.");
+        }
+        Instant removedAt = request.removedAt() == null ? Instant.now(clock) : request.removedAt();
+        assertRemovalTimeIsValid(equipment, removedAt);
+        equipment.remove(removedAt, request.memo());
+        entityManager.flush();
+        return BikeEquipmentReadResponse.from(equipment, LocalDate.now(clock));
+    }
+
+    private void assertActiveBikeReference(UUID bikeId) {
+        if (bikeRepository.findByIdAndDeletedAtIsNull(bikeId).isPresent()) {
+            return;
+        }
+        if (bikeRepository.existsById(bikeId)) {
+            throw new ReferenceDeletedException("Bike", bikeId);
+        }
+        throw new ReferenceNotFoundException("Bike", bikeId);
+    }
+
+    private EquipmentType findEnabledEquipmentTypeReference(UUID equipmentTypeId) {
+        EquipmentType type = equipmentTypeRepository.findById(equipmentTypeId)
+                .orElseThrow(() -> new ReferenceNotFoundException("EquipmentType", equipmentTypeId));
+        if (type.isDeleted()) {
+            throw new ReferenceDeletedException("EquipmentType", equipmentTypeId);
+        }
+        if (!type.isEnabled()) {
+            throw new InvalidStateTransitionException("Equipment type is disabled and cannot be attached.");
+        }
+        return type;
+    }
+
+    private void assertSerialNumberIsNotDuplicated(String serialNumber) {
+        if (StringUtils.hasText(serialNumber)
+                && bikeEquipmentRepository.existsBySerialNumberAndRemovedAtIsNullAndDeletedAtIsNull(serialNumber)) {
+            throw new DuplicateActiveResourceException("BikeEquipment", "serialNumber");
+        }
+    }
+
+    private void assertRemovalTimeIsValid(BikeEquipment equipment, Instant removedAt) {
+        if (removedAt.isBefore(equipment.getInstalledAt())) {
+            throw new InvalidStateTransitionException("Bike equipment removal time cannot be before installed time.");
+        }
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -80,7 +80,8 @@ class ArchitectureBoundaryTests {
                         || isRiderBikeContractCommand(method)
                         || isDeviceCommand(method)
                         || isBikeDeviceInstallationCommand(method)
-                        || isEquipmentTypeCommand(method)) {
+                        || isEquipmentTypeCommand(method)
+                        || isBikeEquipmentCommand(method)) {
                     return;
                 }
 
@@ -109,7 +110,8 @@ class ArchitectureBoundaryTests {
                         && !isRiderBikeContractCommand(method)
                         && !isDeviceCommand(method)
                         && !isBikeDeviceInstallationCommand(method)
-                        && !isEquipmentTypeCommand(method)) {
+                        && !isEquipmentTypeCommand(method)
+                        && !isBikeEquipmentCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -169,6 +171,13 @@ class ArchitectureBoundaryTests {
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isBikeEquipmentCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.equipment.controller.BikeEquipmentCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("remove"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeEquipmentCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeEquipmentCommandApiContractTests.java
@@ -1,0 +1,419 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BikeEquipmentCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final ZoneId OPERATION_ZONE = ZoneId.of("Asia/Seoul");
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID OTHER_BIKE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID EQUIPMENT_TYPE_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID OTHER_EQUIPMENT_TYPE_ID = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID BIKE_EQUIPMENT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID OTHER_BIKE_EQUIPMENT_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_equipments");
+        jdbcTemplate.update("delete from equipment_types");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createBikeEquipmentGeneratesIdentifiersIgnoresSystemFieldsAndComputesStatus() throws Exception {
+        seedBike(BIKE_ID, false);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+        LocalDate dueSoonDate = today().plusDays(3);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/bike-equipments")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "bikeId":"%s",
+                                  "equipmentTypeId":"%s",
+                                  "equipmentLabel":"전륜 브레이크",
+                                  "modelName":"Brake V1",
+                                  "serialNumber":"SER-EQ-001",
+                                  "installedAt":"2026-04-30T00:00:00Z",
+                                  "removedAt":"2026-05-01T00:00:00Z",
+                                  "managementDueDate":"%s",
+                                  "managementNote":"3일 뒤 점검",
+                                  "memo":"현장 장착",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId, BIKE_ID, EQUIPMENT_TYPE_ID, dueSoonDate)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/bike-equipments/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.equipmentTypeId").value(EQUIPMENT_TYPE_ID.toString()))
+                .andExpect(jsonPath("$.equipmentLabel").value("전륜 브레이크"))
+                .andExpect(jsonPath("$.modelName").value("Brake V1"))
+                .andExpect(jsonPath("$.serialNumber").value("SER-EQ-001"))
+                .andExpect(jsonPath("$.managementDueDate").value(dueSoonDate.toString()))
+                .andExpect(jsonPath("$.managementStatus").value("DUE_SOON"))
+                .andReturn();
+
+        mockMvc.perform(get("/api/v1/bike-equipments/{id}", extractId(result))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.removedAt").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.managementStatus").value("DUE_SOON"));
+    }
+
+    @Test
+    void createBikeEquipmentValidatesRequiredFieldsAndReferences() throws Exception {
+        seedBike(BIKE_ID, false);
+        seedBike(OTHER_BIKE_ID, true);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        seedEquipmentType(OTHER_EQUIPMENT_TYPE_ID, "삭제타입", true, "now()");
+        UUID disabledTypeId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        seedEquipmentType(disabledTypeId, "비활성타입", false, null);
+
+        mockMvc.perform(post("/api/v1/bike-equipments")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+
+        UUID missingBikeId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        mockMvc.perform(postCreateRequest(missingBikeId, EQUIPMENT_TYPE_ID, "SER-MISSING-BIKE"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+
+        mockMvc.perform(postCreateRequest(OTHER_BIKE_ID, EQUIPMENT_TYPE_ID, "SER-DELETED-BIKE"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        UUID missingTypeId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        mockMvc.perform(postCreateRequest(BIKE_ID, missingTypeId, "SER-MISSING-TYPE"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, OTHER_EQUIPMENT_TYPE_ID, "SER-DELETED-TYPE"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, disabledTypeId, "SER-DISABLED-TYPE"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void createAllowsSameBikeAndTypeButRejectsDuplicateActiveSerialUntilRemoved() throws Exception {
+        seedBike(BIKE_ID, false);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, "SER-DUP", today().plusDays(10), null);
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, EQUIPMENT_TYPE_ID, "SER-SECOND"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.equipmentTypeId").value(EQUIPMENT_TYPE_ID.toString()));
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, EQUIPMENT_TYPE_ID, "SER-DUP"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        jdbcTemplate.update("update bike_equipments set removed_at = now() where id = ?", BIKE_EQUIPMENT_ID);
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, EQUIPMENT_TYPE_ID, "SER-DUP"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.serialNumber").value("SER-DUP"));
+    }
+
+    @Test
+    void updateBikeEquipmentChangesMutableFieldsWithoutMovingBikeOrTypeAndRejectsDuplicateSerial() throws Exception {
+        seedBike(BIKE_ID, false);
+        seedBike(OTHER_BIKE_ID, false);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        seedEquipmentType(OTHER_EQUIPMENT_TYPE_ID, "타이어", true, null);
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, "SER-OLD", today().plusDays(10), null);
+        seedBikeEquipment(OTHER_BIKE_EQUIPMENT_ID, OTHER_BIKE_ID, OTHER_EQUIPMENT_TYPE_ID, "SER-OTHER", today().plusDays(10), null);
+        Long originalIdx = jdbcTemplate.queryForObject(
+                "select idx from bike_equipments where id = ?",
+                Long.class,
+                BIKE_EQUIPMENT_ID
+        );
+        LocalDate overdueDate = today().minusDays(1);
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}", BIKE_EQUIPMENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "idx":999,
+                                  "bikeId":"%s",
+                                  "equipmentTypeId":"%s",
+                                  "installedAt":"2026-05-01T00:00:00Z",
+                                  "removedAt":"2026-05-02T00:00:00Z",
+                                  "equipmentLabel":"후륜 브레이크",
+                                  "modelName":"Brake V2",
+                                  "serialNumber":"SER-NEW",
+                                  "managementDueDate":"%s",
+                                  "managementNote":"기한 초과",
+                                  "memo":"수정 메모",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(OTHER_BIKE_ID, OTHER_EQUIPMENT_TYPE_ID, overdueDate)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(BIKE_EQUIPMENT_ID.toString()))
+                .andExpect(jsonPath("$.idx").value(originalIdx))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.equipmentTypeId").value(EQUIPMENT_TYPE_ID.toString()))
+                .andExpect(jsonPath("$.equipmentLabel").value("후륜 브레이크"))
+                .andExpect(jsonPath("$.modelName").value("Brake V2"))
+                .andExpect(jsonPath("$.serialNumber").value("SER-NEW"))
+                .andExpect(jsonPath("$.managementDueDate").value(overdueDate.toString()))
+                .andExpect(jsonPath("$.managementStatus").value("OVERDUE"));
+
+        Boolean stillNotDeleted = jdbcTemplate.queryForObject(
+                "select deleted_at is null from bike_equipments where id = ?",
+                Boolean.class,
+                BIKE_EQUIPMENT_ID
+        );
+        Instant installedAt = jdbcTemplate.queryForObject(
+                "select installed_at from bike_equipments where id = ?",
+                Instant.class,
+                BIKE_EQUIPMENT_ID
+        );
+        Boolean stillNotRemoved = jdbcTemplate.queryForObject(
+                "select removed_at is null from bike_equipments where id = ?",
+                Boolean.class,
+                BIKE_EQUIPMENT_ID
+        );
+        assertThat(stillNotDeleted).isTrue();
+        assertThat(installedAt).isEqualTo(Instant.parse("2026-04-30T00:00:00Z"));
+        assertThat(stillNotRemoved).isTrue();
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}", BIKE_EQUIPMENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"serialNumber":"SER-OTHER"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        UUID missingId = UUID.fromString("66666666-6666-6666-6666-666666666666");
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"memo":"missing"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void removeBikeEquipmentPreservesHistoryRejectsInvalidTransitionsAndStopsSerialBlocking() throws Exception {
+        seedBike(BIKE_ID, false);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "브레이크", true, null);
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, "SER-REMOVE", today().plusDays(10), null);
+        Instant removedAt = Instant.parse("2026-05-01T00:00:00Z");
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}/remove", BIKE_EQUIPMENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"removedAt":"%s","memo":"탈거 완료"}
+                                """.formatted(removedAt)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(BIKE_EQUIPMENT_ID.toString()))
+                .andExpect(jsonPath("$.removedAt").value("2026-05-01T00:00:00Z"))
+                .andExpect(jsonPath("$.memo").value("탈거 완료"));
+
+        mockMvc.perform(get("/api/v1/bike-equipments/{id}", BIKE_EQUIPMENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.removedAt").value("2026-05-01T00:00:00Z"));
+
+        mockMvc.perform(postCreateRequest(BIKE_ID, EQUIPMENT_TYPE_ID, "SER-REMOVE"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}/remove", BIKE_EQUIPMENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        UUID anotherId = UUID.fromString("77777777-7777-7777-7777-777777777777");
+        seedBikeEquipment(anotherId, BIKE_ID, EQUIPMENT_TYPE_ID, "SER-INVALID-REMOVE", today().plusDays(10), null);
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}/remove", anotherId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"removedAt":"2026-04-29T00:00:00Z"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/bike-equipments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}", BIKE_EQUIPMENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/bike-equipments/{id}/remove", BIKE_EQUIPMENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private org.springframework.test.web.servlet.RequestBuilder postCreateRequest(
+            UUID bikeId,
+            UUID equipmentTypeId,
+            String serialNumber
+    ) {
+        return post("/api/v1/bike-equipments")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "bikeId":"%s",
+                          "equipmentTypeId":"%s",
+                          "equipmentLabel":"전륜 브레이크",
+                          "modelName":"Brake V1",
+                          "serialNumber":"%s",
+                          "installedAt":"2026-04-30T00:00:00Z",
+                          "managementDueDate":"%s",
+                          "managementNote":"정기 관리",
+                          "memo":"장착 메모"
+                        }
+                        """.formatted(bikeId, equipmentTypeId, serialNumber, today().plusDays(14)));
+    }
+
+    private void seedBike(UUID id, boolean deleted) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, deleted_at)
+                values (?, ?, ?, 'Thunder M1', 'READY', %s)
+                """.formatted(deleted ? "now()" : "null"), id, "서울E-" + id.toString().substring(0, 4), "VIN-EQ-" + id);
+    }
+
+    private void seedEquipmentType(UUID id, String name, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name, description, enabled, deleted_at)
+                values (?, ?, 'fixture type', ?, %s)
+                """.formatted(deletedAtExpression), id, name, enabled);
+    }
+
+    private void seedBikeEquipment(
+            UUID id,
+            UUID bikeId,
+            UUID equipmentTypeId,
+            String serialNumber,
+            LocalDate managementDueDate,
+            String removedAtSql
+    ) {
+        String removedAtExpression = removedAtSql == null ? "null" : removedAtSql;
+        jdbcTemplate.update("""
+                insert into bike_equipments (
+                    id, bike_id, equipment_type_id, equipment_label, model_name, serial_number,
+                    installed_at, removed_at, management_due_date, management_note, memo
+                ) values (?, ?, ?, 'fixture equipment', 'EQ-100', ?, '2026-04-30T00:00:00Z', %s, ?, 'fixture note', 'fixture memo')
+                """.formatted(removedAtExpression), id, bikeId, equipmentTypeId, serialNumber, managementDueDate);
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(OPERATION_ZONE);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -236,7 +236,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
                 "/api/v1/bike-operation-status-histories",
                 "/api/v1/insurance-items",
                 "/api/v1/rider-insurances",
-                "/api/v1/bike-equipments",
                 "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"
         )) {
@@ -258,6 +257,14 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
             mockMvc.perform(delete(endpoint + "/{id}", id).with(user("ops-admin")))
                     .andExpect(status().isMethodNotAllowed());
         }
+
+        mockMvc.perform(put("/api/v1/bike-equipments/{id}", id)
+                        .with(user("ops-admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(delete("/api/v1/bike-equipments/{id}", id).with(user("ops-admin")))
+                .andExpect(status().isMethodNotAllowed());
 
         mockMvc.perform(put("/api/v1/equipment-types/{id}", id)
                         .with(user("ops-admin"))

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -311,3 +311,28 @@ Boundary decision:
 - Equipment type soft-delete disables the type and blocks deletion while active `bike_equipments` rows reference it.
 - Removed/historical bike-equipment rows do not block type soft-delete, preserving history by UUID reference without JPA relationships.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and equipment type registry commands at this stage.
+
+## Bike equipment lifecycle command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#61
+- Target issue: EVNSolution/thundercrew-domain#34
+- Branch: `cc-61-bike-equipment-lifecycle-command`
+
+Issue-size decision:
+
+- This slice adds only the bike equipment lifecycle command baseline after the equipment type registry command baseline.
+- Included operations are authenticated `POST /api/v1/bike-equipments`, `PATCH /api/v1/bike-equipments/{id}`, and `PATCH /api/v1/bike-equipments/{id}/remove`.
+- Equipment type registry, frontend selectors/forms, telemetry/current-state ingestion, dashboard/map APIs, job scheduling, hard delete/restore, bulk import/export, and integrity scan implementation remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only selector-produced references plus operator-managed equipment fields; UI must choose bikes by plate/VIN and equipment types by name instead of asking users to type raw database IDs.
+- Generic update keeps `bikeId`, `equipmentTypeId`, `installedAt`, id, idx, deleted/audit fields, and removed lifecycle fields server-owned/out of scope. Transfer or type reclassification requires remove + create or a future dedicated correction workflow.
+- Bike and equipment type references are validated in the service layer without DB foreign keys or JPA relationships.
+- Deleted/missing bike references and missing/deleted/disabled equipment types are rejected through the existing reference/invalid-state error contracts.
+- Active `serialNumber` is unique and can be reused after removal.
+- Removal preserves history by setting `removedAt`; it does not soft-delete the row.
+- Read DTOs compute `managementStatus` from `managementDueDate` using Asia/Seoul local date: `OVERDUE`, `DUE_SOON`, `NORMAL`.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and bike equipment lifecycle commands at this stage.


### PR DESCRIPTION
## Summary

- Adds authenticated bike equipment lifecycle command endpoints:
  - `POST /api/v1/bike-equipments`
  - `PATCH /api/v1/bike-equipments/{id}`
  - `PATCH /api/v1/bike-equipments/{id}/remove`
- Keeps request DTOs limited to selector-produced `bikeId`/`equipmentTypeId` plus operator fields; no raw user-entered database IDs should be collected by UI.
- Validates bike and equipment type references in the service layer without JPA relationships.
- Rejects deleted/missing bikes, missing/deleted/disabled equipment types, duplicate active serial numbers, and invalid removal transitions.
- Preserves history via `removedAt` and computes `managementStatus` (`NORMAL`, `DUE_SOON`, `OVERDUE`) from `managementDueDate`.
- Updates architecture/read-only contract tests and backend docs/ledger.

## Trace

- Change-control issue: EVNSolution/clever-change-control#61
- Target issue: EVNSolution/thundercrew-domain#34
- Branch: `cc-61-bike-equipment-lifecycle-command`

## Concurrent work gate

Decision: `allowed-with-non-overlap`

Evidence:
- Target repo open PRs checked before PR creation: none.
- Target repo open issues checked before PR creation: only EVNSolution/thundercrew-domain#34 for this bike equipment lifecycle slice.
- Active target branches checked: `main`, `dev`, `cc-61-bike-equipment-lifecycle-command`.
- Change-control open issues checked: #61 plus unrelated historical/project-start/control issues.

Non-overlap reason:
- This PR only touches `service-ops-api` bike equipment lifecycle commands, tests, and docs.
- Equipment type registry, frontend, telemetry/current status, dashboard/map, station/insurance commands, deployment work, and maintenance jobs remain outside this PR.

## Verification

- `git diff --check`
- `(cd development/service-ops-api && ./gradlew test --tests '*BikeEquipmentCommandApiContractTests' --tests '*ReadOnlyApiContractTests' --tests '*ArchitectureBoundaryTests')`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Review evidence

- Architect subagent: scope checklist PASS before implementation.
- Code-reviewer subagent: PASS; non-blocking test-hardening suggestion was applied before PR.
