### PR TITLE
Frontend contract admin API integration baseline (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Frontend ↔ backend baseline:
   관계없이 로컬 HTTP-only 쿠키를 제거합니다.
 - 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
 - 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
+- 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -16,7 +16,7 @@
 
 - 차량: `vehicle_id` 입력 금지 → 차량번호/모델/상태/위치와 라이더 선택
 - 라이더: `rider_id` 입력 금지 → 이름/연락처/소속/구역 입력
-- 계약: `contract_id`, `rider_id` 입력 금지 → 라이더 이름/연락처 선택
+- 계약: `contract_id`, `rider_id`, `vehicle_id`, `contract_template_id` 입력 금지 → 라이더 이름/연락처, 차량번호, 계약 양식 선택
 - 보험: `insurance_id`, `rider_id`, `vehicle_id` 입력 금지 → 라이더 또는 차량 식별 정보 선택
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
 
@@ -75,6 +75,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
 - 차량 목록/상세/등록/수정/차체 상태 변경은 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다.
 - 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
+- 계약 목록/상세/등록/메모 수정/종료는 server action/server component에서 `/api/v1/contract-templates`와 `/api/v1/rider-bike-contracts`를 호출합니다.
+- 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.

--- a/development/front-admin-web/app/contracts/[slug]/page.tsx
+++ b/development/front-admin-web/app/contracts/[slug]/page.tsx
@@ -1,23 +1,87 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { terminateContractAction, updateContractMemoAction } from "@/app/contracts/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { DetailActionPanel } from "@/components/ui/MockActions";
-import { contracts } from "@/lib/services/mock-data";
+import { Field } from "@/components/ui/FormField";
+import { loadContractDetail } from "@/lib/services/contract-data";
 
-export default async function ContractDetailPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  const contract = contracts.find((c) => c.slug === slug) ?? contracts[0];
+const statusMessage: Record<string, string> = {
+  created: "계약이 등록되었습니다.",
+  "mock-updated": "서비스 API가 연결되지 않아 메모 저장을 mock 피드백으로만 처리했습니다.",
+  "mock-terminated": "서비스 API가 연결되지 않아 계약 종료를 mock 피드백으로만 처리했습니다.",
+  "save-error": "계약 메모 저장에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  terminated: "계약이 종료 처리되었습니다.",
+  "terminate-error": "계약 종료 처리에 실패했습니다. 종료일시와 계약 상태를 확인하세요.",
+  updated: "계약 메모가 수정되었습니다."
+};
+
+export default async function ContractDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadContractDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const contract = detail.contract;
+  const message = status ? statusMessage[status] : null;
+  const memoAction = updateContractMemoAction.bind(null, slug);
+  const terminateAction = terminateContractAction.bind(null, slug);
 
   return (
     <div className="page-container">
       <PageHeader title={contract.contractType} description={`${contract.riderName} 계약 상세`} />
-      <section className="card">
-        <div className="detail-list">
-          <div className="detail-row"><span>라이더</span><strong>{contract.riderName}</strong></div>
-          <div className="detail-row"><span>기간</span><strong>{contract.startsAt} ~ {contract.endsAt}</strong></div>
-          <div className="detail-row"><span>상태</span><Badge>{contract.status}</Badge></div>
-          <div className="detail-row"><span>구역</span><strong>{contract.area}</strong></div>
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>계약 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>라이더</span><strong>{contract.riderLabel ?? contract.riderName}</strong></div>
+            <div className="detail-row"><span>차량</span><strong>{contract.bikeLabel ?? "차량 연결 후 표시"}</strong></div>
+            <div className="detail-row"><span>계약 양식</span><strong>{contract.contractType}</strong></div>
+            <div className="detail-row"><span>기간</span><strong>{contract.startsAt} ~ {contract.endsAt}</strong></div>
+            <div className="detail-row"><span>상태</span><Badge>{contract.status}</Badge></div>
+            <div className="detail-row"><span>구역</span><strong>{contract.area}</strong></div>
+            {contract.memo ? <div className="detail-row"><span>메모</span><strong>{contract.memo}</strong></div> : null}
+            {contract.terminatedAt ? <div className="detail-row"><span>종료일시</span><strong>{contract.terminatedAt}</strong></div> : null}
+            {contract.terminatedReason ? <div className="detail-row"><span>종료 사유</span><strong>{contract.terminatedReason}</strong></div> : null}
+          </div>
+          <div className="form-actions">
+            <Link className="button-secondary" href="/contracts">목록</Link>
+            <Link className="button-secondary" href="/contracts/new">새 계약 등록</Link>
+          </div>
         </div>
-        <DetailActionPanel secondaryHref="/contracts" primaryLabel="계약 상태 변경" logLabel="계약 로그" feedbackMessage="계약 상태 변경 요청을 확인했습니다. MVP mock에서는 실제 저장 없이 피드백만 표시합니다." logItems={["계약 생성: 2026-03-01", "최근 상태 확인: 활성", "만료 30일 전 알림 대상 아님"]} />
+        <aside className="detail-panel">
+          <h2>계약 작업</h2>
+          <form action={memoAction} className="action-panel">
+            <Field label="운영 메모"><textarea className="input" defaultValue={contract.memo ?? ""} name="memo" placeholder="계약 운영 메모" rows={4} /></Field>
+            <div className="form-actions">
+              <button className="button-primary" type="submit">메모 저장</button>
+            </div>
+          </form>
+          <hr style={{ border: 0, borderTop: "1px solid var(--color-border)", margin: "20px 0" }} />
+          {contract.status === "종료" ? (
+            <p className="notice">이미 종료된 계약입니다. 종료 이력은 보존됩니다.</p>
+          ) : (
+            <form action={terminateAction} className="action-panel">
+              <Field label="계약 종료일시" hint="서울 시간(KST) 기준으로 종료 처리합니다."><input className="input" name="terminatedAt" required type="datetime-local" /></Field>
+              <Field label="종료 사유"><input className="input" maxLength={200} name="terminatedReason" placeholder="예: 계약 만료, 운영 종료" /></Field>
+              <p className="notice">계약 종료는 이력을 보존하는 상태 변경입니다. 계약 ID 직접 입력 없이 현재 상세 대상에만 적용됩니다.</p>
+              <div className="form-actions">
+                <button className="button-ghost-mint" type="submit">계약 종료</button>
+              </div>
+            </form>
+          )}
+        </aside>
       </section>
     </div>
   );

--- a/development/front-admin-web/app/contracts/actions.ts
+++ b/development/front-admin-web/app/contracts/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toRiderBikeContractCreatePayload,
+  toRiderBikeContractMemoPayload,
+  toRiderBikeContractTerminatePayload
+} from "@/lib/services/contract-command-payload";
+
+export async function createContractAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/contracts?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let contract;
+  try {
+    contract = await client.createRiderBikeContract(toRiderBikeContractCreatePayload(formData));
+  } catch {
+    redirect("/contracts/new?status=save-error");
+  }
+
+  revalidatePath("/contracts");
+  redirect(`/contracts/${contract.id}?status=created`);
+}
+
+export async function updateContractMemoAction(contractId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/contracts/${contractId}?status=mock-updated`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let contract;
+  try {
+    contract = await client.updateRiderBikeContract(contractId, toRiderBikeContractMemoPayload(formData));
+  } catch {
+    redirect(`/contracts/${contractId}?status=save-error`);
+  }
+
+  revalidatePath("/contracts");
+  revalidatePath(`/contracts/${contract.id}`);
+  redirect(`/contracts/${contract.id}?status=updated`);
+}
+
+export async function terminateContractAction(contractId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/contracts/${contractId}?status=mock-terminated`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let contract;
+  try {
+    contract = await client.terminateRiderBikeContract(contractId, toRiderBikeContractTerminatePayload(formData));
+  } catch {
+    redirect(`/contracts/${contractId}?status=terminate-error`);
+  }
+
+  revalidatePath("/contracts");
+  revalidatePath(`/contracts/${contract.id}`);
+  redirect(`/contracts/${contract.id}?status=terminated`);
+}

