### PR TITLE
Dashboard map-state frontend integration (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,6 @@ Frontend ↔ backend baseline:
   `development/service-ops-api`의 `/api/v1`을 호출합니다.
 - 관리자 로그인은 service-ops JWT를 HTTP-only 쿠키에 저장하고, 라이더 목록/상세/등록/수정
   server action은 해당 쿠키에서 Bearer token을 붙입니다.
+- 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
+  summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -71,6 +71,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `SERVICE_OPS_API_BASE_URL`이 설정되면 `/login`은 `POST /api/v1/auth/login`으로 관리자 인증을 수행합니다.
 - access/refresh token은 localStorage, URL, rendered HTML에 두지 않고 HTTP-only cookie로 저장합니다.
 - 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
+- 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.
 
@@ -174,6 +175,8 @@ Preview 환경변수는 현재 Vercel 프로젝트에 Git repository가 연결�
 - 라이더 검색 결과는 라이더 상세 정보로 연결됩니다.
 - 우측에는 넓은 고정 정보 패널을 둡니다.
 - 지도 API 없이도 지도 요소 컴포넌트로 `라이더 위치`와 `배터리 스테이션 위치`를 표시합니다.
+- service-ops `map-state`가 연결되면 배터리 스테이션 핀은 backend `pinLabel`을 사용해 `이름 사용가능/최대` 형식으로 표시합니다.
+- backend `map-state`는 라이더 전화번호/ID를 노출하지 않으므로, service-ops 모드에서 라이더 상세 링크는 별도 selector/API 통합 범위에서 연결합니다.
 
 ## Workspace relocation note
 

--- a/development/front-admin-web/app/dashboard/page.tsx
+++ b/development/front-admin-web/app/dashboard/page.tsx
@@ -1,5 +1,8 @@
 import { ControlMap } from "@/components/dashboard/ControlMap";
+import { loadDashboardMapData } from "@/lib/services/dashboard-map-data";
 
-export default function DashboardPage() {
-  return <ControlMap />;
+export default async function DashboardPage() {
+  const data = await loadDashboardMapData();
+
+  return <ControlMap data={data} />;
 }

--- a/development/front-admin-web/components/dashboard/ControlMap.tsx
+++ b/development/front-admin-web/components/dashboard/ControlMap.tsx
@@ -3,49 +3,34 @@
 import Link from "next/link";
 import { useState } from "react";
 import { Badge } from "@/components/ui/Badge";
-import { riders, stations, vehicles } from "@/lib/services/mock-data";
+import type {
+  ControlMapData,
+  ControlMapRegion,
+  ControlMapRider
+} from "@/lib/services/dashboard-map-data";
 
 type PanelMode = "region" | "rider";
 type SearchTab = "region" | "rider";
-type Region = (typeof regions)[number];
-type Rider = (typeof riders)[number];
 
-const regions = [
-  { name: "강남/역삼", activeVehicles: 1, activeRiders: 1, stations: 1, batteries: 31 },
-  { name: "서초/방배", activeVehicles: 1, activeRiders: 1, stations: 1, batteries: 19 },
-  { name: "송파/잠실", activeVehicles: 0, activeRiders: 0, stations: 1, batteries: 4 }
-];
-
-const riderPins = [
-  { rider: riders[0], vehicle: vehicles[0], left: "34%", top: "42%" },
-  { rider: riders[1], vehicle: vehicles[2], left: "58%", top: "54%" },
-  { rider: riders[2], vehicle: undefined, left: "72%", top: "36%" }
-];
-
-const stationPins = [
-  { station: stations[0], region: regions[0], left: "40%", top: "32%" },
-  { station: stations[1], region: regions[1], left: "54%", top: "64%" },
-  { station: stations[2], region: regions[2], left: "76%", top: "48%" }
-];
-
-export function ControlMap() {
+export function ControlMap({ data }: { data: ControlMapData }) {
   const [panelMode, setPanelMode] = useState<PanelMode | null>(null);
-  const [selectedRegion, setSelectedRegion] = useState<Region | null>(null);
-  const [selectedRider, setSelectedRider] = useState<Rider | null>(null);
+  const [selectedRegion, setSelectedRegion] = useState<ControlMapRegion | null>(null);
+  const [selectedRider, setSelectedRider] = useState<ControlMapRider | null>(null);
   const [searchOpen, setSearchOpen] = useState(true);
   const [searchTab, setSearchTab] = useState<SearchTab>("region");
-  const selectedVehicle = selectedRider ? vehicles.find((vehicle) => vehicle.riderName === selectedRider.name) : undefined;
   const panelOpen = panelMode !== null;
 
-  const openRegionPanel = (region: Region) => {
+  const openRegionPanel = (region: ControlMapRegion) => {
     setSelectedRegion(region);
     setPanelMode("region");
   };
 
-  const openRiderPanel = (rider: Rider) => {
+  const openRiderPanel = (rider: ControlMapRider) => {
     setSelectedRider(rider);
     setPanelMode("rider");
   };
+
+  const sourceLabel = data.source === "service-ops" ? "service-ops" : "mock";
 
   return (
     <section className="control-map-page" aria-label="지도 기반 전기 이륜차 관제 시스템">
@@ -61,23 +46,23 @@ export function ControlMap() {
 
         {searchOpen ? (
           <div className="map-search-body">
+            {data.notice ? <p className="notice">{data.notice}</p> : null}
             <div className="search-tabs" role="tablist" aria-label="검색 대상 선택">
               <button className={searchTab === "region" ? "is-active" : ""} type="button" role="tab" aria-selected={searchTab === "region"} onClick={() => setSearchTab("region")}>지역</button>
               <button className={searchTab === "rider" ? "is-active" : ""} type="button" role="tab" aria-selected={searchTab === "rider"} onClick={() => setSearchTab("rider")}>라이더</button>
             </div>
             <input className="input" placeholder={searchTab === "region" ? "지역명 검색 예: 강남, 서초, 송파" : "라이더 이름 또는 연락처 검색"} />
             <div className="search-choice-list" aria-label={searchTab === "region" ? "지역 검색 결과" : "라이더 검색 결과"}>
-              {searchTab === "region" ? regions.map((region) => (
+              {searchTab === "region" ? data.regions.map((region) => (
                 <button key={region.name} className={`search-choice-card${selectedRegion?.name === region.name ? " is-selected" : ""}`} type="button" onClick={() => openRegionPanel(region)}>
                   <strong>{region.name}</strong>
                   <span>운행 {region.activeVehicles}대 · 라이더 {region.activeRiders}명 · 교체 가능 {region.batteries}개</span>
                 </button>
-              )) : riders.map((rider) => {
-                const vehicle = vehicles.find((item) => item.riderName === rider.name);
+              )) : data.riders.map((rider) => {
                 return (
                   <button key={rider.slug} className={`search-choice-card${selectedRider?.slug === rider.slug ? " is-selected" : ""}`} type="button" onClick={() => openRiderPanel(rider)}>
                     <strong>{rider.name}</strong>
-                    <span>{rider.phone} · {rider.area} · {vehicle?.plateNumber ?? "배정 차량 없음"}</span>
+                    <span>{rider.phone} · {rider.area} · {rider.vehiclePlateNumber ?? "배정 차량 없음"}</span>
                   </button>
                 );
               })}
@@ -87,16 +72,16 @@ export function ControlMap() {
       </div>
 
       <div className="map-object-layer" aria-label="지도 요소">
-        {riderPins.map(({ rider, vehicle, left, top }) => (
-          <button key={rider.slug} className="map-object map-object-rider" style={{ left, top }} aria-label={`${rider.name} 라이더 위치`} onClick={() => openRiderPanel(rider)} type="button">
+        {data.bikePins.map(({ key, rider, label, left, top }) => (
+          <button key={key} className="map-object map-object-rider" style={{ left, top }} aria-label={`${label} 라이더 위치`} onClick={() => rider ? openRiderPanel(rider) : undefined} type="button">
             <span className="map-object-dot">R</span>
-            <span className="map-object-label">{rider.name}{vehicle ? ` · ${vehicle.plateNumber}` : ""}</span>
+            <span className="map-object-label">{label}</span>
           </button>
         ))}
-        {stationPins.map(({ station, region, left, top }) => (
-          <button key={station.slug} className="map-object map-object-station" style={{ left, top }} aria-label={`${station.name} 배터리 스테이션 위치`} onClick={() => openRegionPanel(region)} type="button">
+        {data.stationPins.map(({ key, label, left, regionName, top }) => (
+          <button key={key} className="map-object map-object-station" style={{ left, top }} aria-label={`${label} 배터리 스테이션 위치`} onClick={() => openRegionPanel(data.regions.find((region) => region.name === regionName) ?? data.regions[0])} type="button">
             <span className="map-object-dot">B</span>
-            <span className="map-object-label">{station.name} {station.replaceableCount}/{station.batteryCount}</span>
+            <span className="map-object-label">{label}</span>
           </button>
         ))}
       </div>
@@ -109,7 +94,7 @@ export function ControlMap() {
               <p className="hero-kicker">{panelMode === "region" ? "Region Summary" : "Rider Detail"}</p>
               <h1>{panelMode === "region" ? `${selectedRegion?.name ?? "선택 지역"} 관제 요약` : `${selectedRider?.name ?? "선택 라이더"} 정보`}</h1>
             </div>
-            <Badge tone="active">실시간 mock</Badge>
+            <Badge tone="active">{sourceLabel}</Badge>
           </div>
 
           {panelMode === "region" && selectedRegion ? (
@@ -125,7 +110,8 @@ export function ControlMap() {
               </div>
               <div className="map-info-section">
                 <h2>지역 내 지도 요소</h2>
-                <p>배터리 스테이션, 운행 라이더, 교체 가능 배터리 수량을 지역 기준으로 요약합니다. 실제 지도 API 연결 전까지 mock 위치 컴포넌트로 표시합니다.</p>
+                <p>배터리 스테이션, 운행 라이더, 교체 가능 배터리 수량을 지도 관제 기준으로 요약합니다. 실제 지도 SDK 연결 전까지 좌표 기반 위치 컴포넌트로 표시합니다.</p>
+                {data.generatedAt ? <p>생성 시각: {data.generatedAt}</p> : null}
               </div>
             </>
           ) : null}
@@ -138,13 +124,18 @@ export function ControlMap() {
                   <div className="detail-row"><span>이름</span><strong>{selectedRider.name}</strong></div>
                   <div className="detail-row"><span>연락처</span><strong>{selectedRider.phone}</strong></div>
                   <div className="detail-row"><span>담당 구역</span><strong>{selectedRider.area}</strong></div>
-                  <div className="detail-row"><span>배정 차량</span><strong>{selectedVehicle?.plateNumber ?? "없음"}</strong></div>
-                  <div className="detail-row"><span>차량 상태</span><strong>{selectedVehicle?.status ?? "대기"}</strong></div>
+                  <div className="detail-row"><span>배정 차량</span><strong>{selectedRider.vehiclePlateNumber ?? "없음"}</strong></div>
+                  <div className="detail-row"><span>차량 상태</span><strong>{selectedRider.vehicleStatus ?? "대기"}</strong></div>
+                  <div className="detail-row"><span>연결 상태</span><strong>{selectedRider.connectionStatus ?? "mock"}</strong></div>
                 </div>
               </div>
-              <div className="form-actions">
-                <Link className="button-secondary" href={`/riders/${selectedRider.slug}`}>라이더 상세로 이동</Link>
-              </div>
+              {selectedRider.detailHref ? (
+                <div className="form-actions">
+                  <Link className="button-secondary" href={selectedRider.detailHref}>라이더 상세로 이동</Link>
+                </div>
+              ) : (
+                <p className="notice">map-state 응답은 라이더 전화번호/ID를 노출하지 않습니다. 라이더 상세 연결은 라이더 API selector 연동 범위에서 처리합니다.</p>
+              )}
             </>
           ) : null}
         </aside>

--- a/development/front-admin-web/lib/services/dashboard-map-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-data.ts
@@ -1,0 +1,267 @@
+import {
+  type FrontendDashboardMapState,
+  type FrontendDashboardBikePin,
+  type FrontendDashboardStationPin,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { riders, stations, vehicles } from "@/lib/services/mock-data";
+
+export type ControlMapSource = "mock" | "service-ops";
+
+export type ControlMapRegion = {
+  name: string;
+  activeVehicles: number;
+  activeRiders: number;
+  stations: number;
+  batteries: number;
+};
+
+export type ControlMapRider = {
+  slug: string;
+  name: string;
+  phone: string;
+  area: string;
+  team?: string;
+  status: "활동" | "대기" | "휴면";
+  vehiclePlateNumber?: string;
+  vehicleStatus?: string;
+  vehicleBatteryPercent?: number | null;
+  connectionStatus?: string;
+  detailHref?: string;
+};
+
+export type ControlMapBikePin = {
+  key: string;
+  label: string;
+  left: string;
+  top: string;
+  plateNumber: string;
+  rider?: ControlMapRider;
+};
+
+export type ControlMapStationPin = {
+  key: string;
+  label: string;
+  left: string;
+  top: string;
+  regionName: string;
+};
+
+export type ControlMapData = {
+  source: ControlMapSource;
+  generatedAt?: string;
+  notice?: string;
+  regions: ControlMapRegion[];
+  riders: ControlMapRider[];
+  bikePins: ControlMapBikePin[];
+  stationPins: ControlMapStationPin[];
+};
+
+type ProjectedPosition = {
+  left: string;
+  top: string;
+};
+
+export async function loadDashboardMapData(): Promise<ControlMapData> {
+  const fallback = mockDashboardMapData();
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 지도 관제 데이터를 표시합니다. 백엔드 연결 시 map-state API로 전환됩니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 지도 관제 데이터를 표시합니다. 관리자 로그인 후 실제 map-state로 전환됩니다."
+    };
+  }
+
+  try {
+    return serviceOpsDashboardMapData(await client.getDashboardMapState());
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API map-state 조회 실패로 mock 지도 관제 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export function mockDashboardMapData(): ControlMapData {
+  const regions: ControlMapRegion[] = [
+    { name: "강남/역삼", activeVehicles: 1, activeRiders: 1, stations: 1, batteries: 31 },
+    { name: "서초/방배", activeVehicles: 1, activeRiders: 1, stations: 1, batteries: 19 },
+    { name: "송파/잠실", activeVehicles: 0, activeRiders: 0, stations: 1, batteries: 4 }
+  ];
+
+  const mapRiders: ControlMapRider[] = riders.map((rider) => {
+    const vehicle = vehicles.find((item) => item.riderName === rider.name);
+    return {
+      area: rider.area,
+      detailHref: `/riders/${rider.slug}`,
+      name: rider.name,
+      phone: rider.phone,
+      slug: rider.slug,
+      status: rider.status,
+      team: rider.team,
+      vehicleBatteryPercent: vehicle?.batteryPercent,
+      vehiclePlateNumber: vehicle?.plateNumber,
+      vehicleStatus: vehicle?.status
+    };
+  });
+
+  return {
+    bikePins: [
+      toMockBikePin(mapRiders[0], "34%", "42%"),
+      toMockBikePin(mapRiders[1], "58%", "54%"),
+      toMockBikePin(mapRiders[2], "72%", "36%")
+    ],
+    regions,
+    riders: mapRiders,
+    source: "mock",
+    stationPins: [
+      toMockStationPin(stations[0], regions[0], "40%", "32%"),
+      toMockStationPin(stations[1], regions[1], "54%", "64%"),
+      toMockStationPin(stations[2], regions[2], "76%", "48%")
+    ]
+  };
+}
+
+export function serviceOpsDashboardMapData(mapState: FrontendDashboardMapState): ControlMapData {
+  const allPoints = [
+    ...mapState.bikePins.map((pin) => ({ key: `bike-${pin.slug}`, latitude: pin.latitude, longitude: pin.longitude })),
+    ...mapState.stationPins.map((pin) => ({ key: `station-${pin.slug}`, latitude: pin.latitude, longitude: pin.longitude }))
+  ];
+  const positions = projectPositions(allPoints);
+  const riderByLabel = new Map<string, ControlMapRider>();
+
+  mapState.bikePins.forEach((pin) => {
+    if (!pin.activeRiderLabel || riderByLabel.has(pin.activeRiderLabel)) {
+      return;
+    }
+
+    riderByLabel.set(pin.activeRiderLabel, toServiceOpsRider(pin));
+  });
+
+  const ridersFromPins = Array.from(riderByLabel.values());
+
+  return {
+    bikePins: mapState.bikePins.map((pin, index) => ({
+      key: pin.slug,
+      label: pin.pinLabel,
+      left: positions.get(`bike-${pin.slug}`)?.left ?? fallbackLeft(index),
+      plateNumber: pin.plateNumber,
+      rider: pin.activeRiderLabel ? riderByLabel.get(pin.activeRiderLabel) : undefined,
+      top: positions.get(`bike-${pin.slug}`)?.top ?? fallbackTop(index)
+    })),
+    generatedAt: mapState.generatedAt,
+    regions: [
+      {
+        activeRiders: riderByLabel.size,
+        activeVehicles: mapState.summary.onlineBikeCount,
+        batteries: mapState.summary.availableBatteryCount,
+        name: "전체 관제",
+        stations: mapState.summary.stationPinCount
+      }
+    ],
+    riders: ridersFromPins,
+    source: "service-ops",
+    stationPins: mapState.stationPins.map((pin, index) => ({
+      key: pin.slug,
+      label: pin.pinLabel,
+      left: positions.get(`station-${pin.slug}`)?.left ?? fallbackLeft(index + mapState.bikePins.length),
+      regionName: "전체 관제",
+      top: positions.get(`station-${pin.slug}`)?.top ?? fallbackTop(index + mapState.bikePins.length)
+    }))
+  };
+}
+
+function toMockBikePin(rider: ControlMapRider, left: string, top: string): ControlMapBikePin {
+  return {
+    key: rider.slug,
+    label: `${rider.name}${rider.vehiclePlateNumber ? ` · ${rider.vehiclePlateNumber}` : ""}`,
+    left,
+    plateNumber: rider.vehiclePlateNumber ?? "배정 차량 없음",
+    rider,
+    top
+  };
+}
+
+function toMockStationPin(
+  station: (typeof stations)[number],
+  region: ControlMapRegion,
+  left: string,
+  top: string
+): ControlMapStationPin {
+  return {
+    key: station.slug,
+    label: `${station.name} ${station.replaceableCount}/${station.batteryCount}`,
+    left,
+    regionName: region.name,
+    top
+  };
+}
+
+function toServiceOpsRider(pin: FrontendDashboardBikePin): ControlMapRider {
+  return {
+    area: "전체 관제",
+    connectionStatus: pin.connectionStatus,
+    name: pin.activeRiderLabel ?? "미지정 라이더",
+    phone: "map-state 미제공",
+    slug: `map-rider-${pin.bikeId}`,
+    status: pin.connectionStatus === "ONLINE" ? "활동" : "대기",
+    vehicleBatteryPercent: pin.batteryPercent,
+    vehiclePlateNumber: pin.plateNumber,
+    vehicleStatus: pin.drivingStatus
+  };
+}
+
+function projectPositions(points: Array<{ key: string; latitude: number; longitude: number }>): Map<string, ProjectedPosition> {
+  const finitePoints = points.filter((point) => Number.isFinite(point.latitude) && Number.isFinite(point.longitude));
+  const latitudes = finitePoints.map((point) => point.latitude);
+  const longitudes = finitePoints.map((point) => point.longitude);
+  const minLat = Math.min(...latitudes);
+  const maxLat = Math.max(...latitudes);
+  const minLng = Math.min(...longitudes);
+  const maxLng = Math.max(...longitudes);
+  const latRange = maxLat - minLat;
+  const lngRange = maxLng - minLng;
+  const projected = new Map<string, ProjectedPosition>();
+
+  finitePoints.forEach((point, index) => {
+    const normalizedLng = lngRange === 0 ? 0.5 : (point.longitude - minLng) / lngRange;
+    const normalizedLat = latRange === 0 ? 0.5 : (point.latitude - minLat) / latRange;
+    projected.set(point.key, {
+      left: `${Math.round(20 + normalizedLng * 60)}%`,
+      top: `${Math.round(25 + (1 - normalizedLat) * 50)}%`
+    });
+
+    if (latRange === 0 && lngRange === 0) {
+      projected.set(point.key, { left: fallbackLeft(index), top: fallbackTop(index) });
+    }
+  });
+
+  return projected;
+}
+
+function fallbackLeft(index: number): string {
+  return `${34 + (index % 4) * 14}%`;
+}
+
+function fallbackTop(index: number): string {
+  return `${36 + (index % 3) * 12}%`;
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -5,6 +5,7 @@ import {
   ServiceOpsApiError,
   createServiceOpsApiClient,
   normalizeServiceOpsBaseUrl,
+  toFrontendDashboardMapState,
   toFrontendRider
 } from "./service-ops-api.ts";
 
@@ -125,6 +126,130 @@ test("HTTP error responses throw ServiceOpsApiError with status and backend code
       error.code === "RESOURCE_NOT_FOUND" &&
       error.message.includes("Rider not found")
   );
+});
+
+test("dashboard map-state request uses backend path and preserves station n/m labels", async () => {
+  const calls = [];
+  const responseBody = {
+    generatedAt: "2026-04-30T08:00:00Z",
+    summary: {
+      totalBikes: 3,
+      bikePinCount: 1,
+      onlineBikeCount: 1,
+      signalLostBikeCount: 0,
+      parkedOfflineBikeCount: 0,
+      lowBatteryBikeCount: 1,
+      activeStationCount: 1,
+      stationPinCount: 1,
+      availableBatteryCount: 5
+    },
+    bikePins: [
+      {
+        bikeId: "55555555-5555-4555-9555-555555555555",
+        bikeIdx: 5,
+        plateNumber: "서울T-2001",
+        modelName: "Thunder M1",
+        operationStatus: "IN_SERVICE",
+        activeRiderLabel: "김지도",
+        deviceId: "66666666-6666-4666-9666-666666666666",
+        lastReceivedAt: "2026-04-30T07:59:00Z",
+        latitude: 37.5007,
+        longitude: 127.0364,
+        speedKph: 12.3,
+        batteryPercent: 44,
+        ignitionStatus: "ON",
+        telemetrySource: "DEVICE_API",
+        drivingStatus: "DRIVING",
+        connectionStatus: "ONLINE",
+        batteryStatus: "LOW",
+        pinLabel: "서울T-2001 · 김지도"
+      }
+    ],
+    stationPins: [
+      {
+        stationId: "77777777-7777-4777-9777-777777777777",
+        stationIdx: 1,
+        name: "강남 스테이션",
+        address: "서울 강남구 테헤란로 1",
+        latitude: 37.501,
+        longitude: 127.037,
+        status: "ACTIVE",
+        maxBatteryCapacity: 12,
+        currentBatteryCount: 7,
+        availableBatteryCount: 5,
+        availableBatteryLabel: "5/12",
+        availableBatteryPercentage: 42,
+        pinLabel: "강남 스테이션 5/12"
+      }
+    ]
+  };
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify(responseBody), {
+        headers: { "content-type": "application/json" },
+        status: 200
+      });
+    }
+  });
+
+  const mapState = await client.getDashboardMapState();
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/dashboard/map-state");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(calls[0].init?.cache, "no-store");
+  assert.equal(mapState.stationPins[0].availableBatteryLabel, "5/12");
+  assert.equal(mapState.stationPins[0].pinLabel, "강남 스테이션 5/12");
+  assert.equal(mapState.bikePins[0].activeRiderLabel, "김지도");
+});
+
+test("toFrontendDashboardMapState keeps dashboard summary and avoids rider phone/id fields", () => {
+  const mapState = toFrontendDashboardMapState({
+    generatedAt: "2026-04-30T08:00:00Z",
+    summary: {
+      totalBikes: 1,
+      bikePinCount: 1,
+      onlineBikeCount: 1,
+      signalLostBikeCount: 0,
+      parkedOfflineBikeCount: 0,
+      lowBatteryBikeCount: 0,
+      activeStationCount: 0,
+      stationPinCount: 0,
+      availableBatteryCount: 0
+    },
+    bikePins: [
+      {
+        bikeId: "88888888-8888-4888-9888-888888888888",
+        bikeIdx: 8,
+        plateNumber: "서울T-3001",
+        modelName: "Thunder M1",
+        operationStatus: "READY",
+        activeRiderLabel: "라이더A",
+        deviceId: "99999999-9999-4999-9999-999999999999",
+        lastReceivedAt: "2026-04-30T07:59:00Z",
+        latitude: 37.5,
+        longitude: 127,
+        speedKph: 0,
+        batteryPercent: 88,
+        ignitionStatus: "OFF",
+        telemetrySource: "DEVICE_API",
+        drivingStatus: "PARKED",
+        connectionStatus: "ONLINE",
+        batteryStatus: "NORMAL",
+        pinLabel: "서울T-3001 · 라이더A"
+      }
+    ],
+    stationPins: []
+  });
+
+  assert.equal(mapState.summary.totalBikes, 1);
+  assert.equal(mapState.bikePins[0].slug, "88888888-8888-4888-9888-888888888888");
+  assert.equal("activeRiderId" in mapState.bikePins[0], false);
+  assert.equal("activeRiderPhoneNumber" in mapState.bikePins[0], false);
 });
 
 test("toFrontendRider maps backend UUID to route slug without exposing editable ids", () => {

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -75,10 +75,88 @@ export type RiderCreateInput = {
 
 export type RiderUpdateInput = Partial<RiderCreateInput>;
 
+export type ServiceOpsDashboardSummary = {
+  totalBikes: number;
+  bikePinCount: number;
+  onlineBikeCount: number;
+  signalLostBikeCount: number;
+  parkedOfflineBikeCount: number;
+  lowBatteryBikeCount: number;
+  activeStationCount: number;
+  stationPinCount: number;
+  availableBatteryCount: number;
+};
+
+export type ServiceOpsDashboardBikePin = {
+  bikeId: string;
+  bikeIdx: number | null;
+  plateNumber: string;
+  modelName: string;
+  operationStatus: string;
+  activeRiderLabel: string | null;
+  deviceId: string | null;
+  lastReceivedAt: string;
+  latitude: number | string;
+  longitude: number | string;
+  speedKph: number | string | null;
+  batteryPercent: number | string | null;
+  ignitionStatus: string;
+  telemetrySource: string;
+  drivingStatus: string;
+  connectionStatus: string;
+  batteryStatus: string;
+  pinLabel: string;
+};
+
+export type ServiceOpsDashboardStationPin = {
+  stationId: string;
+  stationIdx: number | null;
+  name: string;
+  address: string;
+  latitude: number | string;
+  longitude: number | string;
+  status: string;
+  maxBatteryCapacity: number;
+  currentBatteryCount: number;
+  availableBatteryCount: number;
+  availableBatteryLabel: string;
+  availableBatteryPercentage: number;
+  pinLabel: string;
+};
+
+export type ServiceOpsDashboardMapState = {
+  generatedAt: string;
+  summary: ServiceOpsDashboardSummary;
+  bikePins: ServiceOpsDashboardBikePin[];
+  stationPins: ServiceOpsDashboardStationPin[];
+};
+
+export type FrontendDashboardBikePin = Omit<ServiceOpsDashboardBikePin, "latitude" | "longitude" | "speedKph" | "batteryPercent"> & {
+  slug: string;
+  latitude: number;
+  longitude: number;
+  speedKph: number | null;
+  batteryPercent: number | null;
+};
+
+export type FrontendDashboardStationPin = Omit<ServiceOpsDashboardStationPin, "latitude" | "longitude"> & {
+  slug: string;
+  latitude: number;
+  longitude: number;
+};
+
+export type FrontendDashboardMapState = {
+  generatedAt: string;
+  summary: ServiceOpsDashboardSummary;
+  bikePins: FrontendDashboardBikePin[];
+  stationPins: FrontendDashboardStationPin[];
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
+  getDashboardMapState: () => Promise<FrontendDashboardMapState>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -200,6 +278,8 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     logout: async () => {
       await request<void>("/auth/logout", { method: "POST" });
     },
+    getDashboardMapState: async () =>
+      toFrontendDashboardMapState(await request<ServiceOpsDashboardMapState>("/dashboard/map-state", { method: "GET" })),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {
@@ -222,6 +302,27 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       )
+  };
+}
+
+export function toFrontendDashboardMapState(mapState: ServiceOpsDashboardMapState): FrontendDashboardMapState {
+  return {
+    generatedAt: mapState.generatedAt,
+    summary: mapState.summary,
+    bikePins: mapState.bikePins.map((pin) => ({
+      ...pin,
+      batteryPercent: toNullableNumber(pin.batteryPercent),
+      latitude: toNumber(pin.latitude),
+      longitude: toNumber(pin.longitude),
+      slug: pin.bikeId,
+      speedKph: toNullableNumber(pin.speedKph)
+    })),
+    stationPins: mapState.stationPins.map((pin) => ({
+      ...pin,
+      latitude: toNumber(pin.latitude),
+      longitude: toNumber(pin.longitude),
+      slug: pin.stationId
+    }))
   };
 }
 
@@ -266,6 +367,18 @@ function isApiErrorBody(value: unknown): value is ApiErrorBody {
 function normalizeDisplayText(value: string | null | undefined, fallback: string): string {
   const trimmed = value?.trim();
   return trimmed ? trimmed : fallback;
+}
+
+function toNumber(value: number | string): number {
+  return typeof value === "number" ? value : Number(value);
+}
+
+function toNullableNumber(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return toNumber(value);
 }
 
 function toDateOnly(value: string | null | undefined): string {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -613,3 +613,24 @@ Verification:
 
 - TDD red observed on the frontend service-ops API test before implementation because the client module did not exist.
 - Frontend service-ops client tests cover base URL normalization, Bearer list fetch, create payload system-field exclusion, backend error mapping, and UUID-to-route mapping.
+
+## Dashboard map-state frontend integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#74
+- Target issue: EVNSolution/thundercrew-domain#61
+- Branch: `cc-74-dashboard-mapstate-frontend`
+
+Issue-size decision:
+
+- This slice wires the existing Next.js dashboard map-control page to the existing service-ops-api `GET /api/v1/dashboard/map-state` read endpoint.
+- Included work is a frontend client method, dashboard data adapter, and `ControlMap` prop injection with explicit mock fallback.
+- Backend endpoint/schema changes, map SDK integration, token refresh/logout UX, other domain tab integrations, TimescaleDB/retention/archive, and production Vercel env mutation remain out of scope.
+
+Boundary decision:
+
+- `ControlMap` receives a UI-specific `ControlMapData` shape and does not depend directly on backend DTOs or mock-data globals.
+- Backend map-state station `pinLabel`/`availableBatteryLabel` is preserved so station markers show `name available/max`.
+- Backend map-state intentionally excludes rider phone/raw rider IDs; service-ops mode therefore shows rider info in the map panel but does not fabricate rider-detail links.
+- Missing config/session/API failure falls back to mock map data with a visible notice.


### PR DESCRIPTION
## Trace

- Change-control: EVNSolution/clever-change-control#74
- Target issue: Closes #61
- Branch: `cc-74-dashboard-mapstate-frontend`
- Base: `dev`

## Summary

- Adds dashboard map-state support to the existing service-ops API client.
- Adds a dashboard data adapter that returns UI-specific `ControlMapData` with explicit mock fallback.
- Updates `/dashboard` to load map data server-side and pass it into `ControlMap`.
- Preserves the current search panel, detail panel, map pin UX, and station `name n/m` labels.
- Avoids fabricating rider detail links or rider raw IDs from the map-state endpoint.
- Updates docs/change ledger.

## Concurrent-work gate

Decision: `allowed-with-non-overlap`.

Evidence before PR:
- Target open issues: #61 only.
- Target open PRs: none.
- Target remote heads: `main`, `dev`, `cc-74-dashboard-mapstate-frontend`.

## Verification

- TDD RED observed: `npm run test:service-ops --workspace @thundercrew/front-admin-web` failed before dashboard map-state client export existed.
- `npm run check:workspace` pass.
- `npm run lint` pass.
- `npm run test:service-ops` pass (7/7).
- `npm run typecheck` pass.
- `npm run build` pass.
- `(cd development/service-ops-api && ./gradlew test)` pass.
- `(cd development/service-ops-api && ./gradlew build)` pass.
- `/dashboard` smoke with `SERVICE_OPS_API_BASE_URL` unset confirms visible mock fallback notice and station `name n/m` labels.
- Code review PASS.

## Deferred / not tested

- Live dashboard rendering with a valid service-ops session and populated backend map-state data.
- Token refresh retry/logout UI.
- Real map SDK integration.
- Vercel environment variable changes.
