### PR TITLE
Frontend insurance admin API integration baseline (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Frontend ↔ backend baseline:
 - 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
 - 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
+- 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -17,7 +17,7 @@
 - 차량: `vehicle_id` 입력 금지 → 차량번호/모델/상태/위치와 라이더 선택
 - 라이더: `rider_id` 입력 금지 → 이름/연락처/소속/구역 입력
 - 계약: `contract_id`, `rider_id`, `vehicle_id`, `contract_template_id` 입력 금지 → 라이더 이름/연락처, 차량번호, 계약 양식 선택
-- 보험: `insurance_id`, `rider_id`, `vehicle_id` 입력 금지 → 라이더 또는 차량 식별 정보 선택
+- 보험: `insurance_id`, `rider_id`, `vehicle_id`, `insurance_item_id` 입력 금지 → 라이더 이름/연락처와 보험 항목 선택
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
 
 DB PK/FK는 backend/Postgres에서 자동 생성·관리합니다. 화면 route에 backend UUID가 쓰이더라도 사용자가 직접 입력하거나 수정하는 필드로 노출하지 않습니다.
@@ -77,6 +77,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료는 server action/server component에서 `/api/v1/contract-templates`와 `/api/v1/rider-bike-contracts`를 호출합니다.
 - 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
+- 보험 목록/상세/등록/수정은 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
+- 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.

--- a/development/front-admin-web/app/insurance/[slug]/page.tsx
+++ b/development/front-admin-web/app/insurance/[slug]/page.tsx
@@ -1,23 +1,75 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { updateInsuranceAction } from "@/app/insurance/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { DetailActionPanel } from "@/components/ui/MockActions";
-import { insurancePolicies } from "@/lib/services/mock-data";
+import { Field } from "@/components/ui/FormField";
+import { loadInsuranceDetail } from "@/lib/services/insurance-data";
 
-export default async function InsuranceDetailPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  const policy = insurancePolicies.find((p) => p.slug === slug) ?? insurancePolicies[0];
+const statusMessage: Record<string, string> = {
+  created: "보험 연결이 등록되었습니다.",
+  "mock-updated": "서비스 API가 연결되지 않아 보험 수정 요청을 mock 피드백으로만 처리했습니다.",
+  "save-error": "보험 수정에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  updated: "보험 연결 정보가 수정되었습니다."
+};
+
+export default async function InsuranceDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadInsuranceDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const policy = detail.policy;
+  const message = status ? statusMessage[status] : null;
+  const updateAction = updateInsuranceAction.bind(null, slug);
 
   return (
     <div className="page-container">
       <PageHeader title={`${policy.provider} 보험`} description={policy.holderLabel} />
-      <section className="card">
-        <div className="detail-list">
-          <div className="detail-row"><span>대상 구분</span><strong>{policy.targetType}</strong></div>
-          <div className="detail-row"><span>증권번호</span><strong>{policy.policyNumber}</strong></div>
-          <div className="detail-row"><span>기간</span><strong>{policy.startsAt} ~ {policy.endsAt}</strong></div>
-          <div className="detail-row"><span>상태</span><Badge>{policy.status}</Badge></div>
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>보험 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>대상</span><strong>{policy.holderLabel}</strong></div>
+            <div className="detail-row"><span>대상 구분</span><strong>{policy.targetType}</strong></div>
+            <div className="detail-row"><span>보험 항목</span><strong>{policy.provider}</strong></div>
+            <div className="detail-row"><span>증권번호</span><strong>{policy.policyNumber}</strong></div>
+            <div className="detail-row"><span>기간</span><strong>{policy.startsAt} ~ {policy.endsAt}</strong></div>
+            <div className="detail-row"><span>상태</span><Badge>{policy.status}</Badge></div>
+            {policy.memo ? <div className="detail-row"><span>메모</span><strong>{policy.memo}</strong></div> : null}
+          </div>
+          <div className="form-actions">
+            <Link className="button-secondary" href="/insurance">목록</Link>
+            <Link className="button-secondary" href="/insurance/new">새 보험 등록</Link>
+          </div>
         </div>
-        <DetailActionPanel secondaryHref="/insurance" primaryLabel="보험 상태 변경" logLabel="보험 로그" feedbackMessage="보험 상태 변경 요청을 확인했습니다. MVP mock에서는 실제 저장 없이 피드백만 표시합니다." logItems={["증권 확인 완료", "만료일 알림 기준 등록", "최근 상태: 정상"]} />
+        <aside className="detail-panel">
+          <h2>보험 작업</h2>
+          <form action={updateAction} className="action-panel">
+            <Field label="보험 상태">
+              <select className="select" defaultValue={policy.enabled === false ? "false" : "true"} name="enabled">
+                <option value="true">정상</option>
+                <option value="false">비활성</option>
+              </select>
+            </Field>
+            <Field label="운영 메모"><textarea className="input" defaultValue={policy.memo ?? ""} name="memo" placeholder="보험 연결 관련 운영 메모" rows={4} /></Field>
+            <p className="notice">보험 연결 수정은 현재 상세 대상에만 적용됩니다. 라이더/보험 항목 ID를 직접 입력하지 않습니다.</p>
+            <div className="form-actions">
+              <button className="button-primary" type="submit">변경 저장</button>
+            </div>
+          </form>
+        </aside>
       </section>
     </div>
   );

--- a/development/front-admin-web/app/insurance/actions.ts
+++ b/development/front-admin-web/app/insurance/actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toRiderInsuranceCreatePayload,
+  toRiderInsuranceUpdatePayload
+} from "@/lib/services/insurance-command-payload";
+
+export async function createInsuranceAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/insurance?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let policy;
+  try {
+    policy = await client.createRiderInsurance(toRiderInsuranceCreatePayload(formData));
+  } catch {
+    redirect("/insurance/new?status=save-error");
+  }
+
+  revalidatePath("/insurance");
+  redirect(`/insurance/${policy.id}?status=created`);
+}
+
+export async function updateInsuranceAction(policyId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/insurance/${policyId}?status=mock-updated`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let policy;
+  try {
+    policy = await client.updateRiderInsurance(policyId, toRiderInsuranceUpdatePayload(formData));
+  } catch {
+    redirect(`/insurance/${policyId}?status=save-error`);
+  }
+
+  revalidatePath("/insurance");
+  revalidatePath(`/insurance/${policy.id}`);
+  redirect(`/insurance/${policy.id}?status=updated`);
+}

--- a/development/front-admin-web/app/insurance/new/page.tsx
+++ b/development/front-admin-web/app/insurance/new/page.tsx
@@ -1,3 +1,20 @@
+import { createInsuranceAction } from "@/app/insurance/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { InsuranceForm } from "@/components/insurance/InsuranceForm";
-export default function NewInsurancePage() { return <div className="page-container"><PageHeader title="보험 등록" description="보험 ID는 자동 생성합니다. 대상은 라이더 이름/연락처 또는 차량번호로 선택합니다." /><InsuranceForm /></div>; }
+import { loadInsuranceFormOptions } from "@/lib/services/insurance-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "보험 등록에 실패했습니다. 필수 선택값, 중복 연결, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewInsurancePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, options] = await Promise.all([searchParams, loadInsuranceFormOptions()]);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="보험 등록" description="보험 ID는 자동 생성합니다. 라이더와 보험 항목은 사람이 읽을 수 있는 선택 UI로 연결합니다." />
+      {options.notice ? <p className="notice">{options.notice}</p> : null}
+      <InsuranceForm action={createInsuranceAction} options={options} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/insurance/page.tsx
+++ b/development/front-admin-web/app/insurance/page.tsx
@@ -1,5 +1,45 @@
 import Link from "next/link";
+
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { insurancePolicies } from "@/lib/services/mock-data";
-export default function InsurancePage() { return <div className="page-container"><PageHeader title="보험 관리" description="라이더 또는 차량 기준 보험 정보와 만료 예정 상태를 관리합니다." actionHref="/insurance/new" actionLabel="보험 등록" /><div className="table-card"><table className="table"><thead><tr><th>대상</th><th>구분</th><th>보험사</th><th>증권번호</th><th>기간</th><th>상태</th><th>상세</th></tr></thead><tbody>{insurancePolicies.map((p) => <tr key={p.slug}><td>{p.holderLabel}</td><td>{p.targetType}</td><td>{p.provider}</td><td>{p.policyNumber}</td><td>{p.startsAt} ~ {p.endsAt}</td><td><Badge tone={p.status === "정상" ? "active" : "outline"}>{p.status}</Badge></td><td><Link className="button-secondary" href={`/insurance/${p.slug}`}>보기</Link></td></tr>)}</tbody></table></div></div>; }
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadInsuranceList } from "@/lib/services/insurance-data";
+
+const statusMessage: Record<string, string> = {
+  created: "보험 연결이 등록되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  updated: "보험 연결 정보가 수정되었습니다."
+};
+
+export default async function InsurancePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadInsuranceList()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="보험 관리" description="라이더 기준 보험 항목 연결과 활성 상태를 관리합니다." actionHref="/insurance/new" actionLabel="보험 등록" />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <div className="table-card">
+        {data.policies.length ? (
+          <table className="table">
+            <thead><tr><th>대상</th><th>구분</th><th>보험 항목</th><th>증권번호</th><th>기간</th><th>상태</th><th>상세</th></tr></thead>
+            <tbody>{data.policies.map((policy) => (
+              <tr key={policy.slug}>
+                <td>{policy.holderLabel}</td>
+                <td>{policy.targetType}</td>
+                <td>{policy.provider}</td>
+                <td>{policy.policyNumber}</td>
+                <td>{policy.startsAt} ~ {policy.endsAt}</td>
+                <td><Badge tone={policy.status === "정상" ? "active" : "outline"}>{policy.status}</Badge></td>
+                <td><Link className="button-secondary" href={`/insurance/${policy.slug}`}>보기</Link></td>
+              </tr>
+            ))}</tbody>
+          </table>
+        ) : (
+          <EmptyState actionLabel="보험 등록" description="아직 등록된 보험 연결이 없습니다. 라이더와 보험 항목은 선택 UI로 연결합니다." href="/insurance/new" title="보험 없음" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/development/front-admin-web/components/insurance/InsuranceForm.tsx
+++ b/development/front-admin-web/components/insurance/InsuranceForm.tsx
@@ -1,21 +1,55 @@
-"use client";
+import Link from "next/link";
 
-import { MockFormActions } from "@/components/ui/MockActions";
 import { Field } from "@/components/ui/FormField";
-import { riders, vehicles } from "@/lib/services/mock-data";
+import type { InsuranceSelectionOption } from "@/lib/services/insurance-data";
 
-export function InsuranceForm() {
+type InsuranceFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  options: {
+    items: InsuranceSelectionOption[];
+    riders: InsuranceSelectionOption[];
+  };
+  statusMessage?: string | null;
+};
+
+export function InsuranceForm({ action, cancelHref = "/insurance", options, statusMessage }: InsuranceFormProps) {
   return (
-    <form className="card" onSubmit={(event) => event.preventDefault()} aria-label="보험 등록 폼">
+    <form action={action} className="card" aria-label="보험 등록 폼">
       <div className="form-grid">
-        <Field label="보험 대상" hint="FK ID를 입력하지 않고 라이더/차량 식별 정보로 선택합니다."><select className="select" name="target"><optgroup label="라이더">{riders.map((r) => <option key={r.slug}>라이더 · {r.name} · {r.phone}</option>)}</optgroup><optgroup label="차량">{vehicles.map((v) => <option key={v.slug}>차량 · {v.plateNumber} · {v.model}</option>)}</optgroup></select></Field>
-        <Field label="보험사"><input className="input" name="provider" placeholder="예: 현대해상" /></Field>
-        <Field label="증권번호"><input className="input" name="policyNumber" placeholder="예: HD-26-884102" /></Field>
-        <Field label="보험 시작일"><input className="input" name="startsAt" type="date" /></Field>
-        <Field label="보험 종료일"><input className="input" name="endsAt" type="date" /></Field>
-        <Field label="보험 상태"><select className="select" name="status"><option>정상</option><option>만료 예정</option><option>만료</option></select></Field>
+        <Field label="보험 대상 라이더" hint="rider_id 직접 입력 없이 이름/연락처 기준으로 선택합니다.">
+          <select className="select" name="riderSelection" required>
+            <option value="">라이더 선택</option>
+            {options.riders.map((rider) => (
+              <option key={rider.value} value={rider.value}>{rider.label}{rider.helper ? ` · ${rider.helper}` : ""}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="보험 항목" hint="insurance_id 직접 입력 없이 운영자가 등록한 보험 항목을 선택합니다.">
+          <select className="select" name="insuranceItemSelection" required>
+            <option value="">보험 항목 선택</option>
+            {options.items.map((item) => (
+              <option key={item.value} value={item.value}>{item.label}{item.helper ? ` · ${item.helper}` : ""}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="보험 상태">
+          <select className="select" defaultValue="true" name="enabled">
+            <option value="true">정상</option>
+            <option value="false">비활성</option>
+          </select>
+        </Field>
       </div>
-      <MockFormActions cancelHref="/insurance" submitLabel="보험 등록" successMessage="보험 등록 요청을 확인했습니다. 실제 저장은 Supabase 연결 단계에서 처리됩니다." />
+      <br />
+      <Field label="운영 메모"><textarea className="input" name="memo" placeholder="보험 연결 관련 운영 메모" rows={4} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        현재 service-ops backend 보험 범위는 라이더-보험 항목 연결입니다. 증권번호/보험기간/차량 보험은 후속 확장 범위이며, 이 폼에서는 ID 직접 입력 없이 선택 UI만 사용합니다.
+      </p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">보험 등록</button>
+      </div>
     </form>
   );
 }

--- a/development/front-admin-web/lib/services/insurance-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/insurance-command-payload.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  InsuranceCommandPayloadError,
+  toRiderInsuranceCreatePayload,
+  toRiderInsuranceUpdatePayload
+} from "./insurance-command-payload.ts";
+
+test("rider insurance create payload uses selector fields and ignores direct raw ID field names", () => {
+  const formData = new FormData();
+  formData.set("riderSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("insuranceItemSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("enabled", "true");
+  formData.set("memo", "보험 연결 메모");
+  formData.set("riderId", "99999999-9999-4999-8999-999999999999");
+  formData.set("insuranceItemId", "99999999-9999-4999-8999-999999999999");
+  formData.set("insuranceId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toRiderInsuranceCreatePayload(formData), {
+    enabled: true,
+    insuranceItemId: "22222222-2222-4222-8222-222222222222",
+    memo: "보험 연결 메모",
+    riderId: "11111111-1111-4111-8111-111111111111"
+  });
+});
+
+test("rider insurance payloads reject blank or non-uuid selector values", () => {
+  const formData = new FormData();
+  formData.set("riderSelection", "kim-minjun");
+  formData.set("insuranceItemSelection", "22222222-2222-4222-8222-222222222222");
+
+  assert.throws(() => toRiderInsuranceCreatePayload(formData), InsuranceCommandPayloadError);
+
+  formData.set("riderSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("insuranceItemSelection", "");
+
+  assert.throws(() => toRiderInsuranceCreatePayload(formData), InsuranceCommandPayloadError);
+});
+
+test("rider insurance update payload keeps memo and enabled only", () => {
+  const formData = new FormData();
+  formData.set("memo", "비활성 전환");
+  formData.set("enabled", "false");
+  formData.set("riderId", "11111111-1111-4111-8111-111111111111");
+  formData.set("insuranceItemId", "22222222-2222-4222-8222-222222222222");
+
+  assert.deepEqual(toRiderInsuranceUpdatePayload(formData), {
+    enabled: false,
+    memo: "비활성 전환"
+  });
+});

--- a/development/front-admin-web/lib/services/insurance-command-payload.ts
+++ b/development/front-admin-web/lib/services/insurance-command-payload.ts
@@ -1,0 +1,66 @@
+import type { RiderInsuranceCreateInput, RiderInsuranceUpdateInput } from "./service-ops-api";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class InsuranceCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InsuranceCommandPayloadError";
+  }
+}
+
+export function toRiderInsuranceCreatePayload(formData: FormData): RiderInsuranceCreateInput {
+  return {
+    enabled: toEnabled(formData.get("enabled"), true),
+    insuranceItemId: requiredUuid(formData.get("insuranceItemSelection"), "Insurance item selection is required."),
+    memo: optionalText(formData.get("memo")),
+    riderId: requiredUuid(formData.get("riderSelection"), "Rider selection is required.")
+  };
+}
+
+export function toRiderInsuranceUpdatePayload(formData: FormData): RiderInsuranceUpdateInput {
+  return {
+    enabled: toEnabled(formData.get("enabled"), true),
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+function requiredUuid(value: FormDataEntryValue | null, message: string): string {
+  const text = requiredText(value, message);
+  if (!UUID_PATTERN.test(text)) {
+    throw new InsuranceCommandPayloadError("Invalid selector token. Use the provided rider and insurance item selection controls.");
+  }
+
+  return text;
+}
+
+function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (!text) {
+    return fallback;
+  }
+
+  if (["true", "1", "on", "enabled"].includes(text)) {
+    return true;
+  }
+
+  if (["false", "0", "off", "disabled"].includes(text)) {
+    return false;
+  }
+
+  throw new InsuranceCommandPayloadError("Invalid insurance enabled status.");
+}
+
+function requiredText(value: FormDataEntryValue | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new InsuranceCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}

--- a/development/front-admin-web/lib/services/insurance-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/insurance-data-core.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveInsuranceStatus,
+  mockInsuranceUnconfiguredServiceDetail,
+  mockInsuranceUnavailableServiceDetail,
+  toFrontendInsurancePolicy
+} from "./insurance-data-core.ts";
+
+const mockPolicies = [
+  {
+    endsAt: "보험기간 후속",
+    holderLabel: "김민준 · 010-1111-2222",
+    policyNumber: "증권번호 후속",
+    provider: "라이더 기본 보험",
+    slug: "ins-kim-minjun",
+    startsAt: "2026-04-30",
+    status: "정상",
+    targetType: "라이더"
+  }
+];
+
+const lookup = {
+  items: new Map([
+    ["22222222-2222-4222-8222-222222222222", { enabled: true, id: "22222222-2222-4222-8222-222222222222", name: "라이더 기본 보험" }]
+  ]),
+  riders: new Map([
+    ["11111111-1111-4111-8111-111111111111", { area: "강남/역삼", name: "김민준", phone: "010-1111-2222" }]
+  ])
+};
+
+test("toFrontendInsurancePolicy hydrates rider and insurance labels", () => {
+  const policy = toFrontendInsurancePolicy(
+    {
+      createdAt: "2026-04-30T00:00:00Z",
+      enabled: true,
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      idx: 5,
+      insuranceItemId: "22222222-2222-4222-8222-222222222222",
+      memo: "보험 메모",
+      riderId: "11111111-1111-4111-8111-111111111111",
+      updatedAt: "2026-04-30T00:00:00Z"
+    },
+    lookup
+  );
+
+  assert.equal(policy.holderLabel, "김민준 · 010-1111-2222");
+  assert.equal(policy.provider, "라이더 기본 보험");
+  assert.equal(policy.status, "정상");
+  assert.equal(policy.policyNumber, "증권번호 후속");
+});
+
+test("deriveInsuranceStatus reflects enabled flag", () => {
+  assert.equal(deriveInsuranceStatus(true), "정상");
+  assert.equal(deriveInsuranceStatus(false), "비활성");
+});
+
+test("UUID insurance detail falls back to visible mock detail when service API is unavailable", () => {
+  const missingSession = mockInsuranceUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    mockPolicies,
+    "서비스 API 세션 쿠키가 없어 mock 보험 상세를 표시합니다."
+  );
+  const missingBaseUrl = mockInsuranceUnconfiguredServiceDetail("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", mockPolicies);
+
+  assert.equal(missingSession?.source, "mock");
+  assert.equal(missingSession?.policy.slug, "ins-kim-minjun");
+  assert.match(missingBaseUrl?.notice ?? "", /SERVICE_OPS_API_BASE_URL/);
+});

--- a/development/front-admin-web/lib/services/insurance-data-core.ts
+++ b/development/front-admin-web/lib/services/insurance-data-core.ts
@@ -1,0 +1,113 @@
+import type { InsurancePolicy } from "@/types/domain";
+import type { FrontendRider, ServiceOpsInsuranceItem, ServiceOpsRiderInsurance } from "./service-ops-api";
+
+export type InsuranceDataResult = {
+  policies: InsurancePolicy[];
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type InsuranceDetailResult = {
+  policy: InsurancePolicy;
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type InsuranceLookup = {
+  riders: Map<string, Pick<FrontendRider, "area" | "name" | "phone">>;
+  items: Map<string, Pick<ServiceOpsInsuranceItem, "enabled" | "id" | "name">>;
+};
+
+export function toFrontendInsurancePolicy(policy: ServiceOpsRiderInsurance, lookup: InsuranceLookup): InsurancePolicy {
+  const rider = lookup.riders.get(policy.riderId);
+  const item = lookup.items.get(policy.insuranceItemId);
+
+  return {
+    createdAt: policy.createdAt,
+    enabled: policy.enabled,
+    endsAt: "보험기간 후속",
+    holderLabel: rider ? `${rider.name} · ${rider.phone}` : "라이더 연결 확인 필요",
+    id: policy.id,
+    idx: policy.idx,
+    insuranceItemId: policy.insuranceItemId,
+    memo: policy.memo,
+    policyNumber: "증권번호 후속",
+    provider: item?.name ?? "보험 항목 연결 확인 필요",
+    riderId: policy.riderId,
+    slug: policy.id,
+    source: "service-ops",
+    startsAt: toDateOnly(policy.createdAt),
+    status: deriveInsuranceStatus(policy.enabled),
+    targetType: "라이더",
+    updatedAt: policy.updatedAt
+  };
+}
+
+export function deriveInsuranceStatus(enabled: boolean): InsurancePolicy["status"] {
+  return enabled ? "정상" : "비활성";
+}
+
+export function mockInsuranceList(mockPolicies: InsurancePolicy[]): InsuranceDataResult {
+  return {
+    policies: mockPolicies.map((policy) => ({ ...policy, source: "mock" as const })),
+    source: "mock"
+  };
+}
+
+export function mockInsuranceDetail(slug: string, mockPolicies: InsurancePolicy[]): InsuranceDetailResult | null {
+  const policy = mockPolicies.find((candidate) => candidate.slug === slug);
+  if (!policy) {
+    return null;
+  }
+
+  return {
+    policy: { ...policy, source: "mock" },
+    source: "mock"
+  };
+}
+
+export function mockInsuranceUnavailableServiceDetail(
+  slug: string,
+  mockPolicies: InsurancePolicy[],
+  notice: string
+): InsuranceDetailResult | null {
+  const exactFallback = mockInsuranceDetail(slug, mockPolicies);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockPolicies.length) {
+    return null;
+  }
+
+  return {
+    notice,
+    policy: { ...mockPolicies[0], source: "mock" },
+    source: "mock"
+  };
+}
+
+export function mockInsuranceUnconfiguredServiceDetail(slug: string, mockPolicies: InsurancePolicy[]): InsuranceDetailResult | null {
+  return mockInsuranceUnavailableServiceDetail(
+    slug,
+    mockPolicies,
+    "SERVICE_OPS_API_BASE_URL이 없어 mock 보험 상세를 표시합니다. 백엔드 연결 후 실제 보험 상세로 전환됩니다."
+  );
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function toDateOnly(value: string | null | undefined): string {
+  if (!value) {
+    return "-";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  return date.toISOString().slice(0, 10);
+}

--- a/development/front-admin-web/lib/services/insurance-data.ts
+++ b/development/front-admin-web/lib/services/insurance-data.ts
@@ -1,0 +1,195 @@
+import type { InsurancePolicy } from "@/types/domain";
+import type {
+  FrontendRider,
+  ServiceOpsApiClient,
+  ServiceOpsApiError,
+  ServiceOpsInsuranceItem
+} from "@/lib/services/service-ops-api";
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { insurancePolicies as mockPolicies, riders as mockRiders } from "@/lib/services/mock-data";
+import {
+  type InsuranceDataResult,
+  type InsuranceDetailResult,
+  type InsuranceLookup,
+  isUuidLike,
+  mockInsuranceDetail,
+  mockInsuranceList,
+  mockInsuranceUnconfiguredServiceDetail,
+  mockInsuranceUnavailableServiceDetail,
+  toFrontendInsurancePolicy
+} from "@/lib/services/insurance-data-core";
+
+export type InsuranceSelectionOption = {
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+export type InsuranceFormOptionsResult = {
+  items: InsuranceSelectionOption[];
+  notice?: string;
+  riders: InsuranceSelectionOption[];
+  source: "mock" | "service-ops";
+};
+
+export async function loadInsuranceList(): Promise<InsuranceDataResult> {
+  const fallback = mockInsuranceList(mockPolicies);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 보험 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 보험 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const [insurancePage, lookup] = await Promise.all([
+      client.listRiderInsurances({ page: 0, size: 100 }),
+      loadInsuranceLookup(client)
+    ]);
+
+    return {
+      policies: insurancePage.items.map((policy) => toFrontendInsurancePolicy(policy, lookup)),
+      source: "service-ops"
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 보험 조회 실패로 mock 보험 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadInsuranceDetail(slug: string): Promise<InsuranceDetailResult | null> {
+  const fallback = mockInsuranceDetail(slug, mockPolicies);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockInsuranceUnconfiguredServiceDetail(slug, mockPolicies);
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockInsuranceUnavailableServiceDetail(
+        slug,
+        mockPolicies,
+        "서비스 API 세션 쿠키가 없어 mock 보험 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const [policy, lookup] = await Promise.all([
+        client.getRiderInsurance(slug),
+        loadInsuranceLookup(client)
+      ]);
+      return {
+        policy: toFrontendInsurancePolicy(policy, lookup),
+        source: "service-ops"
+      };
+    } catch (error) {
+      return mockInsuranceUnavailableServiceDetail(
+        slug,
+        mockPolicies,
+        `서비스 API 보험 상세 조회 실패로 mock 보험 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadInsuranceFormOptions(): Promise<InsuranceFormOptionsResult> {
+  const fallback = mockInsuranceFormOptions();
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 선택지를 표시합니다. 백엔드 연결 후 실제 라이더/보험 항목 선택지로 전환됩니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 선택지를 표시합니다. 관리자 로그인 후 실제 선택지로 전환됩니다."
+    };
+  }
+
+  try {
+    const [riderPage, itemPage] = await Promise.all([
+      client.listRiders({ page: 0, size: 100 }),
+      client.listInsuranceItems({ page: 0, size: 100 })
+    ]);
+
+    return {
+      items: itemPage.items
+        .filter((item) => item.enabled)
+        .map((item) => ({
+          helper: item.description ?? undefined,
+          label: item.name,
+          value: item.id
+        })),
+      riders: riderPage.items.map((rider) => ({
+        helper: `${rider.team} · ${rider.area}`,
+        label: `${rider.name} · ${rider.phone}`,
+        value: rider.slug
+      })),
+      source: "service-ops"
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 선택지 조회 실패로 mock 선택지를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+async function loadInsuranceLookup(client: ServiceOpsApiClient): Promise<InsuranceLookup> {
+  const [riderPage, itemPage] = await Promise.all([
+    client.listRiders({ page: 0, size: 100 }),
+    client.listInsuranceItems({ page: 0, size: 100 })
+  ]);
+
+  return {
+    items: new Map(itemPage.items.map((item: ServiceOpsInsuranceItem) => [item.id, item])),
+    riders: new Map(riderPage.items.map((rider: FrontendRider) => [rider.slug, rider]))
+  };
+}
+
+function mockInsuranceFormOptions(): InsuranceFormOptionsResult {
+  const itemNames = Array.from(new Set(mockPolicies.filter((policy) => policy.targetType === "라이더").map((policy) => policy.provider)));
+
+  return {
+    items: itemNames.map((itemName) => ({
+      helper: "mock 보험 항목",
+      label: itemName,
+      value: itemName
+    })),
+    riders: mockRiders.map((rider) => ({
+      helper: `${rider.team} · ${rider.area}`,
+      label: `${rider.name} · ${rider.phone}`,
+      value: rider.slug
+    })),
+    source: "mock"
+  };
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -633,3 +633,83 @@ test("toFrontendRider maps backend UUID to route slug without exposing editable 
   assert.equal(rider.joinedAt, "2026-04-12");
   assert.equal(rider.appLinkStatus, "UNLINKED");
 });
+
+test("insurance item list request uses backend path and bearer token", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              idx: 1,
+              name: "라이더 기본 보험",
+              description: "테스트 보험 항목",
+              enabled: true,
+              createdAt: "2026-04-30T00:00:00Z",
+              updatedAt: "2026-04-30T00:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 100, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listInsuranceItems({ page: 0, size: 100 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/insurance-items");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "100");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].name, "라이더 기본 보험");
+});
+
+test("rider insurance create/update use dedicated insurance endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          idx: 10,
+          riderId: body.riderId ?? "22222222-2222-4222-8222-222222222222",
+          insuranceItemId: body.insuranceItemId ?? "33333333-3333-4333-8333-333333333333",
+          memo: body.memo ?? null,
+          enabled: body.enabled ?? true,
+          createdAt: "2026-04-30T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.createRiderInsurance({
+    enabled: true,
+    insuranceItemId: "33333333-3333-4333-8333-333333333333",
+    memo: "보험 연결 메모",
+    riderId: "22222222-2222-4222-8222-222222222222"
+  });
+  await client.updateRiderInsurance("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", { enabled: false, memo: "비활성 전환" });
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/rider-insurances",
+    "/api/v1/rider-insurances/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["POST", "PATCH"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), ["enabled", "insuranceItemId", "memo", "riderId"]);
+  assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { enabled: false, memo: "비활성 전환" });
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -170,6 +170,39 @@ export type RiderBikeContractTerminateInput = {
   terminatedReason?: string | null;
 };
 
