### PR TITLE
Codify framework process metadata discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ ThunderCrew 전기 이륜차 운영 관제/관리 서비스 워크스페이스�
 
 자세한 구조는 `WORKSPACE.md`와 `repo-map.md`를 봅니다.
 
+## Framework and process
+
+상세한 프레임워크/프로세스 기준은 `docs/process/framework-and-process.md`에 둡니다.
+
+현재 기준:
+
+- Frontend runtime: `development/front-admin-web` — Next.js App Router / TypeScript.
+- Backend runtime: `development/service-ops-api` — Spring Boot / Java 21 / Gradle Kotlin DSL.
+- Integration branch: `dev`.
+- Deploy/promotion branch: `main`.
+- Work branch pattern: `cc-<clever-change-control-issue>-<scope-slug>`.
+- 모든 비사소한 변경은 `clever-change-control` 이슈와 target repository 이슈를
+  양방향으로 연결한 뒤 진행합니다.
+
+### Change-control metadata maintenance
+
+Change-control 기반 메타데이터는 각 이슈 루프의 일부로 유지합니다.
+
+- 작업 전: change-control 이슈, target 이슈, trace branch, concurrent-work
+  decision을 양쪽 GitHub 이슈에 기록합니다.
+- 작업 중: phase, branch, 관련 commit, PR 링크, status, next action을 이슈
+  comment에 갱신합니다.
+- PR body: trace link, 최종 concurrent-work decision, verification evidence를
+  반복해서 남깁니다.
+- merge 후: 양쪽 이슈를 닫고 trace branch를 삭제하며 merge commit을 기록합니다.
+- Local agent memory: `.omx/project-memory.json`과 `.omx/notepad.md`에는
+  non-secret 상태/링크만 기록하고, 완료 후 active issue/branch/PR 필드는 비웁니다.
+- DB password, JWT secret, service-role key, connection string 같은 secret은
+  README, docs, `.omx/project-memory.json`, `.omx/notepad.md`에 저장하지 않습니다.
+
+Local memory의 deployment metadata는 기록일 뿐 source of truth가 아닙니다.
+Vercel/Supabase의 현재 상태를 말할 때는 CLI/API로 다시 확인합니다.
+
 ## Root commands
 
 루트 명령은 현재 frontend workspace로 위임됩니다.

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -30,3 +30,10 @@
 - `dev` is the target repository integration branch.
 - `main` remains the deploy/promotion branch.
 - Product code should stay inside a runtime slice unless it is root orchestration, docs, or shared workflow metadata.
+
+- Keep change-control metadata current: update the CLEVER issue, target issue,
+  PR body, `.omx/project-memory.json`, and `.omx/notepad.md` at durable phase
+  changes; clear active metadata after merge/branch cleanup.
+- Store only non-secret metadata in docs or `.omx` memory. Verify Vercel/Supabase
+  operational state with CLI/API evidence before treating memory values as
+  current truth.

