### PR TITLE
Backend no-FK integrity scan baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,7 +4,7 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold, core persistence baseline, read-only API/DTO contract baseline, admin JWT login/refresh/logout revocation baseline, telemetry current-state baseline, and initial operation command slices:
+This module currently provides the backend scaffold, core persistence baseline, read-only API/DTO contract baseline, admin JWT login/refresh/logout revocation baseline, telemetry current-state baseline, read-only no-FK integrity scan baseline, and initial operation command slices:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -86,6 +86,8 @@ This module currently provides the backend scaffold, core persistence baseline, 
   - `GET /api/v1/telemetry/bikes/{bikeId}/current-state`
 - Dashboard/map aggregate endpoint:
   - `GET /api/v1/dashboard/map-state`
+- Integrity/reference scan endpoint:
+  - `GET /api/v1/integrity/reference-checks`
 - `POST /api/v1/auth/login` for admin access-token and opaque refresh-token issuance
 - `POST /api/v1/auth/refresh` for refresh-token rotation and old-session revocation
 - `POST /api/v1/auth/logout` for current access-token/session revocation
@@ -99,7 +101,7 @@ Out of scope for the current backend baseline:
 - external device API polling/sync-log implementation, TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - password reset, RBAC expansion, external IdP/Supabase auth bridge, or admin-management UI
 - frontend relocation
-- integrity scan/repair job
+- automatic integrity repair job
 
 ## Local environment
 
