### PR TITLE
Frontend admin session refresh/logout baseline (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,13 @@ Frontend ↔ backend baseline:
 
 - `SERVICE_OPS_API_BASE_URL`이 설정되면 Next.js server actions/components가
   `development/service-ops-api`의 `/api/v1`을 호출합니다.
-- 관리자 로그인은 service-ops JWT를 HTTP-only 쿠키에 저장하고, 라이더 목록/상세/등록/수정
-  server action은 해당 쿠키에서 Bearer token을 붙입니다.
+- 관리자 로그인은 service-ops JWT access/refresh token을 HTTP-only 쿠키에 저장하고,
+  localStorage, URL, rendered HTML, editable form field에 토큰을 노출하지 않습니다.
+- refresh-token 쿠키가 남아 있고 access-token 쿠키가 만료된 server action 경로는
+  `POST /api/v1/auth/refresh`로 세션 쿠키를 회전할 수 있습니다.
+- 사이드바 로그아웃은 `POST /api/v1/auth/logout` 호출을 시도한 뒤, API 실패 여부와
+  관계없이 로컬 HTTP-only 쿠키를 제거합니다.
+- 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -69,7 +69,9 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 ## Backend API integration baseline
 
 - `SERVICE_OPS_API_BASE_URL`이 설정되면 `/login`은 `POST /api/v1/auth/login`으로 관리자 인증을 수행합니다.
-- access/refresh token은 localStorage, URL, rendered HTML에 두지 않고 HTTP-only cookie로 저장합니다.
+- access/refresh token은 localStorage, URL, rendered HTML, editable form field에 두지 않고 HTTP-only cookie로 저장합니다.
+- access-token cookie가 없고 refresh-token cookie가 남아 있는 server action은 `/api/v1/auth/refresh`로 cookie를 회전할 수 있습니다.
+- 좌측 sidebar의 관리자 로그아웃은 `/api/v1/auth/logout`을 Bearer access token으로 호출하고, backend 호출 실패 시에도 local HTTP-only cookie를 삭제합니다.
 - 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -156,7 +156,8 @@ textarea { padding-top: 10px; min-height: 96px; }
   .table-card { overflow-x: auto; }
 }
 
