### PR TITLE
Frontend station admin API integration baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Frontend ↔ backend baseline:
 - 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
 - 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -79,6 +79,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
 - 보험 목록/상세/등록/수정은 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다.
+- 스테이션 폼은 이름, 주소, 좌표, 운영 상태, 수량만 다루며 `stationId`, `station_id`, `batteryStationId` 같은 직접 입력 필드를 만들지 않습니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -104,7 +106,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/insurance/[slug]` 보험 상세
 - `/stations` 배터리 스테이션 목록 + mock 지도 영역
 - `/stations/new` 스테이션 등록
-- `/stations/[slug]` 스테이션 상세
+- `/stations/[slug]` 스테이션 상세 + 재고 수량 변경
+- `/stations/[slug]/edit` 스테이션 기본 정보 수정
 - `/settings` 연결 설정 확인
 
 ## Supabase

--- a/development/front-admin-web/app/stations/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/edit/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from "next/navigation";
+
+import { updateStationAction } from "@/app/stations/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { StationForm } from "@/components/stations/StationForm";
+import { loadStationDetail } from "@/lib/services/station-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "스테이션 수정에 실패했습니다. 필수값, 좌표 범위, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditStationPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadStationDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const updateAction = updateStationAction.bind(null, slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="스테이션 수정" description="스테이션 기본 정보만 수정합니다. 재고 수량 변경은 상세 화면의 전용 영역을 사용합니다." />
+      <StationForm
+        action={updateAction}
+        cancelHref={`/stations/${slug}`}
+        defaultValues={{
+          address: detail.station.address,
+          latitude: detail.station.latitude,
+          longitude: detail.station.longitude,
+          memo: detail.station.memo,
+          name: detail.station.name,
+          stationStatus: detail.station.stationStatus
+        }}
+        mode="수정"
+        statusMessage={status ? statusMessage[status] : null}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/stations/[slug]/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/page.tsx
@@ -1,28 +1,90 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { updateStationBatteryCountsAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { DetailActionPanel } from "@/components/ui/MockActions";
-import { stations } from "@/lib/services/mock-data";
+import { Field } from "@/components/ui/FormField";
+import { loadStationDetail } from "@/lib/services/station-data";
+import type { BatteryStation } from "@/types/domain";
 
-export default async function StationDetailPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  const station = stations.find((s) => s.slug === slug) ?? stations[0];
+const statusMessage: Record<string, string> = {
+  "count-error": "재고 수량 변경에 실패했습니다. 수량 규칙과 백엔드 연결 상태를 확인하세요.",
+  "count-updated": "스테이션 재고 수량이 변경되었습니다.",
+  created: "스테이션이 등록되었습니다.",
+  "mock-count-updated": "서비스 API가 연결되지 않아 재고 변경을 mock 피드백으로만 처리했습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 스테이션 화면으로 돌아왔습니다.",
+  updated: "스테이션 기본 정보가 수정되었습니다."
+};
+
+export default async function StationDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadStationDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const station = detail.station;
+  const message = status ? statusMessage[status] : null;
+  const updateCountsAction = updateStationBatteryCountsAction.bind(null, station.slug);
 
   return (
     <div className="page-container">
-      <PageHeader title={station.name} description={station.address} />
+      <PageHeader title={station.name} description={station.address} actionHref={`/stations/${station.slug}/edit`} actionLabel="수정" />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
       <section className="content-grid">
         <div className="card">
           <h2>운영 정보</h2>
           <div className="detail-list">
-            <div className="detail-row"><span>상태</span><Badge>{station.status}</Badge></div>
-            <div className="detail-row"><span>보유 배터리</span><strong>{station.batteryCount}개</strong></div>
-            <div className="detail-row"><span>교체 가능</span><strong>{station.replaceableCount}개</strong></div>
-            <div className="detail-row"><span>mock 좌표</span><strong>{station.latitude}, {station.longitude}</strong></div>
+            <div className="detail-row"><span>상태</span><Badge tone={stationTone(station.status)}>{station.status}</Badge></div>
+            <div className="detail-row"><span>최대 보관 수량</span><strong>{station.maxBatteryCapacity ?? station.batteryCount}개</strong></div>
+            <div className="detail-row"><span>현재 보유 수량</span><strong>{station.currentBatteryCount ?? station.batteryCount}개</strong></div>
+            <div className="detail-row"><span>교체 가능/최대</span><strong>{availableLabel(station)}</strong></div>
+            <div className="detail-row"><span>가동률</span><strong>{station.capacityPercentage ?? 0}%</strong></div>
+            <div className="detail-row"><span>좌표</span><strong>{station.latitude}, {station.longitude}</strong></div>
+            {station.memo ? <div className="detail-row"><span>메모</span><strong>{station.memo}</strong></div> : null}
           </div>
-          <DetailActionPanel secondaryHref="/stations" primaryLabel="재고 로그 등록" logLabel="재고 로그" feedbackMessage="재고 로그 등록 요청을 확인했습니다. MVP mock에서는 실제 저장 없이 피드백만 표시합니다." logItems={[`현재 교체 가능 ${station.replaceableCount}/${station.batteryCount}`, "최근 입고: 완충 배터리 8개", "최근 출고: 교체 배터리 5개"]} />
+          <div className="form-actions">
+            <Link className="button-secondary" href="/stations">목록</Link>
+            <Link className="button-secondary" href={`/stations/${station.slug}/edit`}>기본 정보 수정</Link>
+          </div>
         </div>
-        <aside className="detail-panel"><h2>위치 카드</h2><p>민트 마커는 선택된 위치만 표시합니다. 지도 API 없이도 주소, 상태, 재고 중심 운영이 가능합니다.</p></aside>
+        <aside className="detail-panel">
+          <h2>재고 수량 변경</h2>
+          <form action={updateCountsAction} className="action-panel">
+            <Field label="최대 보관 수량"><input className="input" defaultValue={station.maxBatteryCapacity ?? station.batteryCount} min="0" name="maxBatteryCapacity" required type="number" /></Field>
+            <Field label="현재 보유 수량"><input className="input" defaultValue={station.currentBatteryCount ?? station.batteryCount} min="0" name="currentBatteryCount" required type="number" /></Field>
+            <Field label="교체 가능 수량"><input className="input" defaultValue={station.availableBatteryCount ?? station.replaceableCount} min="0" name="availableBatteryCount" required type="number" /></Field>
+            <Field label="변경 사유"><input className="input" maxLength={100} name="reason" placeholder="예: 입고, 출고, 점검 차감" /></Field>
+            <Field label="재고 메모"><textarea className="input" name="memo" placeholder="재고 변경 관련 메모" rows={3} /></Field>
+            <p className="notice">수량 규칙: 최대 보관 수량 ≥ 현재 보유 수량 ≥ 교체 가능 수량. 이력은 backend 재고 로그로 남깁니다.</p>
+            <div className="form-actions"><button className="button-primary" type="submit">재고 변경</button></div>
+          </form>
+          <br />
+          <h2>위치 카드</h2>
+          <p>지도 API 없이 주소, 위도/경도, 핀 라벨({station.name} {availableLabel(station)})을 우선 준비합니다.</p>
+        </aside>
       </section>
     </div>
   );
+}
+
+function availableLabel(station: BatteryStation): string {
+  return station.availableBatteryLabel ?? `${station.replaceableCount}/${station.maxBatteryCapacity ?? station.batteryCount}`;
+}
+
+function stationTone(status: BatteryStation["status"]): "active" | "muted" | "outline" {
+  if (status === "운영 중") {
+    return "active";
+  }
+
+  return status === "운영 중지" ? "muted" : "outline";
 }

--- a/development/front-admin-web/app/stations/actions.ts
+++ b/development/front-admin-web/app/stations/actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toBatteryStationCountPayload,
+  toBatteryStationCreatePayload,
+  toBatteryStationUpdatePayload
+} from "@/lib/services/station-command-payload";
+
+export async function createStationAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/stations?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let station;
+  try {
+    const payload = toBatteryStationCreatePayload(formData);
+    station = await client.createBatteryStation(payload);
+  } catch {
+    redirect("/stations/new?status=save-error");
+  }
+
+  revalidatePath("/stations");
+  redirect(`/stations/${station.slug}?status=created`);
+}
+
+export async function updateStationAction(stationId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/stations/${stationId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let station;
+  try {
+    const payload = toBatteryStationUpdatePayload(formData);
+    station = await client.updateBatteryStation(stationId, payload);
+  } catch {
+    redirect(`/stations/${stationId}/edit?status=save-error`);
+  }
+
+  revalidatePath("/stations");
+  revalidatePath(`/stations/${station.slug}`);
+  redirect(`/stations/${station.slug}?status=updated`);
+}
+
+export async function updateStationBatteryCountsAction(stationId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/stations/${stationId}?status=mock-count-updated`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let station;
+  try {
+    const payload = toBatteryStationCountPayload(formData);
+    station = await client.updateBatteryStationCounts(stationId, payload);
+  } catch {
+    redirect(`/stations/${stationId}?status=count-error`);
+  }
+
+  revalidatePath("/stations");
+  revalidatePath(`/stations/${station.slug}`);
+  redirect(`/stations/${station.slug}?status=count-updated`);
+}

