### PR TITLE
Add station command baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -70,6 +70,11 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `POST /api/v1/rider-insurances`
   - `PATCH /api/v1/rider-insurances/{id}`
   - `DELETE /api/v1/rider-insurances/{id}`
+- Battery station command endpoints:
+  - `POST /api/v1/battery-stations`
+  - `PATCH /api/v1/battery-stations/{id}`
+  - `PATCH /api/v1/battery-stations/{id}/battery-counts`
+  - `DELETE /api/v1/battery-stations/{id}`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -199,6 +204,28 @@ curl -X POST http://localhost:8080/api/v1/rider-insurances \
 
 Missing/deleted riders and missing/deleted/disabled insurance items are rejected with the shared reference/invalid-state error contracts. Duplicate active rider-insurance pairs return `409 DUPLICATE_ACTIVE_RESOURCE`; deleting a link soft-deletes and disables it so the same pair can be created again while preserving the historical row.
 
+## Battery station command API
+
+The battery station slice manages operator-visible station metadata and battery-count snapshots. UI forms should collect station name, address, map coordinates, status, and count fields; operators must not type generated database IDs. Count-log rows remain read-only from direct API writes and are created by the station battery-count update command.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/battery-stations \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"강남 스테이션","address":"서울 강남구 테헤란로 1","latitude":37.5010000,"longitude":127.0396000,"status":"ACTIVE","maxBatteryCapacity":12,"currentBatteryCount":7,"availableBatteryCount":5}'
+```
+
+Duplicate active station names return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted names may be reused. Count values must satisfy `maxBatteryCapacity >= currentBatteryCount >= availableBatteryCount >= 0`.
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/battery-stations/<station-id>/battery-counts \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"maxBatteryCapacity":12,"currentBatteryCount":7,"availableBatteryCount":5,"reason":"현장 재고 조정","memo":"오전 실사 반영"}'
+```
+
+Station deletion is a soft delete that marks the station inactive while preserving station battery-count log history for audit/read purposes.
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -250,7 +277,6 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Create/update/delete service/controller slices for station resources
 - Rider app-account link/unlink and rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/controller/StationCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/controller/StationCommandController.java