@@ -289,6 +291,18 @@ curl http://localhost:8080/api/v1/telemetry/bikes/<bike-id>/current-state \
   -H "Authorization: Bearer <access-token>"
 ```
 
+
+## Integrity reference scan API
+
+The integrity scan is a read-only no-FK compensation endpoint for admin/operators. It reports missing or soft-deleted references that can appear through historical data, manual DB changes, or future migrations while preserving the current policy of avoiding cross-domain database foreign keys.
+
+```bash
+curl http://localhost:8080/api/v1/integrity/reference-checks \
+  -H "Authorization: Bearer <access-token>"
+```
+
+The response includes `generatedAt`, `totalFindings`, category summary counts, and finding rows with source table/id/idx, reference field/id, target table, and category. Current categories are `REFERENCE_NOT_FOUND` and `REFERENCE_DELETED`. This endpoint does not mutate or repair data; repair/scheduler behavior remains a separate issue scope.
+
 ## Dashboard map aggregate API
 
 The dashboard map slice exposes a read-only, map-ready aggregate for the control screen. It combines current bike telemetry with active rider labels and battery station pin data. It omits rider phone numbers/raw rider IDs from the map response and does not accept user-entered IDs and does not perform writes. Future frontend selectors should display the returned human-readable labels such as plate number, rider name, and station name.
@@ -376,4 +390,4 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 - Frontend map integration
 - External device API polling/sync-log implementation
 - TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
-- Integrity scan implementation
+- Automatic integrity repair/scheduler implementation

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/IntegrityPackage.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/IntegrityPackage.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.integrity;
+
+/** Marker for the integrity bounded package. */
+public final class IntegrityPackage {
+
+    private IntegrityPackage() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/controller/IntegrityScanController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/controller/IntegrityScanController.java
@@ -1,0 +1,23 @@
+package com.thundercrew.opsapi.integrity.controller;
+
+import com.thundercrew.opsapi.integrity.dto.IntegrityScanResponse;
+import com.thundercrew.opsapi.integrity.service.IntegrityScanService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/integrity")
+public class IntegrityScanController {
+
+    private final IntegrityScanService integrityScanService;
+
+    public IntegrityScanController(IntegrityScanService integrityScanService) {
+        this.integrityScanService = integrityScanService;
+    }
+
+    @GetMapping("/reference-checks")
+    IntegrityScanResponse referenceChecks() {
+        return integrityScanService.scanReferences();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityFindingCategory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityFindingCategory.java
@@ -1,0 +1,6 @@
+package com.thundercrew.opsapi.integrity.dto;
+
+public enum IntegrityFindingCategory {
+    REFERENCE_NOT_FOUND,
+    REFERENCE_DELETED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityFindingResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityFindingResponse.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.integrity.dto;
+
+import java.util.UUID;
+
+public record IntegrityFindingResponse(
+        IntegrityFindingCategory category,
+        String sourceTable,
+        UUID sourceId,
+        Long sourceIdx,
+        String referenceField,
+        UUID referenceId,
+        String targetTable,
+        String message
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityScanResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegrityScanResponse.java
@@ -1,0 +1,12 @@
+package com.thundercrew.opsapi.integrity.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record IntegrityScanResponse(
+        Instant generatedAt,
+        long totalFindings,
+        List<IntegritySummaryResponse> summary,
+        List<IntegrityFindingResponse> findings
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegritySummaryResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/dto/IntegritySummaryResponse.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.integrity.dto;
+
+public record IntegritySummaryResponse(
+        IntegrityFindingCategory category,
+        long count
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/repository/IntegrityFindingRow.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/repository/IntegrityFindingRow.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.integrity.repository;
+
+import com.thundercrew.opsapi.integrity.dto.IntegrityFindingCategory;
+import java.util.UUID;
+
+public record IntegrityFindingRow(
+        IntegrityFindingCategory category,
+        String sourceTable,
+        UUID sourceId,
+        Long sourceIdx,
+        String referenceField,
+        UUID referenceId,
+        String targetTable
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/repository/IntegrityScanRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/repository/IntegrityScanRepository.java
@@ -1,0 +1,169 @@
+package com.thundercrew.opsapi.integrity.repository;
+
+import com.thundercrew.opsapi.integrity.dto.IntegrityFindingCategory;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class IntegrityScanRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public IntegrityScanRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<IntegrityFindingRow> findReferenceIntegrityFindings() {
+        return jdbcTemplate.query(REFERENCE_SCAN_SQL, this::mapRow);
+    }
+
+    private IntegrityFindingRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+        return new IntegrityFindingRow(
+                IntegrityFindingCategory.valueOf(resultSet.getString("category")),
+                resultSet.getString("source_table"),
+                resultSet.getObject("source_id", UUID.class),
+                resultSet.getObject("source_idx", Long.class),
+                resultSet.getString("reference_field"),
+                resultSet.getObject("reference_id", UUID.class),
+                resultSet.getString("target_table")
+        );
+    }
+
+    private static final String REFERENCE_SCAN_SQL = """
+            select *
+            from (
+                select
+                    case when r.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end as category,
+                    'rider_bike_contracts' as source_table,
+                    c.id as source_id,
+                    c.idx as source_idx,
+                    'rider_id' as reference_field,
+                    c.rider_id as reference_id,
+                    'riders' as target_table
+                from rider_bike_contracts c
+                left join riders r on r.id = c.rider_id
+                where c.deleted_at is null
+                  and (r.id is null or r.deleted_at is not null)
+
+                union all
+                select
+                    case when b.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'rider_bike_contracts', c.id, c.idx, 'bike_id', c.bike_id, 'bikes'
+                from rider_bike_contracts c
+                left join bikes b on b.id = c.bike_id
+                where c.deleted_at is null
+                  and (b.id is null or b.deleted_at is not null)
+
+                union all
+                select
+                    case when t.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'rider_bike_contracts', c.id, c.idx, 'contract_template_id', c.contract_template_id, 'contract_templates'
+                from rider_bike_contracts c
+                left join contract_templates t on t.id = c.contract_template_id
+                where c.deleted_at is null
+                  and (t.id is null or t.deleted_at is not null)
+
+                union all
+                select
+                    case when r.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'rider_insurances', ri.id, ri.idx, 'rider_id', ri.rider_id, 'riders'
+                from rider_insurances ri
+                left join riders r on r.id = ri.rider_id
+                where ri.deleted_at is null
+                  and (r.id is null or r.deleted_at is not null)
+
+                union all
+                select
+                    case when ii.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'rider_insurances', ri.id, ri.idx, 'insurance_item_id', ri.insurance_item_id, 'insurance_items'
+                from rider_insurances ri
+                left join insurance_items ii on ii.id = ri.insurance_item_id
+                where ri.deleted_at is null
+                  and (ii.id is null or ii.deleted_at is not null)
+
+                union all
+                select
+                    case when b.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_equipments', be.id, be.idx, 'bike_id', be.bike_id, 'bikes'
+                from bike_equipments be
+                left join bikes b on b.id = be.bike_id
+                where be.deleted_at is null
+                  and (b.id is null or b.deleted_at is not null)
+
+                union all
+                select
+                    case when et.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_equipments', be.id, be.idx, 'equipment_type_id', be.equipment_type_id, 'equipment_types'
+                from bike_equipments be
+                left join equipment_types et on et.id = be.equipment_type_id
+                where be.deleted_at is null
+                  and (et.id is null or et.deleted_at is not null)
+
+                union all
+                select
+                    case when b.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_device_installations', bdi.id, bdi.idx, 'bike_id', bdi.bike_id, 'bikes'
+                from bike_device_installations bdi
+                left join bikes b on b.id = bdi.bike_id
+                where bdi.deleted_at is null
+                  and (b.id is null or b.deleted_at is not null)
+
+                union all
+                select
+                    case when d.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_device_installations', bdi.id, bdi.idx, 'device_id', bdi.device_id, 'devices'
+                from bike_device_installations bdi
+                left join devices d on d.id = bdi.device_id
+                where bdi.deleted_at is null
+                  and (d.id is null or d.deleted_at is not null)
+
+                union all
+                select
+                    case when b.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_recent_states', brs.id, brs.idx, 'bike_id', brs.bike_id, 'bikes'
+                from bike_recent_states brs
+                left join bikes b on b.id = brs.bike_id
+                where b.id is null or b.deleted_at is not null
+
+                union all
+                select
+                    case when d.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_recent_states', brs.id, brs.idx, 'device_id', brs.device_id, 'devices'
+                from bike_recent_states brs
+                left join devices d on d.id = brs.device_id
+                where brs.device_id is not null
+                  and (d.id is null or d.deleted_at is not null)
+
+                union all
+                select
+                    case when b.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_current_states', bcs.bike_id, null::bigint, 'bike_id', bcs.bike_id, 'bikes'
+                from bike_current_states bcs
+                left join bikes b on b.id = bcs.bike_id
+                where b.id is null or b.deleted_at is not null
+
+                union all
+                select
+                    case when d.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'bike_current_states', bcs.bike_id, null::bigint, 'device_id', bcs.device_id, 'devices'
+                from bike_current_states bcs
+                left join devices d on d.id = bcs.device_id
+                where bcs.device_id is not null
+                  and (d.id is null or d.deleted_at is not null)
+
+                union all
+                select
+                    case when s.id is null then 'REFERENCE_NOT_FOUND' else 'REFERENCE_DELETED' end,
+                    'station_battery_count_logs', l.id, l.idx, 'station_id', l.station_id, 'battery_stations'
+                from station_battery_count_logs l
+                left join battery_stations s on s.id = l.station_id
+                where l.deleted_at is null
+                  and (s.id is null or s.deleted_at is not null)
+            ) findings
+            order by source_table, source_idx nulls last, reference_field
+            """;
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/service/IntegrityScanService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/integrity/service/IntegrityScanService.java
@@ -1,0 +1,69 @@
+package com.thundercrew.opsapi.integrity.service;
+
+import com.thundercrew.opsapi.integrity.dto.IntegrityFindingCategory;
+import com.thundercrew.opsapi.integrity.dto.IntegrityFindingResponse;
+import com.thundercrew.opsapi.integrity.dto.IntegrityScanResponse;
+import com.thundercrew.opsapi.integrity.dto.IntegritySummaryResponse;
+import com.thundercrew.opsapi.integrity.repository.IntegrityFindingRow;
+import com.thundercrew.opsapi.integrity.repository.IntegrityScanRepository;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class IntegrityScanService {
+
+    private final IntegrityScanRepository integrityScanRepository;
+    private final Clock clock;
+
+    public IntegrityScanService(IntegrityScanRepository integrityScanRepository, Clock clock) {
+        this.integrityScanRepository = integrityScanRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public IntegrityScanResponse scanReferences() {
+        List<IntegrityFindingResponse> findings = integrityScanRepository.findReferenceIntegrityFindings().stream()
+                .map(this::toResponse)
+                .toList();
+        List<IntegritySummaryResponse> summary = summarize(findings);
+        return new IntegrityScanResponse(clock.instant(), findings.size(), summary, findings);
+    }
+
+    private IntegrityFindingResponse toResponse(IntegrityFindingRow row) {
+        return new IntegrityFindingResponse(
+                row.category(),
+                row.sourceTable(),
+                row.sourceId(),
+                row.sourceIdx(),
+                row.referenceField(),
+                row.referenceId(),
+                row.targetTable(),
+                "%s.%s references %s %s".formatted(
+                        row.sourceTable(),
+                        row.referenceField(),
+                        row.category() == IntegrityFindingCategory.REFERENCE_DELETED ? "deleted" : "missing",
+                        row.targetTable()
+                )
+        );
+    }
+
+    private List<IntegritySummaryResponse> summarize(List<IntegrityFindingResponse> findings) {
+        Map<IntegrityFindingCategory, Long> counts = new EnumMap<>(IntegrityFindingCategory.class);
+        for (IntegrityFindingResponse finding : findings) {
+            counts.merge(finding.category(), 1L, Long::sum);
+        }
+        List<IntegritySummaryResponse> summary = new ArrayList<>();
+        for (IntegrityFindingCategory category : IntegrityFindingCategory.values()) {
+            Long count = counts.get(category);
+            if (count != null) {
+                summary.add(new IntegritySummaryResponse(category, count));
+            }
+        }
+        return summary;
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/IntegrityScanApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/IntegrityScanApiContractTests.java
@@ -1,0 +1,215 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class IntegrityScanApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID MISSING_RIDER_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
+    private static final UUID DELETED_RIDER_ID = UUID.fromString("10000000-0000-0000-0000-000000000002");
+    private static final UUID MISSING_BIKE_ID = UUID.fromString("20000000-0000-0000-0000-000000000001");
+    private static final UUID DELETED_BIKE_ID = UUID.fromString("20000000-0000-0000-0000-000000000002");
+    private static final UUID MISSING_TEMPLATE_ID = UUID.fromString("30000000-0000-0000-0000-000000000001");
+    private static final UUID MISSING_INSURANCE_ITEM_ID = UUID.fromString("40000000-0000-0000-0000-000000000001");
+    private static final UUID DELETED_EQUIPMENT_TYPE_ID = UUID.fromString("50000000-0000-0000-0000-000000000002");
+    private static final UUID MISSING_DEVICE_ID = UUID.fromString("60000000-0000-0000-0000-000000000001");
+    private static final UUID DELETED_DEVICE_ID = UUID.fromString("60000000-0000-0000-0000-000000000002");
+    private static final UUID MISSING_STATION_ID = UUID.fromString("70000000-0000-0000-0000-000000000001");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        List.of(
+                "admin_auth_sessions",
+                "bike_current_states",
+                "bike_recent_states",
+                "station_battery_count_logs",
+                "bike_device_installations",
+                "bike_equipments",
+                "rider_insurances",
+                "rider_bike_contracts",
+                "telemetry_ingestion_error_logs",
+                "device_telemetry_logs",
+                "battery_stations",
+                "devices",
+                "equipment_types",
+                "insurance_items",
+                "bikes",
+                "riders",
+                "admin_users"
+        ).forEach(table -> jdbcTemplate.update("delete from " + table));
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void integrityScanRequiresAdminAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/integrity/reference-checks"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void integrityScanReportsDocumentedNoForeignKeyReferenceFindings() throws Exception {
+        seedDeletedTargets();
+        seedBrokenReferenceRows();
+
+        MvcResult result = mockMvc.perform(get("/api/v1/integrity/reference-checks")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.generatedAt").isString())
+                .andExpect(jsonPath("$.totalFindings").value(14))
+                .andExpect(jsonPath("$.summary[?(@.category == 'REFERENCE_NOT_FOUND')].count").value(org.hamcrest.Matchers.contains(8)))
+                .andExpect(jsonPath("$.summary[?(@.category == 'REFERENCE_DELETED')].count").value(org.hamcrest.Matchers.contains(6)))
+                .andExpect(jsonPath("$.findings").isArray())
+                .andReturn();
+
+        String json = result.getResponse().getContentAsString();
+        assertThat(json)
+                .contains("rider_bike_contracts", "rider_id", MISSING_RIDER_ID.toString(), "REFERENCE_NOT_FOUND")
+                .contains("rider_bike_contracts", "bike_id", DELETED_BIKE_ID.toString(), "REFERENCE_DELETED")
+                .contains("rider_bike_contracts", "contract_template_id", MISSING_TEMPLATE_ID.toString())
+                .contains("rider_insurances", "insurance_item_id", MISSING_INSURANCE_ITEM_ID.toString())
+                .contains("bike_equipments", "equipment_type_id", DELETED_EQUIPMENT_TYPE_ID.toString())
+                .contains("bike_device_installations", "device_id", MISSING_DEVICE_ID.toString())
+                .contains("bike_recent_states", "device_id", DELETED_DEVICE_ID.toString())
+                .contains("bike_current_states", "bike_id", DELETED_BIKE_ID.toString())
+                .contains("station_battery_count_logs", "station_id", MISSING_STATION_ID.toString());
+    }
+
+    @Test
+    void integrityScanReturnsEmptyResultWhenReferencesAreClean() throws Exception {
+        mockMvc.perform(get("/api/v1/integrity/reference-checks")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalFindings").value(0))
+                .andExpect(jsonPath("$.summary").isEmpty())
+                .andExpect(jsonPath("$.findings").isEmpty());
+    }
+
+    private void seedDeletedTargets() {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked, memo, deleted_at)
+                values (?, '삭제 라이더', '010-0000-0002', false, 'integrity fixture', now())
+                """, DELETED_RIDER_ID);
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, deleted_at)
+                values (?, '서울T-삭제', 'VIN-DELETED-BIKE', 'TC-100', 'READY', now())
+                """, DELETED_BIKE_ID);
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name, description, enabled, deleted_at)
+                values (?, '삭제 장비유형', 'integrity fixture', false, now())
+                """, DELETED_EQUIPMENT_TYPE_ID);
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled, deleted_at)
+                values (?, 'DEV-DELETED', 'ThunderDevice', 'TD-100', false, now())
+                """, DELETED_DEVICE_ID);
+    }
+
+    private void seedBrokenReferenceRows() {
+        Instant now = Instant.now();
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, memo)
+                values (?, ?, ?, ?, ?::timestamptz, 'broken contract refs')
+                """, UUID.fromString("80000000-0000-0000-0000-000000000001"), MISSING_RIDER_ID,
+                DELETED_BIKE_ID, MISSING_TEMPLATE_ID, now.minusSeconds(3600).toString());
+        jdbcTemplate.update("""
+                insert into rider_insurances (id, rider_id, insurance_item_id, memo, enabled)
+                values (?, ?, ?, 'broken rider insurance refs', true)
+                """, UUID.fromString("80000000-0000-0000-0000-000000000002"), DELETED_RIDER_ID,
+                MISSING_INSURANCE_ITEM_ID);
+        jdbcTemplate.update("""
+                insert into bike_equipments (id, bike_id, equipment_type_id, installed_at, management_due_date, memo)
+                values (?, ?, ?, ?::timestamptz, current_date, 'broken equipment refs')
+                """, UUID.fromString("80000000-0000-0000-0000-000000000003"), MISSING_BIKE_ID,
+                DELETED_EQUIPMENT_TYPE_ID, now.minusSeconds(7200).toString());
+        jdbcTemplate.update("""
+                insert into bike_device_installations (id, bike_id, device_id, installed_at, memo)
+                values (?, ?, ?, ?::timestamptz, 'broken installation refs')
+                """, UUID.fromString("80000000-0000-0000-0000-000000000004"), DELETED_BIKE_ID,
+                MISSING_DEVICE_ID, now.minusSeconds(7200).toString());
+        jdbcTemplate.update("""
+                insert into bike_recent_states (id, bike_id, device_id, received_at, ignition_status, telemetry_source)
+                values (?, ?, ?, ?::timestamptz, 'ON', 'POLLING')
+                """, UUID.fromString("80000000-0000-0000-0000-000000000005"), MISSING_BIKE_ID,
+                DELETED_DEVICE_ID, now.minusSeconds(600).toString());
+        jdbcTemplate.update("""
+                insert into bike_current_states (bike_id, device_id, last_received_at, ignition_status, telemetry_source)
+                values (?, ?, ?::timestamptz, 'OFF', 'WEBHOOK')
+                """, DELETED_BIKE_ID, MISSING_DEVICE_ID, now.minusSeconds(300).toString());
+        jdbcTemplate.update("""
+                insert into station_battery_count_logs (
+                    id, station_id,
+                    before_max_battery_capacity, after_max_battery_capacity,
+                    before_current_battery_count, after_current_battery_count,
+                    before_available_battery_count, after_available_battery_count,
+                    reason, changed_at
+                ) values (?, ?, 10, 10, 5, 6, 2, 3, 'broken station ref', ?::timestamptz)
+                """, UUID.fromString("80000000-0000-0000-0000-000000000006"), MISSING_STATION_ID,
+                now.minusSeconds(120).toString());
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        if (!matcher.find()) {
+            throw new AssertionError("accessToken was not present in login response: "
+                    + result.getResponse().getContentAsString());
+        }
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ScaffoldPackageSkeletonTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ScaffoldPackageSkeletonTests.java
@@ -21,6 +21,7 @@ class ScaffoldPackageSkeletonTests {
                 "com.thundercrew.opsapi.telemetry.TelemetryPackage",
                 "com.thundercrew.opsapi.station.StationPackage",
                 "com.thundercrew.opsapi.dashboard.DashboardPackage",
+                "com.thundercrew.opsapi.integrity.IntegrityPackage",
                 "com.thundercrew.opsapi.common.CommonPackage");
 
         markerClasses.forEach(className -> assertThatCode(() -> Class.forName(className))

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -532,3 +532,30 @@ Verification:
 
 - TDD red observed on auth contract/Flyway tests before implementation because `admin_auth_sessions`, refresh response fields, and refresh/logout endpoints did not exist.
 - Targeted auth API, Flyway baseline, and architecture tests pass after implementation.
+
+## No-FK integrity scan baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#71
+- Target issue: EVNSolution/thundercrew-domain#54
+- Branch: `cc-71-integrity-scan-baseline`
+
+Issue-size decision:
+
+- This slice adds only the authenticated read-only no-FK reference integrity scan baseline after admin auth refresh/revocation.
+- Included operation is `GET /api/v1/integrity/reference-checks`.
+- Included scan targets are rider-bike contracts, rider-insurance links, bike equipment, bike-device installations, bike recent/current states, and station battery count logs.
+- Automatic repair/mutation endpoints, schedulers/background jobs, frontend UI integration, TimescaleDB retention/archive work, external device polling, and DB foreign key introduction remain follow-up scopes.
+
+Boundary decision:
+
+- The endpoint compensates for the intentional no cross-domain FK policy by reporting missing/deleted references without mutating source data.
+- Findings include source table/id/idx, reference field/id, target table, category, and a concise message.
+- Current categories are `REFERENCE_NOT_FOUND` and `REFERENCE_DELETED`; API write error categories remain unchanged.
+- Architecture stays read-only for the integrity package; no JPA relationships or database FKs are introduced.
+
+Verification:
+
+- TDD red observed on `IntegrityScanApiContractTests` before implementation because the authenticated endpoint did not exist.
+- Targeted integrity scan API tests pass after implementation.

--- a/docs/backend/01-prd-scope.md
+++ b/docs/backend/01-prd-scope.md
@@ -195,7 +195,7 @@ System input source, not a manual user.
 
 | Risk | Control |
 |---|---|
-| No-FK design can create orphan references | service validation, repository tests, integrity scan job, and explicit error contract |
+| No-FK design can create orphan references | service validation, repository tests, read-only integrity scan endpoint, and explicit error contract |
 | `service-ops-api` can become too broad | package boundaries, module facades, ArchUnit dependency tests |
 | Contract-as-assignment can drift | overlap validation and transaction/lock strategy |
 | Telemetry raw/recent/current can diverge | idempotency key, current upsert rule, retry/rebuild policy |


### PR DESCRIPTION
## Summary
- Adds authenticated read-only `GET /api/v1/integrity/reference-checks` for no-FK reference drift visibility.
- Reports missing/soft-deleted references across contracts, rider insurance links, bike equipment/device/current-state data, and station battery logs without mutating data.
- Updates backend docs/ledger and PRD risk controls to mark repair/scheduler/UI as follow-up scope.

## Trace
- Change-control: EVNSolution/clever-change-control#71
- Target issue: EVNSolution/thundercrew-domain#54
- Branch: `cc-71-integrity-scan-baseline`
- Commit: `55435d1`

## Concurrent work gate
- Decision: `allowed-with-non-overlap`
- Evidence: target repo open PRs were none; target open issues only #54 for this scope; change-control open issues #44/#40/#35/#24/#23 are unrelated context/control-plane items.
- Pre-PR comments: EVNSolution/thundercrew-domain#54 and EVNSolution/clever-change-control#71.

## Validation
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.IntegrityScanApiContractTests --tests com.thundercrew.opsapi.ScaffoldPackageSkeletonTests --tests com.thundercrew.opsapi.ArchitectureBoundaryTests --no-daemon)`
- `(cd development/service-ops-api && ./gradlew cleanTest test --max-workers=1 --no-daemon --stacktrace)`
- `(cd development/service-ops-api && ./gradlew build --max-workers=1 --no-daemon)`
- Code-reviewer subagent: PASS

## Not included
- Automatic repair/mutation endpoint
- Scheduled integrity scan jobs
- Frontend UI consumption
- TimescaleDB retention/archive work
- External device polling
- Database foreign keys or JPA relationships
