### PR TITLE
Backend external device sync evidence baseline

### DIFF
--- a/development/service-ops-api/README.md
+++ b/development/service-ops-api/README.md
@@ -4,7 +4,7 @@ Spring Boot operations API baseline for ThunderCrew domain management.
 
 ## Scope
 
-This module currently provides the backend scaffold, core persistence baseline, read-only API/DTO contract baseline, admin JWT login/refresh/logout revocation baseline, telemetry current-state baseline, read-only no-FK integrity scan baseline, and initial operation command slices:
+This module currently provides the backend scaffold, core persistence baseline, read-only API/DTO contract baseline, admin JWT login/refresh/logout revocation baseline, telemetry current-state baseline, external device API sync evidence baseline, read-only no-FK integrity scan baseline, and initial operation command slices:
 
 - Spring Boot 3.x / Java 21
 - Gradle Kotlin DSL
@@ -23,7 +23,7 @@ This module currently provides the backend scaffold, core persistence baseline, 
   - equipment types and bike equipment
   - devices and bike-device installation history
   - battery stations and station count logs
-  - telemetry raw logs, bike recent states, bike current states, and telemetry ingestion error logs
+  - telemetry raw logs, bike recent states, bike current states, telemetry ingestion error logs, and device API sync run/result logs
 
 - Read-only `GET /api/v1/**` list/detail endpoints and response DTOs for:
   - riders
@@ -84,6 +84,12 @@ This module currently provides the backend scaffold, core persistence baseline, 
   - `POST /api/v1/telemetry/device-events`
   - `GET /api/v1/telemetry/bike-current-states`
   - `GET /api/v1/telemetry/bikes/{bikeId}/current-state`
+- Device API sync evidence endpoints:
+  - `POST /api/v1/device-api-sync-runs`
+  - `POST /api/v1/device-api-sync-runs/{runId}/results`
+  - `PATCH /api/v1/device-api-sync-runs/{runId}/complete`
+  - `GET /api/v1/device-api-sync-runs`
+  - `GET /api/v1/device-api-sync-runs/{runId}`
 - Dashboard/map aggregate endpoint:
   - `GET /api/v1/dashboard/map-state`
 - Integrity/reference scan endpoint:
@@ -98,7 +104,7 @@ Out of scope for the current backend baseline:
 
 - Create/update/delete command endpoints and request DTOs outside delivered command slices
 - frontend map integration
-- external device API polling/sync-log implementation, TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
+- real external device vendor polling/scheduler integration, TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - password reset, RBAC expansion, external IdP/Supabase auth bridge, or admin-management UI
 - frontend relocation
 - automatic integrity repair job
@@ -291,6 +297,31 @@ curl http://localhost:8080/api/v1/telemetry/bikes/<bike-id>/current-state \
   -H "Authorization: Bearer <access-token>"
 ```
 
+## Device API sync evidence API
+
+The device API sync baseline records server-owned evidence for future external vendor polling/webhook reconciliation without performing real vendor HTTP calls. It is separate from telemetry ingestion: sync runs/results track API interaction evidence, while `device_telemetry_logs`, recent state, and current state remain the normalized telemetry path.
+
+Requests may include `requestSummary` and `responseSummary`; the backend redacts sensitive keys such as authorization, token, password, secret, and API key before persistence. Free-text evidence fields such as error messages are also redacted before persistence. Do not store vendor credentials or full secret-bearing payloads in this API. Device references are resolved by `deviceUid`; unknown or disabled devices are logged as deterministic result statuses without creating devices or updating telemetry state. Clients may submit only operational result statuses (`SUCCESS`, `FAILED`, `SKIPPED`); `DEVICE_UNKNOWN` and `DEVICE_DISABLED` are server-owned resolution outcomes.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/device-api-sync-runs \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"syncType":"POLLING","externalTraceId":"vendor-run-001","requestSummary":{"endpoint":"/vendor/devices"}}'
+
+curl -X POST http://localhost:8080/api/v1/device-api-sync-runs/<run-id>/results \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"deviceUid":"DEV-SEOUL-001","status":"SUCCESS","httpStatus":200,"responseSummary":{"safe":"summary"}}'
+
+curl -X PATCH http://localhost:8080/api/v1/device-api-sync-runs/<run-id>/complete \
+  -H "Authorization: Bearer <access-token>" \
+  -H 'Content-Type: application/json' \
+  -d '{"responseSummary":{"safe":"done"}}'
+```
+
+Run status is computed from result counts on completion: all success -> `SUCCESS`, all failures -> `FAILED`, mixed results -> `PARTIAL_FAILURE`. This baseline does not run a scheduler or call a vendor API; those remain separate traced issue scopes.
+
 
 ## Integrity reference scan API
 
@@ -388,6 +419,6 @@ Tests use Testcontainers PostgreSQL when Docker is available. On Colima, Gradle 
 
 - Password reset/RBAC expansion/admin-management UI
 - Frontend map integration
