### PR TITLE
Preserve workspace root boundaries after relocation

### DIFF
--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -336,3 +336,24 @@ Boundary decision:
 - Removal preserves history by setting `removedAt`; it does not soft-delete the row.
 - Read DTOs compute `managementStatus` from `managementDueDate` using Asia/Seoul local date: `OVERDUE`, `DUE_SOON`, `NORMAL`.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and bike equipment lifecycle commands at this stage.
+
+## Workspace cleanup and duplicate-removal pass
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#62
+- Target issue: EVNSolution/thundercrew-domain#36
+- Branch: `cc-62-workspace-cleanup-dedup`
+
+Issue-size decision:
+
+- This slice is a behavior-preserving workspace hygiene pass.
+- Runtime behavior, API contracts, database schema, package dependencies, secrets, Vercel/Supabase settings, and product UI changes are out of scope.
+- Safe local cleanup is limited to ignored generated/OS artifacts that make the repository root look like the old frontend app root.
+
+Boundary decision:
+
+- Repository root remains the workspace orchestration layer, not a Next.js runtime root.
+- Root-level stale frontend generated artifacts such as `.next/`, `next-env.d.ts`, and `tsconfig.tsbuildinfo` are treated as cleanup failures by `npm run check:workspace`.
+- Active runtime caches under `development/front-admin-web` and `development/service-ops-api` may be recreated by verification commands and are not product source.
+- Backend design docs should not continue to list the completed frontend relocation or workspace-map introduction as unresolved decisions.

--- a/docs/backend/01-prd-scope.md
+++ b/docs/backend/01-prd-scope.md
@@ -30,7 +30,7 @@ equipment, telemetry-derived control state, and battery stations.
 - Do not finalize actual device vendor payload fields.
 - Do not require cross-domain DB FK constraints as the coupling mechanism.
 - Do not create a rider-bike assignment table separate from contracts.
-- Do not relocate the existing frontend into `development/front-admin-web` in this issue.
+- Do not add more frontend relocation or UI feature work in backend-only issues.
 
 ## Target repository shape
 
@@ -54,8 +54,10 @@ thundercrew-domain/
 └── clever-agent-workspace/
 ```
 
-This issue documents the backend design. Actual directory relocation/scaffold is a
-follow-up implementation issue.
+The original backend design issue documented this target shape before scaffold work.
+Frontend relocation and the first `service-ops-api` scaffold now exist as separate
+trace issues. The current canonical workspace shape is enforced by `WORKSPACE.md`,
+`repo-map.md`, and `npm run check:workspace`.
 
 ## Runtime slice choice
 
@@ -213,6 +215,6 @@ Implementation-blocking:
 Not blocking this design PR:
 
 - Exact vendor payload shape.
-- Exact frontend relocation timing.
+- Exact frontend/backend API integration timing.
 - Long-term analytics/read-model tables.
 - Insurance period expansion.

--- a/docs/backend/04-open-questions.md
+++ b/docs/backend/04-open-questions.md
@@ -9,8 +9,6 @@
 5. Whether TimescaleDB extension is available in the target Postgres environment.
 6. Expected telemetry device count, polling cadence, webhook volume, and daily write volume.
 7. Initial Flyway migration granularity and whether to use PostgreSQL extensions such as `pgcrypto`.
-8. Whether root `WORKSPACE.md` and `repo-map.md` should be introduced before or with scaffold.
-9. Existing frontend relocation plan: keep current app structure for now or move under `development/front-admin-web` in a separate PR.
 
 ## Resolved in this design branch
 
@@ -25,6 +23,8 @@
 9. Station `current_battery_count` and `available_battery_count` are stored operator-managed data; logs are audit.
 10. Telemetry current state updates only when incoming telemetry is newer.
 11. Contract overlap concurrency uses deterministic PostgreSQL advisory transaction locks on rider/bike assignment keys plus service overlap queries; PostgreSQL exclusion constraints are deferred.
+12. Root `WORKSPACE.md` and `repo-map.md` were introduced as the workspace operating/map documents.
+13. The admin frontend was relocated under `development/front-admin-web`; future backend issues should not carry frontend relocation as an open decision.
 
 ## Can resolve during implementation
 

--- a/repo-map.md
+++ b/repo-map.md
@@ -7,7 +7,7 @@
 - `WORKSPACE.md` — workspace operating model.
 - `repo-map.md` — this file.
 - `docs/` — design/change ledgers and traceability documents.
-- `scripts/check-workspace-layout.mjs` — guard for the intended runtime-slice layout.
+- `scripts/check-workspace-layout.mjs` — guard for the intended runtime-slice layout and stale root frontend artifacts.
 
 ## Frontend: `development/front-admin-web`
 

--- a/scripts/check-workspace-layout.mjs
+++ b/scripts/check-workspace-layout.mjs
@@ -19,6 +19,7 @@ const required = [
 
 const forbiddenRootFrontendDirs = ['app', 'components', 'lib', 'types'];
 const forbiddenRootFrontendFiles = ['next.config.ts', 'tsconfig.json', 'eslint.config.mjs'];
+const forbiddenRootFrontendArtifacts = ['.next', 'next-env.d.ts', 'tsconfig.tsbuildinfo'];
 const failures = [];
 
 for (const path of required) {
@@ -36,6 +37,12 @@ for (const path of forbiddenRootFrontendDirs) {
 for (const path of forbiddenRootFrontendFiles) {
   if (existsSync(join(root, path))) {
     failures.push(`frontend config file must not live at repository root: ${path}`);
+  }
+}
+
+for (const path of forbiddenRootFrontendArtifacts) {
+  if (existsSync(join(root, path))) {
+    failures.push(`stale frontend generated artifact must not live at repository root: ${path}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a root workspace guard that fails when stale frontend generated artifacts (`.next`, `next-env.d.ts`, `tsconfig.tsbuildinfo`) reappear at repository root.
- Reconcile backend design docs that still treated completed frontend relocation/workspace-map introduction as unresolved.
- Record the cleanup/dedup pass in the backend change ledger.

## Trace
- Change-control: EVNSolution/clever-change-control#62
- Target issue: EVNSolution/thundercrew-domain#36
- Root project-start: EVNSolution/clever-change-control#45
- Branch: `cc-62-workspace-cleanup-dedup`

## Concurrent work gate
Decision: allowed-with-non-overlap

Evidence checked before PR creation:
- No open target PRs existed before this PR was opened.
- The only open target issue was this cleanup issue (#36).
- Other open change-control issues were unrelated to the thundercrew-domain workspace cleanup/documentation dedup surface.

## Verification
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- `git diff --check`
- code-reviewer subagent: PASS

## Notes
- Runtime behavior, API contracts, DB schema, package dependencies, secrets, and Vercel/Supabase settings were not changed.
- Ignored local root artifacts (`.next`, `next-env.d.ts`, `tsconfig.tsbuildinfo`, `.DS_Store`) were removed locally; only tracked guard/docs changes are in this PR.
