### PR TITLE
Add rider app-account link commands

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -36,6 +36,8 @@ This module currently provides the backend scaffold, non-telemetry core persiste
 - Rider basic profile command endpoints:
   - `POST /api/v1/riders`
   - `PATCH /api/v1/riders/{id}`
+  - `PATCH /api/v1/riders/{id}/app-account/link`
+  - `PATCH /api/v1/riders/{id}/app-account/unlink`
   - `DELETE /api/v1/riders/{id}`
 - Bike command endpoints:
   - `POST /api/v1/bikes`
@@ -131,6 +133,26 @@ curl -X POST http://localhost:8080/api/v1/riders \
 ```
 
 Duplicate active phone numbers return `409 DUPLICATE_ACTIVE_RESOURCE`; soft-deleted phone numbers may be reused. Rider deletion is a soft delete and returns `409 INVALID_STATE_TRANSITION` when active bike-contract or rider-insurance references still exist.
+
+## Rider app-account link command API
+
+The rider app-account slice manages whether an operations rider is linked to a rider-app account. UI forms should choose an app account by human-readable rider-app context such as phone/email/account summary; operators must not type raw database IDs. The backend accepts the selector-produced `appAccountId` and owns the linked timestamp.
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/riders/<rider-id>/app-account/link \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"appAccountId":"<selected-app-account-id>"}'
+```
+
+Linking sets `appAccountLinked=true`, stores the selected `appAccountId`, and sets `appLinkedAt` from server time. Re-linking the same app account is idempotent; linking a different account requires unlinking first. Duplicate active `appAccountId` values return `409 DUPLICATE_ACTIVE_RESOURCE`.
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/riders/<rider-id>/app-account/unlink \
+  -H "Authorization: Bearer <access-token>"
+```
+
+Unlinking clears `appAccountLinked`, `appAccountId`, and `appLinkedAt` while preserving the rider row.
 
 ## Device registry command API
 
@@ -277,7 +299,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 ## Follow-up implementation issues
 
-- Rider app-account link/unlink and rider relationship assignment commands
+- Rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
 - Telemetry schema and raw/recent/current ingestion
 - Dashboard/map read API

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderCommandController.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.rider.controller;
 
 import com.thundercrew.opsapi.rider.dto.RiderCreateRequest;
 import com.thundercrew.opsapi.rider.dto.RiderReadResponse;
+import com.thundercrew.opsapi.rider.dto.RiderAppAccountLinkRequest;
 import com.thundercrew.opsapi.rider.dto.RiderUpdateRequest;
 import com.thundercrew.opsapi.rider.service.RiderCommandService;
 import jakarta.validation.Valid;
@@ -42,5 +43,18 @@ public class RiderCommandController {
     ResponseEntity<Void> delete(@PathVariable UUID id) {
         riderCommandService.softDelete(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/app-account/link")
+    RiderReadResponse linkAppAccount(
+            @PathVariable UUID id,
+            @Valid @RequestBody RiderAppAccountLinkRequest request
+    ) {
+        return riderCommandService.linkAppAccount(id, request);
+    }
+
+    @PatchMapping("/{id}/app-account/unlink")
+    RiderReadResponse unlinkAppAccount(@PathVariable UUID id) {
+        return riderCommandService.unlinkAppAccount(id);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/Rider.java
@@ -73,6 +73,18 @@ public class Rider extends DisplaySequencedEntity {
         }
     }
 
+    public void linkAppAccount(UUID appAccountId, Instant appLinkedAt) {
+        this.appAccountLinked = true;
+        this.appAccountId = appAccountId;
+        this.appLinkedAt = appLinkedAt;
+    }
+
+    public void unlinkAppAccount() {
+        this.appAccountLinked = false;
+        this.appAccountId = null;
+        this.appLinkedAt = null;
+    }
+
     public String getName() {
         return name;
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderAppAccountLinkRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderAppAccountLinkRequest.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RiderAppAccountLinkRequest(
+        @NotNull UUID appAccountId
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
@@ -21,6 +21,10 @@ public interface RiderRepository extends Repository<Rider, UUID> {
 
     boolean existsByPhoneNumberAndIdNotAndDeletedAtIsNull(String phoneNumber, UUID id);
 
+    boolean existsByAppAccountIdAndDeletedAtIsNull(UUID appAccountId);
+
+    boolean existsByAppAccountIdAndIdNotAndDeletedAtIsNull(UUID appAccountId, UUID id);
+
     Rider save(Rider rider);
 
     @Query(value = """

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderCommandService.java
@@ -4,6 +4,7 @@ import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
 import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.dto.RiderAppAccountLinkRequest;
 import com.thundercrew.opsapi.rider.dto.RiderCreateRequest;
 import com.thundercrew.opsapi.rider.dto.RiderReadResponse;
 import com.thundercrew.opsapi.rider.dto.RiderUpdateRequest;
@@ -11,6 +12,7 @@ import com.thundercrew.opsapi.rider.repository.RiderRepository;
 import jakarta.persistence.EntityManager;
 import org.springframework.dao.DataIntegrityViolationException;
 import java.time.Clock;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,6 +80,39 @@ public class RiderCommandService {
                 .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
         assertNoActiveDependentRecords(id);
         rider.markDeleted(null, clock.instant());
+    }
+
+    @Transactional
+    public RiderReadResponse linkAppAccount(UUID id, RiderAppAccountLinkRequest request) {
+        Rider rider = riderRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
+        if (rider.isAppAccountLinked() && Objects.equals(rider.getAppAccountId(), request.appAccountId())) {
+            return RiderReadResponse.from(rider);
+        }
+        if (rider.isAppAccountLinked()) {
+            throw new InvalidStateTransitionException(
+                    "Rider is already linked to another app account. Unlink before linking a new account."
+            );
+        }
+        if (riderRepository.existsByAppAccountIdAndIdNotAndDeletedAtIsNull(request.appAccountId(), id)) {
+            throw new DuplicateActiveResourceException("Rider", "appAccountId");
+        }
+        try {
+            rider.linkAppAccount(request.appAccountId(), clock.instant());
+            entityManager.flush();
+            return RiderReadResponse.from(rider);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("Rider", "appAccountId");
+        }
+    }
+
+    @Transactional
+    public RiderReadResponse unlinkAppAccount(UUID id) {
+        Rider rider = riderRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
+        rider.unlinkAppAccount();
+        entityManager.flush();
+        return RiderReadResponse.from(rider);
     }
 
     private void assertPhoneIsNotDuplicated(String phoneNumber) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -136,6 +136,8 @@ class ArchitectureBoundaryTests {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.rider.controller.RiderCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("update")
+                || method.getName().equals("linkAppAccount")
+                || method.getName().equals("unlinkAppAccount")
                 || method.getName().equals("delete"));
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderCommandApiContractTests.java
@@ -35,6 +35,8 @@ class RiderCommandApiContractTests extends PostgresContainerSupport {
 
     private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID OTHER_RIDER_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID APP_ACCOUNT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
 
     @Autowired
@@ -173,8 +175,7 @@ class RiderCommandApiContractTests extends PostgresContainerSupport {
     @Test
     void updateRiderRejectsMissingOrDuplicateTargets() throws Exception {
         seedRider(RIDER_ID, "기존 라이더", "010-1000-2000", null);
-        UUID otherId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-        seedRider(otherId, "다른 라이더", "010-2222-3333", null);
+        seedRider(OTHER_RIDER_ID, "다른 라이더", "010-2222-3333", null);
 
         UUID missingId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
         mockMvc.perform(patch("/api/v1/riders/{id}", missingId)
@@ -210,6 +211,117 @@ class RiderCommandApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
                 .andExpect(jsonPath("$.fieldViolations").isArray());
+    }
+
+    @Test
+    void linkRiderAppAccountUsesSelectorProducedReferenceAndServerOwnedTimestamp() throws Exception {
+        seedRider(RIDER_ID, "앱 연동 라이더", "010-1000-2000", null);
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "appAccountId":"%s",
+                                  "appLinkedAt":"2026-04-30T01:02:03Z",
+                                  "id":"99999999-9999-9999-9999-999999999999",
+                                  "riderId":"88888888-8888-8888-8888-888888888888"
+                                }
+                                """.formatted(APP_ACCOUNT_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.appAccountLinked").value(true))
+                .andExpect(jsonPath("$.appAccountId").value(APP_ACCOUNT_ID.toString()))
+                .andExpect(jsonPath("$.appLinkStatus").value("LINKED"))
+                .andExpect(jsonPath("$.appLinkedAt").isString())
+                .andExpect(jsonPath("$.appLinkedAt").value(org.hamcrest.Matchers.not("2026-04-30T01:02:03Z")));
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appAccountLinked").value(true))
+                .andExpect(jsonPath("$.appAccountId").value(APP_ACCOUNT_ID.toString()));
+    }
+
+    @Test
+    void unlinkRiderAppAccountClearsLinkFieldsAndIsIdempotent() throws Exception {
+        seedLinkedRider(RIDER_ID, "앱 해제 라이더", "010-1000-2000", APP_ACCOUNT_ID, null);
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/unlink", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.appAccountLinked").value(false))
+                .andExpect(jsonPath("$.appAccountId").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.appLinkedAt").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.appLinkStatus").value("NOT_LINKED"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/unlink", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appAccountLinked").value(false))
+                .andExpect(jsonPath("$.appAccountId").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    void linkRiderAppAccountRejectsDuplicateOrConflictingActiveLinks() throws Exception {
+        UUID otherAppAccountId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        seedLinkedRider(RIDER_ID, "기존 앱 라이더", "010-1000-2000", APP_ACCOUNT_ID, null);
+        seedRider(OTHER_RIDER_ID, "다른 라이더", "010-2222-3333", null);
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", OTHER_RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"appAccountId":"%s"}
+                                """.formatted(APP_ACCOUNT_ID)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"appAccountId":"%s"}
+                                """.formatted(otherAppAccountId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"appAccountId":"%s"}
+                                """.formatted(APP_ACCOUNT_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appAccountId").value(APP_ACCOUNT_ID.toString()));
+    }
+
+    @Test
+    void linkAndUnlinkRiderAppAccountRejectMissingOrDeletedRidersAndInvalidRequest() throws Exception {
+        seedRider(RIDER_ID, "삭제 앱 라이더", "010-1000-2000", "now()");
+        UUID missingId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", missingId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"appAccountId":"%s"}
+                                """.formatted(APP_ACCOUNT_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/unlink", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
     }
 
     @Test
@@ -300,6 +412,18 @@ class RiderCommandApiContractTests extends PostgresContainerSupport {
                                 """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/link", RIDER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"appAccountId":"%s"}
+                                """.formatted(APP_ACCOUNT_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/riders/{id}/app-account/unlink", RIDER_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
     }
 
     private void seedRider(UUID id, String name, String phoneNumber, String deletedAtSql) {
@@ -308,6 +432,22 @@ class RiderCommandApiContractTests extends PostgresContainerSupport {
                 insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
                 values (?, ?, ?, '강남팀', '서울 강남', false, 'fixture rider', %s)
                 """.formatted(deletedAtExpression), id, name, phoneNumber);
+    }
+
+    private void seedLinkedRider(
+            UUID id,
+            String name,
+            String phoneNumber,
+            UUID appAccountId,
+            String deletedAtSql
+    ) {
+        String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
+        jdbcTemplate.update("""
+                insert into riders (
+                    id, name, phone_number, team_name, area_name,
+                    app_account_linked, app_account_id, app_linked_at, memo, deleted_at
+                ) values (?, ?, ?, '강남팀', '서울 강남', true, ?, now(), 'fixture rider', %s)
+                """.formatted(deletedAtExpression), id, name, phoneNumber, appAccountId);
     }
 
     private String loginAndExtractToken() throws Exception {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -406,3 +406,27 @@ Boundary decision:
 - Count updates must satisfy `maxBatteryCapacity >= currentBatteryCount >= availableBatteryCount >= 0` and create station battery-count log history in the same transaction.
 - Station soft-delete marks the station inactive while preserving count-log history as read-only audit data.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the station command controller at this stage.
+
+## Rider app-account link command baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#66
+- Target issue: EVNSolution/thundercrew-domain#44
+- Branch: `cc-66-rider-app-account-link`
+
+Issue-size decision:
+
+- This slice adds only the rider app-account link/unlink command baseline after the station command slice.
+- Included operations are authenticated `PATCH /api/v1/riders/{id}/app-account/link` and `PATCH /api/v1/riders/{id}/app-account/unlink`.
+- Rider-app service implementation, app-account lookup APIs, auth-provider/user-management schema expansion, frontend selectors/forms, telemetry/dashboard/map APIs, and hard delete/restore remain follow-up scopes.
+
+Boundary decision:
+
+- Client request DTOs expose only a selector-produced `appAccountId`; UI must choose the app account by human-readable rider-app context rather than asking users to type raw IDs.
+- Server-generated id, idx, audit/deleted fields, and `appLinkedAt` remain non-client inputs and are ignored when sent.
+- Linking sets `appAccountLinked=true`, stores the selected app-account id, and assigns `appLinkedAt` from the server clock.
+- Linking the same app account to the same rider is idempotent; linking a different account requires unlinking first.
+- Active `appAccountId` values are unique across non-deleted riders; deleted riders no longer reserve the app-account id.
+- Unlinking clears app-link fields while preserving the rider row and is idempotent.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the expanded rider command controller methods at this stage.


### PR DESCRIPTION
## Summary
- Add authenticated rider app-account link/unlink command endpoints.
- Keep rider basic profile commands separate from app-link lifecycle state.
- Enforce active app-account uniqueness, same-account idempotency, and server-owned app-linked timestamps.
- Update command contract tests, architecture route guard, backend README, and backend change ledger.

## Trace
- change-control anchor: EVNSolution/clever-change-control#66
- target issue: EVNSolution/thundercrew-domain#44
- branch: cc-66-rider-app-account-link

## Concurrent work decision
Decision: allowed-with-non-overlap

Evidence:
- target repo open PRs checked before implementation and before PR.
- target repo open issues checked before implementation and before PR.
- clever-change-control open issues checked before implementation and before PR.

Non-overlap reason:
- This PR is limited to service-ops-api rider app-account link/unlink endpoints, tests, and backend docs.
- No other open PR affects the same repo/service/API/data/deploy/file scope.

## Validation
- npm run check:workspace
- npm run lint
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew test --max-workers=1 --tests '*RiderCommandApiContractTests' --tests '*ArchitectureBoundaryTests' --tests '*ReadOnlyApiContractTests')
- (cd development/service-ops-api && ./gradlew cleanTest test --max-workers=1)
- (cd development/service-ops-api && ./gradlew build --max-workers=1)
- code-reviewer subagent: reviewed; blocker was untracked DTO, resolved before commit by staging the new DTO.

## Notes
- A simultaneous full Gradle run during code-reviewer verification hit the known XML report write collision; rerun after the reviewer finished passed cleanly.
