### PR TITLE
Add service-ops telemetry current-state baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,7 +4,7 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold, non-telemetry core persistence baseline, read-only API/DTO contract baseline, admin JWT login/access-token baseline, and initial operation command slices:
+This module currently provides the backend scaffold, core persistence baseline, read-only API/DTO contract baseline, admin JWT login/access-token baseline, telemetry current-state baseline, and initial operation command slices:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -15,7 +15,7 @@ This module currently provides the backend scaffold, non-telemetry core persiste
 - ArchUnit boundary tests
 - common API error/audit/soft-delete/time baseline
 - Flyway baseline for `admin_users`, `contract_templates`, and the system `무제한 계약` seed
-- Flyway + JPA entity mappings for non-telemetry core operations:
+- Flyway + JPA entity mappings for core operations:
   - riders
   - bikes and operation status history
   - rider-bike contracts
@@ -23,6 +23,7 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - equipment types and bike equipment
   - devices and bike-device installation history
   - battery stations and station count logs
+  - telemetry raw logs, bike recent states, bike current states, and telemetry ingestion error logs
 
 - Read-only `GET /api/v1/**` list/detail endpoints and response DTOs for:
   - riders
@@ -77,6 +78,10 @@ This module currently provides the backend scaffold, non-telemetry core persiste
   - `PATCH /api/v1/battery-stations/{id}`
   - `PATCH /api/v1/battery-stations/{id}/battery-counts`
   - `DELETE /api/v1/battery-stations/{id}`
+- Telemetry ingestion/current-state endpoints:
+  - `POST /api/v1/telemetry/device-events`
+  - `GET /api/v1/telemetry/bike-current-states`
+  - `GET /api/v1/telemetry/bikes/{bikeId}/current-state`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -84,11 +89,10 @@ This module currently provides the backend scaffold, non-telemetry core persiste
 Out of scope for the current backend baseline:
 
 - Create/update/delete command endpoints and request DTOs outside delivered command slices
-- computed business DTOs that depend on telemetry, dashboard, map, or multi-table/time logic
-- telemetry tables and ingestion write paths
+- dashboard/map aggregate APIs and frontend map integration
+- external device API polling/sync-log implementation, TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - refresh token, logout/revocation, password reset, RBAC expansion, or admin-management UI
 - frontend relocation
-- TimescaleDB setup
 - integrity scan/repair job
 
 ## Local environment
@@ -248,6 +252,29 @@ curl -X PATCH http://localhost:8080/api/v1/battery-stations/<station-id>/battery
 
 Station deletion is a soft delete that marks the station inactive while preserving station battery-count log history for audit/read purposes.
 