@@ -1,0 +1,55 @@
+package com.thundercrew.opsapi.station.controller;
+
+import com.thundercrew.opsapi.station.dto.BatteryStationCountUpdateRequest;
+import com.thundercrew.opsapi.station.dto.BatteryStationCreateRequest;
+import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
+import com.thundercrew.opsapi.station.dto.BatteryStationUpdateRequest;
+import com.thundercrew.opsapi.station.service.StationCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/battery-stations")
+public class StationCommandController {
+
+    private final StationCommandService stationCommandService;
+
+    public StationCommandController(StationCommandService stationCommandService) {
+        this.stationCommandService = stationCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<BatteryStationReadResponse> create(@Valid @RequestBody BatteryStationCreateRequest request) {
+        BatteryStationReadResponse response = stationCommandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/battery-stations/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    BatteryStationReadResponse update(@PathVariable UUID id, @Valid @RequestBody BatteryStationUpdateRequest request) {
+        return stationCommandService.update(id, request);
+    }
+
+    @PatchMapping("/{id}/battery-counts")
+    BatteryStationReadResponse updateBatteryCounts(
+            @PathVariable UUID id,
+            @Valid @RequestBody BatteryStationCountUpdateRequest request
+    ) {
+        return stationCommandService.updateBatteryCounts(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        stationCommandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/BatteryStation.java
@@ -7,6 +7,8 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "battery_stations")
@@ -39,6 +41,72 @@ public class BatteryStation extends DisplaySequencedEntity {
 
     private String memo;
 
+    public static BatteryStation create(
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BatteryStationStatus status,
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount,
+            String memo
+    ) {
+        BatteryStation station = new BatteryStation();
+        station.name = name;
+        station.address = address;
+        station.latitude = latitude;
+        station.longitude = longitude;
+        station.status = status;
+        station.maxBatteryCapacity = maxBatteryCapacity;
+        station.currentBatteryCount = currentBatteryCount;
+        station.availableBatteryCount = availableBatteryCount;
+        station.memo = memo;
+        return station;
+    }
+
+    public void updateOperatorManagedFields(
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BatteryStationStatus status,
+            String memo
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (address != null) {
+            this.address = address;
+        }
+        if (latitude != null) {
+            this.latitude = latitude;
+        }
+        if (longitude != null) {
+            this.longitude = longitude;
+        }
+        if (status != null) {
+            this.status = status;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public void updateBatteryCounts(
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount
+    ) {
+        this.maxBatteryCapacity = maxBatteryCapacity;
+        this.currentBatteryCount = currentBatteryCount;
+        this.availableBatteryCount = availableBatteryCount;
+    }
+
+    public void markInactiveAndDeleted(UUID actorId, Instant deletedAt) {
+        this.status = BatteryStationStatus.INACTIVE;
+        markDeleted(actorId, deletedAt);
+    }
 
     public String getName() {
         return name;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/domain/StationBatteryCountLog.java
@@ -42,6 +42,33 @@ public class StationBatteryCountLog extends DisplaySequencedEntity {
 
     private UUID changedBy;
 
+    public static StationBatteryCountLog create(
+            UUID stationId,
+            int beforeMaxBatteryCapacity,
+            int afterMaxBatteryCapacity,
+            int beforeCurrentBatteryCount,
+            int afterCurrentBatteryCount,
+            int beforeAvailableBatteryCount,
+            int afterAvailableBatteryCount,
+            String reason,
+            String memo,
+            Instant changedAt,
+            UUID changedBy
+    ) {
+        StationBatteryCountLog log = new StationBatteryCountLog();
+        log.stationId = stationId;
+        log.beforeMaxBatteryCapacity = beforeMaxBatteryCapacity;
+        log.afterMaxBatteryCapacity = afterMaxBatteryCapacity;
+        log.beforeCurrentBatteryCount = beforeCurrentBatteryCount;
+        log.afterCurrentBatteryCount = afterCurrentBatteryCount;
+        log.beforeAvailableBatteryCount = beforeAvailableBatteryCount;
+        log.afterAvailableBatteryCount = afterAvailableBatteryCount;
+        log.reason = reason;
+        log.memo = memo;
+        log.changedAt = changedAt;
+        log.changedBy = changedBy;
+        return log;
+    }
 
     public java.util.UUID getStationId() {
         return stationId;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationCountUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationCountUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.thundercrew.opsapi.station.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BatteryStationCountUpdateRequest(
+        @NotNull @PositiveOrZero Integer maxBatteryCapacity,
+        @NotNull @PositiveOrZero Integer currentBatteryCount,
+        @NotNull @PositiveOrZero Integer availableBatteryCount,
+        @Size(max = 100) String reason,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationCreateRequest.java
@@ -1,0 +1,25 @@
+package com.thundercrew.opsapi.station.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BatteryStationCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotBlank @Size(max = 255) String address,
+        @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") BigDecimal latitude,
+        @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
+        @NotNull BatteryStationStatus status,
+        @NotNull @PositiveOrZero Integer maxBatteryCapacity,
+        @NotNull @PositiveOrZero Integer currentBatteryCount,
+        @NotNull @PositiveOrZero Integer availableBatteryCount,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/dto/BatteryStationUpdateRequest.java
@@ -1,0 +1,81 @@
+package com.thundercrew.opsapi.station.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BatteryStationUpdateRequest {
+
+    @Size(max = 100)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String name;
+
+    @Size(max = 255)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided")
+    private String address;
+
+    @DecimalMin("-90.0")
+    @DecimalMax("90.0")
+    private BigDecimal latitude;
+
+    @DecimalMin("-180.0")
+    @DecimalMax("180.0")
+    private BigDecimal longitude;
+
+    private BatteryStationStatus status;
+
+    private String memo;
+
+    public String name() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String address() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public BigDecimal latitude() {
+        return latitude;
+    }
+
+    public void setLatitude(BigDecimal latitude) {
+        this.latitude = latitude;
+    }
+
+    public BigDecimal longitude() {
+        return longitude;
+    }
+
+    public void setLongitude(BigDecimal longitude) {
+        this.longitude = longitude;
+    }
+
+    public BatteryStationStatus status() {
+        return status;
+    }
+
+    public void setStatus(BatteryStationStatus status) {
+        this.status = status;
+    }
+
+    public String memo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
@@ -11,5 +11,13 @@ public interface BatteryStationRepository extends Repository<BatteryStation, UUI
 
     Page<BatteryStation> findByDeletedAtIsNull(Pageable pageable);
 
+    Optional<BatteryStation> findById(UUID id);
+
     Optional<BatteryStation> findByIdAndDeletedAtIsNull(UUID id);
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
+
+    boolean existsByNameAndIdNotAndDeletedAtIsNull(String name, UUID id);
+
+    BatteryStation save(BatteryStation station);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/StationBatteryCountLogRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/StationBatteryCountLogRepository.java
@@ -12,4 +12,6 @@ public interface StationBatteryCountLogRepository extends Repository<StationBatt
     Page<StationBatteryCountLog> findByDeletedAtIsNull(Pageable pageable);
 
     Optional<StationBatteryCountLog> findByIdAndDeletedAtIsNull(UUID id);
+
+    StationBatteryCountLog save(StationBatteryCountLog log);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationCommandService.java
@@ -1,0 +1,147 @@
+package com.thundercrew.opsapi.station.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.station.domain.BatteryStation;
+import com.thundercrew.opsapi.station.domain.StationBatteryCountLog;
+import com.thundercrew.opsapi.station.dto.BatteryStationCountUpdateRequest;
+import com.thundercrew.opsapi.station.dto.BatteryStationCreateRequest;
+import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
+import com.thundercrew.opsapi.station.dto.BatteryStationUpdateRequest;
+import com.thundercrew.opsapi.station.repository.BatteryStationRepository;
+import com.thundercrew.opsapi.station.repository.StationBatteryCountLogRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class StationCommandService {
+
+    private final BatteryStationRepository batteryStationRepository;
+    private final StationBatteryCountLogRepository countLogRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public StationCommandService(
+            BatteryStationRepository batteryStationRepository,
+            StationBatteryCountLogRepository countLogRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.batteryStationRepository = batteryStationRepository;
+        this.countLogRepository = countLogRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public BatteryStationReadResponse create(BatteryStationCreateRequest request) {
+        assertNameIsNotDuplicated(request.name());
+        assertCountInvariant(request.maxBatteryCapacity(), request.currentBatteryCount(), request.availableBatteryCount());
+        BatteryStation station = BatteryStation.create(
+                request.name(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.status(),
+                request.maxBatteryCapacity(),
+                request.currentBatteryCount(),
+                request.availableBatteryCount(),
+                request.memo()
+        );
+        try {
+            BatteryStation saved = batteryStationRepository.save(station);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return BatteryStationReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("BatteryStation", "name");
+        }
+    }
+
+    @Transactional
+    public BatteryStationReadResponse update(UUID id, BatteryStationUpdateRequest request) {
+        BatteryStation station = findActiveStation(id);
+        if (StringUtils.hasText(request.name())
+                && batteryStationRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
+            throw new DuplicateActiveResourceException("BatteryStation", "name");
+        }
+        try {
+            station.updateOperatorManagedFields(
+                    request.name(),
+                    request.address(),
+                    request.latitude(),
+                    request.longitude(),
+                    request.status(),
+                    request.memo()
+            );
+            entityManager.flush();
+            return BatteryStationReadResponse.from(station);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("BatteryStation", "name");
+        }
+    }
+
+    @Transactional
+    public BatteryStationReadResponse updateBatteryCounts(UUID id, BatteryStationCountUpdateRequest request) {
+        BatteryStation station = findActiveStation(id);
+        assertCountInvariant(request.maxBatteryCapacity(), request.currentBatteryCount(), request.availableBatteryCount());
+        Instant changedAt = Instant.now(clock);
+        StationBatteryCountLog log = StationBatteryCountLog.create(
+                station.getId(),
+                station.getMaxBatteryCapacity(),
+                request.maxBatteryCapacity(),
+                station.getCurrentBatteryCount(),
+                request.currentBatteryCount(),
+                station.getAvailableBatteryCount(),
+                request.availableBatteryCount(),
+                request.reason(),
+                request.memo(),
+                changedAt,
+                null
+        );
+        station.updateBatteryCounts(
+                request.maxBatteryCapacity(),
+                request.currentBatteryCount(),
+                request.availableBatteryCount()
+        );
+        countLogRepository.save(log);
+        entityManager.flush();
+        return BatteryStationReadResponse.from(station);
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        BatteryStation station = findActiveStation(id);
+        station.markInactiveAndDeleted(null, clock.instant());
+    }
+
+    private BatteryStation findActiveStation(UUID id) {
+        return batteryStationRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("BatteryStation", id));
+    }
+
+    private void assertNameIsNotDuplicated(String name) {
+        if (batteryStationRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new DuplicateActiveResourceException("BatteryStation", "name");
+        }
+    }
+
+    private void assertCountInvariant(
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount
+    ) {
+        if (currentBatteryCount > maxBatteryCapacity || availableBatteryCount > currentBatteryCount) {
+            throw new InvalidStateTransitionException(
+                    "Battery station counts must satisfy maxBatteryCapacity >= currentBatteryCount >= availableBatteryCount."
+            );
+        }
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -83,7 +83,8 @@ class ArchitectureBoundaryTests {
                         || isEquipmentTypeCommand(method)
                         || isBikeEquipmentCommand(method)
                         || isInsuranceItemCommand(method)
-                        || isRiderInsuranceCommand(method)) {
+                        || isRiderInsuranceCommand(method)
+                        || isStationCommand(method)) {
                     return;
                 }
 
@@ -115,7 +116,8 @@ class ArchitectureBoundaryTests {
                         && !isEquipmentTypeCommand(method)
                         && !isBikeEquipmentCommand(method)
                         && !isInsuranceItemCommand(method)
-                        && !isRiderInsuranceCommand(method)) {
+                        && !isRiderInsuranceCommand(method)
+                        && !isStationCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -195,6 +197,14 @@ class ArchitectureBoundaryTests {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.insurance.controller.RiderInsuranceCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
+                || method.getName().equals("delete"));
+    }
+
+    private static boolean isStationCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.station.controller.StationCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
+                || method.getName().equals("updateBatteryCounts")
                 || method.getName().equals("delete"));
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReadOnlyApiContractTests.java
@@ -234,7 +234,6 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
         UUID id = RIDER_ID;
         for (String endpoint : List.of(
                 "/api/v1/bike-operation-status-histories",
-                "/api/v1/battery-stations",
                 "/api/v1/station-battery-count-logs"
         )) {
             mockMvc.perform(post(endpoint)
@@ -285,7 +284,8 @@ class ReadOnlyApiContractTests extends PostgresContainerSupport {
 
         for (String endpoint : List.of(
                 "/api/v1/insurance-items",
-                "/api/v1/rider-insurances"
+                "/api/v1/rider-insurances",
+                "/api/v1/battery-stations"
         )) {
             mockMvc.perform(put(endpoint + "/{id}", id)
                             .with(user("ops-admin"))

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/StationCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/StationCommandApiContractTests.java
@@ -1,0 +1,430 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StationCommandApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID STATION_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID OTHER_STATION_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID COUNT_LOG_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from station_battery_count_logs");
+        jdbcTemplate.update("delete from battery_stations");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createStationGeneratesIdentifiersAndIgnoresClientSuppliedSystemAndLogFields() throws Exception {
+        String clientSuppliedId = "99999999-9999-9999-9999-999999999999";
+
+        MvcResult result = mockMvc.perform(post("/api/v1/battery-stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"%s",
+                                  "idx":999,
+                                  "name":"서울 강남 스테이션",
+                                  "address":"서울 강남구 테헤란로 1",
+                                  "latitude":37.5665000,
+                                  "longitude":126.9780000,
+                                  "status":"ACTIVE",
+                                  "maxBatteryCapacity":8,
+                                  "currentBatteryCount":6,
+                                  "availableBatteryCount":3,
+                                  "availableBatteryLabel":"999/999",
+                                  "capacityPercentage":999,
+                                  "memo":"지도 핀 기준",
+                                  "stationBatteryCountLogId":"11111111-1111-1111-1111-111111111111",
+                                  "deletedAt":"2026-01-01T00:00:00Z"
+                                }
+                                """.formatted(clientSuppliedId)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/battery-stations/")))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value(org.hamcrest.Matchers.not(clientSuppliedId)))
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.name").value("서울 강남 스테이션"))
+                .andExpect(jsonPath("$.address").value("서울 강남구 테헤란로 1"))
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.maxBatteryCapacity").value(8))
+                .andExpect(jsonPath("$.currentBatteryCount").value(6))
+                .andExpect(jsonPath("$.availableBatteryCount").value(3))
+                .andExpect(jsonPath("$.availableBatteryLabel").value("3/8"))
+                .andExpect(jsonPath("$.capacityPercentage").value(75))
+                .andExpect(jsonPath("$.memo").value("지도 핀 기준"))
+                .andReturn();
+
+        String createdId = extractId(result);
+        mockMvc.perform(get("/api/v1/battery-stations/{id}", createdId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("서울 강남 스테이션"));
+
+        Integer logCount = jdbcTemplate.queryForObject("select count(*) from station_battery_count_logs", Integer.class);
+        assertThat(logCount).isZero();
+    }
+
+    @Test
+    void createStationRejectsMissingHumanRequiredFieldsAndInvalidCounts() throws Exception {
+        mockMvc.perform(post("/api/v1/battery-stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"","address":"","status":"ACTIVE"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.fieldViolations").isArray());
+
+        mockMvc.perform(post("/api/v1/battery-stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 스테이션",
+                                  "address":"서울 중구 세종대로 1",
+                                  "latitude":37.5665000,
+                                  "longitude":126.9780000,
+                                  "status":"ACTIVE",
+                                  "maxBatteryCapacity":5,
+                                  "currentBatteryCount":6,
+                                  "availableBatteryCount":2
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void createStationRejectsDuplicateActiveName() throws Exception {
+        seedStation(STATION_ID, "강남 스테이션", "ACTIVE", 10, 7, 4, null);
+
+        mockMvc.perform(post("/api/v1/battery-stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"강남 스테이션",
+                                  "address":"서울 강남구 역삼로 1",
+                                  "latitude":37.5000000,
+                                  "longitude":127.0300000,
+                                  "status":"ACTIVE",
+                                  "maxBatteryCapacity":10,
+                                  "currentBatteryCount":5,
+                                  "availableBatteryCount":2
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateStationChangesOnlyOperatorManagedFieldsAndIgnoresCountFields() throws Exception {
+        seedStation(STATION_ID, "수정 전 스테이션", "ACTIVE", 10, 7, 4, null);
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "idx":999,
+                                  "name":"수정 후 스테이션",
+                                  "address":"서울 마포구 월드컵북로 1",
+                                  "latitude":37.5500000,
+                                  "longitude":126.9100000,
+                                  "status":"MAINTENANCE",
+                                  "maxBatteryCapacity":99,
+                                  "currentBatteryCount":88,
+                                  "availableBatteryCount":77,
+                                  "memo":"운영자 정보 수정"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(STATION_ID.toString()))
+                .andExpect(jsonPath("$.name").value("수정 후 스테이션"))
+                .andExpect(jsonPath("$.address").value("서울 마포구 월드컵북로 1"))
+                .andExpect(jsonPath("$.status").value("MAINTENANCE"))
+                .andExpect(jsonPath("$.maxBatteryCapacity").value(10))
+                .andExpect(jsonPath("$.currentBatteryCount").value(7))
+                .andExpect(jsonPath("$.availableBatteryCount").value(4))
+                .andExpect(jsonPath("$.memo").value("운영자 정보 수정"));
+    }
+
+    @Test
+    void updateStationRejectsMissingOrDuplicateTargets() throws Exception {
+        seedStation(STATION_ID, "강남 스테이션", "ACTIVE", 10, 7, 4, null);
+        seedStation(OTHER_STATION_ID, "마포 스테이션", "ACTIVE", 12, 8, 3, null);
+
+        UUID missingId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"없는 스테이션"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"마포 스테이션"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void updateBatteryCountsChangesStationAndWritesHistoryLog() throws Exception {
+        seedStation(STATION_ID, "강남 스테이션", "ACTIVE", 10, 6, 3, null);
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}/battery-counts", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "maxBatteryCapacity":12,
+                                  "currentBatteryCount":7,
+                                  "availableBatteryCount":5,
+                                  "reason":"현장 재고 조정",
+                                  "memo":"오전 실사 반영",
+                                  "changedAt":"2026-04-30T01:02:03Z",
+                                  "id":"99999999-9999-9999-9999-999999999999"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(STATION_ID.toString()))
+                .andExpect(jsonPath("$.maxBatteryCapacity").value(12))
+                .andExpect(jsonPath("$.currentBatteryCount").value(7))
+                .andExpect(jsonPath("$.availableBatteryCount").value(5))
+                .andExpect(jsonPath("$.availableBatteryLabel").value("5/12"))
+                .andExpect(jsonPath("$.capacityPercentage").value(58));
+
+        mockMvc.perform(get("/api/v1/station-battery-count-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].stationId").value(STATION_ID.toString()))
+                .andExpect(jsonPath("$.items[0].beforeMaxBatteryCapacity").value(10))
+                .andExpect(jsonPath("$.items[0].afterMaxBatteryCapacity").value(12))
+                .andExpect(jsonPath("$.items[0].beforeCurrentBatteryCount").value(6))
+                .andExpect(jsonPath("$.items[0].afterCurrentBatteryCount").value(7))
+                .andExpect(jsonPath("$.items[0].beforeAvailableBatteryCount").value(3))
+                .andExpect(jsonPath("$.items[0].afterAvailableBatteryCount").value(5))
+                .andExpect(jsonPath("$.items[0].reason").value("현장 재고 조정"))
+                .andExpect(jsonPath("$.items[0].memo").value("오전 실사 반영"))
+                .andExpect(jsonPath("$.items[0].changedAt").isString())
+                .andExpect(jsonPath("$.items[0].changedAt").value(org.hamcrest.Matchers.not("2026-04-30T01:02:03Z")));
+    }
+
+    @Test
+    void updateBatteryCountsRejectsMissingStationsAndInvalidCountInvariants() throws Exception {
+        seedStation(STATION_ID, "강남 스테이션", "ACTIVE", 10, 6, 3, null);
+        UUID missingId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}/battery-counts", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"maxBatteryCapacity":12,"currentBatteryCount":7,"availableBatteryCount":5}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}/battery-counts", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"maxBatteryCapacity":12,"currentBatteryCount":7,"availableBatteryCount":8}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void deleteStationSoftDeletesAllowsNameReuseAndPreservesCountLogHistory() throws Exception {
+        seedStation(STATION_ID, "삭제 대상 스테이션", "ACTIVE", 10, 6, 3, null);
+        seedCountLog(COUNT_LOG_ID, STATION_ID);
+
+        mockMvc.perform(delete("/api/v1/battery-stations/{id}", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        String status = jdbcTemplate.queryForObject(
+                "select status from battery_stations where id = ?",
+                String.class,
+                STATION_ID
+        );
+        assertThat(status).isEqualTo("INACTIVE");
+
+        mockMvc.perform(get("/api/v1/battery-stations/{id}", STATION_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/station-battery-count-logs/{id}", COUNT_LOG_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stationId").value(STATION_ID.toString()));
+
+        mockMvc.perform(post("/api/v1/battery-stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"삭제 대상 스테이션",
+                                  "address":"서울 용산구 한강대로 1",
+                                  "latitude":37.5290000,
+                                  "longitude":126.9640000,
+                                  "status":"ACTIVE",
+                                  "maxBatteryCapacity":10,
+                                  "currentBatteryCount":5,
+                                  "availableBatteryCount":2
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("삭제 대상 스테이션"));
+    }
+
+    @Test
+    void commandRequestsRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/battery-stations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"무권한","address":"서울","latitude":37.0,"longitude":127.0,"status":"ACTIVE","maxBatteryCapacity":1,"currentBatteryCount":1,"availableBatteryCount":1}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}", STATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"memo":"NoAuth"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/battery-stations/{id}/battery-counts", STATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"maxBatteryCapacity":1,"currentBatteryCount":1,"availableBatteryCount":1}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(delete("/api/v1/battery-stations/{id}", STATION_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedStation(
+            UUID id,
+            String name,
+            String status,
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount,
+            String deletedAtSql
+    ) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into battery_stations (
+                    id, name, address, latitude, longitude, status,
+                    max_battery_capacity, current_battery_count, available_battery_count,
+                    memo, deleted_at
+                ) values (?, ?, '서울 강남구 테헤란로 1', 37.5010000, 127.0396000, ?, ?, ?, ?, 'fixture station', %s)
+                """.formatted(deletedAtExpression), id, name, status, maxBatteryCapacity, currentBatteryCount, availableBatteryCount);
+    }
+
+    private void seedCountLog(UUID id, UUID stationId) {
+        jdbcTemplate.update("""
+                insert into station_battery_count_logs (
+                    id, station_id,
+                    before_max_battery_capacity, after_max_battery_capacity,
+                    before_current_battery_count, after_current_battery_count,
+                    before_available_battery_count, after_available_battery_count,
+                    reason, memo, changed_at
+                ) values (?, ?, 10, 10, 4, 6, 2, 3, 'fixture count', 'fixture memo', '2026-04-30T00:00:00Z')
+                """, id, stationId);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\\\"id\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -383,3 +383,26 @@ Boundary decision:
 - Re-enabling a disabled rider-insurance link revalidates the existing rider and insurance item references before changing state.
 - Rider-insurance delete soft-deletes and disables the link, preserving history while allowing the same pair to be created again.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the insurance command controllers at this stage.
+
+## Battery station command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#65
+- Target issue: EVNSolution/thundercrew-domain#42
+- Branch: `cc-65-station-command-baseline`
+
+Issue-size decision:
+
+- This slice adds only the battery station command baseline after the insurance command slice.
+- Included operations are authenticated `POST /api/v1/battery-stations`, `PATCH /api/v1/battery-stations/{id}`, `PATCH /api/v1/battery-stations/{id}/battery-counts`, and `DELETE /api/v1/battery-stations/{id}`.
+- Direct command endpoints for `station_battery_count_logs`, map API integration, frontend selectors/forms, dashboard/map read API expansion, telemetry/current state, hard delete/restore, bulk import/export, and advanced search remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only operator-managed station metadata and count values: name, address, coordinates, status, max/current/available counts, reason, and memo.
+- Server-generated id, idx, audit/deleted fields, computed read labels, and count-log system fields remain non-client inputs and are ignored when sent.
+- Station `name` is unique among active, non-deleted rows; soft-deleted names may be reused through the existing active partial unique index.
+- Count updates must satisfy `maxBatteryCapacity >= currentBatteryCount >= availableBatteryCount >= 0` and create station battery-count log history in the same transaction.
+- Station soft-delete marks the station inactive while preserving count-log history as read-only audit data.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the station command controller at this stage.


### PR DESCRIPTION
## Summary
- Add authenticated battery station create/update/soft-delete command endpoints.
- Add a station battery-count update endpoint that writes station count-log history in the same transaction.
- Keep direct station battery count-log write routes unsupported and keep log timestamps server-owned.
- Update API contract tests, architecture/read-only route guards, backend README, and backend change ledger.

## Trace
- change-control anchor: EVNSolution/clever-change-control#65
- target issue: EVNSolution/thundercrew-domain#42
- branch: cc-65-station-command-baseline

## Concurrent work decision
Decision: allowed-with-non-overlap

Evidence:
- target repo open PRs checked before implementation and before PR.
- target repo open issues checked before implementation and before PR.
- clever-change-control open issues checked before implementation and before PR.

Non-overlap reason:
- This PR is limited to service-ops-api battery station command endpoints, station count-log creation through count updates, tests, and backend docs.
- No other open PR affects the same repo/service/API/data/deploy/file scope.

## Validation
- npm run check:workspace
- npm run lint
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew cleanTest test --max-workers=1)
- (cd development/service-ops-api && ./gradlew build --max-workers=1)
- code-reviewer subagent: PASS

## Notes
- A simultaneous local Gradle run attempted during subagent review caused a test XML report write collision; rerunning after the reviewer finished passed cleanly.