-- External device API polling/sync-log implementation
+- Real external device vendor polling/scheduler integration
 - TimescaleDB hypertables, telemetry retention schedulers, and bulk archival jobs
 - Automatic integrity repair/scheduler implementation

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/DeviceSyncPackage.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/DeviceSyncPackage.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.devicesync;
+
+/** Marker for the device API sync bounded package. */
+public final class DeviceSyncPackage {
+
+    private DeviceSyncPackage() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/controller/DeviceApiSyncController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/controller/DeviceApiSyncController.java
@@ -1,0 +1,71 @@
+package com.thundercrew.opsapi.devicesync.controller;
+
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncResultCreateRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncResultResponse;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunCompleteRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunCreateRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunListResponse;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunResponse;
+import com.thundercrew.opsapi.devicesync.service.DeviceApiSyncService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/device-api-sync-runs")
+public class DeviceApiSyncController {
+
+    private final DeviceApiSyncService deviceApiSyncService;
+
+    public DeviceApiSyncController(DeviceApiSyncService deviceApiSyncService) {
+        this.deviceApiSyncService = deviceApiSyncService;
+    }
+
+    @PostMapping
+    ResponseEntity<DeviceApiSyncRunResponse> createRun(@Valid @RequestBody DeviceApiSyncRunCreateRequest request) {
+        DeviceApiSyncRunResponse response = deviceApiSyncService.createRun(request);
+        return ResponseEntity.created(URI.create("/api/v1/device-api-sync-runs/" + response.id()))
+                .body(response);
+    }
+
+    @PostMapping("/{runId}/results")
+    ResponseEntity<DeviceApiSyncResultResponse> recordResult(
+            @PathVariable UUID runId,
+            @Valid @RequestBody DeviceApiSyncResultCreateRequest request
+    ) {
+        DeviceApiSyncResultResponse response = deviceApiSyncService.recordResult(runId, request);
+        return ResponseEntity.created(URI.create("/api/v1/device-api-sync-runs/" + runId))
+                .body(response);
+    }
+
+    @PatchMapping("/{runId}/complete")
+    DeviceApiSyncRunResponse completeRun(
+            @PathVariable UUID runId,
+            @Valid @RequestBody DeviceApiSyncRunCompleteRequest request
+    ) {
+        return deviceApiSyncService.completeRun(runId, request);
+    }
+
+    @GetMapping
+    DeviceApiSyncRunListResponse listRuns(
+            @PageableDefault(size = 20, sort = "startedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return deviceApiSyncService.listRuns(pageable);
+    }
+
+    @GetMapping("/{runId}")
+    DeviceApiSyncRunResponse getRun(@PathVariable UUID runId) {
+        return deviceApiSyncService.getRun(runId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncRequestedResultStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncRequestedResultStatus.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.devicesync.domain;
+
+public enum DeviceApiSyncRequestedResultStatus {
+    SUCCESS,
+    FAILED,
+    SKIPPED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncResultStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncResultStatus.java
@@ -1,0 +1,9 @@
+package com.thundercrew.opsapi.devicesync.domain;
+
+public enum DeviceApiSyncResultStatus {
+    SUCCESS,
+    FAILED,
+    DEVICE_UNKNOWN,
+    DEVICE_DISABLED,
+    SKIPPED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncRunStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncRunStatus.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.devicesync.domain;
+
+public enum DeviceApiSyncRunStatus {
+    RUNNING,
+    SUCCESS,
+    PARTIAL_FAILURE,
+    FAILED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/domain/DeviceApiSyncType.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.devicesync.domain;
+
+public enum DeviceApiSyncType {
+    POLLING,
+    WEBHOOK_RECONCILIATION,
+    MANUAL_AUDIT
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncResultCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncResultCreateRequest.java
@@ -1,0 +1,21 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRequestedResultStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DeviceApiSyncResultCreateRequest(
+        @NotBlank @Size(max = 100) String deviceUid,
+        @Size(max = 200) String externalEventId,
+        @NotNull DeviceApiSyncRequestedResultStatus status,
+        @Min(100) @Max(599) Integer httpStatus,
+        JsonNode requestSummary,
+        JsonNode responseSummary,
+        @Size(max = 100) String errorCode,
+        String errorMessage
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncResultResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncResultResponse.java
@@ -1,0 +1,23 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncResultStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DeviceApiSyncResultResponse(
+        UUID id,
+        Long idx,
+        UUID runId,
+        String deviceUid,
+        UUID deviceId,
+        DeviceApiSyncResultStatus status,
+        Integer httpStatus,
+        String externalEventId,
+        JsonNode requestSummary,
+        JsonNode responseSummary,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunCompleteRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunCompleteRequest.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.Size;
+
+public record DeviceApiSyncRunCompleteRequest(
+        JsonNode responseSummary,
+        @Size(max = 100) String errorCode,
+        String errorMessage
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunCreateRequest.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DeviceApiSyncRunCreateRequest(
+        @NotNull DeviceApiSyncType syncType,
+        @Size(max = 200) String externalTraceId,
+        JsonNode requestSummary
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunListResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunListResponse.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import java.util.List;
+
+public record DeviceApiSyncRunListResponse(
+        List<DeviceApiSyncRunResponse> items,
+        Page page
+) {
+    public record Page(
+            int number,
+            int size,
+            long totalItems,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/dto/DeviceApiSyncRunResponse.java
@@ -1,0 +1,29 @@
+package com.thundercrew.opsapi.devicesync.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRunStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncType;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record DeviceApiSyncRunResponse(
+        UUID id,
+        Long idx,
+        DeviceApiSyncType syncType,
+        DeviceApiSyncRunStatus status,
+        String externalTraceId,
+        Instant startedAt,
+        Instant finishedAt,
+        int totalCount,
+        int successCount,
+        int failureCount,
+        JsonNode requestSummary,
+        JsonNode responseSummary,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt,
+        Instant updatedAt,
+        List<DeviceApiSyncResultResponse> results
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncCounts.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncCounts.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.devicesync.repository;
+
+public record DeviceApiSyncCounts(
+        int totalCount,
+        int successCount,
+        int failureCount
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncRepository.java
@@ -1,0 +1,220 @@
+package com.thundercrew.opsapi.devicesync.repository;
+
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncResultStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRunStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DeviceApiSyncRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DeviceApiSyncRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public DeviceApiSyncRunRow insertRun(
+            UUID id,
+            DeviceApiSyncType syncType,
+            String externalTraceId,
+            UUID requestedByAdminId,
+            Instant startedAt,
+            String requestSummary
+    ) {
+        return jdbcTemplate.queryForObject("""
+                insert into device_api_sync_runs (
+                    id, sync_type, status, external_trace_id, requested_by_admin_id,
+                    started_at, request_summary
+                ) values (?, ?, ?, ?, ?, ?::timestamptz, ?::jsonb)
+                returning *
+                """, this::mapRun,
+                id,
+                syncType.name(),
+                DeviceApiSyncRunStatus.RUNNING.name(),
+                externalTraceId,
+                requestedByAdminId,
+                startedAt.toString(),
+                requestSummary);
+    }
+
+    public Optional<DeviceApiSyncRunRow> findRun(UUID id) {
+        List<DeviceApiSyncRunRow> rows = jdbcTemplate.query(
+                "select * from device_api_sync_runs where id = ?",
+                this::mapRun,
+                id);
+        return rows.stream().findFirst();
+    }
+
+    public List<DeviceApiSyncRunRow> findRuns(int limit, long offset) {
+        return jdbcTemplate.query("""
+                select *
+                from device_api_sync_runs
+                order by started_at desc, idx desc
+                limit ? offset ?
+                """, this::mapRun, limit, offset);
+    }
+
+    public long countRuns() {
+        Long count = jdbcTemplate.queryForObject("select count(*) from device_api_sync_runs", Long.class);
+        return count == null ? 0L : count;
+    }
+
+    public DeviceApiSyncResultRow insertResult(
+            UUID id,
+            UUID runId,
+            String deviceUid,
+            UUID deviceId,
+            DeviceApiSyncResultStatus status,
+            Integer httpStatus,
+            String externalEventId,
+            String requestSummary,
+            String responseSummary,
+            String errorCode,
+            String errorMessage
+    ) {
+        List<DeviceApiSyncResultRow> rows = jdbcTemplate.query(connection -> {
+            var ps = connection.prepareStatement("""
+                    insert into device_api_sync_results (
+                        id, run_id, device_uid, device_id, status, http_status, external_event_id,
+                        request_summary, response_summary, error_code, error_message
+                    ) values (?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?)
+                    returning *
+                    """);
+            ps.setObject(1, id);
+            ps.setObject(2, runId);
+            ps.setString(3, deviceUid);
+            if (deviceId == null) {
+                ps.setNull(4, Types.OTHER);
+            } else {
+                ps.setObject(4, deviceId);
+            }
+            ps.setString(5, status.name());
+            if (httpStatus == null) {
+                ps.setNull(6, Types.INTEGER);
+            } else {
+                ps.setInt(6, httpStatus);
+            }
+            ps.setString(7, externalEventId);
+            ps.setString(8, requestSummary);
+            ps.setString(9, responseSummary);
+            ps.setString(10, errorCode);
+            ps.setString(11, errorMessage);
+            return ps;
+        }, this::mapResult);
+        return rows.stream().findFirst()
+                .orElseThrow(() -> new IllegalStateException("Device API sync result insert returned no row."));
+    }
+
+    public List<DeviceApiSyncResultRow> findResults(UUID runId) {
+        return jdbcTemplate.query("""
+                select *
+                from device_api_sync_results
+                where run_id = ?
+                order by idx asc
+                """, this::mapResult, runId);
+    }
+
+    public DeviceApiSyncCounts countResults(UUID runId) {
+        return jdbcTemplate.queryForObject("""
+                select
+                    count(*)::int as total_count,
+                    count(*) filter (where status = 'SUCCESS')::int as success_count,
+                    count(*) filter (where status <> 'SUCCESS')::int as failure_count
+                from device_api_sync_results
+                where run_id = ?
+                """, (rs, rowNum) -> new DeviceApiSyncCounts(
+                rs.getInt("total_count"),
+                rs.getInt("success_count"),
+                rs.getInt("failure_count")
+        ), runId);
+    }
+
+    public DeviceApiSyncRunRow completeRun(
+            UUID id,
+            DeviceApiSyncRunStatus status,
+            Instant finishedAt,
+            DeviceApiSyncCounts counts,
+            String responseSummary,
+            String errorCode,
+            String errorMessage
+    ) {
+        return jdbcTemplate.queryForObject("""
+                update device_api_sync_runs
+                set status = ?,
+                    finished_at = ?::timestamptz,
+                    total_count = ?,
+                    success_count = ?,
+                    failure_count = ?,
+                    response_summary = ?::jsonb,
+                    error_code = ?,
+                    error_message = ?,
+                    updated_at = now()
+                where id = ?
+                returning *
+                """, this::mapRun,
+                status.name(),
+                finishedAt.toString(),
+                counts.totalCount(),
+                counts.successCount(),
+                counts.failureCount(),
+                responseSummary,
+                errorCode,
+                errorMessage,
+                id);
+    }
+
+    private DeviceApiSyncRunRow mapRun(ResultSet rs, int rowNumber) throws SQLException {
+        return new DeviceApiSyncRunRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                DeviceApiSyncType.valueOf(rs.getString("sync_type")),
+                DeviceApiSyncRunStatus.valueOf(rs.getString("status")),
+                rs.getString("external_trace_id"),
+                rs.getObject("requested_by_admin_id", UUID.class),
+                getInstant(rs, "started_at"),
+                getInstant(rs, "finished_at"),
+                rs.getInt("total_count"),
+                rs.getInt("success_count"),
+                rs.getInt("failure_count"),
+                rs.getString("request_summary"),
+                rs.getString("response_summary"),
+                rs.getString("error_code"),
+                rs.getString("error_message"),
+                getInstant(rs, "created_at"),
+                getInstant(rs, "updated_at")
+        );
+    }
+
+    private DeviceApiSyncResultRow mapResult(ResultSet rs, int rowNumber) throws SQLException {
+        return new DeviceApiSyncResultRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                rs.getObject("run_id", UUID.class),
+                rs.getString("device_uid"),
+                rs.getObject("device_id", UUID.class),
+                DeviceApiSyncResultStatus.valueOf(rs.getString("status")),
+                (Integer) rs.getObject("http_status"),
+                rs.getString("external_event_id"),
+                rs.getString("request_summary"),
+                rs.getString("response_summary"),
+                rs.getString("error_code"),
+                rs.getString("error_message"),
+                getInstant(rs, "created_at")
+        );
+    }
+
+    private Instant getInstant(ResultSet rs, String columnLabel) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnLabel);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncResultRow.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncResultRow.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.devicesync.repository;
+
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncResultStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DeviceApiSyncResultRow(
+        UUID id,
+        Long idx,
+        UUID runId,
+        String deviceUid,
+        UUID deviceId,
+        DeviceApiSyncResultStatus status,
+        Integer httpStatus,
+        String externalEventId,
+        String requestSummary,
+        String responseSummary,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncRunRow.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/repository/DeviceApiSyncRunRow.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.devicesync.repository;
+
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRunStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DeviceApiSyncRunRow(
+        UUID id,
+        Long idx,
+        DeviceApiSyncType syncType,
+        DeviceApiSyncRunStatus status,
+        String externalTraceId,
+        UUID requestedByAdminId,
+        Instant startedAt,
+        Instant finishedAt,
+        int totalCount,
+        int successCount,
+        int failureCount,
+        String requestSummary,
+        String responseSummary,
+        String errorCode,
+        String errorMessage,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/service/DeviceApiSyncService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/service/DeviceApiSyncService.java
@@ -1,0 +1,206 @@
+package com.thundercrew.opsapi.devicesync.service;
+
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.device.domain.Device;
+import com.thundercrew.opsapi.device.repository.DeviceRepository;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncResultStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRunStatus;
+import com.thundercrew.opsapi.devicesync.domain.DeviceApiSyncRequestedResultStatus;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncResultCreateRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncResultResponse;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunCompleteRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunCreateRequest;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunListResponse;
+import com.thundercrew.opsapi.devicesync.dto.DeviceApiSyncRunResponse;
+import com.thundercrew.opsapi.devicesync.repository.DeviceApiSyncCounts;
+import com.thundercrew.opsapi.devicesync.repository.DeviceApiSyncRepository;
+import com.thundercrew.opsapi.devicesync.repository.DeviceApiSyncResultRow;
+import com.thundercrew.opsapi.devicesync.repository.DeviceApiSyncRunRow;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class DeviceApiSyncService {
+
+    private final DeviceApiSyncRepository syncRepository;
+    private final DeviceRepository deviceRepository;
+    private final DeviceApiSyncSummaryRedactor redactor;
+    private final Clock clock;
+
+    public DeviceApiSyncService(
+            DeviceApiSyncRepository syncRepository,
+            DeviceRepository deviceRepository,
+            DeviceApiSyncSummaryRedactor redactor,
+            Clock clock
+    ) {
+        this.syncRepository = syncRepository;
+        this.deviceRepository = deviceRepository;
+        this.redactor = redactor;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public DeviceApiSyncRunResponse createRun(DeviceApiSyncRunCreateRequest request) {
+        DeviceApiSyncRunRow row = syncRepository.insertRun(
+                UUID.randomUUID(),
+                request.syncType(),
+                redactedTextOrNull(request.externalTraceId()),
+                null,
+                Instant.now(clock),
+                redactor.toRedactedJson(request.requestSummary())
+        );
+        return toRunResponse(row, List.of());
+    }
+
+    @Transactional
+    public DeviceApiSyncResultResponse recordResult(UUID runId, DeviceApiSyncResultCreateRequest request) {
+        DeviceApiSyncRunRow run = findRunOrThrow(runId);
+        if (run.status() != DeviceApiSyncRunStatus.RUNNING) {
+            throw new InvalidStateTransitionException("Device API sync run is already completed.");
+        }
+        Optional<Device> device = deviceRepository.findByDeviceUidAndDeletedAtIsNull(request.deviceUid());
+        DeviceApiSyncResultStatus effectiveStatus = resolveStatus(device, request.status());
+        DeviceApiSyncResultRow row = syncRepository.insertResult(
+                UUID.randomUUID(),
+                runId,
+                request.deviceUid(),
+                device.map(Device::getId).orElse(null),
+                effectiveStatus,
+                request.httpStatus(),
+                redactedTextOrNull(request.externalEventId()),
+                redactor.toRedactedJson(request.requestSummary()),
+                redactor.toRedactedJson(request.responseSummary()),
+                redactedTextOrNull(request.errorCode()),
+                redactedTextOrNull(request.errorMessage())
+        );
+        return toResultResponse(row);
+    }
+
+    @Transactional
+    public DeviceApiSyncRunResponse completeRun(UUID runId, DeviceApiSyncRunCompleteRequest request) {
+        DeviceApiSyncRunRow run = findRunOrThrow(runId);
+        if (run.status() != DeviceApiSyncRunStatus.RUNNING) {
+            throw new InvalidStateTransitionException("Device API sync run is already completed.");
+        }
+        DeviceApiSyncCounts counts = syncRepository.countResults(runId);
+        DeviceApiSyncRunStatus status = resolveRunStatus(counts);
+        DeviceApiSyncRunRow completed = syncRepository.completeRun(
+                runId,
+                status,
+                Instant.now(clock),
+                counts,
+                redactor.toRedactedJson(request.responseSummary()),
+                redactedTextOrNull(request.errorCode()),
+                redactedTextOrNull(request.errorMessage())
+        );
+        return toRunResponse(completed, syncRepository.findResults(runId));
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceApiSyncRunResponse getRun(UUID runId) {
+        DeviceApiSyncRunRow run = findRunOrThrow(runId);
+        return toRunResponse(run, syncRepository.findResults(runId));
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceApiSyncRunListResponse listRuns(Pageable pageable) {
+        int size = Math.max(1, pageable.getPageSize());
+        long offset = pageable.getOffset();
+        long total = syncRepository.countRuns();
+        List<DeviceApiSyncRunResponse> items = syncRepository.findRuns(size, offset).stream()
+                .map(row -> toRunResponse(row, List.of()))
+                .toList();
+        boolean hasNext = offset + items.size() < total;
+        return new DeviceApiSyncRunListResponse(
+                items,
+                new DeviceApiSyncRunListResponse.Page(
+                        pageable.getPageNumber(),
+                        size,
+                        total,
+                        hasNext,
+                        pageable.getPageNumber() > 0
+                )
+        );
+    }
+
+    private DeviceApiSyncRunRow findRunOrThrow(UUID runId) {
+        return syncRepository.findRun(runId)
+                .orElseThrow(() -> new ResourceNotFoundException("DeviceApiSyncRun", runId));
+    }
+
+    private DeviceApiSyncResultStatus resolveStatus(Optional<Device> device, DeviceApiSyncRequestedResultStatus requestedStatus) {
+        if (device.isEmpty()) {
+            return DeviceApiSyncResultStatus.DEVICE_UNKNOWN;
+        }
+        if (!device.get().isEnabled()) {
+            return DeviceApiSyncResultStatus.DEVICE_DISABLED;
+        }
+        return switch (requestedStatus) {
+            case SUCCESS -> DeviceApiSyncResultStatus.SUCCESS;
+            case FAILED -> DeviceApiSyncResultStatus.FAILED;
+            case SKIPPED -> DeviceApiSyncResultStatus.SKIPPED;
+        };
+    }
+
+    private DeviceApiSyncRunStatus resolveRunStatus(DeviceApiSyncCounts counts) {
+        if (counts.failureCount() == 0) {
+            return DeviceApiSyncRunStatus.SUCCESS;
+        }
+        if (counts.successCount() == 0) {
+            return DeviceApiSyncRunStatus.FAILED;
+        }
+        return DeviceApiSyncRunStatus.PARTIAL_FAILURE;
+    }
+
+    private DeviceApiSyncRunResponse toRunResponse(DeviceApiSyncRunRow row, List<DeviceApiSyncResultRow> resultRows) {
+        return new DeviceApiSyncRunResponse(
+                row.id(),
+                row.idx(),
+                row.syncType(),
+                row.status(),
+                row.externalTraceId(),
+                row.startedAt(),
+                row.finishedAt(),
+                row.totalCount(),
+                row.successCount(),
+                row.failureCount(),
+                redactor.toResponseNode(row.requestSummary()),
+                redactor.toResponseNode(row.responseSummary()),
+                row.errorCode(),
+                row.errorMessage(),
+                row.createdAt(),
+                row.updatedAt(),
+                resultRows.stream().map(this::toResultResponse).toList()
+        );
+    }
+
+    private DeviceApiSyncResultResponse toResultResponse(DeviceApiSyncResultRow row) {
+        return new DeviceApiSyncResultResponse(
+                row.id(),
+                row.idx(),
+                row.runId(),
+                row.deviceUid(),
+                row.deviceId(),
+                row.status(),
+                row.httpStatus(),
+                row.externalEventId(),
+                redactor.toResponseNode(row.requestSummary()),
+                redactor.toResponseNode(row.responseSummary()),
+                row.errorCode(),
+                row.errorMessage(),
+                row.createdAt()
+        );
+    }
+
+    private String redactedTextOrNull(String value) {
+        return StringUtils.hasText(value) ? redactor.redactText(value) : null;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/service/DeviceApiSyncSummaryRedactor.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/devicesync/service/DeviceApiSyncSummaryRedactor.java
@@ -1,0 +1,104 @@
+package com.thundercrew.opsapi.devicesync.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+class DeviceApiSyncSummaryRedactor {
+
+    private static final String REDACTED_VALUE = "[REDACTED]";
+    private static final Pattern AUTHORIZATION_TEXT_PATTERN = Pattern.compile(
+            "(?i)(authorization\\s*[:=]\\s*)([^,;\\]}]+)"
+    );
+    private static final Pattern BEARER_TOKEN_PATTERN = Pattern.compile("(?i)bearer\\s+[^\\s,;]+");
+    private static final Pattern QUOTED_SENSITIVE_VALUE_PATTERN = Pattern.compile(
+            "(?i)(\"(?:authorization|api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|password|secret|token|cookie|set[-_]?cookie|session[-_]?(?:id|token)?|session)\"\\s*:\\s*\")([^\"]*)(\")"
+    );
+    private static final Pattern SENSITIVE_ASSIGNMENT_PATTERN = Pattern.compile(
+            "(?i)((?:api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|password|secret|token|cookie|set[-_]?cookie|session[-_]?(?:id|token)?|session)(?:\\s*[:=]\\s*))([^\\s,;\\]}]+)"
+    );
+
+    private final ObjectMapper objectMapper;
+
+    DeviceApiSyncSummaryRedactor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    String toRedactedJson(JsonNode summary) {
+        if (summary == null || summary.isNull()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(redact(summary));
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("Device API sync summary cannot be serialized.", exception);
+        }
+    }
+
+    JsonNode toResponseNode(String summary) {
+        if (summary == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(summary);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Persisted device API sync summary is not valid JSON.", exception);
+        }
+    }
+
+    String redactText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String redacted = AUTHORIZATION_TEXT_PATTERN.matcher(value).replaceAll("$1" + REDACTED_VALUE);
+        redacted = BEARER_TOKEN_PATTERN.matcher(redacted).replaceAll("Bearer " + REDACTED_VALUE);
+        redacted = QUOTED_SENSITIVE_VALUE_PATTERN.matcher(redacted).replaceAll("$1" + REDACTED_VALUE + "$3");
+        return SENSITIVE_ASSIGNMENT_PATTERN.matcher(redacted).replaceAll("$1" + REDACTED_VALUE);
+    }
+
+    private JsonNode redact(JsonNode source) {
+        if (source.isObject()) {
+            ObjectNode target = objectMapper.createObjectNode();
+            Iterator<String> fieldNames = source.fieldNames();
+            while (fieldNames.hasNext()) {
+                String fieldName = fieldNames.next();
+                if (!isSensitiveKey(fieldName)) {
+                    target.set(fieldName, redact(source.get(fieldName)));
+                }
+            }
+            return target;
+        }
+        if (source.isArray()) {
+            ArrayNode target = objectMapper.createArrayNode();
+            source.forEach(value -> target.add(redact(value)));
+            return target;
+        }
+        if (source.isTextual()) {
+            return TextNode.valueOf(redactText(source.asText()));
+        }
+        return source;
+    }
+
+    private boolean isSensitiveKey(String key) {
+        String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+        return normalized.contains("authorization")
+                || normalized.contains("password")
+                || normalized.contains("secret")
+                || normalized.contains("apikey")
+                || normalized.contains("accesstoken")
+                || normalized.contains("refreshtoken")
+                || normalized.contains("cookie")
+                || normalized.contains("session")
+                || normalized.equals("token")
+                || normalized.endsWith("token");
+    }
+
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V6__init_device_api_sync_logs.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V6__init_device_api_sync_logs.sql
@@ -1,0 +1,57 @@
+create table device_api_sync_runs (
+    id uuid primary key,
+    idx bigserial not null unique,
+    sync_type varchar(50) not null,
+    status varchar(30) not null,
+    external_trace_id varchar(200),
+    requested_by_admin_id uuid,
+    started_at timestamptz not null,
+    finished_at timestamptz,
+    total_count integer not null default 0,
+    success_count integer not null default 0,
+    failure_count integer not null default 0,
+    request_summary jsonb,
+    response_summary jsonb,
+    error_code varchar(100),
+    error_message text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint ck_device_api_sync_runs_type check (sync_type in ('POLLING', 'WEBHOOK_RECONCILIATION', 'MANUAL_AUDIT')),
+    constraint ck_device_api_sync_runs_status check (status in ('RUNNING', 'SUCCESS', 'PARTIAL_FAILURE', 'FAILED')),
+    constraint ck_device_api_sync_runs_finished_after_started check (finished_at is null or finished_at >= started_at),
+    constraint ck_device_api_sync_runs_counts_nonnegative check (total_count >= 0 and success_count >= 0 and failure_count >= 0),
+    constraint ck_device_api_sync_runs_counts_within_total check (success_count + failure_count <= total_count)
+);
+
+create index ix_device_api_sync_runs_status_started
+    on device_api_sync_runs(status, started_at desc);
+
+create index ix_device_api_sync_runs_external_trace
+    on device_api_sync_runs(external_trace_id)
+    where external_trace_id is not null;
+
+create table device_api_sync_results (
+    id uuid primary key,
+    idx bigserial not null unique,
+    run_id uuid not null,
+    device_uid varchar(100) not null,
+    device_id uuid,
+    status varchar(30) not null,
+    http_status integer,
+    external_event_id varchar(200),
+    request_summary jsonb,
+    response_summary jsonb,
+    error_code varchar(100),
+    error_message text,
+    created_at timestamptz not null default now(),
+    constraint ck_device_api_sync_results_status check (
+        status in ('SUCCESS', 'FAILED', 'DEVICE_UNKNOWN', 'DEVICE_DISABLED', 'SKIPPED')
+    ),
+    constraint ck_device_api_sync_results_http_status check (http_status is null or (http_status >= 100 and http_status <= 599))
+);
+
+create index ix_device_api_sync_results_run_idx
+    on device_api_sync_results(run_id, idx asc);
+
+create index ix_device_api_sync_results_device_uid
+    on device_api_sync_results(device_uid, created_at desc);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -36,6 +36,7 @@ class ArchitectureBoundaryTests {
                     "..insurance..",
                     "..equipment..",
                     "..device..",
+                    "..devicesync..",
                     "..telemetry..",
                     "..station..",
                     "..dashboard..");
@@ -102,7 +103,8 @@ class ArchitectureBoundaryTests {
                         || isInsuranceItemCommand(method)
                         || isRiderInsuranceCommand(method)
                         || isStationCommand(method)
-                        || isTelemetryIngestionCommand(method)) {
+                        || isTelemetryIngestionCommand(method)
+                        || isDeviceApiSyncCommand(method)) {
                     return;
                 }
 
@@ -136,7 +138,8 @@ class ArchitectureBoundaryTests {
                         && !isInsuranceItemCommand(method)
                         && !isRiderInsuranceCommand(method)
                         && !isStationCommand(method)
-                        && !isTelemetryIngestionCommand(method)) {
+                        && !isTelemetryIngestionCommand(method)
+                        && !isDeviceApiSyncCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -236,6 +239,13 @@ class ArchitectureBoundaryTests {
     private static boolean isTelemetryIngestionCommand(JavaMethod method) {
         return method.getOwner().getName().equals("com.thundercrew.opsapi.telemetry.controller.TelemetryIngestionController")
                 && method.getName().equals("ingest");
+    }
+
+    private static boolean isDeviceApiSyncCommand(JavaMethod method) {
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.devicesync.controller.DeviceApiSyncController")
+                && (method.getName().equals("createRun")
+                || method.getName().equals("recordResult")
+                || method.getName().equals("completeRun"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/CorePersistenceBaselineTests.java
@@ -37,7 +37,9 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
             "device_telemetry_logs",
             "bike_recent_states",
             "bike_current_states",
-            "telemetry_ingestion_error_logs");
+            "telemetry_ingestion_error_logs",
+            "device_api_sync_runs",
+            "device_api_sync_results");
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -83,7 +85,9 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                     'device_telemetry_logs',
                     'bike_recent_states',
                     'bike_current_states',
-                    'telemetry_ingestion_error_logs'
+                    'telemetry_ingestion_error_logs',
+                    'device_api_sync_runs',
+                    'device_api_sync_results'
                   )
                 """, Integer.class);
 
@@ -122,7 +126,11 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                 "ix_bike_recent_states_cleanup",
                 "ix_bike_current_states_last_received",
                 "ix_telemetry_ingestion_errors_retryable",
-                "ix_telemetry_ingestion_errors_device_received");
+                "ix_telemetry_ingestion_errors_device_received",
+                "ix_device_api_sync_runs_status_started",
+                "ix_device_api_sync_runs_external_trace",
+                "ix_device_api_sync_results_run_idx",
+                "ix_device_api_sync_results_device_uid");
 
         List<String> telemetryTables = jdbcTemplate.queryForList("""
                 select table_name
@@ -132,7 +140,9 @@ class CorePersistenceBaselineTests extends PostgresContainerSupport {
                     'device_telemetry_logs',
                     'bike_recent_states',
                     'bike_current_states',
-                    'telemetry_ingestion_error_logs'
+                    'telemetry_ingestion_error_logs',
+                    'device_api_sync_runs',
+                    'device_api_sync_results'
                   )
                 """, String.class);
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeviceApiSyncContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeviceApiSyncContractTests.java
@@ -1,0 +1,415 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DeviceApiSyncContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID ACTIVE_DEVICE_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
+    private static final UUID DISABLED_DEVICE_ID = UUID.fromString("10000000-0000-0000-0000-000000000002");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+    private static final Pattern ID_PATTERN = Pattern.compile("\\\"id\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        deleteIfExists("device_api_sync_results");
+        deleteIfExists("device_api_sync_runs");
+        List.of(
+                "admin_auth_sessions",
+                "bike_device_installations",
+                "devices",
+                "admin_users"
+        ).forEach(table -> jdbcTemplate.update("delete from " + table));
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void deviceApiSyncTablesExistWithoutForeignKeysAndExposeOperationalIndexes() {
+        List<String> tables = jdbcTemplate.queryForList("""
+                select table_name
+                from information_schema.tables
+                where table_schema = current_schema()
+                  and table_name in ('device_api_sync_runs', 'device_api_sync_results')
+                order by table_name
+                """, String.class);
+        Integer foreignKeyCount = jdbcTemplate.queryForObject("""
+                select count(*)
+                from information_schema.table_constraints
+                where table_schema = current_schema()
+                  and constraint_type = 'FOREIGN KEY'
+                  and table_name in ('device_api_sync_runs', 'device_api_sync_results')
+                """, Integer.class);
+        List<String> indexNames = jdbcTemplate.queryForList("""
+                select indexname
+                from pg_indexes
+                where schemaname = current_schema()
+                  and tablename in ('device_api_sync_runs', 'device_api_sync_results')
+                order by indexname
+                """, String.class);
+
+        assertThat(tables).containsExactly("device_api_sync_results", "device_api_sync_runs");
+        assertThat(foreignKeyCount).isZero();
+        assertThat(indexNames).contains(
+                "ix_device_api_sync_runs_status_started",
+                "ix_device_api_sync_runs_external_trace",
+                "ix_device_api_sync_results_run_idx",
+                "ix_device_api_sync_results_device_uid");
+    }
+
+    @Test
+    void deviceApiSyncEndpointsRequireAdminAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/device-api-sync-runs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createRunJson()))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/device-api-sync-runs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deviceApiSyncRunRecordsDeviceOutcomesAndCompletesWithSummaryCounts() throws Exception {
+        seedDevice(ACTIVE_DEVICE_ID, "DEV-SYNC-001", true);
+        seedDevice(DISABLED_DEVICE_ID, "DEV-SYNC-002", false);
+
+        UUID runId = createRun();
+
+        mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(resultJson("DEV-SYNC-001", "SUCCESS", 200, "evt-success")))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/device-api-sync-runs/" + runId))
+                .andExpect(jsonPath("$.runId").value(runId.toString()))
+                .andExpect(jsonPath("$.deviceUid").value("DEV-SYNC-001"))
+                .andExpect(jsonPath("$.deviceId").value(ACTIVE_DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(resultJson("DEV-SYNC-002", "SUCCESS", 200, "evt-disabled")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceId").value(DISABLED_DEVICE_ID.toString()))
+                .andExpect(jsonPath("$.status").value("DEVICE_DISABLED"));
+
+        mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(resultJson("DEV-SYNC-UNKNOWN", "SUCCESS", 404, "evt-unknown")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceId").doesNotExist())
+                .andExpect(jsonPath("$.status").value("DEVICE_UNKNOWN"));
+
+        mockMvc.perform(patch("/api/v1/device-api-sync-runs/{runId}/complete", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(completeJson()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(runId.toString()))
+                .andExpect(jsonPath("$.status").value("PARTIAL_FAILURE"))
+                .andExpect(jsonPath("$.totalCount").value(3))
+                .andExpect(jsonPath("$.successCount").value(1))
+                .andExpect(jsonPath("$.failureCount").value(2))
+                .andExpect(jsonPath("$.results").isArray());
+
+        mockMvc.perform(get("/api/v1/device-api-sync-runs/{runId}", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results.length()").value(3));
+
+        mockMvc.perform(get("/api/v1/device-api-sync-runs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].id").value(runId.toString()))
+                .andExpect(jsonPath("$.items[0].status").value("PARTIAL_FAILURE"));
+    }
+
+    @Test
+    void deviceApiSyncSummariesAreRedactedBeforePersistence() throws Exception {
+        seedDevice(ACTIVE_DEVICE_ID, "DEV-SYNC-SECRET", true);
+        UUID runId = createRun();
+
+        mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(resultJson("DEV-SYNC-SECRET", "FAILED", 502, "evt-secret")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.requestSummary.Authorization").doesNotExist())
+                .andExpect(jsonPath("$.requestSummary.apiKey").doesNotExist())
+                .andExpect(jsonPath("$.requestSummary.Cookie").doesNotExist())
+                .andExpect(jsonPath("$.requestSummary.sessionId").doesNotExist())
+                .andExpect(jsonPath("$.requestSummary.nested.password").doesNotExist())
+                .andExpect(jsonPath("$.requestSummary.message").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("messagebearer123"))))
+                .andExpect(jsonPath("$.requestSummary.message").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("json-fragment-secret"))))
+                .andExpect(jsonPath("$.requestSummary.message").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("json-fragment-token"))))
+                .andExpect(jsonPath("$.requestSummary.message").value(org.hamcrest.Matchers.containsString("[REDACTED]")))
+                .andExpect(jsonPath("$.responseSummary.refreshToken").doesNotExist())
+                .andExpect(jsonPath("$.responseSummary.setCookie").doesNotExist())
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("detailaccess123"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("detailrefresh123"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("detailkey123"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("detailcookie123"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("json-detail-secret"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("json-detail-cookie"))))
+                .andExpect(jsonPath("$.responseSummary.detail").value(org.hamcrest.Matchers.containsString("[REDACTED]")))
+                .andExpect(jsonPath("$.status").value("FAILED"));
+
+        String persisted = jdbcTemplate.queryForObject("""
+                select coalesce(request_summary::text, '') || coalesce(response_summary::text, '')
+                from device_api_sync_results
+                where device_uid = 'DEV-SYNC-SECRET'
+                """, String.class);
+        assertThat(persisted)
+                .doesNotContain(
+                        "Bearer vendor-secret-token",
+                        "plain-password",
+                        "super-secret-api-key",
+                        "refresh-secret-value",
+                        "messagebearer123",
+                        "messagepass123",
+                        "detailaccess123",
+                        "detailrefresh123",
+                        "detailkey123",
+                        "detailcookie123",
+                        "json-fragment-secret",
+                        "json-fragment-token",
+                        "json-detail-secret",
+                        "json-detail-cookie",
+                        "cookie-secret",
+                        "session-id-secret",
+                        "set-cookie-secret")
+                .contains("safe-request", "safe-response", "[REDACTED]");
+    }
+
+
+    @Test
+    void deviceApiSyncErrorMessagesAreRedactedBeforePersistence() throws Exception {
+        seedDevice(ACTIVE_DEVICE_ID, "DEV-SYNC-ERROR-SECRET", true);
+        UUID runId = createRun();
+
+        MvcResult result = mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "deviceUid":"DEV-SYNC-ERROR-SECRET",
+                                  "externalEventId":"evt-error-secret",
+                                  "status":"FAILED",
+                                  "httpStatus":502,
+                                  "errorCode":"VENDOR_FAILURE",
+                                  "errorMessage":"Authorization: Basic result-basic-secret-token; Authorization: Bearer result-secret-token; api_key=result-api-secret; password=plain-password; Cookie=session-secret; {\\"apiKey\\":\\"result-json-secret\\",\\"Cookie\\":\\"result-json-cookie\\"}"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+        assertThat(result.getResponse().getContentAsString())
+                .doesNotContain("result-basic-secret-token", "result-secret-token", "result-api-secret", "plain-password", "session-secret", "result-json-secret", "result-json-cookie")
+                .contains("[REDACTED]");
+
+        MvcResult completed = mockMvc.perform(patch("/api/v1/device-api-sync-runs/{runId}/complete", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "errorCode":"VENDOR_COMPLETE_FAILURE",
+                                  "errorMessage":"Bearer completion-secret-token access_token=completion-access-token refresh_token=completion-refresh-token secret=completion-secret {\\"token\\":\\"completion-json-token\\"}"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(completed.getResponse().getContentAsString())
+                .doesNotContain("completion-secret-token", "completion-access-token", "completion-refresh-token", "completion-secret")
+                .contains("[REDACTED]");
+
+        String persisted = jdbcTemplate.queryForObject("""
+                select coalesce((select error_message from device_api_sync_results where device_uid = 'DEV-SYNC-ERROR-SECRET'), '')
+                    || ' ' ||
+                    coalesce((select error_message from device_api_sync_runs where id = ?), '')
+                """, String.class, runId);
+        assertThat(persisted)
+                .doesNotContain(
+                        "result-basic-secret-token",
+                        "result-secret-token",
+                        "result-api-secret",
+                        "plain-password",
+                        "session-secret",
+                        "completion-secret-token",
+                        "completion-access-token",
+                        "completion-refresh-token",
+                        "completion-secret",
+                        "result-json-secret",
+                        "result-json-cookie",
+                        "completion-json-token")
+                .contains("[REDACTED]");
+    }
+
+    @Test
+    void deviceApiSyncReservedResolutionStatusesCannotBeClientSubmittedForActiveDevices() throws Exception {
+        seedDevice(ACTIVE_DEVICE_ID, "DEV-SYNC-RESERVED", true);
+        UUID runId = createRun();
+
+        mockMvc.perform(post("/api/v1/device-api-sync-runs/{runId}/results", runId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(resultJson("DEV-SYNC-RESERVED", "DEVICE_UNKNOWN", 200, "evt-reserved")))
+                .andExpect(status().isBadRequest());
+
+        Integer rows = jdbcTemplate.queryForObject(
+                "select count(*) from device_api_sync_results where device_uid = 'DEV-SYNC-RESERVED'",
+                Integer.class);
+        assertThat(rows).isZero();
+    }
+
+    private UUID createRun() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/device-api-sync-runs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createRunJson()))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.startsWith("/api/v1/device-api-sync-runs/")))
+                .andExpect(jsonPath("$.syncType").value("POLLING"))
+                .andExpect(jsonPath("$.status").value("RUNNING"))
+                .andExpect(jsonPath("$.totalCount").value(0))
+                .andReturn();
+        return extractId(result);
+    }
+
+    private String createRunJson() {
+        return """
+                {
+                  "syncType":"POLLING",
+                  "externalTraceId":"poll-run-001",
+                  "requestSummary":{
+                    "endpoint":"/vendor/devices",
+                    "Authorization":"Bearer vendor-secret-token",
+                    "safe":"safe-request"
+                  }
+                }
+                """;
+    }
+
+    private String resultJson(String deviceUid, String status, int httpStatus, String externalEventId) {
+        return """
+                {
+                  "deviceUid":"%s",
+                  "externalEventId":"%s",
+                  "status":"%s",
+                  "httpStatus":%d,
+                  "errorCode":"VENDOR_%s",
+                  "errorMessage":"sync fixture",
+                  "requestSummary":{
+                    "safe":"safe-request",
+                    "Authorization":"Bearer vendor-secret-token",
+                    "apiKey":"super-secret-api-key",
+                    "Cookie":"session=cookie-secret",
+                    "sessionId":"session-id-secret",
+                    "nested":{"password":"plain-password"},
+                    "message":"Authorization: Bearer messagebearer123 password=messagepass123 {\\"apiKey\\":\\"json-fragment-secret\\",\\"accessToken\\":\\"json-fragment-token\\"}"
+                  },
+                  "responseSummary":{
+                    "safe":"safe-response",
+                    "refreshToken":"refresh-secret-value",
+                    "setCookie":"session=set-cookie-secret",
+                    "detail":"access_token=detailaccess123 refresh_token=detailrefresh123 api_key=detailkey123 Cookie=detailcookie123 {\\"secret\\":\\"json-detail-secret\\",\\"setCookie\\":\\"json-detail-cookie\\"}"
+                  }
+                }
+                """.formatted(deviceUid, externalEventId, status, httpStatus, status);
+    }
+
+    private String completeJson() {
+        return """
+                {
+                  "responseSummary":{"safe":"safe-response","token":"completion-token"},
+                  "errorCode":"PARTIAL_VENDOR_FAILURE",
+                  "errorMessage":"some devices failed"
+                }
+                """;
+    }
+
+    private UUID extractId(MvcResult result) throws Exception {
+        Matcher matcher = ID_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return UUID.fromString(matcher.group(1));
+    }
+
+    private void seedDevice(UUID id, String deviceUid, boolean enabled) {
+        jdbcTemplate.update("""
+                insert into devices (id, device_uid, manufacturer, model_name, enabled)
+                values (?, ?, 'ThunderDevice', 'TD-100', ?)
+                """, id, deviceUid, enabled);
+    }
+
+    private void deleteIfExists(String tableName) {
+        Boolean exists = jdbcTemplate.queryForObject("select to_regclass(?) is not null", Boolean.class, tableName);
+        if (Boolean.TRUE.equals(exists)) {
+            jdbcTemplate.update("delete from " + tableName);
+        }
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        if (!matcher.find()) {
+            throw new AssertionError("accessToken was not present in login response: "
+                    + result.getResponse().getContentAsString());
+        }
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ScaffoldPackageSkeletonTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ScaffoldPackageSkeletonTests.java
@@ -18,6 +18,7 @@ class ScaffoldPackageSkeletonTests {
                 "com.thundercrew.opsapi.insurance.InsurancePackage",
                 "com.thundercrew.opsapi.equipment.EquipmentPackage",
                 "com.thundercrew.opsapi.device.DevicePackage",
+                "com.thundercrew.opsapi.devicesync.DeviceSyncPackage",
                 "com.thundercrew.opsapi.telemetry.TelemetryPackage",
                 "com.thundercrew.opsapi.station.StationPackage",
                 "com.thundercrew.opsapi.dashboard.DashboardPackage",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -559,3 +559,30 @@ Verification:
 
 - TDD red observed on `IntegrityScanApiContractTests` before implementation because the authenticated endpoint did not exist.
 - Targeted integrity scan API tests pass after implementation.
+
+## External device sync evidence baseline implementation
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#72
+- Target issue: EVNSolution/thundercrew-domain#56
+- Branch: `cc-72-external-device-sync-baseline`
+
+Issue-size decision:
+
+- This slice adds only the backend evidence baseline for external device API sync runs/results after telemetry current-state and integrity scan baselines.
+- Included operations are authenticated `POST /api/v1/device-api-sync-runs`, `POST /api/v1/device-api-sync-runs/{runId}/results`, `PATCH /api/v1/device-api-sync-runs/{runId}/complete`, `GET /api/v1/device-api-sync-runs`, and `GET /api/v1/device-api-sync-runs/{runId}`.
+- Included tables are `device_api_sync_runs` and `device_api_sync_results`.
+- Real vendor HTTP clients, credentials, scheduler/background polling, TimescaleDB retention/archive, frontend UI integration, telemetry table rewrites, and DB foreign key introduction remain follow-up scopes.
+
+Boundary decision:
+
+- Sync evidence is separate from telemetry ingestion: this API logs vendor/API interaction evidence and does not create raw telemetry, recent state, or current state rows.
+- Device references are resolved by `deviceUid`; unknown and disabled devices become deterministic sync result statuses without creating devices or mutating telemetry state.
+- Request/response summaries are redacted before persistence; sensitive keys such as authorization, token, password, secret, and API key are omitted.
+- Architecture remains no-FK/no-JPA-relationship; `run_id` and `device_id` are UUID values without database foreign keys.
+
+Verification:
+
+- TDD red observed on `DeviceApiSyncContractTests` before implementation because sync tables/endpoints did not exist.
+- Targeted device sync, scaffold, architecture, and core persistence tests pass after implementation.

--- a/docs/backend/02-domain-db-draft.md
+++ b/docs/backend/02-domain-db-draft.md
@@ -553,7 +553,7 @@ Update rule:
 3. Insert raw `device_telemetry_logs` with idempotency protection.
 4. Insert normalized `bike_recent_states` when bike association exists.
 5. Upsert `bike_current_states` only if newer than current state.
-6. Record telemetry processing failures in `telemetry_ingestion_error_logs`; use `device_api_sync_logs` later only for external polling/webhook request-response evidence.
+6. Record telemetry processing failures in `telemetry_ingestion_error_logs`; use `device_api_sync_runs` / `device_api_sync_results` only for external polling/webhook request-response evidence.
 
 Failure policy:
 
@@ -579,31 +579,51 @@ Computed DTO information:
 | `battery_status = LOW` | battery >= 20 and battery < 50 |
 | `battery_status = NORMAL` | battery >= 50 |
 
-### `device_api_sync_logs` (future external sync slice)
+### `device_api_sync_runs` / `device_api_sync_results`
 
 External device API polling/webhook request-response evidence. This is for API call/sync trace,
-not for every normalized telemetry processing failure and not part of the first raw/recent/current
-telemetry baseline.
+not for every normalized telemetry processing failure and not part of the raw/recent/current
+telemetry write path. The current baseline is evidence-only; real vendor polling and schedulers
+remain follow-up scopes.
+
+`device_api_sync_runs`:
 
 - `id`, `idx`
-- `device_id uuid null`
-- `device_uid varchar(100) null`
-- `sync_type varchar(50) not null`
-- `request_started_at timestamptz not null`
-- `request_finished_at timestamptz null`
-- `success boolean not null`
-- `http_status integer null`
+- `sync_type varchar(50) not null` (`POLLING`, `WEBHOOK_RECONCILIATION`, `MANUAL_AUDIT`)
+- `status varchar(30) not null` (`RUNNING`, `SUCCESS`, `PARTIAL_FAILURE`, `FAILED`)
 - `external_trace_id varchar(200) null`
-- `error_code varchar(100) null`
-- `error_message text null`
+- `requested_by_admin_id uuid null`
+- `started_at timestamptz not null`
+- `finished_at timestamptz null`
+- `total_count`, `success_count`, `failure_count`
 - `request_summary jsonb null`
 - `response_summary jsonb null`
+- `error_code varchar(100) null`
+- `error_message text null`
+- `created_at`, `updated_at`
+
+`device_api_sync_results`:
+
+- `id`, `idx`
+- `run_id uuid not null` (no DB FK)
+- `device_uid varchar(100) not null`
+- `device_id uuid null` (resolved from registry when possible, no DB FK)
+- `status varchar(30) not null` (`SUCCESS`, `FAILED`, `DEVICE_UNKNOWN`, `DEVICE_DISABLED`, `SKIPPED`)
+- `http_status integer null`
+- `external_event_id varchar(200) null`
+- `request_summary jsonb null`
+- `response_summary jsonb null`
+- `error_code varchar(100) null`
+- `error_message text null`
 - `created_at timestamptz not null`
 
 Payload policy:
 
 - Store summaries/redacted payload only.
 - Never store credentials or full secret-bearing payloads.
+- Sensitive keys such as authorization, token, password, secret, and API key are omitted before persistence.
+- Free-text evidence fields such as error messages are redacted before persistence.
+- API clients submit only `SUCCESS`, `FAILED`, or `SKIPPED`; `DEVICE_UNKNOWN` and `DEVICE_DISABLED` are server-owned resolution outcomes.
 
 ### `telemetry_ingestion_error_logs`
 

--- a/docs/backend/03-scaffold-plan.md
+++ b/docs/backend/03-scaffold-plan.md
@@ -111,7 +111,7 @@ Minimum safe path:
 3. Insert recent state if bike association exists.
 4. Upsert current state only for newer telemetry.
 5. Record telemetry processing failures in `telemetry_ingestion_error_logs` with redacted context and retryability.
-6. Add `device_api_sync_logs` later with the external device polling/webhook integration slice; it is not required for the current raw/recent/current baseline.
+6. Keep `device_api_sync_runs` / `device_api_sync_results` as the external-device API evidence boundary; real vendor polling/schedulers remain separate from the raw/recent/current telemetry baseline.
 
 Fallback if TimescaleDB is unavailable:
 


### PR DESCRIPTION
## Summary

- Adds backend-only external device API sync evidence logging for future vendor polling/webhook reconciliation.
- Introduces `device_api_sync_runs` and `device_api_sync_results` with UUID PK + `idx`, operational indexes, no DB foreign keys, and no JPA relationships.
- Adds authenticated admin endpoints to create a sync run, record per-device outcomes by `deviceUid`, complete runs, list runs, and inspect run detail.
- Keeps `DEVICE_UNKNOWN` / `DEVICE_DISABLED` as server-owned resolution outcomes; clients may submit only `SUCCESS`, `FAILED`, or `SKIPPED`.
- Redacts secret-bearing JSON summary keys, JSON text fragments, and free-text error fields before persistence/response.
- Updates backend README/domain draft/scaffold plan/change ledger for the new evidence boundary.

## Trace

- Change-control: EVNSolution/clever-change-control#72
- Target issue: EVNSolution/thundercrew-domain#56
- Branch: `cc-72-external-device-sync-baseline`
- Pre-PR concurrent gate: `allowed-with-non-overlap`
  - Target open issues: #56 only
  - Target open PRs: none
  - Target remote heads: `main`, `dev`, `cc-72-external-device-sync-baseline`
  - Other open change-control issues are unrelated to this backend sync evidence slice.

## Scope boundaries

Included:
- backend migration/schema baseline
- backend API/service/repository/DTO contract
- admin authentication boundary
- no-FK/MSA-compatible scalar references
- secret redaction tests and persistence assertions

Excluded intentionally:
- real external vendor HTTP polling
- scheduler/background execution
- TimescaleDB retention/archive
- telemetry replay/rewrite
- frontend UI consumption
- production credentials

## Validation

- TDD RED: `DeviceApiSyncContractTests` failed before implementation because tables/endpoints were missing.
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test --tests com.thundercrew.opsapi.DeviceApiSyncContractTests --tests com.thundercrew.opsapi.ScaffoldPackageSkeletonTests --tests com.thundercrew.opsapi.ArchitectureBoundaryTests --tests com.thundercrew.opsapi.CorePersistenceBaselineTests --tests com.thundercrew.opsapi.TelemetryApiContractTests --tests com.thundercrew.opsapi.DeviceCommandApiContractTests --no-daemon)`
- `(cd development/service-ops-api && ./gradlew cleanTest test --max-workers=1 --no-daemon --stacktrace)`
- `(cd development/service-ops-api && ./gradlew build --max-workers=1 --no-daemon)`
- Code-reviewer final PASS after security redaction fixes.
