### PR TITLE
Frontend vehicle admin API integration baseline (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Frontend ↔ backend baseline:
 - 사이드바 로그아웃은 `POST /api/v1/auth/logout` 호출을 시도한 뒤, API 실패 여부와
   관계없이 로컬 HTTP-only 쿠키를 제거합니다.
 - 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -73,6 +73,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - access-token cookie가 없고 refresh-token cookie가 남아 있는 server action은 `/api/v1/auth/refresh`로 cookie를 회전할 수 있습니다.
 - 좌측 sidebar의 관리자 로그아웃은 `/api/v1/auth/logout`을 Bearer access token으로 호출하고, backend 호출 실패 시에도 local HTTP-only cookie를 삭제합니다.
 - 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경은 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다.
+- 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.

--- a/development/front-admin-web/app/vehicles/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/edit/page.tsx
@@ -1,3 +1,46 @@
+import { notFound } from "next/navigation";
+
+import { updateVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { VehicleForm } from "@/components/vehicles/VehicleForm";
-export default async function EditVehiclePage({ params }: { params: Promise<{ slug: string }> }) { const { slug } = await params; return <div className="page-container"><PageHeader title="차량 수정" description="상태와 라이더 배정을 선택형 입력으로 수정합니다." /><VehicleForm mode="수정" cancelHref={`/vehicles/${slug}`} /></div>; }
+import { loadVehicleDetail } from "@/lib/services/vehicle-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "차량 수정에 실패했습니다. 필수값, 중복 차량번호/VIN, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditVehiclePage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadVehicleDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const updateAction = updateVehicleAction.bind(null, slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="차량 수정" description="차량 기본 정보만 수정합니다. 차체 상태 변경은 상세 화면의 전용 상태 변경 영역을 사용합니다." />
+      <VehicleForm
+        action={updateAction}
+        cancelHref={`/vehicles/${slug}`}
+        defaultValues={{
+          memo: detail.vehicle.memo,
+          model: detail.vehicle.model,
+          operationStatus: detail.vehicle.operationStatus,
+          plateNumber: detail.vehicle.plateNumber,
+          vin: detail.vehicle.vin
+        }}
+        mode="수정"
+        statusMessage={status ? statusMessage[status] : null}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/vehicles/[slug]/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/page.tsx
@@ -1,28 +1,79 @@
-import { PageHeader } from "@/components/layout/PageHeader";
-import { Badge } from "@/components/ui/Badge";
-import { DetailActionPanel } from "@/components/ui/MockActions";
-import { vehicles } from "@/lib/services/mock-data";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 
-export default async function VehicleDetailPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  const vehicle = vehicles.find((v) => v.slug === slug) ?? vehicles[0];
+import { changeVehicleOperationStatusAction } from "@/app/vehicles/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { vehicleStatusOptions } from "@/components/vehicles/VehicleForm";
+import { Badge } from "@/components/ui/Badge";
+import { Field } from "@/components/ui/FormField";
+import { loadVehicleDetail } from "@/lib/services/vehicle-data";
+
+const statusMessage: Record<string, string> = {
+  created: "차량이 등록되었습니다.",
+  updated: "차량 기본 정보가 수정되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 차량 화면으로 돌아왔습니다.",
+  "mock-status-updated": "서비스 API가 연결되지 않아 상태 변경을 mock 피드백으로만 처리했습니다.",
+  "status-updated": "차량 차체 상태가 변경되었습니다.",
+  "status-error": "차량 상태 변경에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function VehicleDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadVehicleDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const vehicle = detail.vehicle;
+  const message = status ? statusMessage[status] : null;
+  const changeStatusAction = changeVehicleOperationStatusAction.bind(null, vehicle.slug);
 
   return (
     <div className="page-container">
-      <PageHeader title={vehicle.plateNumber} description="차량 상세, 상태 변경, 라이더 배정 화면입니다." actionHref={`/vehicles/${vehicle.slug}/edit`} actionLabel="수정" />
+      <PageHeader title={vehicle.plateNumber} description="차량 상세, 기본 정보와 차체 상태 변경 화면입니다." actionHref={`/vehicles/${vehicle.slug}/edit`} actionLabel="수정" />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
       <section className="content-grid">
         <div className="card">
           <h2>차량 정보</h2>
           <div className="detail-list">
             <div className="detail-row"><span>모델</span><strong>{vehicle.model}</strong></div>
-            <div className="detail-row"><span>상태</span><Badge>{vehicle.status}</Badge></div>
+            <div className="detail-row"><span>차대번호/VIN</span><strong>{vehicle.vin ?? "미입력"}</strong></div>
+            <div className="detail-row"><span>차체 상태</span><Badge>{vehicle.status}</Badge></div>
             <div className="detail-row"><span>배정</span><strong>{vehicle.riderName ?? vehicle.assignmentStatus}</strong></div>
-            <div className="detail-row"><span>배터리</span><strong>{vehicle.batteryPercent}%</strong></div>
+            <div className="detail-row"><span>배터리</span><strong>{vehicle.batteryPercent === null ? "관제 API 후속" : `${vehicle.batteryPercent}%`}</strong></div>
             <div className="detail-row"><span>위치</span><strong>{vehicle.locationLabel}</strong></div>
+            <div className="detail-row"><span>최근 수정</span><strong>{vehicle.lastSeenAt}</strong></div>
+            {vehicle.memo ? <div className="detail-row"><span>메모</span><strong>{vehicle.memo}</strong></div> : null}
           </div>
-          <DetailActionPanel secondaryHref="/vehicles" primaryLabel="상태 변경" logLabel="운행 로그" feedbackMessage="차량 상태 변경 요청을 확인했습니다. MVP mock에서는 실제 저장 없이 피드백만 표시합니다." logItems={[`최근 위치: ${vehicle.locationLabel}`, `배터리 확인: ${vehicle.batteryPercent}%`, `최근 보고: ${vehicle.lastSeenAt}`]} />
+          <div className="form-actions">
+            <Link className="button-secondary" href="/vehicles">목록</Link>
+            <Link className="button-secondary" href={`/vehicles/${vehicle.slug}/edit`}>기본 정보 수정</Link>
+          </div>
         </div>
-        <aside className="detail-panel"><h2>ID 입력 금지 확인</h2><p>배정 변경은 차량번호와 라이더 이름/연락처 선택 UI로 처리합니다. 내부 PK/FK는 화면에 입력칸으로 노출하지 않습니다.</p></aside>
+        <aside className="detail-panel">
+          <h2>차체 상태 변경</h2>
+          <form action={changeStatusAction} className="action-panel">
+            <Field label="변경할 상태">
+              <select className="select" defaultValue={vehicle.operationStatus ?? "READY"} name="operationStatus">
+                {vehicleStatusOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+              </select>
+            </Field>
+            <Field label="변경 사유"><input className="input" maxLength={200} name="reason" placeholder="예: 정비 입고, 운영 투입" /></Field>
+            <Field label="상태 메모"><textarea className="input" name="memo" placeholder="상태 변경 관련 메모" rows={3} /></Field>
+            <p className="notice">상태 변경은 차량 기본 정보 수정과 분리된 전용 API로 처리합니다.</p>
+            <div className="form-actions">
+              <button className="button-primary" type="submit">상태 변경</button>
+            </div>
+          </form>
+        </aside>
       </section>
     </div>
   );

--- a/development/front-admin-web/app/vehicles/actions.ts
+++ b/development/front-admin-web/app/vehicles/actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toVehicleCreatePayload,
+  toVehicleStatusPayload,
+  toVehicleUpdatePayload
+} from "@/lib/services/vehicle-command-payload";
+
+export async function createVehicleAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/vehicles?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let vehicle;
+  try {
+    const payload = toVehicleCreatePayload(formData);
+    vehicle = await client.createVehicle(payload);
+  } catch {
+    redirect("/vehicles/new?status=save-error");
+  }
+
+  revalidatePath("/vehicles");
+  redirect(`/vehicles/${vehicle.slug}?status=created`);
+}
+
+export async function updateVehicleAction(vehicleId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/vehicles/${vehicleId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let vehicle;
+  try {
+    const payload = toVehicleUpdatePayload(formData);
+    vehicle = await client.updateVehicle(vehicleId, payload);
+  } catch {
+    redirect(`/vehicles/${vehicleId}/edit?status=save-error`);
+  }
+
+  revalidatePath("/vehicles");
+  revalidatePath(`/vehicles/${vehicle.slug}`);
+  redirect(`/vehicles/${vehicle.slug}?status=updated`);
+}
+
+export async function changeVehicleOperationStatusAction(vehicleId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/vehicles/${vehicleId}?status=mock-status-updated`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let vehicle;
+  try {
+    const payload = toVehicleStatusPayload(formData);
+    vehicle = await client.changeVehicleOperationStatus(vehicleId, payload);
+  } catch {
+    redirect(`/vehicles/${vehicleId}?status=status-error`);
+  }
+
+  revalidatePath("/vehicles");
+  revalidatePath(`/vehicles/${vehicle.slug}`);
+  redirect(`/vehicles/${vehicle.slug}?status=status-updated`);
+}

--- a/development/front-admin-web/app/vehicles/new/page.tsx
+++ b/development/front-admin-web/app/vehicles/new/page.tsx
@@ -1,3 +1,18 @@
+import { createVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { VehicleForm } from "@/components/vehicles/VehicleForm";
-export default function NewVehiclePage() { return <div className="page-container"><PageHeader title="차량 등록" description="차량 ID는 DB가 자동 생성합니다. 차량번호, 모델, 상태, 위치와 배정 대상만 입력합니다." /><VehicleForm /></div>; }
+
+const statusMessage: Record<string, string> = {
+  "save-error": "차량 저장에 실패했습니다. 필수값, 중복 차량번호/VIN, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewVehiclePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="차량 등록" description="차량 ID는 DB가 자동 생성합니다. 사용자는 차량번호, VIN, 모델, 초기 차체 상태만 입력합니다." />
+      <VehicleForm action={createVehicleAction} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/vehicles/page.tsx
+++ b/development/front-admin-web/app/vehicles/page.tsx
@@ -1,8 +1,83 @@
 import Link from "next/link";
+
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { vehicles } from "@/lib/services/mock-data";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadVehicleList } from "@/lib/services/vehicle-data";
 
-export default function VehiclesPage() {
-  return <div className="page-container"><PageHeader title="차량 관리" description="차량 목록, 상태, 배정, 배터리와 위치 구조를 관리합니다." actionHref="/vehicles/new" actionLabel="차량 등록" /><div className="filter-bar"><input className="input" placeholder="차량번호 또는 모델 검색" /><select className="select"><option>전체 상태</option><option>운행 중</option><option>점검 필요</option></select><button className="button-ghost-mint">필터 적용</button></div><div className="table-card"><table className="table"><thead><tr><th>차량번호</th><th>모델</th><th>상태</th><th>배정</th><th>배터리</th><th>위치</th><th>상세</th></tr></thead><tbody>{vehicles.map((v) => <tr key={v.slug}><td>{v.plateNumber}</td><td>{v.model}</td><td><Badge tone={v.status === "운행 중" ? "active" : "outline"}>{v.status}</Badge></td><td>{v.riderName ?? v.assignmentStatus}</td><td>{v.batteryPercent}%</td><td>{v.locationLabel}</td><td><Link className="button-secondary" href={`/vehicles/${v.slug}`}>보기</Link></td></tr>)}</tbody></table></div></div>;
+const statusMessage: Record<string, string> = {
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  created: "차량이 등록되었습니다.",
+  updated: "차량 기본 정보가 수정되었습니다.",
+  "status-updated": "차량 차체 상태가 변경되었습니다."
+};
+
+export default async function VehiclesPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadVehicleList()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref="/vehicles/new"
+        actionLabel="차량 등록"
+        description="차량 기본 정보와 차체 상태를 관리합니다. 배정/단말/관제 데이터는 별도 도메인 API에서 연결합니다."
+        title="차량 관리"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <div className="filter-bar">
+        <input className="input" placeholder="차량번호 또는 모델 검색" />
+        <select className="select">
+          <option>전체 상태</option>
+          <option>대기</option>
+          <option>운행 중</option>
+          <option>수리</option>
+          <option>점검 필요</option>
+        </select>
+        <button className="button-ghost-mint" type="button">필터 적용</button>
+      </div>
+      <div className="table-card">
+        {data.vehicles.length ? (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>차량번호</th>
+                <th>모델</th>
+                <th>차체 상태</th>
+                <th>배정</th>
+                <th>배터리</th>
+                <th>위치</th>
+                <th>상세</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.vehicles.map((vehicle) => (
+                <tr key={vehicle.slug}>
+                  <td>{vehicle.plateNumber}</td>
+                  <td>{vehicle.model}</td>
+                  <td><Badge tone={vehicle.status === "운행 중" ? "active" : vehicle.status === "대기" ? "muted" : "outline"}>{vehicle.status}</Badge></td>
+                  <td>{vehicle.riderName ?? vehicle.assignmentStatus}</td>
+                  <td>{formatBattery(vehicle.batteryPercent)}</td>
+                  <td>{vehicle.locationLabel}</td>
+                  <td><Link className="button-secondary" href={`/vehicles/${vehicle.slug}`}>보기</Link></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <EmptyState
+            actionLabel="차량 등록"
+            description="아직 등록된 차량이 없습니다. DB ID 입력 없이 차량번호와 VIN부터 등록합니다."
+            href="/vehicles/new"
+            title="차량 없음"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatBattery(value: number | null): string {
+  return value === null ? "관제 API 후속" : `${value}%`;
 }

--- a/development/front-admin-web/components/vehicles/VehicleForm.tsx
+++ b/development/front-admin-web/components/vehicles/VehicleForm.tsx
@@ -1,21 +1,62 @@
-"use client";
+import Link from "next/link";
 
-import { MockFormActions } from "@/components/ui/MockActions";
 import { Field } from "@/components/ui/FormField";
-import { riders, stations } from "@/lib/services/mock-data";
+import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 
-export function VehicleForm({ mode = "등록", cancelHref = "/vehicles" }: { mode?: "등록" | "수정"; cancelHref?: string }) {
+export const vehicleStatusOptions: Array<{ label: string; value: ServiceOpsBikeOperationStatus }> = [
+  { label: "대기", value: "READY" },
+  { label: "운행 중", value: "IN_SERVICE" },
+  { label: "수리", value: "REPAIRING" },
+  { label: "점검 필요", value: "INSPECTION_REQUIRED" }
+];
+
+type VehicleFormValues = Pick<FrontendVehicle, "memo" | "model" | "operationStatus" | "plateNumber" | "vin">;
+
+type VehicleFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<VehicleFormValues>;
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+};
+
+export function VehicleForm({ action, cancelHref = "/vehicles", defaultValues, mode = "등록", statusMessage }: VehicleFormProps) {
+  const isCreateMode = mode === "등록";
+
   return (
-    <form className="card" onSubmit={(event) => event.preventDefault()} aria-label={`차량 ${mode} 폼`}>
+    <form action={action} className="card" aria-label={`차량 ${mode} 폼`}>
       <div className="form-grid">
-        <Field label="차량번호"><input className="input" name="plateNumber" placeholder="예: 서울바4821" /></Field>
-        <Field label="모델"><input className="input" name="model" placeholder="예: Thundercrew E2" /></Field>
-        <Field label="상태"><select className="select" name="status"><option>대기</option><option>운행 중</option><option>정지</option><option>점검 필요</option></select></Field>
-        <Field label="라이더 배정" hint="ID를 입력하지 않고 라이더 이름/연락처로 선택합니다."><select className="select" name="rider"><option>미배정</option>{riders.map((r) => <option key={r.slug}>{r.name} · {r.phone}</option>)}</select></Field>
-        <Field label="현재 위치 기준"><select className="select" name="location">{stations.map((s) => <option key={s.slug}>{s.name} · {s.address}</option>)}<option>직접 위치 설명 입력</option></select></Field>
-        <Field label="배터리 상태"><select className="select" name="battery"><option>충분함 (80% 이상)</option><option>교체 권장 (30~79%)</option><option>즉시 교체 필요 (30% 미만)</option></select></Field>
+        <Field label="차량번호">
+          <input className="input" defaultValue={defaultValues?.plateNumber ?? ""} maxLength={50} name="plateNumber" placeholder="예: 서울A-1001" required />
+        </Field>
+        <Field label="차대번호/VIN">
+          <input className="input" defaultValue={defaultValues?.vin ?? ""} maxLength={100} name="vin" placeholder="예: VIN-BIKE-001" required />
+        </Field>
+        <Field label="모델">
+          <input className="input" defaultValue={defaultValues?.model ?? ""} maxLength={100} name="modelName" placeholder="예: Thunder M1" />
+        </Field>
+        {isCreateMode ? (
+          <Field label="초기 차체 상태">
+            <select className="select" defaultValue={defaultValues?.operationStatus ?? "READY"} name="operationStatus">
+              {vehicleStatusOptions.map((status) => <option key={status.value} value={status.value}>{status.label}</option>)}
+            </select>
+          </Field>
+        ) : (
+          <Field label="현재 차체 상태" hint="상태 변경은 상세 화면의 전용 상태 변경 영역에서 처리합니다.">
+            <input className="input" disabled value={vehicleStatusOptions.find((status) => status.value === defaultValues?.operationStatus)?.label ?? "대기"} />
+          </Field>
+        )}
       </div>
-      <MockFormActions cancelHref={cancelHref} submitLabel={`차량 ${mode}`} successMessage={`차량 ${mode} 요청을 확인했습니다. 실제 저장은 Supabase 연결 단계에서 처리됩니다.`} />
+      <br />
+      <Field label="운영 메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={4} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        라이더/단말기/계약 연결은 ID 직접 입력이 아니라 각 도메인의 선택 UI에서 별도 처리합니다. 이 폼은 차량 기본 정보와 차체 상태만 다룹니다.
+      </p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">차량 {mode}</button>
+      </div>
     </form>
   );
 }

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -6,6 +6,7 @@ import {
   createServiceOpsApiClient,
   normalizeServiceOpsBaseUrl,
   toFrontendDashboardMapState,
+  toFrontendVehicle,
   toFrontendRider
 } from "./service-ops-api.ts";
 
@@ -129,6 +130,200 @@ test("HTTP error responses throw ServiceOpsApiError with status and backend code
 });
 
 
+
+
+
+test("bike list request maps service bikes to frontend vehicles", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              idx: 12,
+              plateNumber: "서울A-1001",
+              vin: "VIN-BIKE-001",
+              modelName: "Thunder M1",
+              operationStatus: "IN_SERVICE",
+              memo: "강남 운영 차량",
+              createdAt: "2026-04-01T00:00:00Z",
+              updatedAt: "2026-04-30T00:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listVehicles({ page: 0, size: 20 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/bikes");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "20");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].slug, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+  assert.equal(page.items[0].plateNumber, "서울A-1001");
+  assert.equal(page.items[0].model, "Thunder M1");
+  assert.equal(page.items[0].status, "운행 중");
+  assert.equal(page.items[0].vin, "VIN-BIKE-001");
+  assert.equal(page.items[0].assignmentStatus, "배정 API 후속");
+});
+
+test("invalid backend bike operation status does not display as READY", () => {
+  assert.throws(
+    () =>
+      toFrontendVehicle({
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        idx: 12,
+        plateNumber: "서울A-1001",
+        vin: "VIN-BIKE-001",
+        modelName: "Thunder M1",
+        operationStatus: "DECOMMISSIONED",
+        memo: null,
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-30T00:00:00Z"
+      }),
+    (error) =>
+      error instanceof ServiceOpsApiError &&
+      error.code === "SERVICE_OPS_UNSUPPORTED_BIKE_STATUS" &&
+      error.message.includes("Unsupported bike operation status")
+  );
+});
+
+test("createVehicle sends only operator-editable bike fields", async () => {
+  let requestBody = null;
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (_url, init) => {
+      requestBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          idx: 14,
+          plateNumber: requestBody.plateNumber,
+          vin: requestBody.vin,
+          modelName: requestBody.modelName,
+          operationStatus: requestBody.operationStatus,
+          memo: requestBody.memo,
+          createdAt: "2026-04-01T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: 201 }
+      );
+    }
+  });
+
+  await client.createVehicle({
+    memo: "운영 메모",
+    modelName: "Thunder M1",
+    operationStatus: "READY",
+    plateNumber: "서울A-1001",
+    vin: "VIN-BIKE-001"
+  });
+
+  assert.deepEqual(Object.keys(requestBody).sort(), ["memo", "modelName", "operationStatus", "plateNumber", "vin"]);
+  assert.equal("id" in requestBody, false);
+  assert.equal("bikeId" in requestBody, false);
+  assert.equal("riderId" in requestBody, false);
+  assert.equal("deviceId" in requestBody, false);
+});
+
+
+
+test("updateVehicle uses bike basic-profile endpoint without status or relationship fields", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          idx: 16,
+          plateNumber: "서울D-4004",
+          vin: "VIN-BIKE-004",
+          modelName: "Thunder M4",
+          operationStatus: "READY",
+          memo: "기본 정보 수정",
+          createdAt: "2026-04-01T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  await client.updateVehicle("dddddddd-dddd-4ddd-8ddd-dddddddddddd", {
+    memo: "기본 정보 수정",
+    modelName: "Thunder M4",
+    plateNumber: "서울D-4004",
+    vin: "VIN-BIKE-004"
+  });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  const requestBody = JSON.parse(String(calls[0].init?.body));
+  assert.equal(url.pathname, "/api/v1/bikes/dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+  assert.equal(calls[0].init?.method, "PATCH");
+  assert.deepEqual(Object.keys(requestBody).sort(), ["memo", "modelName", "plateNumber", "vin"]);
+  assert.equal("operationStatus" in requestBody, false);
+  assert.equal("riderId" in requestBody, false);
+  assert.equal("deviceId" in requestBody, false);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("changeVehicleOperationStatus uses dedicated status endpoint", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          idx: 15,
+          plateNumber: "서울C-3003",
+          vin: "VIN-BIKE-003",
+          modelName: "Thunder M3",
+          operationStatus: "INSPECTION_REQUIRED",
+          memo: "점검 필요",
+          createdAt: "2026-04-01T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  await client.changeVehicleOperationStatus("cccccccc-cccc-4ccc-8ccc-cccccccccccc", {
+    memo: "브레이크 점검",
+    operationStatus: "INSPECTION_REQUIRED",
+    reason: "운영자 확인"
+  });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/bikes/cccccccc-cccc-4ccc-8ccc-cccccccccccc/operation-status");
+  assert.equal(calls[0].init?.method, "PATCH");
+  assert.deepEqual(JSON.parse(String(calls[0].init?.body)), {
+    memo: "브레이크 점검",
+    operationStatus: "INSPECTION_REQUIRED",
+    reason: "운영자 확인"
+  });
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
 
 test("refresh request posts refresh token without bearer token", async () => {
   const calls = [];

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -75,6 +75,56 @@ export type RiderCreateInput = {
 
 export type RiderUpdateInput = Partial<RiderCreateInput>;
 
+export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE" | "REPAIRING" | "INSPECTION_REQUIRED";
+
+export type ServiceOpsBike = {
+  id: string;
+  idx: number | null;
+  plateNumber: string;
+  vin: string;
+  modelName: string | null;
+  operationStatus: ServiceOpsBikeOperationStatus;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type FrontendVehicle = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  plateNumber: string;
+  vin?: string | null;
+  model: string;
+  status: "운행 중" | "수리" | "점검 필요" | "대기";
+  operationStatus?: ServiceOpsBikeOperationStatus;
+  assignmentStatus: string;
+  batteryPercent: number | null;
+  riderName?: string;
+  locationLabel: string;
+  lastSeenAt: string;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
+};
+
+export type VehicleCreateInput = {
+  plateNumber: string;
+  vin: string;
+  modelName?: string | null;
+  operationStatus: ServiceOpsBikeOperationStatus;
+  memo?: string | null;
+};
+
+export type VehicleUpdateInput = Partial<Omit<VehicleCreateInput, "operationStatus">>;
+
+export type VehicleOperationStatusChangeInput = {
+  operationStatus: ServiceOpsBikeOperationStatus;
+  reason?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -157,6 +207,11 @@ export type ServiceOpsApiClient = {
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
   getDashboardMapState: () => Promise<FrontendDashboardMapState>;
+  listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
+  getVehicle: (id: string) => Promise<FrontendVehicle>;
+  createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
+  updateVehicle: (id: string, request: VehicleUpdateInput) => Promise<FrontendVehicle>;
+  changeVehicleOperationStatus: (id: string, request: VehicleOperationStatusChangeInput) => Promise<FrontendVehicle>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -280,6 +335,35 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     },
     getDashboardMapState: async () =>
       toFrontendDashboardMapState(await request<ServiceOpsDashboardMapState>("/dashboard/map-state", { method: "GET" })),
+    listVehicles: async ({ page = 0, size = 20, sort } = {}) => {
+      const response = await request<ServiceOpsPage<ServiceOpsBike>>("/bikes", { method: "GET" }, { page, size, sort });
+      return {
+        ...response,
+        items: response.items.map(toFrontendVehicle)
+      };
+    },
+    getVehicle: async (id) => toFrontendVehicle(await request<ServiceOpsBike>(`/bikes/${encodeURIComponent(id)}`, { method: "GET" })),
+    createVehicle: async (createRequest) =>
+      toFrontendVehicle(
+        await request<ServiceOpsBike>("/bikes", {
+          body: JSON.stringify(createRequest),
+          method: "POST"
+        })
+      ),
+    updateVehicle: async (id, updateRequest) =>
+      toFrontendVehicle(
+        await request<ServiceOpsBike>(`/bikes/${encodeURIComponent(id)}`, {
+          body: JSON.stringify(updateRequest),
+          method: "PATCH"
+        })
+      ),
+    changeVehicleOperationStatus: async (id, statusRequest) =>
+      toFrontendVehicle(
+        await request<ServiceOpsBike>(`/bikes/${encodeURIComponent(id)}/operation-status`, {
+          body: JSON.stringify(statusRequest),
+          method: "PATCH"
+        })
+      ),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {
@@ -324,6 +408,44 @@ export function toFrontendDashboardMapState(mapState: ServiceOpsDashboardMapStat
       slug: pin.stationId
     }))
   };
+}
+
+export function toFrontendVehicle(bike: ServiceOpsBike): FrontendVehicle {
+  return {
+    slug: bike.id,
+    id: bike.id,
+    idx: bike.idx,
+    plateNumber: bike.plateNumber,
+    vin: bike.vin,
+    model: normalizeDisplayText(bike.modelName, "모델 미지정"),
+    status: toFrontendVehicleStatus(bike.operationStatus),
+    operationStatus: bike.operationStatus,
+    assignmentStatus: "배정 API 후속",
+    batteryPercent: null,
+    locationLabel: "지도/텔레메트리 제외 범위",
+    lastSeenAt: toDateOnly(bike.updatedAt),
+    memo: bike.memo,
+    createdAt: bike.createdAt,
+    updatedAt: bike.updatedAt,
+    source: "service-ops"
+  };
+}
+
+export function toFrontendVehicleStatus(status: ServiceOpsBikeOperationStatus): FrontendVehicle["status"] {
+  switch (status) {
+    case "IN_SERVICE":
+      return "운행 중";
+    case "REPAIRING":
+      return "수리";
+    case "INSPECTION_REQUIRED":
+      return "점검 필요";
+    case "READY":
+      return "대기";
+  }
+
+  throw new ServiceOpsApiError("Unsupported bike operation status returned by service ops API.", 0, "SERVICE_OPS_UNSUPPORTED_BIKE_STATUS", {
+    operationStatus: status
+  });
 }
 
 export function toFrontendRider(rider: ServiceOpsRider): FrontendRider {

--- a/development/front-admin-web/lib/services/vehicle-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/vehicle-command-payload.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  VehicleCommandPayloadError,
+  toOperationStatus,
+  toVehicleCreatePayload,
+  toVehicleStatusPayload,
+  toVehicleUpdatePayload
+} from "./vehicle-command-payload.ts";
+
+test("toOperationStatus rejects invalid or missing status instead of defaulting to READY", () => {
+  assert.equal(toOperationStatus("READY"), "READY");
+  assert.throws(() => toOperationStatus("BROKEN"), VehicleCommandPayloadError);
+  assert.throws(() => toOperationStatus(null), VehicleCommandPayloadError);
+});
+
+test("vehicle command payloads expose only service-owned bike fields", () => {
+  const formData = new FormData();
+  formData.set("plateNumber", "서울A-1001");
+  formData.set("vin", "VIN-BIKE-001");
+  formData.set("modelName", "Thunder M1");
+  formData.set("operationStatus", "IN_SERVICE");
+  formData.set("memo", "운영 메모");
+  formData.set("bikeId", "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  formData.set("riderId", "rrrrrrrr-rrrr-4rrr-8rrr-rrrrrrrrrrrr");
+  formData.set("deviceId", "dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+
+  const createPayload = toVehicleCreatePayload(formData);
+  const updatePayload = toVehicleUpdatePayload(formData);
+  const statusPayload = toVehicleStatusPayload(formData);
+
+  assert.deepEqual(Object.keys(createPayload).sort(), ["memo", "modelName", "operationStatus", "plateNumber", "vin"]);
+  assert.deepEqual(Object.keys(updatePayload).sort(), ["memo", "modelName", "plateNumber", "vin"]);
+  assert.deepEqual(Object.keys(statusPayload).sort(), ["memo", "operationStatus", "reason"]);
+  assert.equal("bikeId" in createPayload, false);
+  assert.equal("riderId" in createPayload, false);
+  assert.equal("deviceId" in createPayload, false);
+  assert.equal("operationStatus" in updatePayload, false);
+});
+
+test("vehicle command payloads reject blank required vehicle fields", () => {
+  const formData = new FormData();
+  formData.set("plateNumber", " ");
+  formData.set("vin", "VIN-BIKE-001");
+  formData.set("operationStatus", "READY");
+
+  assert.throws(() => toVehicleCreatePayload(formData), VehicleCommandPayloadError);
+
+  formData.set("plateNumber", "서울A-1001");
+  formData.set("vin", "");
+
+  assert.throws(() => toVehicleUpdatePayload(formData), VehicleCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/vehicle-command-payload.ts
+++ b/development/front-admin-web/lib/services/vehicle-command-payload.ts
@@ -1,0 +1,65 @@
+import type {
+  ServiceOpsBikeOperationStatus,
+  VehicleCreateInput,
+  VehicleOperationStatusChangeInput,
+  VehicleUpdateInput
+} from "./service-ops-api";
+
+const OPERATION_STATUS_VALUES = ["READY", "IN_SERVICE", "REPAIRING", "INSPECTION_REQUIRED"] as const;
+
+export class VehicleCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VehicleCommandPayloadError";
+  }
+}
+
+export function toVehicleCreatePayload(formData: FormData): VehicleCreateInput {
+  return {
+    memo: optionalText(formData.get("memo")),
+    modelName: optionalText(formData.get("modelName")),
+    operationStatus: toOperationStatus(formData.get("operationStatus")),
+    plateNumber: requiredText(formData.get("plateNumber"), "Vehicle plate number is required."),
+    vin: requiredText(formData.get("vin"), "Vehicle VIN is required.")
+  };
+}
+
+export function toVehicleUpdatePayload(formData: FormData): VehicleUpdateInput {
+  return {
+    memo: optionalText(formData.get("memo")),
+    modelName: optionalText(formData.get("modelName")),
+    plateNumber: requiredText(formData.get("plateNumber"), "Vehicle plate number is required."),
+    vin: requiredText(formData.get("vin"), "Vehicle VIN is required.")
+  };
+}
+
+export function toVehicleStatusPayload(formData: FormData): VehicleOperationStatusChangeInput {
+  return {
+    memo: optionalText(formData.get("memo")),
+    operationStatus: toOperationStatus(formData.get("operationStatus")),
+    reason: optionalText(formData.get("reason"))
+  };
+}
+
+export function toOperationStatus(value: FormDataEntryValue | null): ServiceOpsBikeOperationStatus {
+  const status = requiredText(value, "Vehicle operation status is required.");
+  if (OPERATION_STATUS_VALUES.includes(status as ServiceOpsBikeOperationStatus)) {
+    return status as ServiceOpsBikeOperationStatus;
+  }
+
+  throw new VehicleCommandPayloadError("Invalid vehicle operation status.");
+}
+
+function requiredText(value: FormDataEntryValue | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new VehicleCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}

--- a/development/front-admin-web/lib/services/vehicle-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/vehicle-data-core.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mockVehicleUnconfiguredServiceDetail, mockVehicleUnavailableServiceDetail } from "./vehicle-data-core.ts";
+
+const mockVehicles = [
+  {
+    assignmentStatus: "미배정",
+    batteryPercent: 78,
+    lastSeenAt: "3분 전",
+    locationLabel: "강남역",
+    model: "Thunder M1",
+    plateNumber: "서울A-1001",
+    slug: "seoul-a-1001",
+    status: "대기"
+  }
+];
+
+test("UUID vehicle detail falls back to visible mock detail when service session is missing", () => {
+  const fallback = mockVehicleUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    mockVehicles,
+    "서비스 API 세션 쿠키가 없어 mock 차량 상세를 표시합니다."
+  );
+
+  assert.equal(fallback?.source, "mock");
+  assert.equal(fallback?.vehicle.slug, "seoul-a-1001");
+  assert.match(fallback?.notice ?? "", /서비스 API 세션/);
+});
+
+test("UUID vehicle detail falls back to visible mock detail when service API base URL is unconfigured", () => {
+  const fallback = mockVehicleUnconfiguredServiceDetail("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", mockVehicles);
+
+  assert.equal(fallback?.source, "mock");
+  assert.equal(fallback?.vehicle.slug, "seoul-a-1001");
+  assert.match(fallback?.notice ?? "", /SERVICE_OPS_API_BASE_URL/);
+});
+
+test("non-UUID missing vehicle detail does not fabricate a fallback", () => {
+  assert.equal(mockVehicleUnavailableServiceDetail("missing-slug", mockVehicles, "notice"), null);
+});

--- a/development/front-admin-web/lib/services/vehicle-data-core.ts
+++ b/development/front-admin-web/lib/services/vehicle-data-core.ts
@@ -1,0 +1,66 @@
+import type { FrontendVehicle } from "./service-ops-api";
+
+export type VehicleDataResult = {
+  source: "mock" | "service-ops";
+  vehicles: FrontendVehicle[];
+  notice?: string;
+};
+
+export type VehicleDetailResult = {
+  source: "mock" | "service-ops";
+  vehicle: FrontendVehicle;
+  notice?: string;
+};
+
+export function mockVehicleList(mockVehicles: FrontendVehicle[]): VehicleDataResult {
+  return {
+    source: "mock",
+    vehicles: mockVehicles.map((vehicle) => ({ ...vehicle, source: "mock" as const }))
+  };
+}
+
+export function mockVehicleDetail(slug: string, mockVehicles: FrontendVehicle[]): VehicleDetailResult | null {
+  const vehicle = mockVehicles.find((candidate) => candidate.slug === slug);
+
+  if (!vehicle) {
+    return null;
+  }
+
+  return {
+    source: "mock",
+    vehicle: { ...vehicle, source: "mock" }
+  };
+}
+
+export function mockVehicleUnavailableServiceDetail(
+  slug: string,
+  mockVehicles: FrontendVehicle[],
+  notice: string
+): VehicleDetailResult | null {
+  const exactFallback = mockVehicleDetail(slug, mockVehicles);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockVehicles.length) {
+    return null;
+  }
+
+  return {
+    notice,
+    source: "mock",
+    vehicle: { ...mockVehicles[0], source: "mock" }
+  };
+}
+
+export function mockVehicleUnconfiguredServiceDetail(slug: string, mockVehicles: FrontendVehicle[]): VehicleDetailResult | null {
+  return mockVehicleUnavailableServiceDetail(
+    slug,
+    mockVehicles,
+    "SERVICE_OPS_API_BASE_URL이 없어 mock 차량 상세를 표시합니다. 백엔드 연결 후 실제 차량 상세로 전환됩니다."
+  );
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}

--- a/development/front-admin-web/lib/services/vehicle-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-data.ts
@@ -1,0 +1,86 @@
+import {
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { vehicles as mockVehicles } from "@/lib/services/mock-data";
+import {
+  type VehicleDataResult,
+  type VehicleDetailResult,
+  isUuidLike,
+  mockVehicleDetail,
+  mockVehicleList,
+  mockVehicleUnconfiguredServiceDetail,
+  mockVehicleUnavailableServiceDetail
+} from "@/lib/services/vehicle-data-core";
+
+export async function loadVehicleList(): Promise<VehicleDataResult> {
+  const fallback = mockVehicleList(mockVehicles);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 차량 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 차량 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const page = await client.listVehicles({ page: 0, size: 100 });
+    return { source: "service-ops", vehicles: page.items };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 차량 조회 실패로 mock 차량 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadVehicleDetail(slug: string): Promise<VehicleDetailResult | null> {
+  const fallback = mockVehicleDetail(slug, mockVehicles);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockVehicleUnconfiguredServiceDetail(slug, mockVehicles);
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockVehicleUnavailableServiceDetail(
+        slug,
+        mockVehicles,
+        "서비스 API 세션 쿠키가 없어 mock 차량 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const vehicle = await client.getVehicle(slug);
+      return { source: "service-ops", vehicle };
+    } catch (error) {
+      return mockVehicleUnavailableServiceDetail(
+        slug,
+        mockVehicles,
+        `서비스 API 차량 상세 조회 실패로 mock 차량 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const vehicleSchema = z.object({
   plateNumber: z.string().min(2, "차량번호를 입력하세요."),
   model: z.string().min(2, "모델명을 입력하세요."),
-  status: z.enum(["운행 중", "정지", "점검 필요", "대기"]),
+  status: z.enum(["운행 중", "수리", "점검 필요", "대기"]),
   assignmentTarget: z.string().optional(),
   stationOrLocation: z.string().min(2, "위치 기준을 입력하세요.")
 });

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/supabase/migrations/202604290001_initial_thundercrew_domain.sql
+++ b/development/front-admin-web/supabase/migrations/202604290001_initial_thundercrew_domain.sql
@@ -3,7 +3,7 @@
 
 create extension if not exists pgcrypto;
 
-create type vehicle_status as enum ('운행 중', '정지', '점검 필요', '대기');
+create type vehicle_status as enum ('운행 중', '수리', '점검 필요', '대기');
 create type assignment_status as enum ('배정됨', '미배정', '교대 예정');
 create type rider_status as enum ('활동', '대기', '휴면');
 create type contract_status as enum ('활성', '만료 예정', '종료', '초안');

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -1,4 +1,4 @@
-export type VehicleStatus = "운행 중" | "정지" | "점검 필요" | "대기";
+export type VehicleStatus = "운행 중" | "수리" | "점검 필요" | "대기";
 export type AssignmentStatus = "배정됨" | "미배정" | "교대 예정";
 export type ContractStatus = "활성" | "만료 예정" | "종료" | "초안";
 export type InsuranceStatus = "정상" | "만료 예정" | "만료";
@@ -20,10 +20,18 @@ export type Vehicle = {
   model: string;
   status: VehicleStatus;
   assignmentStatus: AssignmentStatus;
-  batteryPercent: number;
+  id?: string;
+  idx?: number | null;
+  vin?: string | null;
+  operationStatus?: "READY" | "IN_SERVICE" | "REPAIRING" | "INSPECTION_REQUIRED";
+  batteryPercent: number | null;
   riderName?: string;
   locationLabel: string;
   lastSeenAt: string;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
 };
 
 export type RiderContract = {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -661,3 +661,31 @@ Verification:
 
 - TDD red observed on `service-ops-session-core.test.mjs` before implementation because the session core module did not exist.
 - Frontend service-ops tests cover refresh request shape, logout Bearer request shape, cookie rotation, refresh-failure cleanup, and logout-failure cleanup.
+
+
+## Frontend vehicle admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#79
+- Target issue: EVNSolution/thundercrew-domain#65
+- Branch: `cc-79-vehicle-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires the existing Next.js vehicle management screens to the existing service-ops-api bike endpoints.
+- Included work is a frontend vehicle client/data adapter, list/detail/create/update/status action wiring, service-ops tests, and docs updates.
+- Telemetry, TimescaleDB retention/archive, dashboard map-state, map provider/API, backend endpoint/schema changes, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Vehicle create/update forms expose operator-readable fields only: plate number, VIN, model, memo, and selected operation status for create.
+- Vehicle basic-profile update does not submit `operationStatus`; status changes use the dedicated `/api/v1/bikes/{id}/operation-status` action.
+- No editable `bikeId`, `vehicle_id`, `riderId`, `deviceId`, contract ID, or FK text input is introduced.
+- Service-ops mode shows assignment/battery/location placeholders where the bike API intentionally does not own rider-contract, telemetry, or map data.
+- Missing config/session/API failure falls back to explicit mock vehicle data with a visible notice.
+
+Verification:
+
+- TDD red observed on frontend service-ops vehicle tests before implementation because `listVehicles`, `createVehicle`, and `changeVehicleOperationStatus` did not exist.
+- Frontend service-ops tests cover bike list mapping, create/update payload boundaries, and dedicated operation-status request shape.


### PR DESCRIPTION
## Summary
- Connect vehicle admin list/detail/create/edit/status-change screens to existing service-ops bike APIs.
- Keep operator forms limited to human-readable vehicle fields: plate number, VIN, model, status, memo/reason.
- Add strict payload/data adapter tests so invalid status does not become READY and UUID detail routes show visible mock fallback when service API/session is unavailable.

## Scope boundaries
- Excludes telemetry, map provider/API, assignment, and device workflows.
- No direct editable IDs or FK fields were added.
- Basic profile updates and operation-status transitions stay on separate service endpoints.

## Change control
- Change-control: EVNSolution/clever-change-control#79
- Target issue: Closes #65

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (25/25)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- Code-reviewer re-review: PASS

## Not tested
- Live browser flow against a running service-ops API instance.