--- a/development/front-admin-web/app/stations/new/page.tsx
+++ b/development/front-admin-web/app/stations/new/page.tsx
@@ -1,3 +1,18 @@
+import { createStationAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { StationForm } from "@/components/stations/StationForm";
-export default function NewStationPage() { return <div className="page-container"><PageHeader title="스테이션 등록" description="스테이션 ID는 DB에서 자동 생성합니다. 운영자는 이름, 주소, 상태와 재고 수량만 입력합니다." /><StationForm /></div>; }
+
+const statusMessage: Record<string, string> = {
+  "save-error": "스테이션 저장에 실패했습니다. 필수값, 좌표 범위, 수량 규칙, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewStationPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="스테이션 등록" description="스테이션 ID는 DB가 자동 생성합니다. 운영자는 이름, 주소, 좌표, 상태와 재고 수량만 입력합니다." />
+      <StationForm action={createStationAction} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/stations/page.tsx
+++ b/development/front-admin-web/app/stations/page.tsx
@@ -1,5 +1,101 @@
 import Link from "next/link";
+
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
-import { stations } from "@/lib/services/mock-data";
-export default function StationsPage() { return <div className="page-container"><PageHeader title="배터리 스테이션" description="위치 기반 화면 구조를 카드/리스트/상세 중심으로 먼저 구현합니다." actionHref="/stations/new" actionLabel="스테이션 등록" /><section className="content-grid"><div><div className="map-mock"><div className="map-gridline" />{stations.map((s, i) => <span key={s.slug} className="map-marker" style={{ left: `${24 + i * 24}%`, top: `${36 + i * 14}%` }} title={s.name} />)}</div><br /><div className="table-card"><table className="table"><thead><tr><th>스테이션</th><th>주소</th><th>상태</th><th>보유</th><th>교체 가능</th><th>상세</th></tr></thead><tbody>{stations.map((s) => <tr key={s.slug}><td>{s.name}</td><td>{s.address}</td><td><Badge tone={s.status === "운영 중" ? "active" : "muted"}>{s.status}</Badge></td><td>{s.batteryCount}</td><td>{s.replaceableCount}</td><td><Link className="button-secondary" href={`/stations/${s.slug}`}>보기</Link></td></tr>)}</tbody></table></div></div><aside className="detail-panel"><h2>지도 API 범위</h2><p>1차 MVP는 실제 지도 API 없이 mock 좌표와 위치 카드 구조를 제공합니다. 실제 API 사용 여부는 배포 전 확정합니다.</p></aside></section></div>; }
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadStationList } from "@/lib/services/station-data";
+import type { BatteryStation } from "@/types/domain";
+
+const statusMessage: Record<string, string> = {
+  "count-updated": "스테이션 재고 수량이 변경되었습니다.",
+  created: "스테이션이 등록되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  updated: "스테이션 기본 정보가 수정되었습니다."
+};
+
+export default async function StationsPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadStationList()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref="/stations/new"
+        actionLabel="스테이션 등록"
+        description="배터리 스테이션의 위치, 운영 상태, 보유/교체 가능 배터리 수량을 service-ops API 기준으로 관리합니다."
+        title="배터리 스테이션"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <section className="content-grid">
+        <div>
+          <div className="map-mock" aria-label="스테이션 mock 위치 영역">
+            <div className="map-gridline" />
+            {data.stations.map((station, index) => (
+              <span
+                key={station.slug}
+                className="map-marker"
+                style={{ left: `${24 + index * 24}%`, top: `${36 + index * 14}%` }}
+                title={`${station.name} ${availableLabel(station)}`}
+              >
+                <span className="sr-only">{station.name} {availableLabel(station)}</span>
+              </span>
+            ))}
+          </div>
+          <br />
+          <div className="table-card">
+            {data.stations.length ? (
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>스테이션</th>
+                    <th>주소</th>
+                    <th>상태</th>
+                    <th>보유</th>
+                    <th>교체 가능/최대</th>
+                    <th>상세</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.stations.map((station) => (
+                    <tr key={station.slug}>
+                      <td>{station.name}</td>
+                      <td>{station.address}</td>
+                      <td><Badge tone={stationTone(station.status)}>{station.status}</Badge></td>
+                      <td>{station.batteryCount}개</td>
+                      <td><strong>{availableLabel(station)}</strong></td>
+                      <td><Link className="button-secondary" href={`/stations/${station.slug}`}>보기</Link></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <EmptyState
+                actionLabel="스테이션 등록"
+                description="아직 등록된 스테이션이 없습니다. DB ID 입력 없이 이름, 주소, 좌표와 수량부터 등록합니다."
+                href="/stations/new"
+                title="스테이션 없음"
+              />
+            )}
+          </div>
+        </div>
+        <aside className="detail-panel">
+          <h2>지도 API 제외 범위</h2>
+          <p>이번 범위는 실제 지도 SDK/API를 붙이지 않습니다. 대신 좌표, 주소, 핀 라벨, 카드/리스트/상세 구조만 API 데이터로 준비합니다.</p>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function availableLabel(station: BatteryStation): string {
+  return station.availableBatteryLabel ?? `${station.replaceableCount}/${station.maxBatteryCapacity ?? station.batteryCount}`;
+}
+
+function stationTone(status: BatteryStation["status"]): "active" | "muted" | "outline" {
+  if (status === "운영 중") {
+    return "active";
+  }
+
+  return status === "운영 중지" ? "muted" : "outline";
+}

--- a/development/front-admin-web/components/stations/StationForm.tsx
+++ b/development/front-admin-web/components/stations/StationForm.tsx
@@ -1,20 +1,78 @@
-"use client";
+import Link from "next/link";
 
-import { MockFormActions } from "@/components/ui/MockActions";
 import { Field } from "@/components/ui/FormField";
+import type { BatteryStation } from "@/types/domain";
+import type { ServiceOpsStationStatus } from "@/lib/services/service-ops-api";
 
-export function StationForm() {
+export const stationStatusOptions: Array<{ label: BatteryStation["status"]; value: ServiceOpsStationStatus }> = [
+  { label: "운영 중", value: "ACTIVE" },
+  { label: "점검 중", value: "MAINTENANCE" },
+  { label: "운영 중지", value: "INACTIVE" }
+];
+
+type StationFormValues = Pick<
+  BatteryStation,
+  | "address"
+  | "availableBatteryCount"
+  | "currentBatteryCount"
+  | "latitude"
+  | "longitude"
+  | "maxBatteryCapacity"
+  | "memo"
+  | "name"
+  | "stationStatus"
+>;
+
+type StationFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<StationFormValues>;
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+};
+
+export function StationForm({ action, cancelHref = "/stations", defaultValues, mode = "등록", statusMessage }: StationFormProps) {
+  const isCreateMode = mode === "등록";
+
   return (
-    <form className="card" onSubmit={(event) => event.preventDefault()} aria-label="스테이션 등록 폼">
+    <form action={action} className="card" aria-label={`스테이션 ${mode} 폼`}>
       <div className="form-grid">
-        <Field label="스테이션명"><input className="input" name="name" placeholder="예: 강남 교체 스테이션" /></Field>
-        <Field label="주소"><input className="input" name="address" placeholder="도로명 주소" /></Field>
-        <Field label="운영 상태"><select className="select" name="status"><option>운영 중</option><option>점검 중</option><option>운영 중지</option></select></Field>
-        <Field label="보유 배터리 수량"><input className="input" name="batteryCount" type="number" min="0" placeholder="0" /></Field>
-        <Field label="교체 가능 수량"><input className="input" name="replaceableCount" type="number" min="0" placeholder="0" /></Field>
-        <Field label="위치 메모"><input className="input" name="locationNote" placeholder="예: 지하 1층 우측 출입구" /></Field>
+        <Field label="스테이션명">
+          <input className="input" defaultValue={defaultValues?.name ?? ""} maxLength={100} name="name" placeholder="예: 강남 교체 스테이션" required />
+        </Field>
+        <Field label="주소">
+          <input className="input" defaultValue={defaultValues?.address ?? ""} maxLength={255} name="address" placeholder="도로명 주소" required />
+        </Field>
+        <Field label="운영 상태">
+          <select className="select" defaultValue={defaultValues?.stationStatus ?? "ACTIVE"} name="status">
+            {stationStatusOptions.map((status) => <option key={status.value} value={status.value}>{status.label}</option>)}
+          </select>
+        </Field>
+        <Field label="위도" hint="지도 API 연동 전에도 핀 상세에 사용할 좌표를 저장합니다.">
+          <input className="input" defaultValue={defaultValues?.latitude ?? ""} max="90" min="-90" name="latitude" placeholder="37.5007" required step="0.000001" type="number" />
+        </Field>
+        <Field label="경도" hint="지도 API 연동 전에도 핀 상세에 사용할 좌표를 저장합니다.">
+          <input className="input" defaultValue={defaultValues?.longitude ?? ""} max="180" min="-180" name="longitude" placeholder="127.0364" required step="0.000001" type="number" />
+        </Field>
+        {isCreateMode ? (
+          <>
+            <Field label="최대 보관 수량"><input className="input" defaultValue={defaultValues?.maxBatteryCapacity ?? 0} min="0" name="maxBatteryCapacity" required type="number" /></Field>
+            <Field label="현재 보유 수량"><input className="input" defaultValue={defaultValues?.currentBatteryCount ?? 0} min="0" name="currentBatteryCount" required type="number" /></Field>
+            <Field label="교체 가능 수량"><input className="input" defaultValue={defaultValues?.availableBatteryCount ?? 0} min="0" name="availableBatteryCount" required type="number" /></Field>
+          </>
+        ) : null}
       </div>
-      <MockFormActions cancelHref="/stations" submitLabel="스테이션 등록" successMessage="스테이션 등록 요청을 확인했습니다. 실제 저장은 Supabase 연결 단계에서 처리됩니다." />
+      <br />
+      <Field label="운영 메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={4} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        스테이션 ID는 DB가 자동 생성합니다. 사용자는 이름, 주소, 좌표, 상태와 재고 수량처럼 사람이 이해할 수 있는 값만 입력합니다.
+      </p>
+      {isCreateMode ? <p className="notice">수량 규칙: 최대 보관 수량 ≥ 현재 보유 수량 ≥ 교체 가능 수량.</p> : null}
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">스테이션 {mode}</button>
+      </div>
     </form>
   );
 }

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -5,6 +5,7 @@ import {
   ServiceOpsApiError,
   createServiceOpsApiClient,
   normalizeServiceOpsBaseUrl,
+  toFrontendBatteryStation,
   toFrontendDashboardMapState,
   toFrontendVehicle,
   toFrontendRider
@@ -712,4 +713,161 @@ test("rider insurance create/update use dedicated insurance endpoints", async ()
   assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), ["enabled", "insuranceItemId", "memo", "riderId"]);
   assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { enabled: false, memo: "비활성 전환" });
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("battery station list request maps service stations to frontend labels", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "44444444-4444-4444-8444-444444444444",
+              idx: 4,
+              name: "강남 교체 스테이션",
+              address: "서울 강남구 테헤란로 152",
+              latitude: "37.5007",
+              longitude: "127.0364",
+              status: "ACTIVE",
+              maxBatteryCapacity: 48,
+              currentBatteryCount: 41,
+              availableBatteryCount: 31,
+              availableBatteryLabel: "31/48",
+              capacityPercentage: 85,
+              memo: "B1 우측 출입구",
+              createdAt: "2026-04-30T00:00:00Z",
+              updatedAt: "2026-04-30T00:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listBatteryStations({ page: 0, size: 20 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/battery-stations");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "20");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].slug, "44444444-4444-4444-8444-444444444444");
+  assert.equal(page.items[0].status, "운영 중");
+  assert.equal(page.items[0].availableBatteryLabel, "31/48");
+  assert.equal(page.items[0].latitude, 37.5007);
+  assert.equal(page.items[0].longitude, 127.0364);
+});
+
+test("battery station create/update/count methods use dedicated backend endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          id: "55555555-5555-4555-8555-555555555555",
+          idx: 5,
+          name: body.name ?? "강남 교체 스테이션",
+          address: body.address ?? "서울 강남구 테헤란로 152",
+          latitude: body.latitude ?? 37.5007,
+          longitude: body.longitude ?? 127.0364,
+          status: body.status ?? "ACTIVE",
+          maxBatteryCapacity: body.maxBatteryCapacity ?? 48,
+          currentBatteryCount: body.currentBatteryCount ?? 41,
+          availableBatteryCount: body.availableBatteryCount ?? 31,
+          availableBatteryLabel: `${body.availableBatteryCount ?? 31}/${body.maxBatteryCapacity ?? 48}`,
+          capacityPercentage: 85,
+          memo: body.memo ?? null,
+          createdAt: "2026-04-30T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.createBatteryStation({
+    address: "서울 강남구 테헤란로 152",
+    availableBatteryCount: 31,
+    currentBatteryCount: 41,
+    latitude: 37.5007,
+    longitude: 127.0364,
+    maxBatteryCapacity: 48,
+    memo: "B1 우측 출입구",
+    name: "강남 교체 스테이션",
+    status: "ACTIVE"
+  });
+  await client.updateBatteryStation("55555555-5555-4555-8555-555555555555", {
+    address: "서울 강남구 테헤란로 153",
+    latitude: 37.5008,
+    longitude: 127.0365,
+    memo: "주소 보정",
+    name: "강남 교체 스테이션",
+    status: "MAINTENANCE"
+  });
+  await client.updateBatteryStationCounts("55555555-5555-4555-8555-555555555555", {
+    availableBatteryCount: 28,
+    currentBatteryCount: 38,
+    maxBatteryCapacity: 48,
+    memo: "재고 보정",
+    reason: "출고"
+  });
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/battery-stations",
+    "/api/v1/battery-stations/55555555-5555-4555-8555-555555555555",
+    "/api/v1/battery-stations/55555555-5555-4555-8555-555555555555/battery-counts"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["POST", "PATCH", "PATCH"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), [
+    "address",
+    "availableBatteryCount",
+    "currentBatteryCount",
+    "latitude",
+    "longitude",
+    "maxBatteryCapacity",
+    "memo",
+    "name",
+    "status"
+  ]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[1].init?.body))).sort(), ["address", "latitude", "longitude", "memo", "name", "status"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["availableBatteryCount", "currentBatteryCount", "maxBatteryCapacity", "memo", "reason"]);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("invalid backend station status does not display as active", () => {
+  assert.throws(
+    () =>
+      toFrontendBatteryStation({
+        id: "66666666-6666-4666-8666-666666666666",
+        idx: 6,
+        name: "상태 오류 스테이션",
+        address: "서울 강남구",
+        latitude: 37.5,
+        longitude: 127.0,
+        status: "UNKNOWN",
+        maxBatteryCapacity: 10,
+        currentBatteryCount: 5,
+        availableBatteryCount: 3,
+        availableBatteryLabel: "3/10",
+        capacityPercentage: 50,
+        memo: null,
+        createdAt: "2026-04-30T00:00:00Z",
+        updatedAt: "2026-04-30T00:00:00Z"
+      }),
+    (error) =>
+      error instanceof ServiceOpsApiError &&
+      error.code === "SERVICE_OPS_UNSUPPORTED_STATION_STATUS" &&
+      error.message.includes("Unsupported battery station status")
+  );
 });

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1,3 +1,5 @@
+import type { BatteryStation } from "@/types/domain";
+
 export type ServiceOpsFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 export type ServiceOpsPage<T> = {
@@ -203,6 +205,57 @@ export type RiderInsuranceUpdateInput = {
   enabled?: boolean | null;
 };
 
+export type ServiceOpsStationStatus = "ACTIVE" | "MAINTENANCE" | "INACTIVE";
+
+export type ServiceOpsBatteryStation = {
+  id: string;
+  idx: number | null;
+  name: string;
+  address: string;
+  latitude: number | string;
+  longitude: number | string;
+  status: ServiceOpsStationStatus;
+  maxBatteryCapacity: number;
+  currentBatteryCount: number;
+  availableBatteryCount: number;
+  availableBatteryLabel: string;
+  capacityPercentage: number;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type FrontendBatteryStation = BatteryStation;
+
+export type BatteryStationCreateInput = {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  status: ServiceOpsStationStatus;
+  maxBatteryCapacity: number;
+  currentBatteryCount: number;
+  availableBatteryCount: number;
+  memo?: string | null;
+};
+
+export type BatteryStationUpdateInput = {
+  name?: string | null;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  status?: ServiceOpsStationStatus | null;
+  memo?: string | null;
+};
+
+export type BatteryStationCountUpdateInput = {
+  maxBatteryCapacity: number;
+  currentBatteryCount: number;
+  availableBatteryCount: number;
+  reason?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -303,6 +356,11 @@ export type ServiceOpsApiClient = {
   getRiderInsurance: (id: string) => Promise<ServiceOpsRiderInsurance>;
   createRiderInsurance: (request: RiderInsuranceCreateInput) => Promise<ServiceOpsRiderInsurance>;
   updateRiderInsurance: (id: string, request: RiderInsuranceUpdateInput) => Promise<ServiceOpsRiderInsurance>;
+  listBatteryStations: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendBatteryStation>>;
+  getBatteryStation: (id: string) => Promise<FrontendBatteryStation>;
+  createBatteryStation: (request: BatteryStationCreateInput) => Promise<FrontendBatteryStation>;
+  updateBatteryStation: (id: string, request: BatteryStationUpdateInput) => Promise<FrontendBatteryStation>;
+  updateBatteryStationCounts: (id: string, request: BatteryStationCountUpdateInput) => Promise<FrontendBatteryStation>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -496,6 +554,40 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify(updateRequest),
         method: "PATCH"
       }),
+    listBatteryStations: async ({ page = 0, size = 20, sort } = {}) => {
+      const response = await request<ServiceOpsPage<ServiceOpsBatteryStation>>(
+        "/battery-stations",
+        { method: "GET" },
+        { page, size, sort }
+      );
+      return {
+        ...response,
+        items: response.items.map(toFrontendBatteryStation)
+      };
+    },
+    getBatteryStation: async (id) =>
+      toFrontendBatteryStation(await request<ServiceOpsBatteryStation>(`/battery-stations/${encodeURIComponent(id)}`, { method: "GET" })),
+    createBatteryStation: async (createRequest) =>
+      toFrontendBatteryStation(
+        await request<ServiceOpsBatteryStation>("/battery-stations", {
+          body: JSON.stringify(createRequest),
+          method: "POST"
+        })
+      ),
+    updateBatteryStation: async (id, updateRequest) =>
+      toFrontendBatteryStation(
+        await request<ServiceOpsBatteryStation>(`/battery-stations/${encodeURIComponent(id)}`, {
+          body: JSON.stringify(updateRequest),
+          method: "PATCH"
+        })
+      ),
+    updateBatteryStationCounts: async (id, countRequest) =>
+      toFrontendBatteryStation(
+        await request<ServiceOpsBatteryStation>(`/battery-stations/${encodeURIComponent(id)}/battery-counts`, {
+          body: JSON.stringify(countRequest),
+          method: "PATCH"
+        })
+      ),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {
@@ -600,6 +692,50 @@ export function toFrontendRider(rider: ServiceOpsRider): FrontendRider {
     updatedAt: rider.updatedAt,
     source: "service-ops"
   };
+}
+
+export function toFrontendBatteryStation(station: ServiceOpsBatteryStation): FrontendBatteryStation {
+  const maxBatteryCapacity = station.maxBatteryCapacity;
+  const currentBatteryCount = station.currentBatteryCount;
+  const availableBatteryCount = station.availableBatteryCount;
+
+  return {
+    address: station.address,
+    availableBatteryCount,
+    availableBatteryLabel: station.availableBatteryLabel,
+    batteryCount: currentBatteryCount,
+    capacityPercentage: station.capacityPercentage,
+    createdAt: station.createdAt,
+    currentBatteryCount,
+    id: station.id,
+    idx: station.idx,
+    latitude: toNumber(station.latitude),
+    longitude: toNumber(station.longitude),
+    maxBatteryCapacity,
+    memo: station.memo,
+    name: station.name,
+    replaceableCount: availableBatteryCount,
+    slug: station.id,
+    source: "service-ops",
+    stationStatus: station.status,
+    status: toFrontendStationStatus(station.status),
+    updatedAt: station.updatedAt
+  };
+}
+
+export function toFrontendStationStatus(status: ServiceOpsStationStatus): FrontendBatteryStation["status"] {
+  switch (status) {
+    case "ACTIVE":
+      return "운영 중";
+    case "MAINTENANCE":
+      return "점검 중";
+    case "INACTIVE":
+      return "운영 중지";
+  }
+
+  throw new ServiceOpsApiError("Unsupported battery station status returned by service ops API.", 0, "SERVICE_OPS_UNSUPPORTED_STATION_STATUS", {
+    status
+  });
 }
 
 function parseResponseBody(responseText: string): unknown {

--- a/development/front-admin-web/lib/services/station-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/station-command-payload.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  StationCommandPayloadError,
+  toBatteryStationCountPayload,
+  toBatteryStationCreatePayload,
+  toBatteryStationUpdatePayload
+} from "./station-command-payload.ts";
+
+test("battery station create payload uses operator fields and ignores direct raw ID field names", () => {
+  const formData = new FormData();
+  formData.set("name", "강남 교체 스테이션");
+  formData.set("address", "서울 강남구 테헤란로 152");
+  formData.set("latitude", "37.5007");
+  formData.set("longitude", "127.0364");
+  formData.set("status", "ACTIVE");
+  formData.set("maxBatteryCapacity", "48");
+  formData.set("currentBatteryCount", "41");
+  formData.set("availableBatteryCount", "31");
+  formData.set("memo", "B1 우측 출입구");
+  formData.set("stationId", "99999999-9999-4999-8999-999999999999");
+  formData.set("batteryStationId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBatteryStationCreatePayload(formData), {
+    address: "서울 강남구 테헤란로 152",
+    availableBatteryCount: 31,
+    currentBatteryCount: 41,
+    latitude: 37.5007,
+    longitude: 127.0364,
+    maxBatteryCapacity: 48,
+    memo: "B1 우측 출입구",
+    name: "강남 교체 스테이션",
+    status: "ACTIVE"
+  });
+});
+
+test("battery station update payload excludes count and system fields", () => {
+  const formData = new FormData();
+  formData.set("name", "강남 교체 스테이션");
+  formData.set("address", "서울 강남구 테헤란로 153");
+  formData.set("latitude", "37.5008");
+  formData.set("longitude", "127.0365");
+  formData.set("status", "MAINTENANCE");
+  formData.set("memo", "주소 보정");
+  formData.set("maxBatteryCapacity", "99");
+  formData.set("stationId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBatteryStationUpdatePayload(formData), {
+    address: "서울 강남구 테헤란로 153",
+    latitude: 37.5008,
+    longitude: 127.0365,
+    memo: "주소 보정",
+    name: "강남 교체 스테이션",
+    status: "MAINTENANCE"
+  });
+});
+
+test("battery station count payload is separated from station metadata", () => {
+  const formData = new FormData();
+  formData.set("maxBatteryCapacity", "48");
+  formData.set("currentBatteryCount", "38");
+  formData.set("availableBatteryCount", "28");
+  formData.set("reason", "출고");
+  formData.set("memo", "재고 보정");
+  formData.set("name", "무시할 이름");
+  formData.set("stationId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBatteryStationCountPayload(formData), {
+    availableBatteryCount: 28,
+    currentBatteryCount: 38,
+    maxBatteryCapacity: 48,
+    memo: "재고 보정",
+    reason: "출고"
+  });
+});
+
+test("battery station payloads reject invalid statuses, coordinates, and count ordering", () => {
+  const formData = new FormData();
+  formData.set("name", "강남 교체 스테이션");
+  formData.set("address", "서울 강남구 테헤란로 152");
+  formData.set("latitude", "91");
+  formData.set("longitude", "127.0364");
+  formData.set("status", "ACTIVE");
+  formData.set("maxBatteryCapacity", "48");
+  formData.set("currentBatteryCount", "41");
+  formData.set("availableBatteryCount", "31");
+
+  assert.throws(() => toBatteryStationCreatePayload(formData), StationCommandPayloadError);
+
+  formData.set("latitude", "37.5007");
+  formData.set("status", "운영 중");
+  assert.throws(() => toBatteryStationCreatePayload(formData), StationCommandPayloadError);
+
+  formData.set("status", "ACTIVE");
+  formData.set("availableBatteryCount", "42");
+  assert.throws(() => toBatteryStationCreatePayload(formData), StationCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/station-command-payload.ts
+++ b/development/front-admin-web/lib/services/station-command-payload.ts
@@ -1,0 +1,113 @@
+import type {
+  BatteryStationCountUpdateInput,
+  BatteryStationCreateInput,
+  BatteryStationUpdateInput,
+  ServiceOpsStationStatus
+} from "./service-ops-api";
+
+const STATION_STATUS_VALUES = ["ACTIVE", "MAINTENANCE", "INACTIVE"] as const;
+
+export class StationCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StationCommandPayloadError";
+  }
+}
+
+export function toBatteryStationCreatePayload(formData: FormData): BatteryStationCreateInput {
+  return validateBatteryCounts({
+    address: requiredText(formData.get("address"), "Station address is required."),
+    availableBatteryCount: nonNegativeInteger(formData.get("availableBatteryCount"), "Available battery count is required."),
+    currentBatteryCount: nonNegativeInteger(formData.get("currentBatteryCount"), "Current battery count is required."),
+    latitude: coordinateNumber(formData.get("latitude"), -90, 90, "Latitude is required."),
+    longitude: coordinateNumber(formData.get("longitude"), -180, 180, "Longitude is required."),
+    maxBatteryCapacity: nonNegativeInteger(formData.get("maxBatteryCapacity"), "Max battery capacity is required."),
+    memo: optionalText(formData.get("memo")),
+    name: requiredText(formData.get("name"), "Station name is required."),
+    status: toStationStatus(formData.get("status"))
+  });
+}
+
+export function toBatteryStationUpdatePayload(formData: FormData): BatteryStationUpdateInput {
+  return {
+    address: requiredText(formData.get("address"), "Station address is required."),
+    latitude: coordinateNumber(formData.get("latitude"), -90, 90, "Latitude is required."),
+    longitude: coordinateNumber(formData.get("longitude"), -180, 180, "Longitude is required."),
+    memo: optionalText(formData.get("memo")),
+    name: requiredText(formData.get("name"), "Station name is required."),
+    status: toStationStatus(formData.get("status"))
+  };
+}
+
+export function toBatteryStationCountPayload(formData: FormData): BatteryStationCountUpdateInput {
+  return validateBatteryCounts({
+    availableBatteryCount: nonNegativeInteger(formData.get("availableBatteryCount"), "Available battery count is required."),
+    currentBatteryCount: nonNegativeInteger(formData.get("currentBatteryCount"), "Current battery count is required."),
+    maxBatteryCapacity: nonNegativeInteger(formData.get("maxBatteryCapacity"), "Max battery capacity is required."),
+    memo: optionalText(formData.get("memo")),
+    reason: optionalText(formData.get("reason"))
+  });
+}
+
+export function toStationStatus(value: FormDataEntryValue | null): ServiceOpsStationStatus {
+  const status = requiredText(value, "Station status is required.");
+  if (STATION_STATUS_VALUES.includes(status as ServiceOpsStationStatus)) {
+    return status as ServiceOpsStationStatus;
+  }
+
+  throw new StationCommandPayloadError("Invalid station status.");
+}
+
+function validateBatteryCounts<T extends BatteryStationCountUpdateInput>(payload: T): T {
+  if (payload.maxBatteryCapacity < payload.currentBatteryCount) {
+    throw new StationCommandPayloadError("Max battery capacity must be greater than or equal to current battery count.");
+  }
+
+  if (payload.currentBatteryCount < payload.availableBatteryCount) {
+    throw new StationCommandPayloadError("Current battery count must be greater than or equal to available battery count.");
+  }
+
+  return payload;
+}
+
+function coordinateNumber(value: FormDataEntryValue | null, min: number, max: number, message: string): number {
+  const number = numericValue(value, message);
+  if (number < min || number > max) {
+    throw new StationCommandPayloadError("Station coordinates are outside the supported range.");
+  }
+
+  return number;
+}
+
+function nonNegativeInteger(value: FormDataEntryValue | null, message: string): number {
+  const number = numericValue(value, message);
+  if (!Number.isInteger(number) || number < 0) {
+    throw new StationCommandPayloadError("Battery counts must be non-negative integers.");
+  }
+
+  return number;
+}
+
+function numericValue(value: FormDataEntryValue | null, message: string): number {
+  const text = requiredText(value, message);
+  const number = Number(text);
+  if (!Number.isFinite(number)) {
+    throw new StationCommandPayloadError("Numeric station value is invalid.");
+  }
+
+  return number;
+}
+
+function requiredText(value: FormDataEntryValue | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new StationCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}

--- a/development/front-admin-web/lib/services/station-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/station-data-core.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mockStationUnconfiguredServiceDetail,
+  mockStationUnavailableServiceDetail,
+  normalizeMockStation
+} from "./station-data-core.ts";
+
+const mockStations = [
+  {
+    address: "서울 강남구 테헤란로 152",
+    batteryCount: 41,
+    latitude: 37.5007,
+    longitude: 127.0364,
+    name: "강남 교체 스테이션",
+    replaceableCount: 31,
+    slug: "gangnam-station",
+    status: "운영 중"
+  }
+];
+
+test("normalizeMockStation derives available n/m and capacity fields", () => {
+  const station = normalizeMockStation(mockStations[0]);
+
+  assert.equal(station.maxBatteryCapacity, 41);
+  assert.equal(station.currentBatteryCount, 41);
+  assert.equal(station.availableBatteryCount, 31);
+  assert.equal(station.availableBatteryLabel, "31/41");
+  assert.equal(station.capacityPercentage, 100);
+  assert.equal(station.source, "mock");
+});
+
+test("UUID station detail falls back to visible mock detail when service API is unavailable", () => {
+  const missingSession = mockStationUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    mockStations,
+    "서비스 API 세션 쿠키가 없어 mock 스테이션 상세를 표시합니다."
+  );
+  const missingBaseUrl = mockStationUnconfiguredServiceDetail("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", mockStations);
+
+  assert.equal(missingSession?.source, "mock");
+  assert.equal(missingSession?.station.slug, "gangnam-station");
+  assert.match(missingBaseUrl?.notice ?? "", /SERVICE_OPS_API_BASE_URL/);
+});