--- a/development/front-admin-web/app/contracts/new/page.tsx
+++ b/development/front-admin-web/app/contracts/new/page.tsx
@@ -1,3 +1,20 @@
+import { createContractAction } from "@/app/contracts/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ContractForm } from "@/components/contracts/ContractForm";
-export default function NewContractPage() { return <div className="page-container"><PageHeader title="계약 등록" description="계약 ID는 DB에서 자동 생성합니다. 계약 대상 라이더는 이름/연락처 기준으로 선택합니다." /><ContractForm /></div>; }
+import { loadContractFormOptions } from "@/lib/services/contract-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "계약 등록에 실패했습니다. 필수 선택값, 기간 중복, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewContractPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, options] = await Promise.all([searchParams, loadContractFormOptions()]);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="계약 등록" description="계약 ID는 DB에서 자동 생성합니다. 계약 대상 라이더, 차량, 계약 양식은 사람이 읽을 수 있는 선택 UI로 연결합니다." />
+      {options.notice ? <p className="notice">{options.notice}</p> : null}
+      <ContractForm action={createContractAction} options={options} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/contracts/page.tsx
+++ b/development/front-admin-web/app/contracts/page.tsx
@@ -1,5 +1,77 @@
 import Link from "next/link";
+
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { contracts } from "@/lib/services/mock-data";
-export default function ContractsPage() { return <div className="page-container"><PageHeader title="계약 관리" description="라이더 계약 목록, 등록, 상세와 계약 상태를 관리합니다." actionHref="/contracts/new" actionLabel="계약 등록" /><div className="table-card"><table className="table"><thead><tr><th>라이더</th><th>계약 유형</th><th>시작일</th><th>종료일</th><th>상태</th><th>구역</th><th>상세</th></tr></thead><tbody>{contracts.map((c) => <tr key={c.slug}><td>{c.riderName}</td><td>{c.contractType}</td><td>{c.startsAt}</td><td>{c.endsAt}</td><td><Badge tone={c.status === "활성" ? "active" : c.status === "초안" ? "muted" : "outline"}>{c.status}</Badge></td><td>{c.area}</td><td><Link className="button-secondary" href={`/contracts/${c.slug}`}>보기</Link></td></tr>)}</tbody></table></div></div>; }
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadContractList } from "@/lib/services/contract-data";
+import type { RiderContract } from "@/types/domain";
+
+const statusMessage: Record<string, string> = {
+  created: "계약이 등록되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  terminated: "계약이 종료 처리되었습니다.",
+  updated: "계약 메모가 수정되었습니다."
+};
+
+export default async function ContractsPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadContractList()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title="계약 관리"
+        description="라이더-차량 계약 목록, 등록, 메모 수정과 종료 처리를 관리합니다. 계약 기간은 선택한 계약 양식 기준으로 계산됩니다."
+        actionHref="/contracts/new"
+        actionLabel="계약 등록"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <div className="table-card">
+        {data.contracts.length ? (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>라이더</th>
+                <th>차량</th>
+                <th>계약 양식</th>
+                <th>시작</th>
+                <th>종료</th>
+                <th>상태</th>
+                <th>상세</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.contracts.map((contract) => (
+                <tr key={contract.slug}>
+                  <td>{contract.riderName}</td>
+                  <td>{contract.bikeLabel ?? "차량 연결 후 표시"}</td>
+                  <td>{contract.contractType}</td>
+                  <td>{contract.startsAt}</td>
+                  <td>{contract.endsAt}</td>
+                  <td><Badge tone={badgeTone(contract)}>{contract.status}</Badge></td>
+                  <td><Link className="button-secondary" href={`/contracts/${contract.slug}`}>보기</Link></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <EmptyState
+            actionLabel="계약 등록"
+            description="아직 등록된 계약이 없습니다. 라이더/차량/계약양식은 선택 UI로 연결합니다."
+            href="/contracts/new"
+            title="계약 없음"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function badgeTone(contract: RiderContract): "active" | "muted" | "outline" {
+  if (contract.status === "활성") {
+    return "active";
+  }
+
+  return contract.status === "초안" ? "muted" : "outline";
+}

--- a/development/front-admin-web/components/contracts/ContractForm.tsx
+++ b/development/front-admin-web/components/contracts/ContractForm.tsx
@@ -1,20 +1,61 @@
-"use client";
+import Link from "next/link";
 
-import { MockFormActions } from "@/components/ui/MockActions";
 import { Field } from "@/components/ui/FormField";
-import { riders } from "@/lib/services/mock-data";
+import type { ContractSelectionOption } from "@/lib/services/contract-data";
 
-export function ContractForm() {
+type ContractFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  options: {
+    riders: ContractSelectionOption[];
+    templates: ContractSelectionOption[];
+    vehicles: ContractSelectionOption[];
+  };
+  statusMessage?: string | null;
+};
+
+export function ContractForm({ action, cancelHref = "/contracts", options, statusMessage }: ContractFormProps) {
   return (
-    <form className="card" onSubmit={(event) => event.preventDefault()} aria-label="계약 등록 폼">
+    <form action={action} className="card" aria-label="계약 등록 폼">
       <div className="form-grid">
-        <Field label="계약 대상 라이더" hint="contract_id 또는 rider_id 입력 없이 이름/연락처로 선택합니다."><select className="select" name="rider">{riders.map((r) => <option key={r.slug}>{r.name} · {r.phone} · {r.area}</option>)}</select></Field>
-        <Field label="계약 유형"><select className="select" name="contractType"><option>위탁 운영 계약</option><option>정규 운영 계약</option><option>파트타임 계약</option></select></Field>
-        <Field label="계약 시작일"><input className="input" name="startsAt" type="date" /></Field>
-        <Field label="계약 종료일"><input className="input" name="endsAt" type="date" /></Field>
-        <Field label="계약 상태"><select className="select" name="status"><option>초안</option><option>활성</option><option>만료 예정</option><option>종료</option></select></Field>
+        <Field label="계약 대상 라이더" hint="rider_id 직접 입력 없이 이름/연락처 기준으로 선택합니다.">
+          <select className="select" name="riderSelection" required>
+            <option value="">라이더 선택</option>
+            {options.riders.map((rider) => (
+              <option key={rider.value} value={rider.value}>{rider.label}{rider.helper ? ` · ${rider.helper}` : ""}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="연결 차량" hint="vehicle_id 직접 입력 없이 차량번호/모델 기준으로 선택합니다.">
+          <select className="select" name="bikeSelection" required>
+            <option value="">차량 선택</option>
+            {options.vehicles.map((vehicle) => (
+              <option key={vehicle.value} value={vehicle.value}>{vehicle.label}{vehicle.helper ? ` · ${vehicle.helper}` : ""}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="계약 양식" hint="계약 기간과 종료일은 선택한 양식 기준으로 백엔드가 계산합니다.">
+          <select className="select" name="contractTemplateSelection" required>
+            <option value="">계약 양식 선택</option>
+            {options.templates.map((template) => (
+              <option key={template.value} value={template.value}>{template.label}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="계약 시작일시" hint="서울 시간(KST) 기준으로 저장합니다. 종료일시는 계약 양식 기간으로 자동 계산됩니다.">
+          <input className="input" name="startAt" required type="datetime-local" />
+        </Field>
       </div>
-      <MockFormActions cancelHref="/contracts" submitLabel="계약 등록" successMessage="계약 등록 요청을 확인했습니다. 실제 저장은 Supabase 연결 단계에서 처리됩니다." />
+      <br />
+      <Field label="운영 메모"><textarea className="input" name="memo" placeholder="계약 운영 메모" rows={4} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        계약/라이더/차량/계약양식 ID는 입력받지 않습니다. 운영자는 사람이 읽을 수 있는 선택지만 사용하고, 저장 payload는 선택 UI 결과로 생성됩니다.
+      </p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">계약 등록</button>
+      </div>
     </form>
   );
 }

--- a/development/front-admin-web/lib/services/contract-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/contract-command-payload.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ContractCommandPayloadError,
+  toRiderBikeContractCreatePayload,
+  toRiderBikeContractMemoPayload,
+  toRiderBikeContractTerminatePayload
+} from "./contract-command-payload.ts";
+
+test("contract create payload uses selector fields and ignores raw direct ID field names", () => {
+  const formData = new FormData();
+  formData.set("riderSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("bikeSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("contractTemplateSelection", "33333333-3333-4333-8333-333333333333");
+  formData.set("startAt", "2026-05-01T09:30");
+  formData.set("memo", "선택 UI 기반 계약");
+  formData.set("riderId", "99999999-9999-4999-8999-999999999999");
+  formData.set("bikeId", "99999999-9999-4999-8999-999999999999");
+  formData.set("contractTemplateId", "99999999-9999-4999-8999-999999999999");
+
+  const payload = toRiderBikeContractCreatePayload(formData);
+
+  assert.deepEqual(payload, {
+    bikeId: "22222222-2222-4222-8222-222222222222",
+    contractTemplateId: "33333333-3333-4333-8333-333333333333",
+    memo: "선택 UI 기반 계약",
+    riderId: "11111111-1111-4111-8111-111111111111",
+    startAt: "2026-05-01T00:30:00.000Z"
+  });
+});
+
+test("contract create payload rejects blank or non-uuid selector values", () => {
+  const formData = new FormData();
+  formData.set("riderSelection", "kim-minjun");
+  formData.set("bikeSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("contractTemplateSelection", "33333333-3333-4333-8333-333333333333");
+  formData.set("startAt", "2026-05-01T09:30");
+
+  assert.throws(() => toRiderBikeContractCreatePayload(formData), ContractCommandPayloadError);
+
+  formData.set("riderSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("bikeSelection", "");
+
+  assert.throws(() => toRiderBikeContractCreatePayload(formData), ContractCommandPayloadError);
+});
+
+test("contract memo and terminate payloads keep state-specific fields only", () => {
+  const memoForm = new FormData();
+  memoForm.set("memo", "메모 수정");
+  memoForm.set("riderId", "11111111-1111-4111-8111-111111111111");
+  assert.deepEqual(toRiderBikeContractMemoPayload(memoForm), { memo: "메모 수정" });
+
+  const terminateForm = new FormData();
+  terminateForm.set("terminatedAt", "2026-05-10T18:00");
+  terminateForm.set("terminatedReason", "운영 종료");
+  terminateForm.set("contractId", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+  assert.deepEqual(toRiderBikeContractTerminatePayload(terminateForm), {
+    terminatedAt: "2026-05-10T09:00:00.000Z",
+    terminatedReason: "운영 종료"
+  });
+});

--- a/development/front-admin-web/lib/services/contract-command-payload.ts
+++ b/development/front-admin-web/lib/services/contract-command-payload.ts
@@ -1,0 +1,93 @@
+import type {
+  RiderBikeContractCreateInput,
+  RiderBikeContractTerminateInput,
+  RiderBikeContractUpdateInput
+} from "./service-ops-api";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SEOUL_OFFSET = "+09:00";
+
+export class ContractCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContractCommandPayloadError";
+  }
+}
+
+export function toRiderBikeContractCreatePayload(formData: FormData): RiderBikeContractCreateInput {
+  return {
+    bikeId: requiredUuid(formData.get("bikeSelection"), "Vehicle selection is required."),
+    contractTemplateId: requiredUuid(formData.get("contractTemplateSelection"), "Contract template selection is required."),
+    memo: optionalText(formData.get("memo")),
+    riderId: requiredUuid(formData.get("riderSelection"), "Rider selection is required."),
+    startAt: toServiceInstant(formData.get("startAt"), "Contract start date/time is required.")
+  };
+}
+
+export function toRiderBikeContractMemoPayload(formData: FormData): RiderBikeContractUpdateInput {
+  return {
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+export function toRiderBikeContractTerminatePayload(formData: FormData): RiderBikeContractTerminateInput {
+  return {
+    terminatedAt: toServiceInstant(formData.get("terminatedAt"), "Contract termination date/time is required."),
+    terminatedReason: optionalText(formData.get("terminatedReason"))
+  };
+}
+
+function requiredUuid(value: FormDataEntryValue | null, message: string): string {
+  const text = requiredText(value, message);
+  if (!UUID_PATTERN.test(text)) {
+    throw new ContractCommandPayloadError("Invalid selector token. Use the provided rider, vehicle, and contract template selection controls.");
+  }
+
+  return text;
+}
+
+function toServiceInstant(value: FormDataEntryValue | null, message: string): string {
+  const text = requiredText(value, message);
+  const normalized = normalizeDateTimeInput(text);
+  const date = new Date(normalized);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new ContractCommandPayloadError("Invalid contract date/time.");
+  }
+
+  return date.toISOString();
+}
+
+function normalizeDateTimeInput(value: string): string {
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(value)) {
+    return value;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+    return `${value}:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+    return `${value}${SEOUL_OFFSET}`;
+  }
+
+  return value;
+}
+
+function requiredText(value: FormDataEntryValue | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new ContractCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}

--- a/development/front-admin-web/lib/services/contract-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/contract-data-core.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveContractStatus,
+  mockContractUnconfiguredServiceDetail,
+  mockContractUnavailableServiceDetail,
+  toFrontendContract
+} from "./contract-data-core.ts";
+
+const mockContracts = [
+  {
+    area: "강남/역삼",
+    contractType: "위탁 운영 계약",
+    endsAt: "2026-12-31",
+    riderName: "김민준",
+    slug: "contract-kim-minjun-2026",
+    startsAt: "2026-01-15",
+    status: "활성"
+  }
+];
+
+const lookup = {
+  riders: new Map([
+    ["11111111-1111-4111-8111-111111111111", { area: "강남/역삼", name: "김민준", phone: "010-1111-2222" }]
+  ]),
+  templates: new Map([
+    ["33333333-3333-4333-8333-333333333333", { durationMinutes: null, enabled: true, id: "33333333-3333-4333-8333-333333333333", name: "무제한 계약", unlimited: true }]
+  ]),
+  vehicles: new Map([
+    ["22222222-2222-4222-8222-222222222222", { model: "Thunder M1", plateNumber: "서울A-1001", status: "대기" }]
+  ])
+};
+
+test("toFrontendContract hydrates labels without exposing raw ids as display text", () => {
+  const contract = toFrontendContract(
+    {
+      bikeId: "22222222-2222-4222-8222-222222222222",
+      contractTemplateId: "33333333-3333-4333-8333-333333333333",
+      createdAt: "2026-04-30T00:00:00Z",
+      endAt: null,
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      idx: 7,
+      memo: "계약 메모",
+      riderId: "11111111-1111-4111-8111-111111111111",
+      startAt: "2026-05-01T00:30:00Z",
+      terminatedAt: null,
+      terminatedReason: null,
+      updatedAt: "2026-04-30T00:00:00Z"
+    },
+    lookup,
+    new Date("2026-05-02T00:00:00Z")
+  );
+
+  assert.equal(contract.riderName, "김민준");
+  assert.equal(contract.bikeLabel, "서울A-1001 · Thunder M1");
+  assert.equal(contract.contractType, "무제한 계약");
+  assert.equal(contract.endsAt, "무제한");
+  assert.equal(contract.status, "활성");
+});
+
+test("deriveContractStatus uses terminatedAt and endAt lifecycle fields", () => {
+  const now = new Date("2026-05-01T00:00:00Z");
+  assert.equal(deriveContractStatus({ endAt: null, terminatedAt: null }, now), "활성");
+  assert.equal(deriveContractStatus({ endAt: "2026-05-10T00:00:00Z", terminatedAt: null }, now), "만료 예정");
+  assert.equal(deriveContractStatus({ endAt: "2026-04-01T00:00:00Z", terminatedAt: null }, now), "종료");
+  assert.equal(deriveContractStatus({ endAt: null, terminatedAt: "2026-04-15T00:00:00Z" }, now), "종료");
+});
+
+test("UUID contract detail falls back to visible mock detail when service API is unavailable", () => {
+  const missingSession = mockContractUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    mockContracts,
+    "서비스 API 세션 쿠키가 없어 mock 계약 상세를 표시합니다."
+  );
+  const missingBaseUrl = mockContractUnconfiguredServiceDetail("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", mockContracts);
+
+  assert.equal(missingSession?.source, "mock");
+  assert.equal(missingSession?.contract.slug, "contract-kim-minjun-2026");
+  assert.match(missingBaseUrl?.notice ?? "", /SERVICE_OPS_API_BASE_URL/);
+});

--- a/development/front-admin-web/lib/services/contract-data-core.ts
+++ b/development/front-admin-web/lib/services/contract-data-core.ts
@@ -1,0 +1,155 @@
+import type { RiderContract } from "@/types/domain";
+import type {
+  FrontendRider,
+  FrontendVehicle,
+  ServiceOpsContractTemplate,
+  ServiceOpsRiderBikeContract
+} from "./service-ops-api";
+
+export type ContractDataResult = {
+  contracts: RiderContract[];
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type ContractDetailResult = {
+  contract: RiderContract;
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type ContractLookup = {
+  riders: Map<string, Pick<FrontendRider, "area" | "name" | "phone">>;
+  vehicles: Map<string, Pick<FrontendVehicle, "model" | "plateNumber" | "status">>;
+  templates: Map<string, Pick<ServiceOpsContractTemplate, "durationMinutes" | "enabled" | "id" | "name" | "unlimited">>;
+};
+
+export function toFrontendContract(
+  contract: ServiceOpsRiderBikeContract,
+  lookup: ContractLookup,
+  now = new Date()
+): RiderContract {
+  const rider = lookup.riders.get(contract.riderId);
+  const vehicle = lookup.vehicles.get(contract.bikeId);
+  const template = lookup.templates.get(contract.contractTemplateId);
+
+  const riderName = rider?.name ?? "라이더 연결 확인 필요";
+  const bikeLabel = vehicle ? `${vehicle.plateNumber} · ${vehicle.model}` : "차량 연결 확인 필요";
+  const templateName = template?.name ?? "계약 양식 연결 확인 필요";
+
+  return {
+    area: rider?.area ?? "미지정",
+    bikeId: contract.bikeId,
+    bikeLabel,
+    contractTemplateId: contract.contractTemplateId,
+    contractType: templateName,
+    createdAt: contract.createdAt,
+    endAt: contract.endAt,
+    endsAt: contract.endAt ? toDateTimeLabel(contract.endAt) : "무제한",
+    id: contract.id,
+    idx: contract.idx,
+    memo: contract.memo,
+    riderId: contract.riderId,
+    riderLabel: rider ? `${rider.name} · ${rider.phone}` : riderName,
+    riderName,
+    slug: contract.id,
+    source: "service-ops",
+    startAt: contract.startAt,
+    startsAt: toDateTimeLabel(contract.startAt),
+    status: deriveContractStatus(contract, now),
+    templateName,
+    terminatedAt: contract.terminatedAt,
+    terminatedReason: contract.terminatedReason,
+    updatedAt: contract.updatedAt
+  };
+}
+
+export function deriveContractStatus(
+  contract: Pick<ServiceOpsRiderBikeContract, "endAt" | "terminatedAt">,
+  now = new Date()
+): RiderContract["status"] {
+  if (contract.terminatedAt) {
+    return "종료";
+  }
+
+  if (!contract.endAt) {
+    return "활성";
+  }
+
+  const endAt = new Date(contract.endAt);
+  if (Number.isNaN(endAt.getTime())) {
+    return "활성";
+  }
+
+  if (endAt.getTime() < now.getTime()) {
+    return "종료";
+  }
+
+  const expiresSoonMs = 60 * 24 * 60 * 60 * 1000;
+  return endAt.getTime() - now.getTime() <= expiresSoonMs ? "만료 예정" : "활성";
+}
+
+export function mockContractList(mockContracts: RiderContract[]): ContractDataResult {
+  return {
+    contracts: mockContracts.map((contract) => ({ ...contract, source: "mock" as const })),
+    source: "mock"
+  };
+}
+
+export function mockContractDetail(slug: string, mockContracts: RiderContract[]): ContractDetailResult | null {
+  const contract = mockContracts.find((candidate) => candidate.slug === slug);
+  if (!contract) {
+    return null;
+  }
+
+  return {
+    contract: { ...contract, source: "mock" },
+    source: "mock"
+  };
+}
+
+export function mockContractUnavailableServiceDetail(
+  slug: string,
+  mockContracts: RiderContract[],
+  notice: string
+): ContractDetailResult | null {
+  const exactFallback = mockContractDetail(slug, mockContracts);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockContracts.length) {
+    return null;
+  }
+
+  return {
+    contract: { ...mockContracts[0], source: "mock" },
+    notice,
+    source: "mock"
+  };
+}
+
+export function mockContractUnconfiguredServiceDetail(slug: string, mockContracts: RiderContract[]): ContractDetailResult | null {
+  return mockContractUnavailableServiceDetail(
+    slug,
+    mockContracts,
+    "SERVICE_OPS_API_BASE_URL이 없어 mock 계약 상세를 표시합니다. 백엔드 연결 후 실제 계약 상세로 전환됩니다."
+  );
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function toDateTimeLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Seoul"
+  }).format(date);
+}

--- a/development/front-admin-web/lib/services/contract-data.ts
+++ b/development/front-admin-web/lib/services/contract-data.ts
@@ -1,0 +1,226 @@
+import type { RiderContract } from "@/types/domain";
+import type {
+  FrontendRider,
+  FrontendVehicle,
+  ServiceOpsApiClient,
+  ServiceOpsApiError,
+  ServiceOpsContractTemplate
+} from "@/lib/services/service-ops-api";
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { contracts as mockContracts, riders as mockRiders, vehicles as mockVehicles } from "@/lib/services/mock-data";
+import {
+  type ContractDataResult,
+  type ContractDetailResult,
+  type ContractLookup,
+  isUuidLike,
+  mockContractDetail,
+  mockContractList,
+  mockContractUnconfiguredServiceDetail,
+  mockContractUnavailableServiceDetail,
+  toFrontendContract
+} from "@/lib/services/contract-data-core";
+
+export type ContractSelectionOption = {
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+export type ContractFormOptionsResult = {
+  notice?: string;
+  riders: ContractSelectionOption[];
+  source: "mock" | "service-ops";
+  templates: ContractSelectionOption[];
+  vehicles: ContractSelectionOption[];
+};
+
+export async function loadContractList(): Promise<ContractDataResult> {
+  const fallback = mockContractList(mockContracts);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 계약 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 계약 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const [contractPage, lookup] = await Promise.all([
+      client.listRiderBikeContracts({ page: 0, size: 100 }),
+      loadContractLookup(client)
+    ]);
+
+    return {
+      contracts: contractPage.items.map((contract) => toFrontendContract(contract, lookup)),
+      source: "service-ops"
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 계약 조회 실패로 mock 계약 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadContractDetail(slug: string): Promise<ContractDetailResult | null> {
+  const fallback = mockContractDetail(slug, mockContracts);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockContractUnconfiguredServiceDetail(slug, mockContracts);
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockContractUnavailableServiceDetail(
+        slug,
+        mockContracts,
+        "서비스 API 세션 쿠키가 없어 mock 계약 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const [contract, lookup] = await Promise.all([
+        client.getRiderBikeContract(slug),
+        loadContractLookup(client)
+      ]);
+      return {
+        contract: toFrontendContract(contract, lookup),
+        source: "service-ops"
+      };
+    } catch (error) {
+      return mockContractUnavailableServiceDetail(
+        slug,
+        mockContracts,
+        `서비스 API 계약 상세 조회 실패로 mock 계약 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadContractFormOptions(): Promise<ContractFormOptionsResult> {
+  const fallback = mockContractFormOptions();
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 선택지를 표시합니다. 백엔드 연결 후 실제 라이더/차량/계약 양식 선택지로 전환됩니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 선택지를 표시합니다. 관리자 로그인 후 실제 선택지로 전환됩니다."
+    };
+  }
+
+  try {
+    const [riderPage, vehiclePage, templatePage] = await Promise.all([
+      client.listRiders({ page: 0, size: 100 }),
+      client.listVehicles({ page: 0, size: 100 }),
+      client.listContractTemplates({ page: 0, size: 100 })
+    ]);
+
+    return {
+      riders: riderPage.items.map((rider) => ({
+        helper: `${rider.team} · ${rider.area}`,
+        label: `${rider.name} · ${rider.phone}`,
+        value: rider.slug
+      })),
+      source: "service-ops",
+      templates: templatePage.items
+        .filter((template) => template.enabled)
+        .map((template) => ({
+          helper: template.description ?? undefined,
+          label: `${template.name} · ${formatDuration(template)}`,
+          value: template.id
+        })),
+      vehicles: vehiclePage.items.map((vehicle) => ({
+        helper: vehicle.status,
+        label: `${vehicle.plateNumber} · ${vehicle.model}`,
+        value: vehicle.slug
+      }))
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 선택지 조회 실패로 mock 선택지를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+async function loadContractLookup(client: ServiceOpsApiClient): Promise<ContractLookup> {
+  const [riderPage, vehiclePage, templatePage] = await Promise.all([
+    client.listRiders({ page: 0, size: 100 }),
+    client.listVehicles({ page: 0, size: 100 }),
+    client.listContractTemplates({ page: 0, size: 100 })
+  ]);
+
+  return {
+    riders: new Map(riderPage.items.map((rider: FrontendRider) => [rider.slug, rider])),
+    templates: new Map(templatePage.items.map((template: ServiceOpsContractTemplate) => [template.id, template])),
+    vehicles: new Map(vehiclePage.items.map((vehicle: FrontendVehicle) => [vehicle.slug, vehicle]))
+  };
+}
+
+function mockContractFormOptions(): ContractFormOptionsResult {
+  const templateNames = Array.from(new Set(mockContracts.map((contract) => contract.contractType)));
+
+  return {
+    riders: mockRiders.map((rider) => ({
+      helper: `${rider.team} · ${rider.area}`,
+      label: `${rider.name} · ${rider.phone}`,
+      value: rider.slug
+    })),
+    source: "mock",
+    templates: templateNames.map((templateName) => ({
+      helper: "mock 계약 양식",
+      label: templateName,
+      value: templateName
+    })),
+    vehicles: mockVehicles.map((vehicle) => ({
+      helper: vehicle.status,
+      label: `${vehicle.plateNumber} · ${vehicle.model}`,
+      value: vehicle.slug
+    }))
+  };
+}
+
+function formatDuration(template: ServiceOpsContractTemplate): string {
+  if (template.unlimited || template.durationMinutes === null) {
+    return "무제한";
+  }
+
+  if (template.durationMinutes % 1440 === 0) {
+    return `${template.durationMinutes / 1440}일`;
+  }
+
+  if (template.durationMinutes % 60 === 0) {
+    return `${template.durationMinutes / 60}시간`;
+  }
+
+  return `${template.durationMinutes}분`;
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -325,6 +325,104 @@ test("changeVehicleOperationStatus uses dedicated status endpoint", async () => 
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
 
+test("contract template list request uses backend path and bearer token", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              idx: 1,
+              name: "무제한 계약",
+              durationMinutes: null,
+              unlimited: true,
+              description: "기간 제한 없음",
+              enabled: true,
+              systemTemplate: true,
+              createdAt: "2026-04-30T00:00:00Z",
+              updatedAt: "2026-04-30T00:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 100, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listContractTemplates({ page: 0, size: 100 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/contract-templates");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "100");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].name, "무제한 계약");
+  assert.equal(page.items[0].unlimited, true);
+});
+
+test("rider-bike contract create/update/terminate use dedicated contract endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          idx: 10,
+          riderId: body.riderId ?? "22222222-2222-4222-8222-222222222222",
+          bikeId: body.bikeId ?? "33333333-3333-4333-8333-333333333333",
+          contractTemplateId: body.contractTemplateId ?? "44444444-4444-4444-8444-444444444444",
+          startAt: body.startAt ?? "2026-05-01T00:00:00Z",
+          endAt: null,
+          terminatedAt: body.terminatedAt ?? null,
+          terminatedReason: body.terminatedReason ?? null,
+          memo: body.memo ?? null,
+          createdAt: "2026-04-30T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.createRiderBikeContract({
+    bikeId: "33333333-3333-4333-8333-333333333333",
+    contractTemplateId: "44444444-4444-4444-8444-444444444444",
+    memo: "운영 메모",
+    riderId: "22222222-2222-4222-8222-222222222222",
+    startAt: "2026-04-30T15:00:00.000Z"
+  });
+  await client.updateRiderBikeContract("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", { memo: "메모 수정" });
+  await client.terminateRiderBikeContract("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+    terminatedAt: "2026-05-10T00:00:00.000Z",
+    terminatedReason: "운영 종료"
+  });
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/rider-bike-contracts",
+    "/api/v1/rider-bike-contracts/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "/api/v1/rider-bike-contracts/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/terminate"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["POST", "PATCH", "PATCH"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), ["bikeId", "contractTemplateId", "memo", "riderId", "startAt"]);
+  assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { memo: "메모 수정" });
+  assert.deepEqual(JSON.parse(String(calls[2].init?.body)), {
+    terminatedAt: "2026-05-10T00:00:00.000Z",
+    terminatedReason: "운영 종료"
+  });
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
 test("refresh request posts refresh token without bearer token", async () => {
   const calls = [];
   const client = createServiceOpsApiClient({

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -125,6 +125,51 @@ export type VehicleOperationStatusChangeInput = {
   memo?: string | null;
 };
 
+export type ServiceOpsContractTemplate = {
+  id: string;
+  idx: number | null;
+  name: string;
+  durationMinutes: number | null;
+  unlimited: boolean;
+  description: string | null;
+  enabled: boolean;
+  systemTemplate: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ServiceOpsRiderBikeContract = {
+  id: string;
+  idx: number | null;
+  riderId: string;
+  bikeId: string;
+  contractTemplateId: string;
+  startAt: string;
+  endAt: string | null;
+  terminatedAt: string | null;
+  terminatedReason: string | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RiderBikeContractCreateInput = {
+  riderId: string;
+  bikeId: string;
+  contractTemplateId: string;
+  startAt: string;
+  memo?: string | null;
+};
+
+export type RiderBikeContractUpdateInput = {
+  memo?: string | null;
+};
+
+export type RiderBikeContractTerminateInput = {
+  terminatedAt: string;
+  terminatedReason?: string | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -212,6 +257,13 @@ export type ServiceOpsApiClient = {
   createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
   updateVehicle: (id: string, request: VehicleUpdateInput) => Promise<FrontendVehicle>;
   changeVehicleOperationStatus: (id: string, request: VehicleOperationStatusChangeInput) => Promise<FrontendVehicle>;
+  listContractTemplates: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsContractTemplate>>;
+  getContractTemplate: (id: string) => Promise<ServiceOpsContractTemplate>;
+  listRiderBikeContracts: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsRiderBikeContract>>;
+  getRiderBikeContract: (id: string) => Promise<ServiceOpsRiderBikeContract>;
+  createRiderBikeContract: (request: RiderBikeContractCreateInput) => Promise<ServiceOpsRiderBikeContract>;
+  updateRiderBikeContract: (id: string, request: RiderBikeContractUpdateInput) => Promise<ServiceOpsRiderBikeContract>;
+  terminateRiderBikeContract: (id: string, request: RiderBikeContractTerminateInput) => Promise<ServiceOpsRiderBikeContract>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -364,6 +416,29 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    listContractTemplates: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsContractTemplate>>("/contract-templates", { method: "GET" }, { page, size, sort }),
+    getContractTemplate: (id) =>
+      request<ServiceOpsContractTemplate>(`/contract-templates/${encodeURIComponent(id)}`, { method: "GET" }),
+    listRiderBikeContracts: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsRiderBikeContract>>("/rider-bike-contracts", { method: "GET" }, { page, size, sort }),
+    getRiderBikeContract: (id) =>
+      request<ServiceOpsRiderBikeContract>(`/rider-bike-contracts/${encodeURIComponent(id)}`, { method: "GET" }),
+    createRiderBikeContract: (createRequest) =>
+      request<ServiceOpsRiderBikeContract>("/rider-bike-contracts", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateRiderBikeContract: (id, updateRequest) =>
+      request<ServiceOpsRiderBikeContract>(`/rider-bike-contracts/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
+        method: "PATCH"
+      }),
+    terminateRiderBikeContract: (id, terminateRequest) =>
+      request<ServiceOpsRiderBikeContract>(`/rider-bike-contracts/${encodeURIComponent(id)}/terminate`, {
+        body: JSON.stringify(terminateRequest),
+        method: "PATCH"
+      }),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -18,10 +18,10 @@ export const riderSchema = z.object({
 
 export const contractSchema = z.object({
   riderSelection: z.string().min(1, "라이더를 선택하세요."),
-  contractType: z.string().min(1, "계약 유형을 선택하세요."),
-  startsAt: z.string().date(),
-  endsAt: z.string().date(),
-  status: z.enum(["활성", "만료 예정", "종료", "초안"])
+  bikeSelection: z.string().min(1, "차량을 선택하세요."),
+  contractTemplateSelection: z.string().min(1, "계약 양식을 선택하세요."),
+  startAt: z.string().min(1, "계약 시작일시를 선택하세요."),
+  memo: z.string().optional()
 });
 
 export const insuranceSchema = z.object({

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -36,12 +36,28 @@ export type Vehicle = {
 
 export type RiderContract = {
   slug: string;
+  id?: string;
+  idx?: number | null;
   riderName: string;
+  riderId?: string;
+  riderLabel?: string;
+  bikeId?: string;
+  bikeLabel?: string;
+  contractTemplateId?: string;
+  templateName?: string;
   contractType: string;
   startsAt: string;
   endsAt: string;
   status: ContractStatus;
   area: string;
+  startAt?: string;
+  endAt?: string | null;
+  terminatedAt?: string | null;
+  terminatedReason?: string | null;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
 };
 
 export type InsurancePolicy = {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -689,3 +689,30 @@ Verification:
 
 - TDD red observed on frontend service-ops vehicle tests before implementation because `listVehicles`, `createVehicle`, and `changeVehicleOperationStatus` did not exist.
 - Frontend service-ops tests cover bike list mapping, create/update payload boundaries, and dedicated operation-status request shape.
+
+## Frontend contract admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#80
+- Target issue: EVNSolution/thundercrew-domain#67
+- Branch: `cc-80-contract-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires the existing Next.js contract management screens to the existing service-ops-api contract-template and rider-bike-contract endpoints.
+- Included work is a frontend contract client/data adapter, contract form selector options, rider-bike contract create, memo update, terminate actions, service-ops tests, and docs updates.
+- Telemetry, map provider/API, new backend schema/API changes, contract template management UI, reassignment/correction/delete/restore flows, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Contract create uses human-readable select controls for rider, bike, and contract template; operators do not type raw `contractId`, `riderId`, `bikeId`, or `contractTemplateId` fields.
+- The server-action payload builder reads only selector field names and ignores direct raw ID field names if present in submitted form data.
+- `endAt` and display status are derived from backend lifecycle fields; the form captures only `startAt` and memo for creation.
+- Contract update is memo-only and contract termination is a separate history-preserving action.
+- Missing config/session/API failure falls back to explicit mock contract data with a visible notice, including service UUID detail routes.
+
+Verification:
+
+- TDD red observed on frontend service-ops contract tests before implementation because contract API client methods and contract command/data helpers did not exist.
+- Frontend service-ops tests cover contract template list request shape, rider-bike create/update/terminate endpoint shape, selector-only payload conversion, lifecycle status derivation, and UUID mock fallback.


### PR DESCRIPTION
## Summary
- Connect contract admin list/detail/create/memo-update/terminate flows to existing service-ops contract APIs.
- Load rider/vehicle/template selector options from service-ops when configured, with explicit mock fallback notices.
- Add tests for contract API request shapes, selector-only payload conversion, lifecycle status derivation, and UUID fallback.

## Scope boundaries
- Excludes telemetry, map provider/API, new backend schema/API changes, reassignment/correction/delete/restore flows, and production env mutation.
- No direct editable contract/rider/bike/template ID fields were added.
- Contract end date remains backend-derived from the selected contract template.

## Change control
- Change-control: EVNSolution/clever-change-control#80
- Target issue: Closes #67

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (33/33)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- Code-reviewer: PASS

## Not tested
- Live browser flow against a running service-ops API instance.