--- a/docs/process/framework-and-process.md
+++ b/docs/process/framework-and-process.md
@@ -1,0 +1,93 @@
+# Framework and process baseline
+
+## Purpose
+
+This document is the durable working contract for `thundercrew-domain` after the
+workspace split. It summarizes the current framework choices and the process that
+keeps implementation work traceable through CLEVER change-control.
+
+## Framework baseline
+
+| Slice | Path | Framework/runtime | Role |
+| --- | --- | --- | --- |
+| Admin web | `development/front-admin-web` | Next.js App Router / TypeScript | 지도 관제와 운영관리 관리자 UI |
+| Operations API | `development/service-ops-api` | Spring Boot / Java 21 / Gradle Kotlin DSL | 운영 도메인 API와 command/read contracts |
+| Database | backend Flyway migrations | PostgreSQL baseline | 운영 데이터 schema baseline |
+| Legacy MVP DB assets | `development/front-admin-web/supabase` | Supabase SQL migration/seed | frontend-first prototype evidence; not the canonical Spring Boot schema |
+| Workspace root | repository root | npm workspace orchestration | command delegation, docs, traceability, process metadata |
+
+The repository root is not a runtime app root. Runtime source must stay in the
+slice that owns it unless the change is explicitly root orchestration, shared
+docs, or workflow metadata.
+
+## Branch and issue process
+
+Every non-trivial implementation or durable process change follows this loop:
+
+1. Identify or create the CLEVER change-control issue in
+   `EVNSolution/clever-change-control`.
+2. Identify or create the target repository issue in
+   `EVNSolution/thundercrew-domain`.
+3. Cross-link both issues with explicit issue mentions.
+4. Create a trace branch named with the change-control issue, for example
+   `cc-63-framework-process-docs`.
+5. Record the concurrent-work gate on both issues before implementation.
+6. Implement only the accepted issue-size scope.
+7. Verify with commands appropriate to the changed surface.
+8. Open a PR into `dev`; repeat the concurrent-work decision in the PR body.
+9. Merge to `dev`, close both issues, delete the trace branch, and prune remotes.
+10. Update metadata and handoff notes.
+
+## Branch roles
+
+| Branch | Meaning |
+| --- | --- |
+| `main` | deploy/promotion branch; not normal day-to-day work |
+| `dev` | target repository integration branch |
+| `cc-<change-control-issue>-<slug>` | scoped trace branch for a concrete issue |
+
+## Change-control metadata maintenance
+
+Metadata is part of the work, not a cleanup afterthought. Keep these records in
+sync with the issue loop:
+
+| Record | When to update | What to keep |
+| --- | --- | --- |
+| `clever-change-control` issue | before work, before PR, after merge | phase, target repo, branch, commits, PR, status, next action |
+| target repo issue | before work, before PR, after merge | change-control link, branch, concurrent decision, verification, completion |
+| PR body | when opening PR | trace links, final concurrent-work decision, verification evidence |
+| `.omx/project-memory.json` | after durable milestones | non-secret IDs/URLs/status, active issue/branch/PR fields, merge commits |
+| `.omx/notepad.md` | after durable milestones or before context loss | narrative handoff, decisions, verification, next candidates |
+| repository docs | when framework/process/runtime boundary changes | durable rules only; avoid per-issue noise in README |
+
+### Active vs completed metadata
+
+During an active issue, `.omx/project-memory.json` should show the active
+change-control issue, target issue, branch, and PR when one exists. After merge
+and cleanup, clear active fields and move the final URLs/merge commit into a
+completed-scope entry.
+
+### Secret and deployment metadata rules
+
+- Never store DB passwords, service-role keys, JWT secrets, or connection strings
+  in README, docs, `.omx/project-memory.json`, or `.omx/notepad.md`.
+- It is acceptable to store non-secret deployment metadata such as Vercel project
+  ID, Supabase project ref, public API URL, production URL, PR URL, and merge
+  commit.
+- Treat deployment metadata as a cached record. Before making operational claims
+  such as "current production deployment" or "Supabase project is healthy",
+  verify with CLI/API evidence.
+
+## Verification expectations
+
+Minimum verification is selected by changed surface:
+
+| Changed surface | Required verification |
+| --- | --- |
+| workspace/root docs or process only | `npm run check:workspace`, `git diff --check` |
+| frontend source/config | `npm run check:workspace`, `npm run lint`, `npm run typecheck`, `npm run build` |
+| backend source/config | `(cd development/service-ops-api && ./gradlew test)`, `(cd development/service-ops-api && ./gradlew build)` |
+| cross-slice changes | frontend and backend verification together |
+| deployment claims | Vercel/Supabase CLI or API inspection plus local build where relevant |
+
+Verification output must be read before claiming completion.

--- a/repo-map.md
+++ b/repo-map.md
@@ -6,7 +6,7 @@
 - `package-lock.json` — npm workspace lockfile.
 - `WORKSPACE.md` — workspace operating model.
 - `repo-map.md` — this file.
-- `docs/` — design/change ledgers and traceability documents.
+- `docs/` — design/change ledgers, traceability documents, and process baselines.
 - `scripts/check-workspace-layout.mjs` — guard for the intended runtime-slice layout and stale root frontend artifacts.
 
 ## Frontend: `development/front-admin-web`
@@ -18,6 +18,10 @@
 - `supabase/` — historical MVP Supabase migration/seed used by the frontend-first prototype.
 - `DESIGN.md` — frontend design direction and visual baseline.
 - `package.json`, `next.config.ts`, `tsconfig.json`, `eslint.config.mjs` — frontend runtime configuration.
+
+## Process docs
+
+- `docs/process/framework-and-process.md` — framework/process baseline and change-control metadata maintenance rules.
 
 ## Backend: `development/service-ops-api`
 


### PR DESCRIPTION
## Summary
- Add a root README framework/process section with explicit change-control metadata maintenance rules.
- Add `docs/process/framework-and-process.md` as the durable framework/process baseline.
- Link the process baseline from `repo-map.md` and reinforce non-secret metadata maintenance in `WORKSPACE.md`.

## Trace
- Change-control: EVNSolution/clever-change-control#63
- Target issue: EVNSolution/thundercrew-domain#38
- Root project-start: EVNSolution/clever-change-control#45
- Branch: `cc-63-framework-process-docs`

## Concurrent work gate
Decision: allowed-with-non-overlap

Evidence checked before PR creation:
- No open target PRs existed before this PR was opened.
- The only open target issue was this framework/process documentation issue (#38).
- Other open change-control issues were unrelated to this target repository framework/process metadata documentation surface.

## Verification
- `npm run check:workspace`
- `git diff --check`
- Markdown link/file checks for README → `docs/process/framework-and-process.md`
- code-reviewer subagent: PASS

## Notes
- Documentation-only change.
- Runtime behavior, API contracts, DB schema, package dependencies, Vercel/Supabase settings, and secrets were not changed.