+export type ServiceOpsInsuranceItem = {
+  id: string;
+  idx: number | null;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ServiceOpsRiderInsurance = {
+  id: string;
+  idx: number | null;
+  riderId: string;
+  insuranceItemId: string;
+  memo: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RiderInsuranceCreateInput = {
+  riderId: string;
+  insuranceItemId: string;
+  memo?: string | null;
+  enabled?: boolean | null;
+};
+
+export type RiderInsuranceUpdateInput = {
+  memo?: string | null;
+  enabled?: boolean | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -264,6 +297,12 @@ export type ServiceOpsApiClient = {
   createRiderBikeContract: (request: RiderBikeContractCreateInput) => Promise<ServiceOpsRiderBikeContract>;
   updateRiderBikeContract: (id: string, request: RiderBikeContractUpdateInput) => Promise<ServiceOpsRiderBikeContract>;
   terminateRiderBikeContract: (id: string, request: RiderBikeContractTerminateInput) => Promise<ServiceOpsRiderBikeContract>;
+  listInsuranceItems: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsInsuranceItem>>;
+  getInsuranceItem: (id: string) => Promise<ServiceOpsInsuranceItem>;
+  listRiderInsurances: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsRiderInsurance>>;
+  getRiderInsurance: (id: string) => Promise<ServiceOpsRiderInsurance>;
+  createRiderInsurance: (request: RiderInsuranceCreateInput) => Promise<ServiceOpsRiderInsurance>;
+  updateRiderInsurance: (id: string, request: RiderInsuranceUpdateInput) => Promise<ServiceOpsRiderInsurance>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -437,6 +476,24 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     terminateRiderBikeContract: (id, terminateRequest) =>
       request<ServiceOpsRiderBikeContract>(`/rider-bike-contracts/${encodeURIComponent(id)}/terminate`, {
         body: JSON.stringify(terminateRequest),
+        method: "PATCH"
+      }),
+    listInsuranceItems: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsInsuranceItem>>("/insurance-items", { method: "GET" }, { page, size, sort }),
+    getInsuranceItem: (id) =>
+      request<ServiceOpsInsuranceItem>(`/insurance-items/${encodeURIComponent(id)}`, { method: "GET" }),
+    listRiderInsurances: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsRiderInsurance>>("/rider-insurances", { method: "GET" }, { page, size, sort }),
+    getRiderInsurance: (id) =>
+      request<ServiceOpsRiderInsurance>(`/rider-insurances/${encodeURIComponent(id)}`, { method: "GET" }),
+    createRiderInsurance: (createRequest) =>
+      request<ServiceOpsRiderInsurance>("/rider-insurances", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateRiderInsurance: (id, updateRequest) =>
+      request<ServiceOpsRiderInsurance>(`/rider-insurances/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
         method: "PATCH"
       }),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -25,12 +25,10 @@ export const contractSchema = z.object({
 });
 
 export const insuranceSchema = z.object({
-  targetSelection: z.string().min(1, "라이더 또는 차량을 선택하세요."),
-  provider: z.string().min(1, "보험사를 입력하세요."),
-  policyNumber: z.string().min(1, "증권번호를 입력하세요."),
-  startsAt: z.string().date(),
-  endsAt: z.string().date(),
-  status: z.enum(["정상", "만료 예정", "만료"])
+  riderSelection: z.string().min(1, "라이더를 선택하세요."),
+  insuranceItemSelection: z.string().min(1, "보험 항목을 선택하세요."),
+  enabled: z.enum(["true", "false"]),
+  memo: z.string().optional()
 });
 
 export const stationSchema = z.object({

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -1,7 +1,7 @@
 export type VehicleStatus = "운행 중" | "수리" | "점검 필요" | "대기";
 export type AssignmentStatus = "배정됨" | "미배정" | "교대 예정";
 export type ContractStatus = "활성" | "만료 예정" | "종료" | "초안";
-export type InsuranceStatus = "정상" | "만료 예정" | "만료";
+export type InsuranceStatus = "정상" | "만료 예정" | "만료" | "비활성";
 export type StationStatus = "운영 중" | "점검 중" | "운영 중지";
 
 export type Rider = {
@@ -62,6 +62,8 @@ export type RiderContract = {
 
 export type InsurancePolicy = {
   slug: string;
+  id?: string;
+  idx?: number | null;
   holderLabel: string;
   targetType: "라이더" | "차량";
   provider: string;
@@ -69,6 +71,13 @@ export type InsurancePolicy = {
   startsAt: string;
   endsAt: string;
   status: InsuranceStatus;
+  riderId?: string;
+  insuranceItemId?: string;
+  memo?: string | null;
+  enabled?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
 };
 
 export type BatteryStation = {

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -716,3 +716,30 @@ Verification:
 
 - TDD red observed on frontend service-ops contract tests before implementation because contract API client methods and contract command/data helpers did not exist.
 - Frontend service-ops tests cover contract template list request shape, rider-bike create/update/terminate endpoint shape, selector-only payload conversion, lifecycle status derivation, and UUID mock fallback.
+
+## Frontend insurance admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#81
+- Target issue: EVNSolution/thundercrew-domain#69
+- Branch: `cc-81-insurance-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires the existing Next.js insurance management screens to the existing service-ops-api insurance-item and rider-insurance endpoints.
+- Included work is a frontend insurance client/data adapter, insurance form selector options, rider-insurance create/update actions, service-ops tests, and docs updates.
+- Telemetry, map provider/API, new backend schema/API changes, vehicle insurance expansion, insurance-item management UI, hard delete/restore/bulk flows, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Insurance create uses human-readable select controls for rider and insurance item; operators do not type raw `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id`, or FK fields.
+- The server-action payload builder reads only selector field names and ignores direct raw ID field names if present in submitted form data.
+- The current service-ops insurance backend owns rider-insurance links only; provider/policy-number/period/vehicle-insurance fields remain follow-up display placeholders or legacy mock fields.
+- Insurance update is limited to memo and enabled status, matching the existing backend DTO.
+- Missing config/session/API failure falls back to explicit mock insurance data with a visible notice, including service UUID detail routes.
+
+Verification:
+
+- TDD red observed on frontend service-ops insurance tests before implementation because insurance API client methods and insurance command/data helpers did not exist.
+- Frontend service-ops tests cover insurance-item list request shape, rider-insurance create/update endpoint shape, selector-only payload conversion, enabled-status derivation, and UUID mock fallback.


### PR DESCRIPTION
## Summary
- Connect insurance admin list/detail/create/update flows to existing service-ops insurance APIs.
- Load rider and insurance item selector options from service-ops when configured, with explicit mock fallback notices.
- Add tests for insurance API request shapes, selector-only payload conversion, enabled/status derivation, and UUID fallback.

## Scope boundaries
- Excludes telemetry, map provider/API, new backend schema/API changes, vehicle insurance expansion, insurance-item management UI, hard delete/restore/bulk flows, and production env mutation.
- No direct editable insurance/rider/item ID fields were added.
- Current backend scope is rider-insurance links; provider/policy-number/period fields remain follow-up placeholders or legacy mock fields.

## Change control
- Change-control: EVNSolution/clever-change-control#81
- Target issue: Closes #69

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (41/41)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- Code-reviewer: PASS

## Not tested
- Live browser flow against a running service-ops API instance.
