### PR TITLE
Add insurance command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -62,6 +62,14 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `POST /api/v1/bike-equipments`
   - `PATCH /api/v1/bike-equipments/{id}`
   - `PATCH /api/v1/bike-equipments/{id}/remove`
+- Insurance item registry command endpoints:
+  - `POST /api/v1/insurance-items`
+  - `PATCH /api/v1/insurance-items/{id}`
+  - `DELETE /api/v1/insurance-items/{id}`
+- Rider-insurance link command endpoints:
+  - `POST /api/v1/rider-insurances`
+  - `PATCH /api/v1/rider-insurances/{id}`
+  - `DELETE /api/v1/rider-insurances/{id}`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -165,6 +173,32 @@ curl -X PATCH http://localhost:8080/api/v1/bike-equipments/<equipment-id>/remove
   -d '{"removedAt":"2026-05-01T00:00:00Z","memo":"장비 탈거"}'
 ```
 
+## Insurance item registry command API
+
+The insurance item registry slice manages the operator-created list of insurance names that can be attached to riders. UI forms should collect a human-readable insurance name/description and enabled state only; operators must not type raw database IDs.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/insurance-items \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"유상운송 보험","description":"라이더 운영 보험","enabled":true}'
+```
+
+Duplicate active insurance item names return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted names may be reused. Insurance item deletion is a soft delete that disables the item and returns `409 INVALID_STATE_TRANSITION` while enabled rider-insurance links still reference it.
+
+## Rider-insurance link command API
+
+The rider-insurance slice links riders to selected insurance items. The backend accepts selector-produced UUID references from a UI that chooses riders by name/phone and insurance items by name; users must not type raw FK IDs. Generic update is limited to link memo/enabled state. Moving a link to another rider or insurance item should be modeled as delete + create or a future correction workflow.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/rider-insurances \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"riderId":"<selected-rider-id>","insuranceItemId":"<selected-insurance-item-id>","memo":"상담 후 연결","enabled":true}'
+```
+
+Missing/deleted riders and missing/deleted/disabled insurance items are rejected with the shared reference/invalid-state error contracts. Duplicate active rider-insurance pairs return `409 DUPLICATE_ACTIVE_RESOURCE`; deleting a link soft-deletes and disables it so the same pair can be created again while preserving the historical row.
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -216,7 +250,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Create/update/delete service/controller slices for insurance and station resources
+- Create/update/delete service/controller slices for station resources
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/InsuranceItemCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/InsuranceItemCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.insurance.controller;
+
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemCreateRequest;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemReadResponse;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemUpdateRequest;
+import com.thundercrew.opsapi.insurance.service.InsuranceItemCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/insurance-items")
+public class InsuranceItemCommandController {
+
+    private final InsuranceItemCommandService insuranceItemCommandService;
+
+    public InsuranceItemCommandController(InsuranceItemCommandService insuranceItemCommandService) {
+        this.insuranceItemCommandService = insuranceItemCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<InsuranceItemReadResponse> create(@Valid @RequestBody InsuranceItemCreateRequest request) {
+        InsuranceItemReadResponse response = insuranceItemCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/insurance-items/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    InsuranceItemReadResponse update(@PathVariable UUID id, @Valid @RequestBody InsuranceItemUpdateRequest request) {
+        return insuranceItemCommandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        insuranceItemCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/RiderInsuranceCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/controller/RiderInsuranceCommandController.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.insurance.controller;
+
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceCreateRequest;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceReadResponse;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceUpdateRequest;
+import com.thundercrew.opsapi.insurance.service.RiderInsuranceCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider-insurances")
+public class RiderInsuranceCommandController {
+
+    private final RiderInsuranceCommandService riderInsuranceCommandService;
+
+    public RiderInsuranceCommandController(RiderInsuranceCommandService riderInsuranceCommandService) {
+        this.riderInsuranceCommandService = riderInsuranceCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<RiderInsuranceReadResponse> create(@Valid @RequestBody RiderInsuranceCreateRequest request) {
+        RiderInsuranceReadResponse response = riderInsuranceCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/rider-insurances/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    RiderInsuranceReadResponse update(@PathVariable UUID id, @Valid @RequestBody RiderInsuranceUpdateRequest request) {
+        return riderInsuranceCommandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        riderInsuranceCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "insurance_items")
@@ -17,6 +19,38 @@ public class InsuranceItem extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    public static InsuranceItem create(
+            String name,
+            String description,
+            Boolean enabled
+    ) {
+        InsuranceItem item = new InsuranceItem();
+        item.name = name;
+        item.description = description;
+        item.enabled = enabled == null || enabled;
+        return item;
+    }
+
+    public void updateOperatorManagedFields(
+            String name,
+            String description,
+            Boolean enabled
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+    }
+
+    public void disableAndMarkDeleted(UUID actorId, Instant deletedAt) {
+        this.enabled = false;
+        markDeleted(actorId, deletedAt);
+    }
 
     public String getName() {
         return name;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
@@ -4,6 +4,7 @@ import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -21,6 +22,36 @@ public class RiderInsurance extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    public static RiderInsurance create(
+            UUID riderId,
+            UUID insuranceItemId,
+            String memo,
+            Boolean enabled
+    ) {
+        RiderInsurance riderInsurance = new RiderInsurance();
+        riderInsurance.riderId = riderId;
+        riderInsurance.insuranceItemId = insuranceItemId;
+        riderInsurance.memo = memo;
+        riderInsurance.enabled = enabled == null || enabled;
+        return riderInsurance;
+    }
+
+    public void updateOperatorManagedFields(
+            String memo,
+            Boolean enabled
+    ) {
+        if (memo != null) {
+            this.memo = memo;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+    }
+
+    public void disableAndMarkDeleted(UUID actorId, Instant deletedAt) {
+        this.enabled = false;
+        markDeleted(actorId, deletedAt);
+    }
 
     public java.util.UUID getRiderId() {
         return riderId;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemCreateRequest.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record InsuranceItemCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        String description,
+        Boolean enabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InsuranceItemUpdateRequest {
+
+    @Size(max = 100)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String name;
+
+    private String description;
+
+    private Boolean enabled;
+
+    public String name() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceCreateRequest.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RiderInsuranceCreateRequest(
+        @NotNull UUID riderId,
+        @NotNull UUID insuranceItemId,
+        String memo,
+        Boolean enabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.insurance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RiderInsuranceUpdateRequest {
+
+    private String memo;
+
+    private Boolean enabled;
+
+    public String memo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public Boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/InsuranceItemRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/InsuranceItemRepository.java
@@ -11,5 +11,13 @@ public interface InsuranceItemRepository extends Repository<InsuranceItem, UUID>
 
     Page<InsuranceItem> findByDeletedAtIsNull(Pageable pageable);
 
+    Optional<InsuranceItem> findById(UUID id);
+
     Optional<InsuranceItem> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
+
+    boolean existsByNameAndIdNotAndDeletedAtIsNull(String name, UUID id);
+
+    InsuranceItem save(InsuranceItem insuranceItem);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/RiderInsuranceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/repository/RiderInsuranceRepository.java
@@ -12,4 +12,10 @@ public interface RiderInsuranceRepository extends Repository<RiderInsurance, UUI
     Page<RiderInsurance> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<RiderInsurance> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByRiderIdAndInsuranceItemIdAndDeletedAtIsNull(UUID riderId, UUID insuranceItemId);
+
+    boolean existsByInsuranceItemIdAndEnabledTrueAndDeletedAtIsNull(UUID insuranceItemId);
+
+    RiderInsurance save(RiderInsurance riderInsurance);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceItemCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceItemCommandService.java
@@ -1,0 +1,96 @@
+package com.thundercrew.opsapi.insurance.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemCreateRequest;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemReadResponse;
+import com.thundercrew.opsapi.insurance.dto.InsuranceItemUpdateRequest;
+import com.thundercrew.opsapi.insurance.repository.InsuranceItemRepository;
+import com.thundercrew.opsapi.insurance.repository.RiderInsuranceRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class InsuranceItemCommandService {
+
+    private final InsuranceItemRepository insuranceItemRepository;
+    private final RiderInsuranceRepository riderInsuranceRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public InsuranceItemCommandService(
+            InsuranceItemRepository insuranceItemRepository,
+            RiderInsuranceRepository riderInsuranceRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.insuranceItemRepository = insuranceItemRepository;
+        this.riderInsuranceRepository = riderInsuranceRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public InsuranceItemReadResponse create(InsuranceItemCreateRequest request) {
+        assertNameIsNotDuplicated(request.name());
+        InsuranceItem item = InsuranceItem.create(
+                request.name(),
+                request.description(),
+                request.enabled()
+        );
+        try {
+            InsuranceItem saved = insuranceItemRepository.save(item);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return InsuranceItemReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("InsuranceItem", "name");
+        }
+    }
+
+    @Transactional
+    public InsuranceItemReadResponse update(UUID id, InsuranceItemUpdateRequest request) {
+        InsuranceItem item = insuranceItemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("InsuranceItem", id));
+        if (StringUtils.hasText(request.name())
+                && insuranceItemRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
+            throw new DuplicateActiveResourceException("InsuranceItem", "name");
+        }
+        try {
+            item.updateOperatorManagedFields(
+                    request.name(),
+                    request.description(),
+                    request.enabled()
+            );
+            entityManager.flush();
+            return InsuranceItemReadResponse.from(item);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("InsuranceItem", "name");
+        }
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        InsuranceItem item = insuranceItemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("InsuranceItem", id));
+        if (riderInsuranceRepository.existsByInsuranceItemIdAndEnabledTrueAndDeletedAtIsNull(id)) {
+            throw new InvalidStateTransitionException(
+                    "Insurance item cannot be deleted while active rider insurance links reference it."
+            );
+        }
+        item.disableAndMarkDeleted(null, clock.instant());
+    }
+
+    private void assertNameIsNotDuplicated(String name) {
+        if (insuranceItemRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new DuplicateActiveResourceException("InsuranceItem", "name");
+        }
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/RiderInsuranceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/RiderInsuranceCommandService.java
@@ -1,0 +1,115 @@
+package com.thundercrew.opsapi.insurance.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ReferenceDeletedException;
+import com.thundercrew.opsapi.common.api.ReferenceNotFoundException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
+import com.thundercrew.opsapi.insurance.domain.RiderInsurance;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceCreateRequest;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceReadResponse;
+import com.thundercrew.opsapi.insurance.dto.RiderInsuranceUpdateRequest;
+import com.thundercrew.opsapi.insurance.repository.InsuranceItemRepository;
+import com.thundercrew.opsapi.insurance.repository.RiderInsuranceRepository;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderInsuranceCommandService {
+
+    private final RiderInsuranceRepository riderInsuranceRepository;
+    private final RiderRepository riderRepository;
+    private final InsuranceItemRepository insuranceItemRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public RiderInsuranceCommandService(
+            RiderInsuranceRepository riderInsuranceRepository,
+            RiderRepository riderRepository,
+            InsuranceItemRepository insuranceItemRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.riderInsuranceRepository = riderInsuranceRepository;
+        this.riderRepository = riderRepository;
+        this.insuranceItemRepository = insuranceItemRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public RiderInsuranceReadResponse create(RiderInsuranceCreateRequest request) {
+        assertActiveRiderReference(request.riderId());
+        findEnabledInsuranceItemReference(request.insuranceItemId());
+        assertRiderInsurancePairIsNotDuplicated(request.riderId(), request.insuranceItemId());
+
+        RiderInsurance riderInsurance = RiderInsurance.create(
+                request.riderId(),
+                request.insuranceItemId(),
+                request.memo(),
+                request.enabled()
+        );
+        try {
+            RiderInsurance saved = riderInsuranceRepository.save(riderInsurance);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return RiderInsuranceReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("RiderInsurance", "riderId/insuranceItemId");
+        }
+    }
+
+    @Transactional
+    public RiderInsuranceReadResponse update(UUID id, RiderInsuranceUpdateRequest request) {
+        RiderInsurance riderInsurance = riderInsuranceRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderInsurance", id));
+        if (Boolean.TRUE.equals(request.enabled())) {
+            assertActiveRiderReference(riderInsurance.getRiderId());
+            findEnabledInsuranceItemReference(riderInsurance.getInsuranceItemId());
+        }
+        riderInsurance.updateOperatorManagedFields(request.memo(), request.enabled());
+        entityManager.flush();
+        return RiderInsuranceReadResponse.from(riderInsurance);
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        RiderInsurance riderInsurance = riderInsuranceRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderInsurance", id));
+        riderInsurance.disableAndMarkDeleted(null, clock.instant());
+    }
+
+    private void assertActiveRiderReference(UUID riderId) {
+        if (riderRepository.findByIdAndDeletedAtIsNull(riderId).isPresent()) {
+            return;
+        }
+        if (riderRepository.existsById(riderId)) {
+            throw new ReferenceDeletedException("Rider", riderId);
+        }
+        throw new ReferenceNotFoundException("Rider", riderId);
+    }
+
+    private InsuranceItem findEnabledInsuranceItemReference(UUID insuranceItemId) {
+        InsuranceItem item = insuranceItemRepository.findById(insuranceItemId)
+                .orElseThrow(() -> new ReferenceNotFoundException("InsuranceItem", insuranceItemId));
+        if (item.isDeleted()) {
+            throw new ReferenceDeletedException("InsuranceItem", insuranceItemId);
+        }
+        if (!item.isEnabled()) {
+            throw new InvalidStateTransitionException("Insurance item is disabled and cannot be linked.");
+        }
+        return item;
+    }
+
+    private void assertRiderInsurancePairIsNotDuplicated(UUID riderId, UUID insuranceItemId) {
+        if (riderInsuranceRepository.existsByRiderIdAndInsuranceItemIdAndDeletedAtIsNull(riderId, insuranceItemId)) {
+            throw new DuplicateActiveResourceException("RiderInsurance", "riderId/insuranceItemId");
+        }
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
@@ -15,6 +15,8 @@ public interface RiderRepository extends Repository<Rider, UUID> {
 
     Optional<Rider> findByIdAndDeletedAtIsNull(UUID id);
 
+    boolean existsById(UUID id);
+
     boolean existsByPhoneNumberAndDeletedAtIsNull(String phoneNumber);
 
     boolean existsByPhoneNumberAndIdNotAndDeletedAtIsNull(String phoneNumber, UUID id);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -81,7 +81,9 @@ class ArchitectureBoundaryTests {
                         || isDeviceCommand(method)
                         || isBikeDeviceInstallationCommand(method)
                         || isEquipmentTypeCommand(method)
-                        || isBikeEquipmentCommand(method)) {
+                        || isBikeEquipmentCommand(method)
+                        || isInsuranceItemCommand(method)
+                        || isRiderInsuranceCommand(method)) {
                     return;
                 }
 
@@ -111,7 +113,9 @@ class ArchitectureBoundaryTests {
                         && !isDeviceCommand(method)
                         && !isBikeDeviceInstallationCommand(method)
                         && !isEquipmentTypeCommand(method)
-                        && !isBikeEquipmentCommand(method)) {
+                        && !isBikeEquipmentCommand(method)
+                        && !isInsuranceItemCommand(method)
+                        && !isRiderInsuranceCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -178,6 +182,20 @@ class ArchitectureBoundaryTests {
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
                 || method.getName().equals("remove"));
+    }
+
+    private static boolean isInsuranceItemCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.insurance.controller.InsuranceItemCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("delete"));
+    }
+
+    private static boolean isRiderInsuranceCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.insurance.controller.RiderInsuranceCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("delete"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/InsuranceItemCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/InsuranceItemCommandApiContractTests.java
@@ -1,0 +1,271 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InsuranceItemCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID INSURANCE_ITEM_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID RIDER_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID RIDER_INSURANCE_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_insurances");
+        jdbcTemplate.update("delete from insurance_items");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createInsuranceItemGeneratesIdentifiersAndIgnoresClientSuppliedSystemFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "name":"기본 보험",
+                                  "description":"운영자 관리 보험명",
+                                  "enabled":true,
+                                  "deletedAt":"2026-01-01T00:00:00Z",
+                                  "riderId":"11111111-1111-1111-1111-111111111111"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/insurance-items/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.name").value("기본 보험"))
+                .andExpect(jsonPath("$.description").value("운영자 관리 보험명"))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andReturn();
+
+        mockMvc.perform(get("/api/v1/insurance-items/{id}", extractId(result))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("기본 보험"));
+    }
+
+    @Test
+    void createInsuranceItemRejectsMissingNameAndDuplicateActiveName() throws Exception {
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+
+        seedInsuranceItem(INSURANCE_ITEM_ID, "화재 보험", true, null);
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"화재 보험"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateInsuranceItemChangesOperatorFieldsAndRejectsMissingOrDuplicateTargets() throws Exception {
+        seedInsuranceItem(INSURANCE_ITEM_ID, "유상운송 보험", true, null);
+        UUID otherId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        seedInsuranceItem(otherId, "책임 보험", true, null);
+        Long originalIdx = jdbcTemplate.queryForObject("select idx from insurance_items where id = ?", Long.class, INSURANCE_ITEM_ID);
+
+        mockMvc.perform(patch("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"11111111-1111-1111-1111-111111111111",
+                                  "idx":999,
+                                  "name":"유상운송 종합보험",
+                                  "description":"수정된 보험 설명",
+                                  "enabled":false,
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(INSURANCE_ITEM_ID.toString()))
+                .andExpect(jsonPath("$.idx").value(originalIdx))
+                .andExpect(jsonPath("$.name").value("유상운송 종합보험"))
+                .andExpect(jsonPath("$.description").value("수정된 보험 설명"))
+                .andExpect(jsonPath("$.enabled").value(false));
+
+        Boolean stillNotDeleted = jdbcTemplate.queryForObject("select deleted_at is null from insurance_items where id = ?", Boolean.class, INSURANCE_ITEM_ID);
+        assertThat(stillNotDeleted).isTrue();
+
+        UUID missingId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        mockMvc.perform(patch("/api/v1/insurance-items/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"없는 보험"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"책임 보험"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void deleteInsuranceItemSoftDeletesDisablesAllowsNameReuseAndBlocksEnabledLinksOnly() throws Exception {
+        seedInsuranceItem(INSURANCE_ITEM_ID, "라이더 보험", true, null);
+        seedRider(RIDER_ID);
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID, true, null);
+
+        mockMvc.perform(delete("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        jdbcTemplate.update("update rider_insurances set enabled = false where id = ?", RIDER_INSURANCE_ID);
+        mockMvc.perform(delete("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        Boolean enabled = jdbcTemplate.queryForObject("select enabled from insurance_items where id = ?", Boolean.class, INSURANCE_ITEM_ID);
+        Boolean deleted = jdbcTemplate.queryForObject("select deleted_at is not null from insurance_items where id = ?", Boolean.class, INSURANCE_ITEM_ID);
+        assertThat(enabled).isFalse();
+        assertThat(deleted).isTrue();
+
+        mockMvc.perform(get("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"라이더 보험"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("라이더 보험"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/insurance-items").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+        mockMvc.perform(patch("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID).contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+        mockMvc.perform(delete("/api/v1/insurance-items/{id}", INSURANCE_ITEM_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedInsuranceItem(UUID id, String name, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into insurance_items (id, name, description, enabled, deleted_at)
+                values (?, ?, 'fixture insurance', ?, %s)
+                """.formatted(deletedAtExpression), id, name, enabled);
+    }
+
+    private void seedRider(UUID id) {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '보험 라이더', ?, false)
+                """, id, "010-" + id.toString().substring(0, 4) + "-0000");
+    }
+
+    private void seedRiderInsurance(UUID id, UUID riderId, UUID insuranceItemId, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into rider_insurances (id, rider_id, insurance_item_id, memo, enabled, deleted_at)
+                values (?, ?, ?, 'fixture rider insurance', ?, %s)
+                """.formatted(deletedAtExpression), id, riderId, insuranceItemId, enabled);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"").matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -234,8 +234,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
         UUID id = RIDER_ID;
         for (String endpoint : List.of(
                 "/api/v1/bike-operation-status-histories",
-                "/api/v1/insurance-items",
-                "/api/v1/rider-insurances",
                 "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"
         )) {
@@ -284,6 +282,17 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isMethodNotAllowed());
         mockMvc.perform(delete("/api/v1/bike-device-installations/{id}", id).with(user("ops-admin")))
                 .andExpect(status().isMethodNotAllowed());
+
+        for (String endpoint : List.of(
+                "/api/v1/insurance-items",
+                "/api/v1/rider-insurances"
+        )) {
+            mockMvc.perform(put(endpoint + "/{id}", id)
+                            .with(user("ops-admin"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
     }
 
     private List<DetailEndpoint> detailEndpoints() {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderInsuranceCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderInsuranceCommandApiContractTests.java
@@ -1,0 +1,346 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderInsuranceCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID OTHER_RIDER_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID INSURANCE_ITEM_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID OTHER_INSURANCE_ITEM_ID = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID RIDER_INSURANCE_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_insurances");
+        jdbcTemplate.update("delete from insurance_items");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createRiderInsuranceGeneratesIdentifiersIgnoresSystemFieldsAndUsesSelectorReferences() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/rider-insurances")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "riderId":"%s",
+                                  "insuranceItemId":"%s",
+                                  "memo":"상담 후 연결",
+                                  "enabled":true,
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId, RIDER_ID, INSURANCE_ITEM_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/rider-insurances/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.riderId").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.insuranceItemId").value(INSURANCE_ITEM_ID.toString()))
+                .andExpect(jsonPath("$.memo").value("상담 후 연결"))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andReturn();
+
+        mockMvc.perform(get("/api/v1/rider-insurances/{id}", extractId(result))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.riderId").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.insuranceItemId").value(INSURANCE_ITEM_ID.toString()));
+    }
+
+    @Test
+    void createRiderInsuranceValidatesRequiredFieldsAndReferences() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedRider(OTHER_RIDER_ID, true);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        seedInsuranceItem(OTHER_INSURANCE_ITEM_ID, "삭제 보험", true, "now()");
+        UUID disabledItemId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        seedInsuranceItem(disabledItemId, "비활성 보험", false, null);
+
+        mockMvc.perform(post("/api/v1/rider-insurances")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+
+        mockMvc.perform(postCreateRequest(UUID.fromString("44444444-4444-4444-4444-444444444444"), INSURANCE_ITEM_ID, "missing rider"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+        mockMvc.perform(postCreateRequest(OTHER_RIDER_ID, INSURANCE_ITEM_ID, "deleted rider"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+        mockMvc.perform(postCreateRequest(RIDER_ID, UUID.fromString("55555555-5555-5555-5555-555555555555"), "missing item"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REFERENCE_NOT_FOUND"));
+        mockMvc.perform(postCreateRequest(RIDER_ID, OTHER_INSURANCE_ITEM_ID, "deleted item"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+        mockMvc.perform(postCreateRequest(RIDER_ID, disabledItemId, "disabled item"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void createRiderInsuranceRejectsDuplicatePairUntilDeleted() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID, true, null);
+
+        mockMvc.perform(postCreateRequest(RIDER_ID, INSURANCE_ITEM_ID, "duplicate"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        mockMvc.perform(delete("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(postCreateRequest(RIDER_ID, INSURANCE_ITEM_ID, "relinked"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void updateRiderInsuranceChangesMemoAndEnabledWithoutMovingSelectedReferences() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedRider(OTHER_RIDER_ID, false);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        seedInsuranceItem(OTHER_INSURANCE_ITEM_ID, "다른 보험", true, null);
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID, true, null);
+        Long originalIdx = jdbcTemplate.queryForObject("select idx from rider_insurances where id = ?", Long.class, RIDER_INSURANCE_ID);
+
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "idx":999,
+                                  "riderId":"%s",
+                                  "insuranceItemId":"%s",
+                                  "memo":"갱신된 메모",
+                                  "enabled":false,
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(OTHER_RIDER_ID, OTHER_INSURANCE_ITEM_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_INSURANCE_ID.toString()))
+                .andExpect(jsonPath("$.idx").value(originalIdx))
+                .andExpect(jsonPath("$.riderId").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.insuranceItemId").value(INSURANCE_ITEM_ID.toString()))
+                .andExpect(jsonPath("$.memo").value("갱신된 메모"))
+                .andExpect(jsonPath("$.enabled").value(false));
+
+        Boolean stillNotDeleted = jdbcTemplate.queryForObject("select deleted_at is null from rider_insurances where id = ?", Boolean.class, RIDER_INSURANCE_ID);
+        assertThat(stillNotDeleted).isTrue();
+
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", UUID.fromString("66666666-6666-6666-6666-666666666666"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"memo":"missing"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void updateRiderInsuranceReenableRevalidatesExistingReferences() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID, false, null);
+
+        jdbcTemplate.update("update riders set deleted_at = now() where id = ?", RIDER_ID);
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"enabled":true}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        jdbcTemplate.update("update riders set deleted_at = null where id = ?", RIDER_ID);
+        jdbcTemplate.update("update insurance_items set deleted_at = now() where id = ?", INSURANCE_ITEM_ID);
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"enabled":true}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_DELETED"));
+
+        jdbcTemplate.update("update insurance_items set deleted_at = null, enabled = false where id = ?", INSURANCE_ITEM_ID);
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"enabled":true}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        jdbcTemplate.update("update insurance_items set enabled = true where id = ?", INSURANCE_ITEM_ID);
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"enabled":true}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true));
+    }
+
+    @Test
+    void deleteRiderInsuranceSoftDeletesDisablesPreservesHistoryAndAllowsPairReuse() throws Exception {
+        seedRider(RIDER_ID, false);
+        seedInsuranceItem(INSURANCE_ITEM_ID, "기본 보험", true, null);
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID, true, null);
+
+        mockMvc.perform(delete("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        Boolean enabled = jdbcTemplate.queryForObject("select enabled from rider_insurances where id = ?", Boolean.class, RIDER_INSURANCE_ID);
+        Boolean deleted = jdbcTemplate.queryForObject("select deleted_at is not null from rider_insurances where id = ?", Boolean.class, RIDER_INSURANCE_ID);
+        assertThat(enabled).isFalse();
+        assertThat(deleted).isTrue();
+
+        mockMvc.perform(get("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(postCreateRequest(RIDER_ID, INSURANCE_ITEM_ID, "recreated"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-insurances").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isUnauthorized()).andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+        mockMvc.perform(patch("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID).contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isUnauthorized()).andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+        mockMvc.perform(delete("/api/v1/rider-insurances/{id}", RIDER_INSURANCE_ID))
+                .andExpect(status().isUnauthorized()).andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private RequestBuilder postCreateRequest(UUID riderId, UUID insuranceItemId, String memo) {
+        return post("/api/v1/rider-insurances")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "riderId":"%s",
+                          "insuranceItemId":"%s",
+                          "memo":"%s",
+                          "enabled":true
+                        }
+                        """.formatted(riderId, insuranceItemId, memo));
+    }
+
+    private void seedRider(UUID id, boolean deleted) {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked, deleted_at)
+                values (?, '보험 라이더', ?, false, %s)
+                """.formatted(deleted ? "now()" : "null"), id, "010-" + id.toString().substring(0, 4) + "-0000");
+    }
+
+    private void seedInsuranceItem(UUID id, String name, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into insurance_items (id, name, description, enabled, deleted_at)
+                values (?, ?, 'fixture insurance', ?, %s)
+                """.formatted(deletedAtExpression), id, name, enabled);
+    }
+
+    private void seedRiderInsurance(UUID id, UUID riderId, UUID insuranceItemId, boolean enabled, String deletedAtSql) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into rider_insurances (id, rider_id, insurance_item_id, memo, enabled, deleted_at)
+                values (?, ?, ?, 'fixture rider insurance', ?, %s)
+                """.formatted(deletedAtExpression), id, riderId, insuranceItemId, enabled);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"").matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -357,3 +357,29 @@ Boundary decision:
 - Root-level stale frontend generated artifacts such as `.next/`, `next-env.d.ts`, and `tsconfig.tsbuildinfo` are treated as cleanup failures by `npm run check:workspace`.
 - Active runtime caches under `development/front-admin-web` and `development/service-ops-api` may be recreated by verification commands and are not product source.
 - Backend design docs should not continue to list the completed frontend relocation or workspace-map introduction as unresolved decisions.
+
+## Insurance command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#64
+- Target issue: EVNSolution/thundercrew-domain#40
+- Branch: `cc-64-insurance-command-baseline`
+
+Issue-size decision:
+
+- This slice adds only the insurance item registry and rider-insurance link command baseline after the equipment lifecycle command slice.
+- Included operations are authenticated `POST /api/v1/insurance-items`, `PATCH /api/v1/insurance-items/{id}`, `DELETE /api/v1/insurance-items/{id}`, `POST /api/v1/rider-insurances`, `PATCH /api/v1/rider-insurances/{id}`, and `DELETE /api/v1/rider-insurances/{id}`.
+- Insurance provider/policy/period expansion, frontend selectors/forms, station commands, rider app-account link/unlink, telemetry/current state, dashboard/map APIs, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only operator-managed insurance item fields or selector-produced rider/insurance references plus link memo/enabled state; UI must choose riders by name/phone and insurance items by name instead of asking users to type raw database IDs.
+- Server-generated id, idx, audit/deleted fields, and relationship/system fields remain non-client inputs and are ignored when sent.
+- Insurance item `name` is unique among active, non-deleted items; soft-deleted names may be reused through the existing active partial unique index.
+- Insurance item soft-delete disables the item and blocks deletion while enabled rider-insurance links reference it.
+- Rider and insurance item references are validated in the service layer without DB foreign keys or JPA relationships.
+- Generic rider-insurance update keeps `riderId` and `insuranceItemId` immutable. Moving a link requires delete + create or a future correction workflow.
+- Re-enabling a disabled rider-insurance link revalidates the existing rider and insurance item references before changing state.
+- Rider-insurance delete soft-deletes and disables the link, preserving history while allowing the same pair to be created again.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the insurance command controllers at this stage.


### PR DESCRIPTION
## Summary

- Add authenticated insurance item registry commands: create, update, soft-delete.
- Add authenticated rider-insurance link commands: create, update memo/enabled, soft-delete.
- Validate rider and insurance item references in service layer without DB FK or JPA relationships.
- Keep user-facing raw ID entry out of API/UI contract docs: selectors should provide UUID references from human-readable rider/insurance choices.
- Add command contract tests, update read-only/architecture guards, and document the command baseline in backend README/change ledger.

## Trace

- Change-control: EVNSolution/clever-change-control#64
- Target issue: EVNSolution/thundercrew-domain#40
- Branch: `cc-64-insurance-command-baseline`

## Concurrent work decision

Decision: `allowed-with-non-overlap`

Evidence:
- Scope is limited to `development/service-ops-api` insurance item/rider-insurance command services, controllers, DTOs, repository methods, backend tests, and docs.
- No station command, rider app-account link/unlink, telemetry/current-state, or frontend-backend integration files are changed in this PR.
- Pre-PR concurrent gate comments were recorded on both EVNSolution/clever-change-control#64 and EVNSolution/thundercrew-domain#40.

## Verification

- `npm run check:workspace` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- `(cd development/service-ops-api && ./gradlew test --max-workers=1 --tests '*RiderInsuranceCommandApiContractTests' --tests '*InsuranceItemCommandApiContractTests' --tests '*ArchitectureBoundaryTests' --tests '*ReadOnlyApiContractTests')` — pass
- `(cd development/service-ops-api && ./gradlew build --max-workers=1)` — pass
- code-reviewer subagent — PASS

## Not included

- Frontend selector integration
- Insurance provider/policy/period expansion
- Station commands
- Rider app-account link/unlink
- Telemetry/current-state ingestion