--- a/development/front-admin-web/lib/services/station-data-core.ts
+++ b/development/front-admin-web/lib/services/station-data-core.ts
@@ -1,0 +1,91 @@
+import type { BatteryStation } from "@/types/domain";
+
+export type StationDataResult = {
+  source: "mock" | "service-ops";
+  stations: BatteryStation[];
+  notice?: string;
+};
+
+export type StationDetailResult = {
+  source: "mock" | "service-ops";
+  station: BatteryStation;
+  notice?: string;
+};
+
+export function mockStationList(mockStations: BatteryStation[]): StationDataResult {
+  return {
+    source: "mock",
+    stations: mockStations.map(normalizeMockStation)
+  };
+}
+
+export function mockStationDetail(slug: string, mockStations: BatteryStation[]): StationDetailResult | null {
+  const station = mockStations.find((candidate) => candidate.slug === slug);
+  if (!station) {
+    return null;
+  }
+
+  return {
+    source: "mock",
+    station: normalizeMockStation(station)
+  };
+}
+
+export function mockStationUnavailableServiceDetail(
+  slug: string,
+  mockStations: BatteryStation[],
+  notice: string
+): StationDetailResult | null {
+  const exactFallback = mockStationDetail(slug, mockStations);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockStations.length) {
+    return null;
+  }
+
+  return {
+    notice,
+    source: "mock",
+    station: normalizeMockStation(mockStations[0])
+  };
+}
+
+export function mockStationUnconfiguredServiceDetail(slug: string, mockStations: BatteryStation[]): StationDetailResult | null {
+  return mockStationUnavailableServiceDetail(
+    slug,
+    mockStations,
+    "SERVICE_OPS_API_BASE_URL이 없어 mock 스테이션 상세를 표시합니다. 백엔드 연결 후 실제 스테이션 상세로 전환됩니다."
+  );
+}
+
+export function normalizeMockStation(station: BatteryStation): BatteryStation {
+  const maxBatteryCapacity = station.maxBatteryCapacity ?? Math.max(station.batteryCount, station.replaceableCount);
+  const currentBatteryCount = station.currentBatteryCount ?? station.batteryCount;
+  const availableBatteryCount = station.availableBatteryCount ?? station.replaceableCount;
+
+  return {
+    ...station,
+    availableBatteryCount,
+    availableBatteryLabel: station.availableBatteryLabel ?? `${availableBatteryCount}/${maxBatteryCapacity}`,
+    batteryCount: currentBatteryCount,
+    capacityPercentage: station.capacityPercentage ?? calculateCapacityPercentage(currentBatteryCount, maxBatteryCapacity),
+    currentBatteryCount,
+    maxBatteryCapacity,
+    replaceableCount: availableBatteryCount,
+    source: "mock"
+  };
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function calculateCapacityPercentage(currentBatteryCount: number, maxBatteryCapacity: number): number {
+  if (maxBatteryCapacity === 0) {
+    return 0;
+  }
+
+  return Math.round((currentBatteryCount * 100) / maxBatteryCapacity);
+}

--- a/development/front-admin-web/lib/services/station-data.ts
+++ b/development/front-admin-web/lib/services/station-data.ts
@@ -1,0 +1,86 @@
+import {
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { stations as mockStations } from "@/lib/services/mock-data";
+import {
+  type StationDataResult,
+  type StationDetailResult,
+  isUuidLike,
+  mockStationDetail,
+  mockStationList,
+  mockStationUnconfiguredServiceDetail,
+  mockStationUnavailableServiceDetail
+} from "@/lib/services/station-data-core";
+
+export async function loadStationList(): Promise<StationDataResult> {
+  const fallback = mockStationList(mockStations);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 스테이션 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 스테이션 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const page = await client.listBatteryStations({ page: 0, size: 100 });
+    return { source: "service-ops", stations: page.items };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 스테이션 조회 실패로 mock 스테이션 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadStationDetail(slug: string): Promise<StationDetailResult | null> {
+  const fallback = mockStationDetail(slug, mockStations);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockStationUnconfiguredServiceDetail(slug, mockStations);
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockStationUnavailableServiceDetail(
+        slug,
+        mockStations,
+        "서비스 API 세션 쿠키가 없어 mock 스테이션 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const station = await client.getBatteryStation(slug);
+      return { source: "service-ops", station };
+    } catch (error) {
+      return mockStationUnavailableServiceDetail(
+        slug,
+        mockStations,
+        `서비스 API 스테이션 상세 조회 실패로 mock 스테이션 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -34,7 +34,17 @@ export const insuranceSchema = z.object({
 export const stationSchema = z.object({
   name: z.string().min(2, "스테이션명을 입력하세요."),
   address: z.string().min(5, "주소를 입력하세요."),
-  status: z.enum(["운영 중", "점검 중", "운영 중지"]),
-  batteryCount: z.coerce.number().int().nonnegative(),
-  replaceableCount: z.coerce.number().int().nonnegative()
+  latitude: z.coerce.number().min(-90).max(90),
+  longitude: z.coerce.number().min(-180).max(180),
+  status: z.enum(["ACTIVE", "MAINTENANCE", "INACTIVE"]),
+  maxBatteryCapacity: z.coerce.number().int().nonnegative(),
+  currentBatteryCount: z.coerce.number().int().nonnegative(),
+  availableBatteryCount: z.coerce.number().int().nonnegative(),
+  memo: z.string().optional()
+}).refine((value) => value.maxBatteryCapacity >= value.currentBatteryCount, {
+  message: "최대 보관 수량은 현재 보유 수량보다 작을 수 없습니다.",
+  path: ["maxBatteryCapacity"]
+}).refine((value) => value.currentBatteryCount >= value.availableBatteryCount, {
+  message: "현재 보유 수량은 교체 가능 수량보다 작을 수 없습니다.",
+  path: ["availableBatteryCount"]
 });

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -82,11 +82,23 @@ export type InsurancePolicy = {
 
 export type BatteryStation = {
   slug: string;
+  id?: string;
+  idx?: number | null;
   name: string;
   address: string;
   status: StationStatus;
+  stationStatus?: "ACTIVE" | "MAINTENANCE" | "INACTIVE";
+  maxBatteryCapacity?: number;
+  currentBatteryCount?: number;
+  availableBatteryCount?: number;
+  availableBatteryLabel?: string;
+  capacityPercentage?: number;
   batteryCount: number;
   replaceableCount: number;
   latitude: number;
   longitude: number;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
 };

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -743,3 +743,30 @@ Verification:
 
 - TDD red observed on frontend service-ops insurance tests before implementation because insurance API client methods and insurance command/data helpers did not exist.
 - Frontend service-ops tests cover insurance-item list request shape, rider-insurance create/update endpoint shape, selector-only payload conversion, enabled-status derivation, and UUID mock fallback.
+
+## Frontend station admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#82
+- Target issue: EVNSolution/thundercrew-domain#71
+- Branch: `cc-82-station-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires the existing Next.js battery station management screens to the existing service-ops-api battery-station endpoints.
+- Included work is a frontend station client/data adapter, create/update/count server actions, station form wiring, service-ops tests, and docs updates.
+- Telemetry, real map provider/API integration, new backend schema/API changes, hard delete/restore/bulk flows, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Station create/update uses only operator-managed station fields: name, address, coordinates, status, memo, and count values where the backend DTO accepts them.
+- Operators do not type raw `stationId`, `station_id`, `batteryStationId`, or FK fields; route UUIDs are used internally after list/detail navigation only.
+- Count updates are separated from basic station metadata and call `/battery-stations/{id}/battery-counts` with max/current/available counts, reason, and memo.
+- Count payloads enforce `maxBatteryCapacity >= currentBatteryCount >= availableBatteryCount` before the backend request.
+- Missing config/session/API failure falls back to explicit mock station data with a visible notice, including service UUID detail routes.
+
+Verification:
+
+- TDD red observed on frontend service-ops station tests before implementation because station API client methods and station command/data helpers did not exist.
+- Frontend service-ops tests cover battery-station list mapping, create/update/count endpoint shape, system-ID field exclusion, status/coordinate/count validation, available `n/m` label preservation, and UUID mock fallback.


### PR DESCRIPTION
## Summary
- Wire station list/detail/create/edit/count-change screens to service-ops battery-station APIs.
- Keep station IDs internal to routes/API calls; operators edit only name, address, coordinates, status, memo, and battery counts.
- Preserve mock fallback and document telemetry/map-provider exclusions.

## Trace
- Change-control: EVNSolution/clever-change-control#82
- Closes EVNSolution/thundercrew-domain#71

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (50/50)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- code-reviewer PASS

## Out of scope
- Telemetry/current-state work.
- Real map provider/API integration.
- Backend schema/API changes.
- Production environment mutation.
