### PR TITLE
Backend dashboard map aggregate API

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -82,6 +82,8 @@ This module currently provides the backend scaffold, core persistence baseline, 
   - `POST /api/v1/telemetry/device-events`
   - `GET /api/v1/telemetry/bike-current-states`
   - `GET /api/v1/telemetry/bikes/{bikeId}/current-state`
+- Dashboard/map aggregate endpoint:
+  - `GET /api/v1/dashboard/map-state`
 - `POST /api/v1/auth/login` for admin access-token issuance
 - Existing protected read APIs accept `Authorization: Bearer <token>`
 - `AUTHENTICATION_FAILED` 401 JSON error contract for invalid/missing/expired tokens
@@ -89,7 +91,7 @@ This module currently provides the backend scaffold, core persistence baseline, 
 Out of scope for the current backend baseline:
 
 - Create/update/delete command endpoints and request DTOs outside delivered command slices
-- dashboard/map aggregate APIs and frontend map integration
+- frontend map integration
 - external device API polling/sync-log implementation, TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - refresh token, logout/revocation, password reset, RBAC expansion, or admin-management UI
 - frontend relocation
@@ -275,6 +277,23 @@ curl http://localhost:8080/api/v1/telemetry/bikes/<bike-id>/current-state \
   -H "Authorization: Bearer <access-token>"
 ```
 
+## Dashboard map aggregate API
+
+The dashboard map slice exposes a read-only, map-ready aggregate for the control screen. It combines current bike telemetry with active rider labels and battery station pin data. It omits rider phone numbers/raw rider IDs from the map response and does not accept user-entered IDs and does not perform writes. Future frontend selectors should display the returned human-readable labels such as plate number, rider name, and station name.
+
+```bash
+curl http://localhost:8080/api/v1/dashboard/map-state \
+  -H "Authorization: Bearer <access-token>"
+```
+
+The response includes:
+
+- `summary`: total active bikes, bike pins, connection/battery status counts, station counts, and available battery sum.
+- `bikePins`: coordinate-ready bike/rider pins derived from `bike_current_states` and active rider-bike contracts.
+- `stationPins`: coordinate-ready station pins with label format `name available/max`, for example `강남 스테이션 5/12`.
+
+External map provider integration, frontend consumption, and telemetry retention remain separate issue scopes.
+
 ## Bike-device installation command API
 
 The installation slice is the bike-device relationship source of truth. The UI should select bikes by plate/VIN and devices by device UID; the backend accepts only selector-produced UUID references and operator lifecycle fields, never raw ID text inputs from users.
@@ -328,7 +347,7 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 - Rider relationship assignment commands
 - Refresh/revocation/password reset/RBAC expansion
-- Dashboard/map read API and frontend map integration
+- Frontend map integration
 - External device API polling/sync-log implementation
 - TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - Contract overlap locking implementation

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/controller/DashboardMapController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/controller/DashboardMapController.java
@@ -1,0 +1,21 @@
+package com.thundercrew.opsapi.dashboard.controller;
+
+import com.thundercrew.opsapi.dashboard.dto.DashboardMapStateResponse;
+import com.thundercrew.opsapi.dashboard.service.DashboardMapStateService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DashboardMapController {
+
+    private final DashboardMapStateService dashboardMapStateService;
+
+    public DashboardMapController(DashboardMapStateService dashboardMapStateService) {
+        this.dashboardMapStateService = dashboardMapStateService;
+    }
+
+    @GetMapping("/api/v1/dashboard/map-state")
+    DashboardMapStateResponse getMapState() {
+        return dashboardMapStateService.getMapState();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
@@ -1,0 +1,68 @@
+package com.thundercrew.opsapi.dashboard.dto;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record DashboardMapStateResponse(
+        Instant generatedAt,
+        DashboardSummary summary,
+        List<BikePin> bikePins,
+        List<StationPin> stationPins
+) {
+    public record DashboardSummary(
+            long totalBikes,
+            int bikePinCount,
+            long onlineBikeCount,
+            long signalLostBikeCount,
+            long parkedOfflineBikeCount,
+            long lowBatteryBikeCount,
+            long activeStationCount,
+            int stationPinCount,
+            long availableBatteryCount
+    ) {
+    }
+
+    public record BikePin(
+            UUID bikeId,
+            Long bikeIdx,
+            String plateNumber,
+            String modelName,
+            BikeOperationStatus operationStatus,
+            String activeRiderLabel,
+            UUID deviceId,
+            Instant lastReceivedAt,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal speedKph,
+            BigDecimal batteryPercent,
+            TelemetryIgnitionStatus ignitionStatus,
+            String telemetrySource,
+            String drivingStatus,
+            String connectionStatus,
+            String batteryStatus,
+            String pinLabel
+    ) {
+    }
+
+    public record StationPin(
+            UUID stationId,
+            Long stationIdx,
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BatteryStationStatus status,
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount,
+            String availableBatteryLabel,
+            int availableBatteryPercentage,
+            String pinLabel
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
@@ -1,0 +1,157 @@
+package com.thundercrew.opsapi.dashboard.repository;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DashboardMapQueryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DashboardMapQueryRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public long countActiveBikes() {
+        Long result = jdbcTemplate.queryForObject("""
+                select count(*)
+                from bikes
+                where deleted_at is null
+                """, Long.class);
+        return result == null ? 0 : result;
+    }
+
+    public List<BikePinRow> findCurrentBikeStates(Instant now) {
+        return jdbcTemplate.query("""
+                select
+                    b.id as bike_id,
+                    b.idx as bike_idx,
+                    b.plate_number,
+                    b.model_name,
+                    b.operation_status,
+                    active_rider.rider_name,
+                    cs.device_id,
+                    cs.last_received_at,
+                    cs.latitude,
+                    cs.longitude,
+                    cs.speed_kph,
+                    cs.battery_percent,
+                    cs.ignition_status,
+                    cs.telemetry_source
+                from bike_current_states cs
+                join bikes b
+                  on b.id = cs.bike_id
+                 and b.deleted_at is null
+                left join lateral (
+                    select
+                        r.name as rider_name
+                    from rider_bike_contracts c
+                    join riders r
+                      on r.id = c.rider_id
+                     and r.deleted_at is null
+                    where c.bike_id = b.id
+                      and c.deleted_at is null
+                      and c.terminated_at is null
+                      and c.start_at <= ?::timestamptz
+                      and (c.end_at is null or c.end_at > ?::timestamptz)
+                    order by c.start_at desc, c.idx desc
+                    limit 1
+                ) active_rider on true
+                order by cs.last_received_at desc, b.idx asc
+                """, this::mapBikePinRow, now.toString(), now.toString());
+    }
+
+    public List<StationPinRow> findStationPins() {
+        return jdbcTemplate.query("""
+                select
+                    id,
+                    idx,
+                    name,
+                    address,
+                    latitude,
+                    longitude,
+                    status,
+                    max_battery_capacity,
+                    current_battery_count,
+                    available_battery_count
+                from battery_stations
+                where deleted_at is null
+                order by idx asc
+                """, this::mapStationPinRow);
+    }
+
+    private BikePinRow mapBikePinRow(ResultSet rs, int rowNum) throws SQLException {
+        return new BikePinRow(
+                rs.getObject("bike_id", UUID.class),
+                rs.getLong("bike_idx"),
+                rs.getString("plate_number"),
+                rs.getString("model_name"),
+                BikeOperationStatus.valueOf(rs.getString("operation_status")),
+                rs.getString("rider_name"),
+                rs.getObject("device_id", UUID.class),
+                rs.getTimestamp("last_received_at").toInstant(),
+                rs.getBigDecimal("latitude"),
+                rs.getBigDecimal("longitude"),
+                rs.getBigDecimal("speed_kph"),
+                rs.getBigDecimal("battery_percent"),
+                TelemetryIgnitionStatus.valueOf(rs.getString("ignition_status")),
+                rs.getString("telemetry_source")
+        );
+    }
+
+    private StationPinRow mapStationPinRow(ResultSet rs, int rowNum) throws SQLException {
+        return new StationPinRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                rs.getString("name"),
+                rs.getString("address"),
+                rs.getBigDecimal("latitude"),
+                rs.getBigDecimal("longitude"),
+                BatteryStationStatus.valueOf(rs.getString("status")),
+                rs.getInt("max_battery_capacity"),
+                rs.getInt("current_battery_count"),
+                rs.getInt("available_battery_count")
+        );
+    }
+
+    public record BikePinRow(
+            UUID bikeId,
+            Long bikeIdx,
+            String plateNumber,
+            String modelName,
+            BikeOperationStatus operationStatus,
+            String activeRiderName,
+            UUID deviceId,
+            Instant lastReceivedAt,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal speedKph,
+            BigDecimal batteryPercent,
+            TelemetryIgnitionStatus ignitionStatus,
+            String telemetrySource
+    ) {
+    }
+
+    public record StationPinRow(
+            UUID stationId,
+            Long stationIdx,
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BatteryStationStatus status,
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
@@ -1,0 +1,169 @@
+package com.thundercrew.opsapi.dashboard.service;
+
+import com.thundercrew.opsapi.dashboard.dto.DashboardMapStateResponse;
+import com.thundercrew.opsapi.dashboard.dto.DashboardMapStateResponse.BikePin;
+import com.thundercrew.opsapi.dashboard.dto.DashboardMapStateResponse.DashboardSummary;
+import com.thundercrew.opsapi.dashboard.dto.DashboardMapStateResponse.StationPin;
+import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository;
+import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository.BikePinRow;
+import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository.StationPinRow;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DashboardMapStateService {
+
+    private static final Duration SIGNAL_LOST_THRESHOLD = Duration.ofMinutes(10);
+
+    private final DashboardMapQueryRepository dashboardMapQueryRepository;
+    private final Clock clock;
+
+    public DashboardMapStateService(DashboardMapQueryRepository dashboardMapQueryRepository, Clock clock) {
+        this.dashboardMapQueryRepository = dashboardMapQueryRepository;
+        this.clock = clock;
+    }
+
+    public DashboardMapStateResponse getMapState() {
+        Instant generatedAt = Instant.now(clock);
+        long totalBikes = dashboardMapQueryRepository.countActiveBikes();
+        List<BikePinRow> currentBikeStates = dashboardMapQueryRepository.findCurrentBikeStates(generatedAt);
+        List<BikePin> bikePins = currentBikeStates.stream()
+                .filter(DashboardMapStateService::hasCoordinates)
+                .map(row -> toBikePin(row, generatedAt))
+                .toList();
+        List<StationPin> stationPins = dashboardMapQueryRepository.findStationPins().stream()
+                .map(this::toStationPin)
+                .toList();
+
+        DashboardSummary summary = new DashboardSummary(
+                totalBikes,
+                bikePins.size(),
+                currentBikeStates.stream().filter(row -> connectionStatus(row, generatedAt).equals("ONLINE")).count(),
+                currentBikeStates.stream().filter(row -> connectionStatus(row, generatedAt).equals("SIGNAL_LOST")).count(),
+                currentBikeStates.stream().filter(row -> connectionStatus(row, generatedAt).equals("PARKED_OFFLINE_NORMAL")).count(),
+                currentBikeStates.stream().filter(row -> batteryStatus(row).equals("LOW") || batteryStatus(row).equals("CRITICAL")).count(),
+                stationPins.stream().filter(pin -> pin.status() == BatteryStationStatus.ACTIVE).count(),
+                stationPins.size(),
+                stationPins.stream().mapToLong(StationPin::availableBatteryCount).sum()
+        );
+
+        return new DashboardMapStateResponse(generatedAt, summary, bikePins, stationPins);
+    }
+
+    private BikePin toBikePin(BikePinRow row, Instant generatedAt) {
+        String drivingStatus = drivingStatus(row);
+        String connectionStatus = connectionStatus(row, generatedAt);
+        String batteryStatus = batteryStatus(row);
+        return new BikePin(
+                row.bikeId(),
+                row.bikeIdx(),
+                row.plateNumber(),
+                row.modelName(),
+                row.operationStatus(),
+                activeRiderLabel(row),
+                row.deviceId(),
+                row.lastReceivedAt(),
+                row.latitude(),
+                row.longitude(),
+                row.speedKph(),
+                row.batteryPercent(),
+                row.ignitionStatus(),
+                row.telemetrySource(),
+                drivingStatus,
+                connectionStatus,
+                batteryStatus,
+                bikePinLabel(row)
+        );
+    }
+
+    private StationPin toStationPin(StationPinRow row) {
+        String availableBatteryLabel = row.availableBatteryCount() + "/" + row.maxBatteryCapacity();
+        return new StationPin(
+                row.stationId(),
+                row.stationIdx(),
+                row.name(),
+                row.address(),
+                row.latitude(),
+                row.longitude(),
+                row.status(),
+                row.maxBatteryCapacity(),
+                row.currentBatteryCount(),
+                row.availableBatteryCount(),
+                availableBatteryLabel,
+                availableBatteryPercentage(row),
+                row.name() + " " + availableBatteryLabel
+        );
+    }
+
+    private static boolean hasCoordinates(BikePinRow row) {
+        return row.latitude() != null && row.longitude() != null;
+    }
+
+    private String bikePinLabel(BikePinRow row) {
+        String activeRiderLabel = activeRiderLabel(row);
+        if (activeRiderLabel == null) {
+            return row.plateNumber();
+        }
+        return row.plateNumber() + " · " + activeRiderLabel;
+    }
+
+    private String activeRiderLabel(BikePinRow row) {
+        if (row.activeRiderName() == null || row.activeRiderName().isBlank()) {
+            return null;
+        }
+        return row.activeRiderName();
+    }
+
+    private String drivingStatus(BikePinRow row) {
+        if (row.ignitionStatus() == TelemetryIgnitionStatus.UNKNOWN) {
+            return "UNKNOWN";
+        }
+        if (row.ignitionStatus() == TelemetryIgnitionStatus.OFF) {
+            return "PARKED";
+        }
+        BigDecimal speedKph = row.speedKph() == null ? BigDecimal.ZERO : row.speedKph();
+        return speedKph.compareTo(BigDecimal.valueOf(3)) >= 0 ? "DRIVING" : "STOPPED";
+    }
+
+    private String connectionStatus(BikePinRow row, Instant generatedAt) {
+        Duration age = Duration.between(row.lastReceivedAt(), generatedAt);
+        if (!age.minus(SIGNAL_LOST_THRESHOLD).isPositive()) {
+            return "ONLINE";
+        }
+        if (row.ignitionStatus() == TelemetryIgnitionStatus.ON) {
+            return "SIGNAL_LOST";
+        }
+        if (row.ignitionStatus() == TelemetryIgnitionStatus.OFF) {
+            return "PARKED_OFFLINE_NORMAL";
+        }
+        return "STALE_UNKNOWN";
+    }
+
+    private String batteryStatus(BikePinRow row) {
+        if (row.batteryPercent() == null) {
+            return "UNKNOWN";
+        }
+        if (row.batteryPercent().compareTo(BigDecimal.valueOf(20)) < 0) {
+            return "CRITICAL";
+        }
+        if (row.batteryPercent().compareTo(BigDecimal.valueOf(50)) < 0) {
+            return "LOW";
+        }
+        return "NORMAL";
+    }
+
+    private int availableBatteryPercentage(StationPinRow row) {
+        if (row.maxBatteryCapacity() == 0) {
+            return 0;
+        }
+        return Math.round((row.availableBatteryCount() * 100.0f) / row.maxBatteryCapacity());
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -17,11 +17,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
 @AnalyzeClasses(packages = "com.thundercrew.opsapi", importOptions = ImportOption.DoNotIncludeTests.class)
@@ -53,9 +51,9 @@ class ArchitectureBoundaryTests {
             .should(onlyAuthLoginMayHaveRequestBodyParameters());
 
     @ArchTest
-    static final ArchRule issue_14_must_not_add_dashboard_controllers_before_scope = noClasses()
-            .that().resideInAPackage("..dashboard..")
-            .should().beAnnotatedWith(RestController.class);
+    static final ArchRule issue_68_dashboard_package_remains_read_only = methods()
+            .that().areDeclaredInClassesThat().resideInAPackage("..dashboard..")
+            .should(notUseWriteRouteMappings());
 
     @ArchTest
     static final ArchRule persistence_baseline_must_not_use_jpa_relationship_annotations = noFields()
@@ -63,6 +61,25 @@ class ArchitectureBoundaryTests {
             .orShould().beAnnotatedWith(OneToMany.class)
             .orShould().beAnnotatedWith(OneToOne.class)
             .orShould().beAnnotatedWith(ManyToMany.class);
+
+
+    private static ArchCondition<JavaMethod> notUseWriteRouteMappings() {
+        return new ArchCondition<>("not use write route mappings") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                boolean hasWriteRouteMapping = method.isAnnotatedWith(PostMapping.class)
+                        || method.isAnnotatedWith(PutMapping.class)
+                        || method.isAnnotatedWith(PatchMapping.class)
+                        || method.isAnnotatedWith(DeleteMapping.class);
+                if (hasWriteRouteMapping) {
+                    events.add(SimpleConditionEvent.violated(
+                            method,
+                            method.getFullName() + " must stay read-only for the dashboard map aggregate scope"
+                    ));
+                }
+            }
+        };
+    }
 
     private static ArchCondition<JavaMethod> onlyAuthLoginMayUseWriteRouteMappings() {
         return new ArchCondition<>("use write route mappings only on AuthController.login") {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardMapApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardMapApiContractTests.java
@@ -1,0 +1,217 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DashboardMapApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ONLINE_BIKE_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID STALE_BIKE_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID NO_STATE_BIKE_ID = UUID.fromString("44444444-4444-4444-4444-444444444444");
+    private static final UUID DEVICE_ID = UUID.fromString("55555555-5555-5555-5555-555555555555");
+    private static final UUID STALE_DEVICE_ID = UUID.fromString("66666666-6666-6666-6666-666666666666");
+    private static final UUID CONTRACT_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+    private static final UUID STATION_ID = UUID.fromString("88888888-8888-8888-8888-888888888888");
+    private static final UUID MAINTENANCE_STATION_ID = UUID.fromString("99999999-9999-9999-9999-999999999999");
+    private static final UUID CONTRACT_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        List.of(
+                "bike_current_states",
+                "rider_bike_contracts",
+                "battery_stations",
+                "riders",
+                "bikes",
+                "admin_users"
+        ).forEach(table -> jdbcTemplate.update("delete from " + table));
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void mapStateReturnsControlSummaryBikePinsAndStationPins() throws Exception {
+        Instant now = Instant.now();
+        seedRider(RIDER_ID, "김지도", "010-1111-2222");
+        seedBike(ONLINE_BIKE_ID, "서울T-2001", "VIN-DASH-001", "IN_SERVICE");
+        seedBike(STALE_BIKE_ID, "서울T-2002", "VIN-DASH-002", "READY");
+        seedBike(NO_STATE_BIKE_ID, "서울T-2003", "VIN-DASH-003", "REPAIRING");
+        seedActiveContract(CONTRACT_ID, RIDER_ID, ONLINE_BIKE_ID, now.minusSeconds(3600));
+        insertCurrentState(ONLINE_BIKE_ID, DEVICE_ID, now.minusSeconds(60), "ON", "12.30", "44.00");
+        insertCurrentState(STALE_BIKE_ID, STALE_DEVICE_ID, now.minusSeconds(11 * 60), "ON", "0.00", "12.00");
+        insertCurrentStateWithoutCoordinates(NO_STATE_BIKE_ID, UUID.fromString("12345678-1234-1234-1234-123456789abc"), now.minusSeconds(120), "OFF", "0.00", "88.00");
+        seedStation(STATION_ID, "강남 스테이션", "서울 강남구 테헤란로 1", "ACTIVE", 12, 7, 5);
+        seedStation(MAINTENANCE_STATION_ID, "마포 스테이션", "서울 마포구 월드컵북로 1", "MAINTENANCE", 8, 5, 2);
+
+        mockMvc.perform(get("/api/v1/dashboard/map-state")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.generatedAt").isString())
+                .andExpect(jsonPath("$.summary.totalBikes").value(3))
+                .andExpect(jsonPath("$.summary.bikePinCount").value(2))
+                .andExpect(jsonPath("$.summary.onlineBikeCount").value(2))
+                .andExpect(jsonPath("$.summary.signalLostBikeCount").value(1))
+                .andExpect(jsonPath("$.summary.parkedOfflineBikeCount").value(0))
+                .andExpect(jsonPath("$.summary.lowBatteryBikeCount").value(2))
+                .andExpect(jsonPath("$.summary.activeStationCount").value(1))
+                .andExpect(jsonPath("$.summary.stationPinCount").value(2))
+                .andExpect(jsonPath("$.summary.availableBatteryCount").value(7))
+                .andExpect(jsonPath("$.bikePins[0].bikeId").value(ONLINE_BIKE_ID.toString()))
+                .andExpect(jsonPath("$.bikePins[0].plateNumber").value("서울T-2001"))
+                .andExpect(jsonPath("$.bikePins[0].activeRiderLabel").value("김지도"))
+                .andExpect(jsonPath("$.bikePins[0].activeRiderId").doesNotExist())
+                .andExpect(jsonPath("$.bikePins[0].activeRiderPhoneNumber").doesNotExist())
+                .andExpect(jsonPath("$.bikePins[0].pinLabel").value("서울T-2001 · 김지도"))
+                .andExpect(jsonPath("$.bikePins[0].drivingStatus").value("DRIVING"))
+                .andExpect(jsonPath("$.bikePins[0].connectionStatus").value("ONLINE"))
+                .andExpect(jsonPath("$.bikePins[0].batteryStatus").value("LOW"))
+                .andExpect(jsonPath("$.bikePins[1].connectionStatus").value("SIGNAL_LOST"))
+                .andExpect(jsonPath("$.bikePins[1].batteryStatus").value("CRITICAL"))
+                .andExpect(jsonPath("$.stationPins[0].stationId").value(STATION_ID.toString()))
+                .andExpect(jsonPath("$.stationPins[0].pinLabel").value("강남 스테이션 5/12"))
+                .andExpect(jsonPath("$.stationPins[0].availableBatteryLabel").value("5/12"))
+                .andExpect(jsonPath("$.stationPins[0].availableBatteryPercentage").value(42));
+    }
+
+    @Test
+    void dashboardMapStateRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/dashboard/map-state"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    private void seedRider(UUID id, String name, String phoneNumber) {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, ?, ?, false)
+                """, id, name, phoneNumber);
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String operationStatus) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, ?, ?, 'Thunder M1', ?)
+                """, id, plateNumber, vin, operationStatus);
+    }
+
+    private void seedActiveContract(UUID id, UUID riderId, UUID bikeId, Instant startAt) {
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, memo)
+                values (?, ?, ?, ?, ?::timestamptz, 'dashboard fixture')
+                """, id, riderId, bikeId, CONTRACT_TEMPLATE_ID, startAt.toString());
+    }
+
+    private void insertCurrentState(
+            UUID bikeId,
+            UUID deviceId,
+            Instant receivedAt,
+            String ignitionStatus,
+            String speedKph,
+            String batteryPercent
+    ) {
+        jdbcTemplate.update("""
+                insert into bike_current_states (
+                    bike_id, device_id, telemetry_log_id, last_received_at,
+                    latitude, longitude, speed_kph, battery_percent, ignition_status, telemetry_source
+                ) values (?, ?, ?, ?::timestamptz, 37.5010000, 127.0396000, ?::numeric, ?::numeric, ?, 'POLLING')
+                """, bikeId, deviceId, UUID.randomUUID(), receivedAt.toString(), speedKph, batteryPercent, ignitionStatus);
+    }
+
+    private void insertCurrentStateWithoutCoordinates(
+            UUID bikeId,
+            UUID deviceId,
+            Instant receivedAt,
+            String ignitionStatus,
+            String speedKph,
+            String batteryPercent
+    ) {
+        jdbcTemplate.update("""
+                insert into bike_current_states (
+                    bike_id, device_id, telemetry_log_id, last_received_at,
+                    speed_kph, battery_percent, ignition_status, telemetry_source
+                ) values (?, ?, ?, ?::timestamptz, ?::numeric, ?::numeric, ?, 'POLLING')
+                """, bikeId, deviceId, UUID.randomUUID(), receivedAt.toString(), speedKph, batteryPercent, ignitionStatus);
+    }
+
+    private void seedStation(
+            UUID id,
+            String name,
+            String address,
+            String status,
+            int maxBatteryCapacity,
+            int currentBatteryCount,
+            int availableBatteryCount
+    ) {
+        jdbcTemplate.update("""
+                insert into battery_stations (
+                    id, name, address, latitude, longitude, status,
+                    max_battery_capacity, current_battery_count, available_battery_count
+                ) values (?, ?, ?, 37.5010000, 127.0396000, ?, ?, ?, ?)
+                """, id, name, address, status, maxBatteryCapacity, currentBatteryCount, availableBatteryCount);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -454,3 +454,25 @@ Boundary decision:
 - Recent state keeps accepted bike telemetry history. Current state updates only when incoming telemetry is newer through a conditional PostgreSQL upsert, so out-of-order or concurrent events do not regress the map-ready state.
 - Current-state DTOs compute `drivingStatus`, `connectionStatus`, and `batteryStatus`; these remain API information, not stored bike table data.
 - Architecture tests allow operation write mappings/request bodies only for auth login, prior command slices, and telemetry ingestion at this stage while dashboard controllers remain out of scope.
+
+## Dashboard/map aggregate API implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#68
+- Target issue: EVNSolution/thundercrew-domain#48
+- Branch: `cc-68-dashboard-map-aggregate`
+
+Issue-size decision:
+
+- This slice adds only the authenticated backend read API for the map/control aggregate after telemetry current-state exists.
+- Included operation is `GET /api/v1/dashboard/map-state`.
+- Included output is summary counts, bike/rider map pins from current telemetry plus active contracts, and battery station pins with `name available/max` labels and available-battery percentages.
+- Frontend integration, external map provider SDKs, external device API polling/sync logs, TimescaleDB retention/archive jobs, new write commands, and correction workflows remain follow-up scopes.
+
+Boundary decision:
+
+- Dashboard remains read-only in this scope; architecture tests explicitly keep dashboard controllers free of write mappings.
+- The dashboard query is a read projection over existing source data and current-state read models; it does not introduce new storage or mutate domain tables.
+- Bike pin labels use human-readable plate/rider data. Station pin labels expose the requested `name available/max` format.
+- Current-state statuses remain API information derived at read time, not stored DB data.


### PR DESCRIPTION
## Summary

- Adds authenticated `GET /api/v1/dashboard/map-state` for the map/control dashboard.
- Aggregates current bike telemetry into map pins and summary counts while keeping coordinate-less current states in summary metrics.
- Adds battery station pins with `name available/max` labels and available-battery percentages.
- Keeps dashboard scope read-only with ArchUnit coverage and records the change in backend docs/ledger.

## CLEVER trace

- Project start: EVNSolution/clever-change-control#45
- Change-control issue: EVNSolution/clever-change-control#68
- Target issue: EVNSolution/thundercrew-domain#48
- Branch: `cc-68-dashboard-map-aggregate`

## Concurrent work decision

`allowed-with-non-overlap`

Rechecked before PR creation: no open target PRs, and no active overlapping issue/branch changing the same backend dashboard/map API, telemetry current-state read model, or station pin aggregate surface.

## Verification

- `npm run check:workspace` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- `(cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.DashboardMapApiContractTests --tests com.thundercrew.opsapi.ArchitectureBoundaryTests --no-daemon)` — pass
- `(cd development/service-ops-api && rm -rf build/test-results/test build/reports/tests/test && ./gradlew cleanTest test --max-workers=1 --no-daemon --stacktrace)` — pass
- `(cd development/service-ops-api && ./gradlew build --max-workers=1 --no-daemon)` — pass
- `git diff --check` — pass
- code-reviewer re-review — PASS / no requested changes

## Notes

- The response intentionally omits rider phone numbers/raw rider IDs from bike pins.
- Frontend consumption, external map provider integration, external device sync logs, and telemetry retention/archive remain follow-up scopes.