-.theme-toggle { width: 100%; border: 0; text-align: left; background: transparent; cursor: pointer; }
+.theme-toggle, .sidebar-button { width: 100%; border: 0; text-align: left; background: transparent; cursor: pointer; }
+.sidebar-action-form { margin: 0; }
 :root[data-theme="dark"] .map-background::before { background: radial-gradient(circle at 30% 22%, rgba(12,239,211,.16), transparent 26%), radial-gradient(circle at 72% 58%, rgba(12,239,211,.09), transparent 24%); }
 
 .map-search-panel {

--- a/development/front-admin-web/app/login/actions.ts
+++ b/development/front-admin-web/app/login/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@supabase/supabase-js";
 import { createServiceOpsApiClient, serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
-import { setServiceOpsSession } from "@/lib/services/service-ops-session";
+import { logoutServiceOpsSession, setServiceOpsSession } from "@/lib/services/service-ops-session";
 
 export async function signInAdmin(formData: FormData) {
   const loginId = String(formData.get("loginId") ?? formData.get("email") ?? "").trim();
@@ -43,4 +43,10 @@ export async function signInAdmin(formData: FormData) {
   }
 
   redirect("/dashboard?auth=supabase");
+}
+
+
+export async function signOutAdmin() {
+  await logoutServiceOpsSession();
+  redirect("/login?status=signed-out");
 }

--- a/development/front-admin-web/app/login/page.tsx
+++ b/development/front-admin-web/app/login/page.tsx
@@ -7,7 +7,8 @@ const statusMessage: Record<string, string> = {
   "auth-error": "로그인에 실패했습니다. 테스트 관리자 이메일/비밀번호를 확인하세요.",
   "missing-credentials": "로그인 ID와 비밀번호를 입력하세요.",
   "service-ops-auth-error": "서비스 API 로그인에 실패했습니다. 백엔드 관리자 계정을 확인하세요.",
-  "session-required": "서비스 API 세션이 필요합니다. 다시 로그인하세요."
+  "session-required": "서비스 API 세션이 필요합니다. 다시 로그인하세요.",
+  "signed-out": "관리자 세션이 종료되었습니다."
 };
 
 export default async function LoginPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {

--- a/development/front-admin-web/app/riders/actions.ts
+++ b/development/front-admin-web/app/riders/actions.ts
@@ -11,7 +11,7 @@ export async function createRiderAction(formData: FormData): Promise<void> {
     redirect("/riders?status=mock-saved");
   }
 
-  const client = await createAuthenticatedServiceOpsApiClient();
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
     redirect("/login?status=session-required");
   }
@@ -32,7 +32,7 @@ export async function updateRiderAction(riderId: string, formData: FormData): Pr
     redirect(`/riders/${riderId}?status=mock-saved`);
   }
 
-  const client = await createAuthenticatedServiceOpsApiClient();
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
     redirect("/login?status=session-required");
   }

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { SidebarToggle } from "@/components/layout/SidebarToggle";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
+import { signOutAdmin } from "@/app/login/actions";
+import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
 
 const operationsItems = [
   { href: "/vehicles", label: "차량 관리", icon: "EV" },
@@ -11,7 +13,9 @@ const operationsItems = [
   { href: "/stations", label: "스테이션 관리", icon: "S" }
 ];
 
-export function AppShell({ children }: { children: ReactNode }) {
+export async function AppShell({ children }: { children: ReactNode }) {
+  const serviceOpsSessionActive = await serviceOpsSessionReady();
+
   return (
     <div className="app-frame">
       <aside className="sidebar" aria-label="주요 메뉴">
@@ -46,10 +50,19 @@ export function AppShell({ children }: { children: ReactNode }) {
             <span className="sidebar-icon">⚙</span>
             <span className="sidebar-label">설정</span>
           </Link>
-          <Link className="sidebar-link" href="/login" title="관리자 로그인">
-            <span className="sidebar-icon">↗</span>
-            <span className="sidebar-label">관리자 로그인</span>
-          </Link>
+          {serviceOpsSessionActive ? (
+            <form action={signOutAdmin} className="sidebar-action-form">
+              <button className="sidebar-link sidebar-button" type="submit" title="관리자 로그아웃">
+                <span className="sidebar-icon">↙</span>
+                <span className="sidebar-label">관리자 로그아웃</span>
+              </button>
+            </form>
+          ) : (
+            <Link className="sidebar-link" href="/login" title="관리자 로그인">
+              <span className="sidebar-icon">↗</span>
+              <span className="sidebar-label">관리자 로그인</span>
+            </Link>
+          )}
         </div>
       </aside>
       <main className="app-main">{children}</main>

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -128,6 +128,71 @@ test("HTTP error responses throw ServiceOpsApiError with status and backend code
   );
 });
 
+
+
+test("refresh request posts refresh token without bearer token", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          accessToken: "new-access-token",
+          admin: {
+            displayName: "운영자",
+            email: "admin@example.com",
+            id: "admin-id",
+            loginId: "admin",
+            role: "ADMIN"
+          },
+          expiresAt: "2026-04-30T09:30:00Z",
+          refreshExpiresAt: "2026-05-30T09:30:00Z",
+          refreshToken: "new-refresh-token",
+          tokenType: "Bearer"
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const response = await client.refresh({ refreshToken: "old-refresh-token" });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  const headers = new Headers(calls[0].init?.headers);
+  assert.equal(url.pathname, "/api/v1/auth/refresh");
+  assert.equal(calls[0].init?.method, "POST");
+  assert.equal(calls[0].init?.cache, "no-store");
+  assert.equal(headers.get("authorization"), null);
+  assert.equal(headers.get("content-type"), "application/json");
+  assert.deepEqual(JSON.parse(String(calls[0].init?.body)), { refreshToken: "old-refresh-token" });
+  assert.equal(response.accessToken, "new-access-token");
+});
+
+test("logout request posts with bearer token and accepts empty success responses", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }
+  });
+
+  await client.logout();
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  const headers = new Headers(calls[0].init?.headers);
+  assert.equal(url.pathname, "/api/v1/auth/logout");
+  assert.equal(calls[0].init?.method, "POST");
+  assert.equal(calls[0].init?.cache, "no-store");
+  assert.equal(headers.get("authorization"), "Bearer access-token");
+  assert.equal(headers.get("content-type"), null);
+});
+
 test("dashboard map-state request uses backend path and preserves station n/m labels", async () => {
   const calls = [];
   const responseBody = {

--- a/development/front-admin-web/lib/services/service-ops-session-core.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-session-core.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SERVICE_OPS_ACCESS_TOKEN_COOKIE,
+  SERVICE_OPS_REFRESH_TOKEN_COOKIE,
+  clearServiceOpsSessionCookies,
+  logoutServiceOpsSessionCookies,
+  readServiceOpsSessionTokens,
+  refreshServiceOpsSessionCookies,
+  setServiceOpsSessionCookies
+} from "./service-ops-session-core.ts";
+
+function memoryCookieStore(initial = {}) {
+  const jar = new Map(Object.entries(initial).map(([name, value]) => [name, { value }]));
+  const operations = [];
+
+  return {
+    operations,
+    delete(name) {
+      operations.push({ name, type: "delete" });
+      jar.delete(name);
+    },
+    get(name) {
+      return jar.get(name);
+    },
+    set(name, value, options) {
+      operations.push({ name, options, type: "set", value });
+      jar.set(name, { options, value });
+    },
+    value(name) {
+      return jar.get(name)?.value ?? null;
+    }
+  };
+}
+
+const authResponse = {
+  accessToken: "new-access-token",
+  admin: {
+    displayName: "운영자",
+    email: "admin@example.com",
+    id: "admin-1",
+    loginId: "admin",
+    role: "ADMIN"
+  },
+  expiresAt: "2026-04-30T09:30:00.000Z",
+  refreshExpiresAt: "2026-05-30T09:30:00.000Z",
+  refreshToken: "new-refresh-token",
+  tokenType: "Bearer"
+};
+
+test("setServiceOpsSessionCookies writes access and refresh tokens as HTTP-only secure cookies", () => {
+  const cookieStore = memoryCookieStore();
+
+  setServiceOpsSessionCookies(cookieStore, authResponse, { secure: true });
+
+  assert.equal(cookieStore.value(SERVICE_OPS_ACCESS_TOKEN_COOKIE), "new-access-token");
+  assert.equal(cookieStore.value(SERVICE_OPS_REFRESH_TOKEN_COOKIE), "new-refresh-token");
+  const accessSet = cookieStore.operations.find((operation) => operation.name === SERVICE_OPS_ACCESS_TOKEN_COOKIE);
+  const refreshSet = cookieStore.operations.find((operation) => operation.name === SERVICE_OPS_REFRESH_TOKEN_COOKIE);
+  assert.equal(accessSet.options.httpOnly, true);
+  assert.equal(accessSet.options.secure, true);
+  assert.equal(accessSet.options.sameSite, "lax");
+  assert.equal(accessSet.options.path, "/");
+  assert.equal(accessSet.options.expires.toISOString(), "2026-04-30T09:30:00.000Z");
+  assert.equal(refreshSet.options.expires.toISOString(), "2026-05-30T09:30:00.000Z");
+});
+
+test("refreshServiceOpsSessionCookies rotates cookies using only the stored refresh token", async () => {
+  const cookieStore = memoryCookieStore({ [SERVICE_OPS_REFRESH_TOKEN_COOKIE]: "old-refresh-token" });
+  const refreshRequests = [];
+  const client = {
+    async refresh(request) {
+      refreshRequests.push(request);
+      return authResponse;
+    }
+  };
+
+  const refreshed = await refreshServiceOpsSessionCookies(cookieStore, client, { secure: false });
+
+  assert.equal(refreshed, true);
+  assert.deepEqual(refreshRequests, [{ refreshToken: "old-refresh-token" }]);
+  assert.equal(cookieStore.value(SERVICE_OPS_ACCESS_TOKEN_COOKIE), "new-access-token");
+  assert.equal(cookieStore.value(SERVICE_OPS_REFRESH_TOKEN_COOKIE), "new-refresh-token");
+  assert.equal(readServiceOpsSessionTokens(cookieStore).accessToken, "new-access-token");
+});
+
+test("refreshServiceOpsSessionCookies clears both cookies when backend refresh fails", async () => {
+  const cookieStore = memoryCookieStore({
+    [SERVICE_OPS_ACCESS_TOKEN_COOKIE]: "old-access-token",
+    [SERVICE_OPS_REFRESH_TOKEN_COOKIE]: "old-refresh-token"
+  });
+  const client = {
+    async refresh() {
+      throw new Error("refresh rejected");
+    }
+  };
+
+  const refreshed = await refreshServiceOpsSessionCookies(cookieStore, client, { secure: false });
+
+  assert.equal(refreshed, false);
+  assert.equal(cookieStore.value(SERVICE_OPS_ACCESS_TOKEN_COOKIE), null);
+  assert.equal(cookieStore.value(SERVICE_OPS_REFRESH_TOKEN_COOKIE), null);
+  assert.deepEqual(
+    cookieStore.operations.filter((operation) => operation.type === "delete").map((operation) => operation.name),
+    [SERVICE_OPS_ACCESS_TOKEN_COOKIE, SERVICE_OPS_REFRESH_TOKEN_COOKIE]
+  );
+});
+
+test("logoutServiceOpsSessionCookies clears local cookies even when backend logout fails", async () => {
+  const cookieStore = memoryCookieStore({
+    [SERVICE_OPS_ACCESS_TOKEN_COOKIE]: "access-token",
+    [SERVICE_OPS_REFRESH_TOKEN_COOKIE]: "refresh-token"
+  });
+  const logoutTokens = [];
+
+  await logoutServiceOpsSessionCookies(cookieStore, {
+    configured: true,
+    createClient(accessToken) {
+      logoutTokens.push(accessToken);
+      return {
+        async logout() {
+          throw new Error("backend logout unavailable");
+        }
+      };
+    }
+  });
+
+  assert.deepEqual(logoutTokens, ["access-token"]);
+  assert.equal(cookieStore.value(SERVICE_OPS_ACCESS_TOKEN_COOKIE), null);
+  assert.equal(cookieStore.value(SERVICE_OPS_REFRESH_TOKEN_COOKIE), null);
+});
+
+test("clearServiceOpsSessionCookies deletes access and refresh cookies without exposing ids", () => {
+  const cookieStore = memoryCookieStore({
+    [SERVICE_OPS_ACCESS_TOKEN_COOKIE]: "access-token",
+    [SERVICE_OPS_REFRESH_TOKEN_COOKIE]: "refresh-token"
+  });
+
+  clearServiceOpsSessionCookies(cookieStore);
+
+  assert.deepEqual(cookieStore.operations, [
+    { name: SERVICE_OPS_ACCESS_TOKEN_COOKIE, type: "delete" },
+    { name: SERVICE_OPS_REFRESH_TOKEN_COOKIE, type: "delete" }
+  ]);
+});

--- a/development/front-admin-web/lib/services/service-ops-session-core.ts
+++ b/development/front-admin-web/lib/services/service-ops-session-core.ts
@@ -1,0 +1,107 @@
+import type { ServiceOpsApiClient, ServiceOpsAuthResponse } from "./service-ops-api";
+
+export const SERVICE_OPS_ACCESS_TOKEN_COOKIE = "thundercrew_ops_access_token";
+export const SERVICE_OPS_REFRESH_TOKEN_COOKIE = "thundercrew_ops_refresh_token";
+
+export type ServiceOpsSessionCookieOptions = {
+  expires: Date;
+  httpOnly: true;
+  path: "/";
+  sameSite: "lax";
+  secure: boolean;
+};
+
+export type ServiceOpsSessionCookieStore = {
+  get: (name: string) => { value: string } | undefined;
+  set: (name: string, value: string, options: ServiceOpsSessionCookieOptions) => void;
+  delete: (name: string) => void;
+};
+
+export type ServiceOpsSessionCookieSecurity = {
+  secure: boolean;
+};
+
+export type ServiceOpsSessionTokens = {
+  accessToken: string | null;
+  refreshToken: string | null;
+};
+
+export type ServiceOpsLogoutOptions = {
+  configured: boolean;
+  createClient: (accessToken: string) => Pick<ServiceOpsApiClient, "logout">;
+};
+
+export function readServiceOpsSessionTokens(cookieStore: Pick<ServiceOpsSessionCookieStore, "get">): ServiceOpsSessionTokens {
+  return {
+    accessToken: cookieStore.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value ?? null,
+    refreshToken: cookieStore.get(SERVICE_OPS_REFRESH_TOKEN_COOKIE)?.value ?? null
+  };
+}
+
+export function setServiceOpsSessionCookies(
+  cookieStore: ServiceOpsSessionCookieStore,
+  auth: ServiceOpsAuthResponse,
+  { secure }: ServiceOpsSessionCookieSecurity
+): void {
+  cookieStore.set(SERVICE_OPS_ACCESS_TOKEN_COOKIE, auth.accessToken, serviceOpsCookieOptions(auth.expiresAt, secure));
+  cookieStore.set(SERVICE_OPS_REFRESH_TOKEN_COOKIE, auth.refreshToken, serviceOpsCookieOptions(auth.refreshExpiresAt, secure));
+}
+
+export function clearServiceOpsSessionCookies(cookieStore: Pick<ServiceOpsSessionCookieStore, "delete">): void {
+  cookieStore.delete(SERVICE_OPS_ACCESS_TOKEN_COOKIE);
+  cookieStore.delete(SERVICE_OPS_REFRESH_TOKEN_COOKIE);
+}
+
+export async function refreshServiceOpsSessionCookies(
+  cookieStore: ServiceOpsSessionCookieStore,
+  client: Pick<ServiceOpsApiClient, "refresh">,
+  security: ServiceOpsSessionCookieSecurity
+): Promise<boolean> {
+  const { refreshToken } = readServiceOpsSessionTokens(cookieStore);
+
+  if (!refreshToken) {
+    return false;
+  }
+
+  try {
+    const auth = await client.refresh({ refreshToken });
+    setServiceOpsSessionCookies(cookieStore, auth, security);
+    return true;
+  } catch {
+    clearServiceOpsSessionCookies(cookieStore);
+    return false;
+  }
+}
+
+export async function logoutServiceOpsSessionCookies(
+  cookieStore: ServiceOpsSessionCookieStore,
+  { configured, createClient }: ServiceOpsLogoutOptions
+): Promise<void> {
+  const { accessToken } = readServiceOpsSessionTokens(cookieStore);
+
+  try {
+    if (configured && accessToken) {
+      await createClient(accessToken).logout();
+    }
+  } catch {
+    // Local cookie cleanup is the source of truth for browser logout. Backend logout failures
+    // should not leave an operator stuck with stale HTTP-only cookies.
+  } finally {
+    clearServiceOpsSessionCookies(cookieStore);
+  }
+}
+
+function serviceOpsCookieOptions(expiresAt: string, secure: boolean): ServiceOpsSessionCookieOptions {
+  return {
+    expires: parseCookieExpires(expiresAt),
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secure
+  };
+}
+
+function parseCookieExpires(value: string): Date {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date(Date.now() + 30 * 60 * 1000) : parsed;
+}

--- a/development/front-admin-web/lib/services/service-ops-session.ts
+++ b/development/front-admin-web/lib/services/service-ops-session.ts
@@ -6,16 +6,40 @@ import {
   createServiceOpsApiClient,
   serviceOpsApiConfigured
 } from "./service-ops-api";
+import {
+  clearServiceOpsSessionCookies,
+  logoutServiceOpsSessionCookies,
+  readServiceOpsSessionTokens,
+  refreshServiceOpsSessionCookies,
+  setServiceOpsSessionCookies
+} from "./service-ops-session-core";
 
-const ACCESS_TOKEN_COOKIE = "thundercrew_ops_access_token";
-const REFRESH_TOKEN_COOKIE = "thundercrew_ops_refresh_token";
+export type CreateAuthenticatedServiceOpsApiClientOptions = {
+  refreshIfMissing?: boolean;
+};
 
-export async function createAuthenticatedServiceOpsApiClient(): Promise<ServiceOpsApiClient | null> {
+export async function createAuthenticatedServiceOpsApiClient({
+  refreshIfMissing = false
+}: CreateAuthenticatedServiceOpsApiClientOptions = {}): Promise<ServiceOpsApiClient | null> {
   if (!serviceOpsApiConfigured()) {
     return null;
   }
 
-  const accessToken = await getServiceOpsAccessToken();
+  const cookieStore = await cookies();
+  let { accessToken } = readServiceOpsSessionTokens(cookieStore);
+
+  if (!accessToken && refreshIfMissing) {
+    const refreshed = await refreshServiceOpsSessionCookies(cookieStore, createServiceOpsApiClient(), {
+      secure: serviceOpsCookieSecure()
+    });
+
+    if (!refreshed) {
+      return null;
+    }
+
+    accessToken = readServiceOpsSessionTokens(cookieStore).accessToken;
+  }
+
   if (!accessToken) {
     return null;
   }
@@ -25,40 +49,54 @@ export async function createAuthenticatedServiceOpsApiClient(): Promise<ServiceO
 
 export async function getServiceOpsAccessToken(): Promise<string | null> {
   const cookieStore = await cookies();
-  return cookieStore.get(ACCESS_TOKEN_COOKIE)?.value ?? null;
+  return readServiceOpsSessionTokens(cookieStore).accessToken;
+}
+
+export async function getServiceOpsRefreshToken(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return readServiceOpsSessionTokens(cookieStore).refreshToken;
 }
 
 export async function serviceOpsSessionReady(): Promise<boolean> {
-  return serviceOpsApiConfigured() && Boolean(await getServiceOpsAccessToken());
+  if (!serviceOpsApiConfigured()) {
+    return false;
+  }
+
+  const cookieStore = await cookies();
+  const { accessToken, refreshToken } = readServiceOpsSessionTokens(cookieStore);
+  return Boolean(accessToken || refreshToken);
+}
+
+export async function refreshServiceOpsSession(): Promise<boolean> {
+  if (!serviceOpsApiConfigured()) {
+    await clearServiceOpsSession();
+    return false;
+  }
+
+  const cookieStore = await cookies();
+  return refreshServiceOpsSessionCookies(cookieStore, createServiceOpsApiClient(), {
+    secure: serviceOpsCookieSecure()
+  });
 }
 
 export async function setServiceOpsSession(auth: ServiceOpsAuthResponse): Promise<void> {
   const cookieStore = await cookies();
-  const secure = process.env.NODE_ENV === "production";
-
-  cookieStore.set(ACCESS_TOKEN_COOKIE, auth.accessToken, {
-    expires: parseCookieExpires(auth.expiresAt),
-    httpOnly: true,
-    path: "/",
-    sameSite: "lax",
-    secure
-  });
-  cookieStore.set(REFRESH_TOKEN_COOKIE, auth.refreshToken, {
-    expires: parseCookieExpires(auth.refreshExpiresAt),
-    httpOnly: true,
-    path: "/",
-    sameSite: "lax",
-    secure
-  });
+  setServiceOpsSessionCookies(cookieStore, auth, { secure: serviceOpsCookieSecure() });
 }
 
 export async function clearServiceOpsSession(): Promise<void> {
   const cookieStore = await cookies();
-  cookieStore.delete(ACCESS_TOKEN_COOKIE);
-  cookieStore.delete(REFRESH_TOKEN_COOKIE);
+  clearServiceOpsSessionCookies(cookieStore);
 }
 
-function parseCookieExpires(value: string): Date {
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? new Date(Date.now() + 30 * 60 * 1000) : parsed;
+export async function logoutServiceOpsSession(): Promise<void> {
+  const cookieStore = await cookies();
+  await logoutServiceOpsSessionCookies(cookieStore, {
+    configured: serviceOpsApiConfigured(),
+    createClient: (accessToken) => createServiceOpsApiClient({ accessToken })
+  });
+}
+
+function serviceOpsCookieSecure(): boolean {
+  return process.env.NODE_ENV === "production";
 }

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -634,3 +634,30 @@ Boundary decision:
 - Backend map-state station `pinLabel`/`availableBatteryLabel` is preserved so station markers show `name available/max`.
 - Backend map-state intentionally excludes rider phone/raw rider IDs; service-ops mode therefore shows rider info in the map panel but does not fabricate rider-detail links.
 - Missing config/session/API failure falls back to mock map data with a visible notice.
+
+
+## Frontend admin session refresh/logout baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#76
+- Target issue: EVNSolution/thundercrew-domain#63
+- Branch: `cc-76-admin-session-refresh-logout`
+
+Issue-size decision:
+
+- This slice connects the existing backend auth refresh/logout contract to the Next.js admin shell.
+- Included work is a frontend session-cookie core, refresh helper for server-action paths, sidebar logout server action/control, service-ops API client tests, and docs updates.
+- Backend endpoint/schema changes, full route-protection middleware, RBAC/profile UI, browser localStorage/sessionStorage token handling, Vercel env mutation, and other domain API integrations remain out of scope.
+
+Boundary decision:
+
+- Service-ops tokens remain server-side HTTP-only cookies; they are not placed in URLs, localStorage/sessionStorage, rendered HTML, or editable form fields.
+- Refresh rotation is exposed through server-side helpers and used only on mutation/server-action paths where cookies may be rewritten safely.
+- Logout attempts backend revocation when an access-token cookie is present, but local cookie deletion is guaranteed even if the backend call fails.
+- Supabase fallback stays available when `SERVICE_OPS_API_BASE_URL` is missing or placeholder-like.
+
+Verification:
+
+- TDD red observed on `service-ops-session-core.test.mjs` before implementation because the session core module did not exist.
+- Frontend service-ops tests cover refresh request shape, logout Bearer request shape, cookie rotation, refresh-failure cleanup, and logout-failure cleanup.


### PR DESCRIPTION
## Summary

- Adds a frontend-only service-ops session-cookie core for admin access/refresh token rotation and cleanup.
- Wires sidebar logout through a server action that attempts backend `/api/v1/auth/logout` and always clears local HTTP-only cookies.
- Extends service-ops frontend tests for refresh/logout request shapes, cookie rotation, refresh failure cleanup, and logout failure cleanup.
- Updates README/front README/change ledger for the refresh/logout boundary.

## Boundary

- Tokens stay in HTTP-only cookies only; they are not stored in localStorage/sessionStorage, URLs, rendered HTML, or editable form fields.
- Refresh rotation is exposed via server-side helpers and used by mutation/server-action paths where cookies can be rewritten safely.
- Supabase fallback remains when `SERVICE_OPS_API_BASE_URL` is missing or placeholder-like.
- No backend endpoint/schema changes, route middleware, RBAC/profile UI, Vercel env mutation, or other domain API integrations are included.

## Change-control

- Change request: EVNSolution/clever-change-control#76
- Target issue: Closes #63
- Branch: `cc-76-admin-session-refresh-logout`
- Final concurrent-work decision: allowed-with-non-overlap; no open target PRs when the branch was prepared and this slice touches only frontend session/logout surfaces plus docs.

## Verification

- `npm run check:workspace` pass
- `npm run lint` pass
- `npm run test:service-ops` pass (14/14)
- `npm run typecheck` pass
- `npm run build` pass
- `(cd development/service-ops-api && ./gradlew test)` pass
- `(cd development/service-ops-api && ./gradlew build)` pass
- code-reviewer PASS

## Not tested

- Live browser logout against a running deployed service-ops-api; production service env/session credentials were not changed in this issue.