+## Telemetry ingestion and current-state API
+
+The telemetry baseline stores raw device events, preserves short-window recent state rows, and upserts a map-ready bike current-state projection. Ingestion is authenticated and uses the registered `deviceUid`; the backend resolves the active bike-device installation at the event `receivedAt` timestamp. Operators and device integrations must not provide bike IDs or database IDs as user-entered input.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/telemetry/device-events \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"deviceUid":"DEV-SEOUL-001","vendorEventId":"evt-001","receivedAt":"2026-04-30T00:00:00Z","latitude":37.5010000,"longitude":127.0396000,"speedKph":12.3,"batteryPercent":76,"ignitionStatus":"ON","telemetrySource":"POLLING","rawPayload":{"vendor":"example"}}'
+```
+
+Duplicate vendor events return `ingestionStatus=IDEMPOTENT_REPLAY` without creating another raw/recent/current row; idempotency is enforced with database `ON CONFLICT DO NOTHING`. Out-of-order events are kept in raw/recent history but do not regress `bike_current_states`; the current-state projection uses a conditional PostgreSQL upsert and the response reports `STALE_TELEMETRY_IGNORED`. Unknown, disabled, or unassigned devices still produce raw/error evidence but do not create bike state.
+
+Current-state reads expose calculated information derived from latest telemetry: `drivingStatus`, `connectionStatus`, and `batteryStatus`. Connection status uses a 10-minute freshness threshold and distinguishes an expected parked/offline bike from signal loss when ignition was still on.
+
+```bash
+curl http://localhost:8080/api/v1/telemetry/bike-current-states \
+  -H "Authorization: Bearer <access-token>"
+
+curl http://localhost:8080/api/v1/telemetry/bikes/<bike-id>/current-state \
+  -H "Authorization: Bearer <access-token>"
+```
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -301,7 +328,8 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 - Rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
-- Telemetry schema and raw/recent/current ingestion
-- Dashboard/map read API
+- Dashboard/map read API and frontend map integration
+- External device API polling/sync-log implementation
+- TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - Contract overlap locking implementation
 - Integrity scan implementation

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/BikeDeviceInstallationRepository.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface BikeDeviceInstallationRepository extends Repository<BikeDeviceInstallation, UUID> {
 
@@ -18,6 +20,21 @@ public interface BikeDeviceInstallationRepository extends Repository<BikeDeviceI
     Optional<BikeDeviceInstallation> findByBikeIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID bikeId);
 
     Optional<BikeDeviceInstallation> findByDeviceIdAndRemovedAtIsNullAndDeletedAtIsNull(UUID deviceId);
+
+    @Query(value = """
+            select *
+            from bike_device_installations
+            where device_id = :deviceId
+              and deleted_at is null
+              and installed_at <= :observedAt
+              and (removed_at is null or removed_at >= :observedAt)
+            order by installed_at desc
+            limit 1
+            """, nativeQuery = true)
+    Optional<BikeDeviceInstallation> findActiveAtByDeviceId(
+            @Param("deviceId") UUID deviceId,
+            @Param("observedAt") java.time.Instant observedAt
+    );
 
     BikeDeviceInstallation save(BikeDeviceInstallation installation);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/device/repository/DeviceRepository.java
@@ -15,6 +15,8 @@ public interface DeviceRepository extends Repository<Device, UUID> {
 
     Optional<Device> findByIdAndDeletedAtIsNull(UUID id);
 
+    Optional<Device> findByDeviceUidAndDeletedAtIsNull(String deviceUid);
+
     boolean existsByDeviceUidAndDeletedAtIsNull(String deviceUid);
 
     boolean existsByDeviceUidAndIdNotAndDeletedAtIsNull(String deviceUid, UUID id);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/controller/TelemetryCurrentStateController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/controller/TelemetryCurrentStateController.java
@@ -1,0 +1,34 @@
+package com.thundercrew.opsapi.telemetry.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.telemetry.dto.BikeCurrentStateReadResponse;
+import com.thundercrew.opsapi.telemetry.service.TelemetryCurrentStateService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TelemetryCurrentStateController {
+
+    private final TelemetryCurrentStateService telemetryCurrentStateService;
+
+    public TelemetryCurrentStateController(TelemetryCurrentStateService telemetryCurrentStateService) {
+        this.telemetryCurrentStateService = telemetryCurrentStateService;
+    }
+
+    @GetMapping("/api/v1/telemetry/bike-current-states")
+    PageResponse<BikeCurrentStateReadResponse> listCurrentStates(
+            @PageableDefault(size = 20, sort = "lastReceivedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return telemetryCurrentStateService.listCurrentStates(pageable);
+    }
+
+    @GetMapping("/api/v1/telemetry/bikes/{bikeId}/current-state")
+    BikeCurrentStateReadResponse getCurrentState(@PathVariable UUID bikeId) {
+        return telemetryCurrentStateService.getCurrentState(bikeId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/controller/TelemetryIngestionController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/controller/TelemetryIngestionController.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.telemetry.controller;
+
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestRequest;
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestResponse;
+import com.thundercrew.opsapi.telemetry.service.TelemetryIngestionService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/telemetry/device-events")
+public class TelemetryIngestionController {
+
+    private final TelemetryIngestionService telemetryIngestionService;
+
+    public TelemetryIngestionController(TelemetryIngestionService telemetryIngestionService) {
+        this.telemetryIngestionService = telemetryIngestionService;
+    }
+
+    @PostMapping
+    ResponseEntity<TelemetryIngestResponse> ingest(@Valid @RequestBody TelemetryIngestRequest request) {
+        TelemetryIngestResponse response = telemetryIngestionService.ingest(request);
+        return ResponseEntity.created(URI.create("/api/v1/telemetry/device-events/" + response.telemetryLogId()))
+                .body(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
@@ -1,0 +1,127 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "bike_current_states")
+public class BikeCurrentState {
+
+    @Id
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    private UUID deviceId;
+
+    private UUID telemetryLogId;
+
+    @Column(nullable = false)
+    private Instant lastReceivedAt;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(precision = 8, scale = 2)
+    private BigDecimal speedKph;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal batteryPercent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetryIgnitionStatus ignitionStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetrySource telemetrySource;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    public static BikeCurrentState from(DeviceTelemetryLog log) {
+        BikeCurrentState state = new BikeCurrentState();
+        state.bikeId = log.getBikeId();
+        state.copyFrom(log);
+        return state;
+    }
+
+    private void copyFrom(DeviceTelemetryLog log) {
+        this.deviceId = log.getDeviceId();
+        this.telemetryLogId = log.getId();
+        this.lastReceivedAt = log.getReceivedAt();
+        this.latitude = log.getLatitude();
+        this.longitude = log.getLongitude();
+        this.speedKph = log.getSpeedKph();
+        this.batteryPercent = log.getBatteryPercent();
+        this.ignitionStatus = log.getIgnitionStatus();
+        this.telemetrySource = log.getTelemetrySource();
+        this.updatedAt = Instant.now();
+    }
+
+    @PrePersist
+    @PreUpdate
+    void onSave() {
+        if (updatedAt == null) {
+            updatedAt = Instant.now();
+        }
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public UUID getDeviceId() {
+        return deviceId;
+    }
+
+    public UUID getTelemetryLogId() {
+        return telemetryLogId;
+    }
+
+    public Instant getLastReceivedAt() {
+        return lastReceivedAt;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BigDecimal getSpeedKph() {
+        return speedKph;
+    }
+
+    public BigDecimal getBatteryPercent() {
+        return batteryPercent;
+    }
+
+    public TelemetryIgnitionStatus getIgnitionStatus() {
+        return ignitionStatus;
+    }
+
+    public TelemetrySource getTelemetrySource() {
+        return telemetrySource;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    protected BikeCurrentState() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
@@ -1,0 +1,134 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "bike_recent_states")
+public class BikeRecentState {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id = UUID.randomUUID();
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Long idx;
+
+    @Column(nullable = false)
+    private UUID bikeId;
+
+    private UUID deviceId;
+
+    private UUID telemetryLogId;
+
+    @Column(nullable = false)
+    private Instant receivedAt;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(precision = 8, scale = 2)
+    private BigDecimal speedKph;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal batteryPercent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetryIgnitionStatus ignitionStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetrySource telemetrySource;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static BikeRecentState from(DeviceTelemetryLog log) {
+        BikeRecentState state = new BikeRecentState();
+        state.bikeId = log.getBikeId();
+        state.deviceId = log.getDeviceId();
+        state.telemetryLogId = log.getId();
+        state.receivedAt = log.getReceivedAt();
+        state.latitude = log.getLatitude();
+        state.longitude = log.getLongitude();
+        state.speedKph = log.getSpeedKph();
+        state.batteryPercent = log.getBatteryPercent();
+        state.ignitionStatus = log.getIgnitionStatus();
+        state.telemetrySource = log.getTelemetrySource();
+        return state;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public UUID getDeviceId() {
+        return deviceId;
+    }
+
+    public UUID getTelemetryLogId() {
+        return telemetryLogId;
+    }
+
+    public Instant getReceivedAt() {
+        return receivedAt;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BigDecimal getSpeedKph() {
+        return speedKph;
+    }
+
+    public BigDecimal getBatteryPercent() {
+        return batteryPercent;
+    }
+
+    public TelemetryIgnitionStatus getIgnitionStatus() {
+        return ignitionStatus;
+    }
+
+    public TelemetrySource getTelemetrySource() {
+        return telemetrySource;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    protected BikeRecentState() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
@@ -1,0 +1,183 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "device_telemetry_logs")
+public class DeviceTelemetryLog {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id = UUID.randomUUID();
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Long idx;
+
+    private UUID deviceId;
+
+    @Column(nullable = false, length = 100)
+    private String deviceUid;
+
+    private UUID bikeId;
+
+    @Column(length = 200)
+    private String vendorEventId;
+
+    @Column(nullable = false, length = 128)
+    private String payloadHash;
+
+    @Column(nullable = false)
+    private Instant receivedAt;
+
+    private Instant deviceReportedAt;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(precision = 8, scale = 2)
+    private BigDecimal speedKph;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal batteryPercent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetryIgnitionStatus ignitionStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TelemetrySource telemetrySource;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private String rawPayload;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static DeviceTelemetryLog create(
+            UUID deviceId,
+            String deviceUid,
+            UUID bikeId,
+            String vendorEventId,
+            String payloadHash,
+            Instant receivedAt,
+            Instant deviceReportedAt,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal speedKph,
+            BigDecimal batteryPercent,
+            TelemetryIgnitionStatus ignitionStatus,
+            TelemetrySource telemetrySource,
+            String rawPayload
+    ) {
+        DeviceTelemetryLog log = new DeviceTelemetryLog();
+        log.deviceId = deviceId;
+        log.deviceUid = deviceUid;
+        log.bikeId = bikeId;
+        log.vendorEventId = vendorEventId;
+        log.payloadHash = payloadHash;
+        log.receivedAt = receivedAt;
+        log.deviceReportedAt = deviceReportedAt;
+        log.latitude = latitude;
+        log.longitude = longitude;
+        log.speedKph = speedKph;
+        log.batteryPercent = batteryPercent;
+        log.ignitionStatus = ignitionStatus;
+        log.telemetrySource = telemetrySource;
+        log.rawPayload = rawPayload;
+        return log;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public UUID getDeviceId() {
+        return deviceId;
+    }
+
+    public String getDeviceUid() {
+        return deviceUid;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public String getVendorEventId() {
+        return vendorEventId;
+    }
+
+    public String getPayloadHash() {
+        return payloadHash;
+    }
+
+    public Instant getReceivedAt() {
+        return receivedAt;
+    }
+
+    public Instant getDeviceReportedAt() {
+        return deviceReportedAt;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public BigDecimal getSpeedKph() {
+        return speedKph;
+    }
+
+    public BigDecimal getBatteryPercent() {
+        return batteryPercent;
+    }
+
+    public TelemetryIgnitionStatus getIgnitionStatus() {
+        return ignitionStatus;
+    }
+
+    public TelemetrySource getTelemetrySource() {
+        return telemetrySource;
+    }
+
+    public String getRawPayload() {
+        return rawPayload;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    protected DeviceTelemetryLog() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIgnitionStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIgnitionStatus.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+public enum TelemetryIgnitionStatus {
+    UNKNOWN,
+    ON,
+    OFF
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIngestionErrorLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIngestionErrorLog.java
@@ -1,0 +1,87 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "telemetry_ingestion_error_logs")
+public class TelemetryIngestionErrorLog {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id = UUID.randomUUID();
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Long idx;
+
+    private UUID telemetryLogId;
+
+    @Column(length = 100)
+    private String deviceUid;
+
+    private UUID bikeId;
+
+    private Instant receivedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private TelemetryIngestionStage ingestionStage;
+
+    @Column(nullable = false)
+    private boolean retryable = true;
+
+    private Instant resolvedAt;
+
+    @Column(nullable = false, length = 100)
+    private String errorCode;
+
+    private String errorMessage;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private String contextSummary;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static TelemetryIngestionErrorLog create(
+            UUID telemetryLogId,
+            String deviceUid,
+            UUID bikeId,
+            Instant receivedAt,
+            TelemetryIngestionStage ingestionStage,
+            String errorCode,
+            String errorMessage,
+            String contextSummary
+    ) {
+        TelemetryIngestionErrorLog log = new TelemetryIngestionErrorLog();
+        log.telemetryLogId = telemetryLogId;
+        log.deviceUid = deviceUid;
+        log.bikeId = bikeId;
+        log.receivedAt = receivedAt;
+        log.ingestionStage = ingestionStage;
+        log.errorCode = errorCode;
+        log.errorMessage = errorMessage;
+        log.contextSummary = contextSummary;
+        return log;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    protected TelemetryIngestionErrorLog() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIngestionStage.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryIngestionStage.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+public enum TelemetryIngestionStage {
+    DEVICE_RESOLUTION,
+    BIKE_ASSOCIATION,
+    CURRENT_STATE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetrySource.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetrySource.java
@@ -1,0 +1,6 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+public enum TelemetrySource {
+    POLLING,
+    WEBHOOK
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
@@ -1,0 +1,85 @@
+package com.thundercrew.opsapi.telemetry.dto;
+
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BikeCurrentStateReadResponse(
+        UUID bikeId,
+        UUID deviceId,
+        UUID telemetryLogId,
+        Instant lastReceivedAt,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        BigDecimal speedKph,
+        BigDecimal batteryPercent,
+        TelemetryIgnitionStatus ignitionStatus,
+        String telemetrySource,
+        String drivingStatus,
+        String connectionStatus,
+        String batteryStatus,
+        Instant updatedAt
+) {
+    private static final Duration SIGNAL_LOST_THRESHOLD = Duration.ofMinutes(10);
+
+    public static BikeCurrentStateReadResponse from(BikeCurrentState state, Clock clock) {
+        return new BikeCurrentStateReadResponse(
+                state.getBikeId(),
+                state.getDeviceId(),
+                state.getTelemetryLogId(),
+                state.getLastReceivedAt(),
+                state.getLatitude(),
+                state.getLongitude(),
+                state.getSpeedKph(),
+                state.getBatteryPercent(),
+                state.getIgnitionStatus(),
+                state.getTelemetrySource().name(),
+                drivingStatus(state),
+                connectionStatus(state, clock),
+                batteryStatus(state),
+                state.getUpdatedAt()
+        );
+    }
+
+    private static String drivingStatus(BikeCurrentState state) {
+        if (state.getIgnitionStatus() == TelemetryIgnitionStatus.UNKNOWN) {
+            return "UNKNOWN";
+        }
+        if (state.getIgnitionStatus() == TelemetryIgnitionStatus.OFF) {
+            return "PARKED";
+        }
+        BigDecimal speedKph = state.getSpeedKph() == null ? BigDecimal.ZERO : state.getSpeedKph();
+        return speedKph.compareTo(BigDecimal.valueOf(3)) >= 0 ? "DRIVING" : "STOPPED";
+    }
+
+    private static String connectionStatus(BikeCurrentState state, Clock clock) {
+        Duration age = Duration.between(state.getLastReceivedAt(), Instant.now(clock));
+        if (!age.minus(SIGNAL_LOST_THRESHOLD).isPositive()) {
+            return "ONLINE";
+        }
+        if (state.getIgnitionStatus() == TelemetryIgnitionStatus.ON) {
+            return "SIGNAL_LOST";
+        }
+        if (state.getIgnitionStatus() == TelemetryIgnitionStatus.OFF) {
+            return "PARKED_OFFLINE_NORMAL";
+        }
+        return "STALE_UNKNOWN";
+    }
+
+    private static String batteryStatus(BikeCurrentState state) {
+        if (state.getBatteryPercent() == null) {
+            return "UNKNOWN";
+        }
+        if (state.getBatteryPercent().compareTo(BigDecimal.valueOf(20)) < 0) {
+            return "CRITICAL";
+        }
+        if (state.getBatteryPercent().compareTo(BigDecimal.valueOf(50)) < 0) {
+            return "LOW";
+        }
+        return "NORMAL";
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.telemetry.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import com.thundercrew.opsapi.telemetry.domain.TelemetrySource;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TelemetryIngestRequest(
+        @NotBlank @Size(max = 100) String deviceUid,
+        @Size(max = 200) String vendorEventId,
+        @NotNull Instant receivedAt,
+        Instant deviceReportedAt,
+        @DecimalMin("-90.0") @DecimalMax("90.0") BigDecimal latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
+        @PositiveOrZero BigDecimal speedKph,
+        @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal batteryPercent,
+        @NotNull TelemetryIgnitionStatus ignitionStatus,
+        @NotNull TelemetrySource telemetrySource,
+        JsonNode rawPayload
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestResponse.java
@@ -1,0 +1,37 @@
+package com.thundercrew.opsapi.telemetry.dto;
+
+import com.thundercrew.opsapi.telemetry.domain.DeviceTelemetryLog;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TelemetryIngestResponse(
+        UUID telemetryLogId,
+        UUID deviceId,
+        String deviceUid,
+        UUID bikeId,
+        Instant receivedAt,
+        boolean duplicate,
+        boolean recentStateCreated,
+        boolean currentStateUpdated,
+        String ingestionStatus
+) {
+    public static TelemetryIngestResponse of(
+            DeviceTelemetryLog log,
+            boolean duplicate,
+            boolean recentStateCreated,
+            boolean currentStateUpdated,
+            String ingestionStatus
+    ) {
+        return new TelemetryIngestResponse(
+                log.getId(),
+                log.getDeviceId(),
+                log.getDeviceUid(),
+                log.getBikeId(),
+                log.getReceivedAt(),
+                duplicate,
+                recentStateCreated,
+                currentStateUpdated,
+                ingestionStatus
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/BikeCurrentStateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/BikeCurrentStateRepository.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.telemetry.repository;
+
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeCurrentStateRepository extends Repository<BikeCurrentState, UUID> {
+
+    Page<BikeCurrentState> findAll(Pageable pageable);
+
+    Optional<BikeCurrentState> findByBikeId(UUID bikeId);
+
+    BikeCurrentState save(BikeCurrentState state);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/BikeRecentStateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/BikeRecentStateRepository.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.telemetry.repository;
+
+import com.thundercrew.opsapi.telemetry.domain.BikeRecentState;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface BikeRecentStateRepository extends Repository<BikeRecentState, UUID> {
+
+    Page<BikeRecentState> findByBikeIdOrderByReceivedAtDesc(UUID bikeId, Pageable pageable);
+
+    BikeRecentState save(BikeRecentState state);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/DeviceTelemetryLogRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/DeviceTelemetryLogRepository.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.telemetry.repository;
+
+import com.thundercrew.opsapi.telemetry.domain.DeviceTelemetryLog;
+import com.thundercrew.opsapi.telemetry.domain.TelemetrySource;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface DeviceTelemetryLogRepository extends Repository<DeviceTelemetryLog, UUID> {
+
+    Optional<DeviceTelemetryLog> findByDeviceUidAndVendorEventId(String deviceUid, String vendorEventId);
+
+    Optional<DeviceTelemetryLog> findByDeviceUidAndReceivedAtAndTelemetrySourceAndPayloadHash(
+            String deviceUid,
+            Instant receivedAt,
+            TelemetrySource telemetrySource,
+            String payloadHash
+    );
+
+    DeviceTelemetryLog save(DeviceTelemetryLog log);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryIngestionErrorLogRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryIngestionErrorLogRepository.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.telemetry.repository;
+
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIngestionErrorLog;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface TelemetryIngestionErrorLogRepository extends Repository<TelemetryIngestionErrorLog, UUID> {
+
+    TelemetryIngestionErrorLog save(TelemetryIngestionErrorLog log);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
@@ -1,0 +1,145 @@
+package com.thundercrew.opsapi.telemetry.repository;
+
+import com.thundercrew.opsapi.telemetry.domain.DeviceTelemetryLog;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TelemetryWriteRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public TelemetryWriteRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public Optional<UUID> insertDeviceTelemetryLogIfAbsent(DeviceTelemetryLog log) {
+        String sql = """
+                insert into device_telemetry_logs (
+                    id, device_id, device_uid, bike_id, vendor_event_id, payload_hash,
+                    received_at, device_reported_at, latitude, longitude, speed_kph,
+                    battery_percent, ignition_status, telemetry_source, raw_payload
+                ) values (
+                    ?, ?, ?, ?, ?, ?,
+                    ?::timestamptz, ?::timestamptz, ?, ?, ?,
+                    ?, ?, ?, ?::jsonb
+                )
+                %s
+                returning id
+                """.formatted(idempotencyConflictClause(log));
+
+        List<UUID> insertedIds = jdbcTemplate.query(
+                connection -> {
+                    PreparedStatement ps = connection.prepareStatement(sql);
+                    bindTelemetryLogInsert(ps, log);
+                    return ps;
+                },
+                (rs, rowNum) -> (UUID) rs.getObject("id")
+        );
+        return insertedIds.stream().findFirst();
+    }
+
+    public boolean upsertBikeCurrentStateIfNewer(DeviceTelemetryLog log) {
+        int affectedRows = jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement("""
+                    insert into bike_current_states (
+                        bike_id, device_id, telemetry_log_id, last_received_at,
+                        latitude, longitude, speed_kph, battery_percent,
+                        ignition_status, telemetry_source, updated_at
+                    ) values (
+                        ?, ?, ?, ?::timestamptz,
+                        ?, ?, ?, ?,
+                        ?, ?, now()
+                    )
+                    on conflict (bike_id) do update set
+                        device_id = excluded.device_id,
+                        telemetry_log_id = excluded.telemetry_log_id,
+                        last_received_at = excluded.last_received_at,
+                        latitude = excluded.latitude,
+                        longitude = excluded.longitude,
+                        speed_kph = excluded.speed_kph,
+                        battery_percent = excluded.battery_percent,
+                        ignition_status = excluded.ignition_status,
+                        telemetry_source = excluded.telemetry_source,
+                        updated_at = now()
+                    where bike_current_states.last_received_at < excluded.last_received_at
+                    """);
+            setUuid(ps, 1, log.getBikeId());
+            setUuid(ps, 2, log.getDeviceId());
+            setUuid(ps, 3, log.getId());
+            setInstantAsIsoString(ps, 4, log.getReceivedAt());
+            ps.setBigDecimal(5, log.getLatitude());
+            ps.setBigDecimal(6, log.getLongitude());
+            ps.setBigDecimal(7, log.getSpeedKph());
+            ps.setBigDecimal(8, log.getBatteryPercent());
+            ps.setString(9, log.getIgnitionStatus().name());
+            ps.setString(10, log.getTelemetrySource().name());
+            return ps;
+        });
+        return affectedRows > 0;
+    }
+
+    private String idempotencyConflictClause(DeviceTelemetryLog log) {
+        if (log.getVendorEventId() != null) {
+            return """
+                    on conflict (device_uid, vendor_event_id)
+                    where vendor_event_id is not null
+                    do nothing
+                    """;
+        }
+        return """
+                on conflict (device_uid, received_at, telemetry_source, payload_hash)
+                where vendor_event_id is null
+                do nothing
+                """;
+    }
+
+    private void bindTelemetryLogInsert(PreparedStatement ps, DeviceTelemetryLog log) throws SQLException {
+        setUuid(ps, 1, log.getId());
+        setUuid(ps, 2, log.getDeviceId());
+        ps.setString(3, log.getDeviceUid());
+        setUuid(ps, 4, log.getBikeId());
+        setNullableString(ps, 5, log.getVendorEventId());
+        ps.setString(6, log.getPayloadHash());
+        setInstantAsIsoString(ps, 7, log.getReceivedAt());
+        setInstantAsIsoString(ps, 8, log.getDeviceReportedAt());
+        ps.setBigDecimal(9, log.getLatitude());
+        ps.setBigDecimal(10, log.getLongitude());
+        ps.setBigDecimal(11, log.getSpeedKph());
+        ps.setBigDecimal(12, log.getBatteryPercent());
+        ps.setString(13, log.getIgnitionStatus().name());
+        ps.setString(14, log.getTelemetrySource().name());
+        setNullableString(ps, 15, log.getRawPayload());
+    }
+
+    private void setUuid(PreparedStatement ps, int index, UUID value) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.OTHER);
+            return;
+        }
+        ps.setObject(index, value);
+    }
+
+    private void setInstantAsIsoString(PreparedStatement ps, int index, Instant value) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.TIMESTAMP_WITH_TIMEZONE);
+            return;
+        }
+        ps.setString(index, value.toString());
+    }
+
+    private void setNullableString(PreparedStatement ps, int index, String value) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.VARCHAR);
+            return;
+        }
+        ps.setString(index, value);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryCurrentStateService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryCurrentStateService.java
@@ -1,0 +1,35 @@
+package com.thundercrew.opsapi.telemetry.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.telemetry.dto.BikeCurrentStateReadResponse;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TelemetryCurrentStateService {
+
+    private final BikeCurrentStateRepository currentStateRepository;
+    private final Clock clock;
+
+    public TelemetryCurrentStateService(BikeCurrentStateRepository currentStateRepository, Clock clock) {
+        this.currentStateRepository = currentStateRepository;
+        this.clock = clock;
+    }
+
+    public PageResponse<BikeCurrentStateReadResponse> listCurrentStates(Pageable pageable) {
+        return PageResponse.of(currentStateRepository.findAll(pageable)
+                .map(state -> BikeCurrentStateReadResponse.from(state, clock)));
+    }
+
+    public BikeCurrentStateReadResponse getCurrentState(UUID bikeId) {
+        return currentStateRepository.findByBikeId(bikeId)
+                .map(state -> BikeCurrentStateReadResponse.from(state, clock))
+                .orElseThrow(() -> new ResourceNotFoundException("BikeCurrentState", bikeId));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
@@ -1,0 +1,195 @@
+package com.thundercrew.opsapi.telemetry.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thundercrew.opsapi.device.domain.BikeDeviceInstallation;
+import com.thundercrew.opsapi.device.domain.Device;
+import com.thundercrew.opsapi.device.repository.BikeDeviceInstallationRepository;
+import com.thundercrew.opsapi.device.repository.DeviceRepository;
+import com.thundercrew.opsapi.telemetry.domain.BikeRecentState;
+import com.thundercrew.opsapi.telemetry.domain.DeviceTelemetryLog;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIngestionErrorLog;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIngestionStage;
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestRequest;
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestResponse;
+import com.thundercrew.opsapi.telemetry.repository.BikeRecentStateRepository;
+import com.thundercrew.opsapi.telemetry.repository.DeviceTelemetryLogRepository;
+import com.thundercrew.opsapi.telemetry.repository.TelemetryIngestionErrorLogRepository;
+import com.thundercrew.opsapi.telemetry.repository.TelemetryWriteRepository;
+import jakarta.persistence.EntityManager;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class TelemetryIngestionService {
+
+    private final DeviceTelemetryLogRepository telemetryLogRepository;
+    private final BikeRecentStateRepository recentStateRepository;
+    private final TelemetryIngestionErrorLogRepository errorLogRepository;
+    private final TelemetryWriteRepository telemetryWriteRepository;
+    private final DeviceRepository deviceRepository;
+    private final BikeDeviceInstallationRepository installationRepository;
+    private final EntityManager entityManager;
+    private final ObjectMapper objectMapper;
+
+    public TelemetryIngestionService(
+            DeviceTelemetryLogRepository telemetryLogRepository,
+            BikeRecentStateRepository recentStateRepository,
+            TelemetryIngestionErrorLogRepository errorLogRepository,
+            TelemetryWriteRepository telemetryWriteRepository,
+            DeviceRepository deviceRepository,
+            BikeDeviceInstallationRepository installationRepository,
+            EntityManager entityManager,
+            ObjectMapper objectMapper
+    ) {
+        this.telemetryLogRepository = telemetryLogRepository;
+        this.recentStateRepository = recentStateRepository;
+        this.errorLogRepository = errorLogRepository;
+        this.telemetryWriteRepository = telemetryWriteRepository;
+        this.deviceRepository = deviceRepository;
+        this.installationRepository = installationRepository;
+        this.entityManager = entityManager;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public TelemetryIngestResponse ingest(TelemetryIngestRequest request) {
+        String rawPayload = writeRawPayload(request);
+        String payloadHash = payloadHash(request, rawPayload);
+        Optional<Device> device = deviceRepository.findByDeviceUidAndDeletedAtIsNull(request.deviceUid());
+        Optional<BikeDeviceInstallation> installation = device
+                .filter(Device::isEnabled)
+                .flatMap(activeDevice -> installationRepository.findActiveAtByDeviceId(activeDevice.getId(), request.receivedAt()));
+
+        DeviceTelemetryLog log = DeviceTelemetryLog.create(
+                device.map(Device::getId).orElse(null),
+                request.deviceUid(),
+                installation.map(BikeDeviceInstallation::getBikeId).orElse(null),
+                blankToNull(request.vendorEventId()),
+                payloadHash,
+                request.receivedAt(),
+                request.deviceReportedAt(),
+                request.latitude(),
+                request.longitude(),
+                request.speedKph(),
+                request.batteryPercent(),
+                request.ignitionStatus(),
+                request.telemetrySource(),
+                rawPayload
+        );
+        Optional<UUID> insertedId = telemetryWriteRepository.insertDeviceTelemetryLogIfAbsent(log);
+        if (insertedId.isEmpty()) {
+            DeviceTelemetryLog duplicate = findDuplicate(request, payloadHash)
+                    .orElseThrow(() -> new IllegalStateException("Duplicate telemetry replay could not be reloaded."));
+            return TelemetryIngestResponse.of(duplicate, true, false, false, "IDEMPOTENT_REPLAY");
+        }
+        DeviceTelemetryLog saved = log;
+
+        if (device.isEmpty()) {
+            recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_NOT_FOUND",
+                    "Device UID is not registered or is deleted.");
+            return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_UNRESOLVED");
+        }
+        if (!device.get().isEnabled()) {
+            recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_DISABLED",
+                    "Device is disabled and cannot update bike current state.");
+            return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_DISABLED");
+        }
+        if (installation.isEmpty()) {
+            recordError(saved, TelemetryIngestionStage.BIKE_ASSOCIATION, "BIKE_INSTALLATION_NOT_FOUND",
+                    "No active bike-device installation exists for the telemetry timestamp.");
+            return TelemetryIngestResponse.of(saved, false, false, false, "BIKE_UNRESOLVED");
+        }
+
+        recentStateRepository.save(BikeRecentState.from(saved));
+        boolean currentStateUpdated = telemetryWriteRepository.upsertBikeCurrentStateIfNewer(saved);
+        entityManager.flush();
+        return TelemetryIngestResponse.of(
+                saved,
+                false,
+                true,
+                currentStateUpdated,
+                currentStateUpdated ? "ACCEPTED" : "STALE_TELEMETRY_IGNORED"
+        );
+    }
+
+    private Optional<DeviceTelemetryLog> findDuplicate(TelemetryIngestRequest request, String payloadHash) {
+        String vendorEventId = blankToNull(request.vendorEventId());
+        if (vendorEventId != null) {
+            return telemetryLogRepository.findByDeviceUidAndVendorEventId(request.deviceUid(), vendorEventId);
+        }
+        return telemetryLogRepository.findByDeviceUidAndReceivedAtAndTelemetrySourceAndPayloadHash(
+                request.deviceUid(),
+                request.receivedAt(),
+                request.telemetrySource(),
+                payloadHash
+        );
+    }
+
+    private void recordError(
+            DeviceTelemetryLog log,
+            TelemetryIngestionStage stage,
+            String errorCode,
+            String errorMessage
+    ) {
+        errorLogRepository.save(TelemetryIngestionErrorLog.create(
+                log.getId(),
+                log.getDeviceUid(),
+                log.getBikeId(),
+                log.getReceivedAt(),
+                stage,
+                errorCode,
+                errorMessage,
+                "{\"telemetryLogId\":\"" + log.getId() + "\"}"
+        ));
+        entityManager.flush();
+    }
+
+    private String writeRawPayload(TelemetryIngestRequest request) {
+        if (request.rawPayload() == null || request.rawPayload().isNull()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(request.rawPayload());
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("Raw telemetry payload cannot be serialized.", exception);
+        }
+    }
+
+    private String payloadHash(TelemetryIngestRequest request, String rawPayload) {
+        String hashInput = String.join("|",
+                request.deviceUid(),
+                blankToEmpty(request.vendorEventId()),
+                request.receivedAt().toString(),
+                request.deviceReportedAt() == null ? "" : request.deviceReportedAt().toString(),
+                request.latitude() == null ? "" : request.latitude().toPlainString(),
+                request.longitude() == null ? "" : request.longitude().toPlainString(),
+                request.speedKph() == null ? "" : request.speedKph().toPlainString(),
+                request.batteryPercent() == null ? "" : request.batteryPercent().toPlainString(),
+                request.ignitionStatus().name(),
+                request.telemetrySource().name(),
+                rawPayload == null ? "" : rawPayload
+        );
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(hashInput.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 digest is not available.", exception);
+        }
+    }
+
+    private String blankToNull(String value) {
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    private String blankToEmpty(String value) {
+        return StringUtils.hasText(value) ? value : "";
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V4__init_telemetry_current_state.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V4__init_telemetry_current_state.sql
@@ -1,0 +1,113 @@
+create table device_telemetry_logs (
+    id uuid primary key,
+    idx bigserial not null unique,
+    device_id uuid,
+    device_uid varchar(100) not null,
+    bike_id uuid,
+    vendor_event_id varchar(200),
+    payload_hash varchar(128) not null,
+    received_at timestamptz not null,
+    device_reported_at timestamptz,
+    latitude numeric(10,7),
+    longitude numeric(10,7),
+    speed_kph numeric(8,2),
+    battery_percent numeric(5,2),
+    ignition_status varchar(20) not null,
+    telemetry_source varchar(20) not null,
+    raw_payload jsonb,
+    created_at timestamptz not null default now(),
+    constraint ck_device_telemetry_logs_latitude check (latitude is null or (latitude >= -90 and latitude <= 90)),
+    constraint ck_device_telemetry_logs_longitude check (longitude is null or (longitude >= -180 and longitude <= 180)),
+    constraint ck_device_telemetry_logs_speed check (speed_kph is null or speed_kph >= 0),
+    constraint ck_device_telemetry_logs_battery check (battery_percent is null or (battery_percent >= 0 and battery_percent <= 100)),
+    constraint ck_device_telemetry_logs_ignition check (ignition_status in ('UNKNOWN', 'ON', 'OFF')),
+    constraint ck_device_telemetry_logs_source check (telemetry_source in ('POLLING', 'WEBHOOK'))
+);
+
+create unique index ux_device_telemetry_logs_vendor_event
+    on device_telemetry_logs(device_uid, vendor_event_id)
+    where vendor_event_id is not null;
+
+create unique index ux_device_telemetry_logs_fallback_event
+    on device_telemetry_logs(device_uid, received_at, telemetry_source, payload_hash)
+    where vendor_event_id is null;
+
+create index ix_device_telemetry_logs_device_received
+    on device_telemetry_logs(device_uid, received_at desc);
+
+create table bike_recent_states (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    device_id uuid,
+    telemetry_log_id uuid,
+    received_at timestamptz not null,
+    latitude numeric(10,7),
+    longitude numeric(10,7),
+    speed_kph numeric(8,2),
+    battery_percent numeric(5,2),
+    ignition_status varchar(20) not null,
+    telemetry_source varchar(20) not null,
+    created_at timestamptz not null default now(),
+    constraint ck_bike_recent_states_latitude check (latitude is null or (latitude >= -90 and latitude <= 90)),
+    constraint ck_bike_recent_states_longitude check (longitude is null or (longitude >= -180 and longitude <= 180)),
+    constraint ck_bike_recent_states_speed check (speed_kph is null or speed_kph >= 0),
+    constraint ck_bike_recent_states_battery check (battery_percent is null or (battery_percent >= 0 and battery_percent <= 100)),
+    constraint ck_bike_recent_states_ignition check (ignition_status in ('UNKNOWN', 'ON', 'OFF')),
+    constraint ck_bike_recent_states_source check (telemetry_source in ('POLLING', 'WEBHOOK'))
+);
+
+create index ix_bike_recent_states_bike_received
+    on bike_recent_states(bike_id, received_at desc);
+
+create index ix_bike_recent_states_cleanup
+    on bike_recent_states(received_at);
+
+create table bike_current_states (
+    bike_id uuid primary key,
+    device_id uuid,
+    telemetry_log_id uuid,
+    last_received_at timestamptz not null,
+    latitude numeric(10,7),
+    longitude numeric(10,7),
+    speed_kph numeric(8,2),
+    battery_percent numeric(5,2),
+    ignition_status varchar(20) not null,
+    telemetry_source varchar(20) not null,
+    updated_at timestamptz not null default now(),
+    constraint ck_bike_current_states_latitude check (latitude is null or (latitude >= -90 and latitude <= 90)),
+    constraint ck_bike_current_states_longitude check (longitude is null or (longitude >= -180 and longitude <= 180)),
+    constraint ck_bike_current_states_speed check (speed_kph is null or speed_kph >= 0),
+    constraint ck_bike_current_states_battery check (battery_percent is null or (battery_percent >= 0 and battery_percent <= 100)),
+    constraint ck_bike_current_states_ignition check (ignition_status in ('UNKNOWN', 'ON', 'OFF')),
+    constraint ck_bike_current_states_source check (telemetry_source in ('POLLING', 'WEBHOOK'))
+);
+
+create index ix_bike_current_states_last_received
+    on bike_current_states(last_received_at desc);
+
+create table telemetry_ingestion_error_logs (
+    id uuid primary key,
+    idx bigserial not null unique,
+    telemetry_log_id uuid,
+    device_uid varchar(100),
+    bike_id uuid,
+    received_at timestamptz,
+    ingestion_stage varchar(50) not null,
+    retryable boolean not null default true,
+    resolved_at timestamptz,
+    error_code varchar(100) not null,
+    error_message text,
+    context_summary jsonb,
+    created_at timestamptz not null default now(),
+    constraint ck_telemetry_ingestion_error_logs_stage check (
+        ingestion_stage in ('DEVICE_RESOLUTION', 'BIKE_ASSOCIATION', 'CURRENT_STATE')
+    )
+);
+
+create index ix_telemetry_ingestion_errors_retryable
+    on telemetry_ingestion_error_logs(retryable, created_at)
+    where resolved_at is null;
+
+create index ix_telemetry_ingestion_errors_device_received
+    on telemetry_ingestion_error_logs(device_uid, received_at desc);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -53,8 +53,8 @@ class ArchitectureBoundaryTests {
             .should(onlyAuthLoginMayHaveRequestBodyParameters());
 
     @ArchTest
-    static final ArchRule issue_14_must_not_add_telemetry_or_dashboard_controllers = noClasses()
-            .that().resideInAnyPackage("..telemetry..", "..dashboard..")
+    static final ArchRule issue_14_must_not_add_dashboard_controllers_before_scope = noClasses()
+            .that().resideInAPackage("..dashboard..")
             .should().beAnnotatedWith(RestController.class);
 
     @ArchTest
@@ -84,7 +84,8 @@ class ArchitectureBoundaryTests {
                         || isBikeEquipmentCommand(method)
                         || isInsuranceItemCommand(method)
                         || isRiderInsuranceCommand(method)
-                        || isStationCommand(method)) {
+                        || isStationCommand(method)
+                        || isTelemetryIngestionCommand(method)) {
                     return;
                 }
 
@@ -117,7 +118,8 @@ class ArchitectureBoundaryTests {
                         && !isBikeEquipmentCommand(method)
                         && !isInsuranceItemCommand(method)
                         && !isRiderInsuranceCommand(method)
-                        && !isStationCommand(method)) {
+                        && !isStationCommand(method)
+                        && !isTelemetryIngestionCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside auth login"
@@ -208,6 +210,11 @@ class ArchitectureBoundaryTests {
                 || method.getName().equals("update")
                 || method.getName().equals("updateBatteryCounts")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isTelemetryIngestionCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.telemetry.controller.TelemetryIngestionController")
+                && method.getName().equals("ingest");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
@@ -33,6 +33,12 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
             "battery_stations",
             "station_battery_count_logs");
 
+    private static final List<String> TELEMETRY_TABLES = List.of(
+            "device_telemetry_logs",
+            "bike_recent_states",
+            "bike_current_states",
+            "telemetry_ingestion_error_logs");
+
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
@@ -42,7 +48,7 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
     }
 
     @Test
-    void flywayCreatesEveryNonTelemetryCoreOperationsTable() {
+    void flywayCreatesEveryCoreOperationsAndTelemetryTable() {
         List<String> tables = jdbcTemplate.queryForList("""
                 select table_name
                 from information_schema.tables
@@ -51,10 +57,11 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                 """, String.class);
 
         assertThat(tables).containsAll(CORE_TABLES);
+        assertThat(tables).containsAll(TELEMETRY_TABLES);
     }
 
     @Test
-    void coreSchemaDoesNotCreateCrossDomainForeignKeys() {
+    void coreAndTelemetrySchemasDoNotCreateCrossDomainForeignKeys() {
         Integer foreignKeyCount = jdbcTemplate.queryForObject("""
                 select count(*)
                 from information_schema.table_constraints
@@ -72,7 +79,11 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                     'devices',
                     'bike_device_installations',
                     'battery_stations',
-                    'station_battery_count_logs'
+                    'station_battery_count_logs',
+                    'device_telemetry_logs',
+                    'bike_recent_states',
+                    'bike_current_states',
+                    'telemetry_ingestion_error_logs'
                   )
                 """, Integer.class);
 
@@ -81,7 +92,7 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
 
 
     @Test
-    void schemaExposesRequiredPartialIndexesAndOmitsTelemetryTables() {
+    void schemaExposesRequiredPartialIndexesAndTelemetryCurrentStateIndexes() {
         List<String> indexNames = jdbcTemplate.queryForList("""
                 select indexname
                 from pg_indexes
@@ -103,6 +114,16 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                 "ux_bike_device_installations_active_device",
                 "ux_battery_stations_name_active");
 
+        assertThat(indexNames).contains(
+                "ux_device_telemetry_logs_vendor_event",
+                "ux_device_telemetry_logs_fallback_event",
+                "ix_device_telemetry_logs_device_received",
+                "ix_bike_recent_states_bike_received",
+                "ix_bike_recent_states_cleanup",
+                "ix_bike_current_states_last_received",
+                "ix_telemetry_ingestion_errors_retryable",
+                "ix_telemetry_ingestion_errors_device_received");
+
         List<String> telemetryTables = jdbcTemplate.queryForList("""
                 select table_name
                 from information_schema.tables
@@ -111,12 +132,11 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                     'device_telemetry_logs',
                     'bike_recent_states',
                     'bike_current_states',
-                    'device_api_sync_logs',
                     'telemetry_ingestion_error_logs'
                   )
                 """, String.class);
 
-        assertThat(telemetryTables).isEmpty();
+        assertThat(telemetryTables).containsExactlyInAnyOrderElementsOf(TELEMETRY_TABLES);
     }
 
     @Test

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TelemetryApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TelemetryApiContractTests.java
@@ -1,0 +1,331 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TelemetryApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID DEVICE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID INSTALLATION_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        List.of(
+                "telemetry_ingestion_error_logs",
+                "bike_current_states",
+                "bike_recent_states",
+                "device_telemetry_logs",
+                "bike_device_installations",
+                "devices",
+                "bikes",
+                "admin_users"
+        ).forEach(table -> jdbcTemplate.update("delete from " + table));
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void ingestTelemetryCreatesRawRecentAndCurrentStateForActiveDeviceInstallation() throws Exception {
+        Instant receivedAt = Instant.now().minusSeconds(60);
+        seedBike(BIKE_ID, "서울T-1001", "VIN-TELEMETRY-001");
+        seedDevice(DEVICE_ID, "DEV-TEL-001", true);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, receivedAt.minusSeconds(3600), null);
+
+        mockMvc.perform(postTelemetry("DEV-TEL-001", "evt-001", receivedAt, "12.30", "76.00", "ON"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/telemetry/device-events/")))
+                .andExpect(jsonPath("$.telemetryLogId").isString())
+                .andExpect(jsonPath("$.deviceId").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.deviceUid").value("DEV-TEL-001"))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.duplicate").value(false))
+                .andExpect(jsonPath("$.recentStateCreated").value(true))
+                .andExpect(jsonPath("$.currentStateUpdated").value(true))
+                .andExpect(jsonPath("$.ingestionStatus").value("ACCEPTED"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(1);
+        assertThat(countRows("bike_recent_states")).isEqualTo(1);
+        assertThat(countRows("bike_current_states")).isEqualTo(1);
+        assertThat(countRows("telemetry_ingestion_error_logs")).isZero();
+
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.deviceId").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.latitude").value(37.501))
+                .andExpect(jsonPath("$.longitude").value(127.0396))
+                .andExpect(jsonPath("$.ignitionStatus").value("ON"))
+                .andExpect(jsonPath("$.drivingStatus").value("DRIVING"))
+                .andExpect(jsonPath("$.connectionStatus").value("ONLINE"))
+                .andExpect(jsonPath("$.batteryStatus").value("NORMAL"));
+
+        mockMvc.perform(get("/api/v1/telemetry/bike-current-states")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .param("size", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.page.size").value(5))
+                .andExpect(jsonPath("$.page.totalItems").value(1));
+    }
+
+    @Test
+    void duplicateVendorEventIsIdempotentAndDoesNotCreateSecondStateRow() throws Exception {
+        Instant receivedAt = Instant.now().minusSeconds(60);
+        seedBike(BIKE_ID, "서울T-1002", "VIN-TELEMETRY-002");
+        seedDevice(DEVICE_ID, "DEV-TEL-002", true);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, receivedAt.minusSeconds(3600), null);
+
+        mockMvc.perform(postTelemetry("DEV-TEL-002", "evt-dup", receivedAt, "6.00", "70.00", "ON"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.duplicate").value(false))
+                .andExpect(jsonPath("$.ingestionStatus").value("ACCEPTED"));
+
+        mockMvc.perform(postTelemetry("DEV-TEL-002", "evt-dup", receivedAt, "6.00", "70.00", "ON"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.duplicate").value(true))
+                .andExpect(jsonPath("$.recentStateCreated").value(false))
+                .andExpect(jsonPath("$.currentStateUpdated").value(false))
+                .andExpect(jsonPath("$.ingestionStatus").value("IDEMPOTENT_REPLAY"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(1);
+        assertThat(countRows("bike_recent_states")).isEqualTo(1);
+        assertThat(countRows("bike_current_states")).isEqualTo(1);
+    }
+
+    @Test
+    void outOfOrderTelemetryKeepsRecentHistoryButDoesNotRegressCurrentState() throws Exception {
+        Instant newerAt = Instant.now().minusSeconds(30);
+        Instant olderAt = newerAt.minusSeconds(300);
+        seedBike(BIKE_ID, "서울T-1003", "VIN-TELEMETRY-003");
+        seedDevice(DEVICE_ID, "DEV-TEL-003", true);
+        seedInstallation(INSTALLATION_ID, BIKE_ID, DEVICE_ID, olderAt.minusSeconds(3600), null);
+
+        mockMvc.perform(postTelemetry("DEV-TEL-003", "evt-newer", newerAt, "18.00", "80.00", "ON"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.currentStateUpdated").value(true))
+                .andExpect(jsonPath("$.ingestionStatus").value("ACCEPTED"));
+
+        mockMvc.perform(postTelemetry("DEV-TEL-003", "evt-older", olderAt, "0.00", "75.00", "OFF"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.recentStateCreated").value(true))
+                .andExpect(jsonPath("$.currentStateUpdated").value(false))
+                .andExpect(jsonPath("$.ingestionStatus").value("STALE_TELEMETRY_IGNORED"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(2);
+        assertThat(countRows("bike_recent_states")).isEqualTo(2);
+        assertThat(countRows("bike_current_states")).isEqualTo(1);
+
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.speedKph").value(18.0))
+                .andExpect(jsonPath("$.ignitionStatus").value("ON"))
+                .andExpect(jsonPath("$.drivingStatus").value("DRIVING"));
+    }
+
+    @Test
+    void unknownOrUnassignedDeviceStillStoresRawLogAndErrorButNoBikeState() throws Exception {
+        Instant receivedAt = Instant.now().minusSeconds(60);
+
+        mockMvc.perform(postTelemetry("DEV-UNKNOWN", "evt-unknown", receivedAt, "0.00", "50.00", "OFF"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceId").doesNotExist())
+                .andExpect(jsonPath("$.bikeId").doesNotExist())
+                .andExpect(jsonPath("$.recentStateCreated").value(false))
+                .andExpect(jsonPath("$.currentStateUpdated").value(false))
+                .andExpect(jsonPath("$.ingestionStatus").value("DEVICE_UNRESOLVED"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(1);
+        assertThat(countRows("telemetry_ingestion_error_logs")).isEqualTo(1);
+        assertThat(countRows("bike_recent_states")).isZero();
+        assertThat(countRows("bike_current_states")).isZero();
+
+        seedDevice(DEVICE_ID, "DEV-NO-INSTALL", true);
+        mockMvc.perform(postTelemetry("DEV-NO-INSTALL", "evt-no-install", receivedAt.plusSeconds(1), "0.00", "50.00", "OFF"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceId").value(DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.bikeId").doesNotExist())
+                .andExpect(jsonPath("$.ingestionStatus").value("BIKE_UNRESOLVED"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(2);
+        assertThat(countRows("telemetry_ingestion_error_logs")).isEqualTo(2);
+        assertThat(countRows("bike_current_states")).isZero();
+    }
+
+    @Test
+    void staleConnectionStatusUsesIgnitionStateBeforeFlaggingSignalLoss() throws Exception {
+        Instant oldReceivedAt = Instant.now().minusSeconds(11 * 60);
+        UUID parkedBikeId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+        insertCurrentState(BIKE_ID, DEVICE_ID, oldReceivedAt, "ON");
+        insertCurrentState(parkedBikeId, UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"), oldReceivedAt, "OFF");
+
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connectionStatus").value("SIGNAL_LOST"));
+
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", parkedBikeId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connectionStatus").value("PARKED_OFFLINE_NORMAL"));
+    }
+
+    @Test
+    void telemetryEndpointsRequireAuthentication() throws Exception {
+        Instant receivedAt = Instant.now().minusSeconds(60);
+
+        mockMvc.perform(post("/api/v1/telemetry/device-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(telemetryJson("DEV-AUTH", "evt-auth", receivedAt, "1.00", "60.00", "ON")))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/telemetry/bike-current-states"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", BIKE_ID))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private MockHttpServletRequestBuilder postTelemetry(
+            String deviceUid,
+            String vendorEventId,
+            Instant receivedAt,
+            String speedKph,
+            String batteryPercent,
+            String ignitionStatus
+    ) {
+        return post("/api/v1/telemetry/device-events")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(telemetryJson(deviceUid, vendorEventId, receivedAt, speedKph, batteryPercent, ignitionStatus));
+    }
+
+    private String telemetryJson(
+            String deviceUid,
+            String vendorEventId,
+            Instant receivedAt,
+            String speedKph,
+            String batteryPercent,
+            String ignitionStatus
+    ) {
+        return """
+                {
+                  "id":"99999999-9999-9999-9999-999999999999",
+                  "bikeId":"11111111-1111-1111-1111-111111111111",
+                  "deviceId":"22222222-2222-2222-2222-222222222222",
+                  "deviceUid":"%s",
+                  "vendorEventId":"%s",
+                  "receivedAt":"%s",
+                  "deviceReportedAt":"%s",
+                  "latitude":37.5010000,
+                  "longitude":127.0396000,
+                  "speedKph":%s,
+                  "batteryPercent":%s,
+                  "ignitionStatus":"%s",
+                  "telemetrySource":"POLLING",
+                  "rawPayload":{"vendor":"test-device","seq":"%s"}
+                }
+                """.formatted(deviceUid, vendorEventId, receivedAt, receivedAt.minusSeconds(2), speedKph, batteryPercent, ignitionStatus, vendorEventId);
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, ?, ?, 'Thunder M1', 'IN_SERVICE')
+                """, id, plateNumber, vin);
+    }
+
+    private void seedDevice(UUID id, String deviceUid, boolean enabled) {
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled)
+                values (?, ?, 'ThunderDevice', 'TD-100', ?)
+                """, id, deviceUid, enabled);
+    }
+
+    private void seedInstallation(UUID id, UUID bikeId, UUID deviceId, Instant installedAt, Instant removedAt) {
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at, removed_at)
+                values (?, ?, ?, ?::timestamptz, ?::timestamptz)
+                """, id, bikeId, deviceId, installedAt.toString(), removedAt == null ? null : removedAt.toString());
+    }
+
+    private void insertCurrentState(UUID bikeId, UUID deviceId, Instant receivedAt, String ignitionStatus) {
+        jdbcTemplate.update("""
+                insert into bike_current_states (
+                    bike_id, device_id, telemetry_log_id, last_received_at,
+                    latitude, longitude, speed_kph, battery_percent, ignition_status, telemetry_source
+                ) values (?, ?, ?, ?::timestamptz, 37.5010000, 127.0396000, 0.00, 70.00, ?, 'POLLING')
+                """, bikeId, deviceId, UUID.randomUUID(), receivedAt.toString(), ignitionStatus);
+    }
+
+    private int countRows(String tableName) {
+        return jdbcTemplate.queryForObject("select count(*) from " + tableName, Integer.class);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -430,3 +430,27 @@ Boundary decision:
 - Active `appAccountId` values are unique across non-deleted riders; deleted riders no longer reserve the app-account id.
 - Unlinking clears app-link fields while preserving the rider row and is idempotent.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and the expanded rider command controller methods at this stage.
+## Telemetry/current-state baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#67
+- Target issue: EVNSolution/thundercrew-domain#46
+- Branch: `cc-67-telemetry-current-state`
+
+Issue-size decision:
+
+- This slice adds the minimum telemetry persistence and current-state read model after the rider app-account link baseline.
+- Included operations are authenticated `POST /api/v1/telemetry/device-events`, `GET /api/v1/telemetry/bike-current-states`, and `GET /api/v1/telemetry/bikes/{bikeId}/current-state`.
+- Included tables are `device_telemetry_logs`, `bike_recent_states`, `bike_current_states`, and `telemetry_ingestion_error_logs`.
+- TimescaleDB hypertables, retention/archival schedulers, external device API polling/sync logs, dashboard/map aggregate APIs, frontend map integration, bulk replay, and correction workflows remain follow-up scopes.
+
+Boundary decision:
+
+- Telemetry ingestion identifies the device by registered `deviceUid`; client-supplied bike/device/database IDs are ignored and operators must not type raw relationship IDs.
+- The service resolves the active bike-device installation at `receivedAt` without DB foreign keys or JPA relationships.
+- Raw telemetry is inserted idempotently by `(deviceUid, vendorEventId)` when a vendor event id exists, otherwise by `(deviceUid, receivedAt, telemetrySource, payloadHash)`, using database `ON CONFLICT DO NOTHING` so concurrent replays do not surface as server errors.
+- Unknown, disabled, or unassigned devices still create raw/error evidence but do not create recent/current bike states.
+- Recent state keeps accepted bike telemetry history. Current state updates only when incoming telemetry is newer through a conditional PostgreSQL upsert, so out-of-order or concurrent events do not regress the map-ready state.
+- Current-state DTOs compute `drivingStatus`, `connectionStatus`, and `batteryStatus`; these remain API information, not stored bike table data.
+- Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and telemetry ingestion at this stage while dashboard controllers remain out of scope.

--- a/docs/backend/02-domain-db-draft.md
+++ b/docs/backend/02-domain-db-draft.md
@@ -553,7 +553,7 @@ Update rule:
 3. Insert raw `device_telemetry_logs` with idempotency protection.
 4. Insert normalized `bike_recent_states` when bike association exists.
 5. Upsert `bike_current_states` only if newer than current state.
-6. Record failure in `device_api_sync_logs` or ingestion error log if any downstream step fails.
+6. Record telemetry processing failures in `telemetry_ingestion_error_logs`; use `device_api_sync_logs` later only for external polling/webhook request-response evidence.
 
 Failure policy:
 
@@ -579,10 +579,11 @@ Computed DTO information:
 | `battery_status = LOW` | battery >= 20 and battery < 50 |
 | `battery_status = NORMAL` | battery >= 50 |
 
-### `device_api_sync_logs`
+### `device_api_sync_logs` (future external sync slice)
 
 External device API polling/webhook request-response evidence. This is for API call/sync trace,
-not for every normalized telemetry processing failure.
+not for every normalized telemetry processing failure and not part of the first raw/recent/current
+telemetry baseline.
 
 - `id`, `idx`
 - `device_id uuid null`

--- a/docs/backend/03-scaffold-plan.md
+++ b/docs/backend/03-scaffold-plan.md
@@ -90,7 +90,7 @@ Draft split:
 - `V1__init_admin_and_common.sql`
 - `V2__init_rider_bike_contract.sql`
 - `V3__init_insurance_equipment_device.sql`
-- `V4__init_telemetry_station.sql`
+- `V4__init_telemetry_current_state.sql`
 - `V5__seed_system_contract_template.sql`
 
 Implementation may adjust split, but must keep these review gates:
@@ -110,8 +110,8 @@ Minimum safe path:
 2. Insert raw telemetry idempotently.
 3. Insert recent state if bike association exists.
 4. Upsert current state only for newer telemetry.
-5. Record API sync evidence in `device_api_sync_logs`.
-6. Record telemetry processing failures in `telemetry_ingestion_error_logs` with redacted context and retryability.
+5. Record telemetry processing failures in `telemetry_ingestion_error_logs` with redacted context and retryability.
+6. Add `device_api_sync_logs` later with the external device polling/webhook integration slice; it is not required for the current raw/recent/current baseline.
 
 Fallback if TimescaleDB is unavailable:
 


### PR DESCRIPTION
## Summary

Implements the service-ops-api telemetry/current-state baseline for the map/control data spine.

- Adds Flyway V4 telemetry tables for raw device logs, bike recent states, bike current states, and telemetry ingestion errors.
- Adds authenticated telemetry ingestion at `POST /api/v1/telemetry/device-events`.
- Adds authenticated current-state reads at:
  - `GET /api/v1/telemetry/bike-current-states`
  - `GET /api/v1/telemetry/bikes/{bikeId}/current-state`
- Resolves bike association from registered `deviceUid` + active bike-device installation at `receivedAt`; no manual DB/FK ID user input.
- Uses DB-level idempotent raw insert (`ON CONFLICT DO NOTHING`) and replay reload.
- Uses conditional PostgreSQL current-state upsert so out-of-order/concurrent telemetry cannot regress current state.
- Updates backend docs, change ledger, architecture/schema tests, and telemetry contract tests.

## Trace

- change-control anchor: EVNSolution/clever-change-control#67
- target issue: EVNSolution/thundercrew-domain#46
- branch: `cc-67-telemetry-current-state`
- commit: `040b481`

## Concurrent work gate

Decision: allowed-with-non-overlap

Evidence:
- target repo open PRs before PR: `[]`
- target repo open issues: only EVNSolution/thundercrew-domain#46 for this slice
- active target branches: `cc-67-telemetry-current-state`, `dev`, `main`
- control-plane open issues reviewed; no overlapping target repo/service/API/data/deploy/file scope found

Non-overlap reason:
- This PR is limited to `development/service-ops-api` telemetry schema/ingest/current-state endpoints/tests and backend docs.
- No open PR touches the same target repository scope.

## Verification

- `npm run check:workspace` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- `(cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.TelemetryApiContractTests --tests com.thundercrew.opsapi.ArchitectureBoundaryTests --tests com.thundercrew.opsapi.CorePersistenceBaselineTests --no-daemon)` — pass after atomic-idempotency/current-upsert fixes
- `(cd development/service-ops-api && ./gradlew cleanTest test --max-workers=1 --no-daemon)` — pass
- `(cd development/service-ops-api && ./gradlew build --max-workers=1 --no-daemon)` — pass
- `git diff --check` — pass
- code-reviewer subagent — PASS after blocker fixes

## Follow-up / non-goals

- External device API polling/sync-log implementation
- TimescaleDB hypertables and retention/archival jobs
- Dashboard/map aggregate API
- Frontend map integration
- Production vendor telemetry contract
