### PR TITLE
Frontend bike equipment admin API integration baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd development/service-ops-api
 관리자 웹 앱 문서는 `development/front-admin-web/README.md`에 있습니다.
 
 - 핵심 화면: 지도 관제
-- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션
+- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비
 - 디자인 기준: `development/front-admin-web/DESIGN.md`
 - Supabase MVP migration/seed: `development/front-admin-web/supabase/`
 
@@ -102,6 +102,7 @@ Frontend ↔ backend baseline:
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
 - 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
+- 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -1,6 +1,6 @@
 # ThunderCrew Front Admin Web
 
-전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
+전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
 
 ## 기술 스택
 
@@ -19,6 +19,7 @@
 - 계약: `contract_id`, `rider_id`, `vehicle_id`, `contract_template_id` 입력 금지 → 라이더 이름/연락처, 차량번호, 계약 양식 선택
 - 보험: `insurance_id`, `rider_id`, `vehicle_id`, `insurance_item_id` 입력 금지 → 라이더 이름/연락처와 보험 항목 선택
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
+- 장비: `bikeId`, `equipmentTypeId`, `equipmentId` 직접 입력 금지 → 차량번호/장비 종류명 기준 선택
 
 DB PK/FK는 backend/Postgres에서 자동 생성·관리합니다. 화면 route에 backend UUID가 쓰이더라도 사용자가 직접 입력하거나 수정하는 필드로 노출하지 않습니다.
 
@@ -81,6 +82,8 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다.
 - 스테이션 폼은 이름, 주소, 좌표, 운영 상태, 수량만 다루며 `stationId`, `station_id`, `batteryStationId` 같은 직접 입력 필드를 만들지 않습니다.
+- 장비 종류와 바이크 장비 목록/상세/등록/수정/제거는 server action/server component에서 `/api/v1/equipment-types`와 `/api/v1/bike-equipments`를 호출합니다.
+- 바이크 장비 등록 폼은 차량과 장비 종류를 select로 고르게 하며 `bikeId`, `equipmentTypeId`, `equipmentId` 같은 직접 입력 필드를 만들지 않습니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -108,6 +111,12 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/stations/new` 스테이션 등록
 - `/stations/[slug]` 스테이션 상세 + 재고 수량 변경
 - `/stations/[slug]/edit` 스테이션 기본 정보 수정
+- `/equipment` 장비 목록 + 장비 종류 관리
+- `/equipment/new` 바이크 장비 등록
+- `/equipment/[slug]` 바이크 장비 상세 + 제거 처리
+- `/equipment/[slug]/edit` 바이크 장비 수정
+- `/equipment/types/new` 장비 종류 등록
+- `/equipment/types/[slug]` 장비 종류 상세/수정
 - `/settings` 연결 설정 확인
 
 ## Supabase

--- a/development/front-admin-web/app/equipment/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/equipment/[slug]/edit/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from "next/navigation";
+
+import { updateBikeEquipmentAction } from "@/app/equipment/actions";
+import { BikeEquipmentForm } from "@/components/equipment/BikeEquipmentForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { loadBikeEquipmentDetail } from "@/lib/services/equipment-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "바이크 장비 수정에 실패했습니다. 날짜, 중복 시리얼, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditBikeEquipmentPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadBikeEquipmentDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const updateAction = updateBikeEquipmentAction.bind(null, slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="바이크 장비 수정" description="장비 표시명, 모델, 시리얼, 관리 기한과 메모만 수정합니다. 차량/장비 종류 변경은 별도 재등록 흐름으로 분리합니다." />
+      <BikeEquipmentForm
+        action={updateAction}
+        cancelHref={`/equipment/${slug}`}
+        defaultValues={{
+          equipmentLabel: detail.equipment.equipmentLabel,
+          managementDueDate: detail.equipment.managementDueDate,
+          managementNote: detail.equipment.managementNote,
+          memo: detail.equipment.memo,
+          modelName: detail.equipment.modelName,
+          serialNumber: detail.equipment.serialNumber
+        }}
+        mode="수정"
+        statusMessage={status ? statusMessage[status] : null}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/equipment/[slug]/page.tsx
+++ b/development/front-admin-web/app/equipment/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { removeBikeEquipmentAction } from "@/app/equipment/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { Field } from "@/components/ui/FormField";
+import { loadBikeEquipmentDetail } from "@/lib/services/equipment-data";
+import type { BikeEquipment } from "@/types/domain";
+
+const statusMessage: Record<string, string> = {
+  created: "바이크 장비가 등록되었습니다.",
+  "mock-removed": "서비스 API가 연결되지 않아 제거 처리를 mock 피드백으로만 처리했습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 장비 화면으로 돌아왔습니다.",
+  "remove-error": "바이크 장비 제거 처리에 실패했습니다. 이미 제거되었거나 백엔드 연결 상태를 확인하세요.",
+  removed: "바이크 장비가 제거 처리되었습니다.",
+  updated: "바이크 장비 정보가 수정되었습니다."
+};
+
+export default async function BikeEquipmentDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadBikeEquipmentDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const equipment = detail.equipment;
+  const message = status ? statusMessage[status] : null;
+  const removeAction = removeBikeEquipmentAction.bind(null, equipment.slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title={equipment.equipmentLabel} description={`${equipment.bikeLabel} · ${equipment.equipmentTypeName}`} actionHref={`/equipment/${equipment.slug}/edit`} actionLabel="수정" />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>장비 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>차량</span><strong>{equipment.bikeLabel}</strong></div>
+            <div className="detail-row"><span>장비 종류</span><strong>{equipment.equipmentTypeName}</strong></div>
+            <div className="detail-row"><span>모델</span><strong>{equipment.modelName ?? "미입력"}</strong></div>
+            <div className="detail-row"><span>시리얼</span><strong>{equipment.serialNumber ?? "미입력"}</strong></div>
+            <div className="detail-row"><span>설치일시</span><strong>{equipment.installedAt}</strong></div>
+            <div className="detail-row"><span>관리 기한</span><strong>{equipment.managementDueDate}</strong></div>
+            <div className="detail-row"><span>관리 상태</span><Badge tone={equipmentTone(equipment)}>{equipment.managementStatus}</Badge></div>
+            <div className="detail-row"><span>제거일시</span><strong>{equipment.removedAt ?? "장착 중"}</strong></div>
+            <div className="detail-row"><span>관리 메모</span><strong>{equipment.managementNote ?? "없음"}</strong></div>
+            <div className="detail-row"><span>운영 메모</span><strong>{equipment.memo ?? "없음"}</strong></div>
+          </div>
+          <div className="form-actions">
+            <Link className="button-secondary" href="/equipment">목록</Link>
+            <Link className="button-secondary" href={`/equipment/${equipment.slug}/edit`}>기본 정보 수정</Link>
+          </div>
+        </div>
+        <aside className="detail-panel">
+          <h2>장비 제거 처리</h2>
+          <form action={removeAction} className="action-panel">
+            <Field label="제거일시"><input className="input" name="removedAt" type="datetime-local" /></Field>
+            <Field label="제거 메모"><textarea className="input" name="memo" placeholder="교체/폐기/탈거 사유" rows={3} /></Field>
+            <p className="notice">제거는 이력 보존을 위한 상태 전환입니다. hard delete를 수행하지 않습니다.</p>
+            <div className="form-actions"><button className="button-primary" type="submit">제거 처리</button></div>
+          </form>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function equipmentTone(equipment: BikeEquipment): "active" | "muted" | "outline" {
+  if (equipment.managementStatus === "정상") {
+    return "active";
+  }
+
+  return equipment.managementStatus === "제거됨" ? "muted" : "outline";
+}

--- a/development/front-admin-web/app/equipment/actions.ts
+++ b/development/front-admin-web/app/equipment/actions.ts
@@ -1,0 +1,122 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toBikeEquipmentCreatePayload,
+  toBikeEquipmentRemovePayload,
+  toBikeEquipmentUpdatePayload,
+  toEquipmentTypeCreatePayload,
+  toEquipmentTypeUpdatePayload
+} from "@/lib/services/equipment-command-payload";
+
+export async function createEquipmentTypeAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/equipment?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let equipmentType;
+  try {
+    equipmentType = await client.createEquipmentType(toEquipmentTypeCreatePayload(formData));
+  } catch {
+    redirect("/equipment/types/new?status=save-error");
+  }
+
+  revalidatePath("/equipment");
+  redirect(`/equipment/types/${equipmentType.id}?status=created`);
+}
+
+export async function updateEquipmentTypeAction(equipmentTypeId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/equipment/types/${equipmentTypeId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let equipmentType;
+  try {
+    equipmentType = await client.updateEquipmentType(equipmentTypeId, toEquipmentTypeUpdatePayload(formData));
+  } catch {
+    redirect(`/equipment/types/${equipmentTypeId}?status=save-error`);
+  }
+
+  revalidatePath("/equipment");
+  revalidatePath(`/equipment/types/${equipmentType.id}`);
+  redirect(`/equipment/types/${equipmentType.id}?status=updated`);
+}
+
+export async function createBikeEquipmentAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/equipment?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let equipment;
+  try {
+    equipment = await client.createBikeEquipment(toBikeEquipmentCreatePayload(formData));
+  } catch {
+    redirect("/equipment/new?status=save-error");
+  }
+
+  revalidatePath("/equipment");
+  redirect(`/equipment/${equipment.id}?status=created`);
+}
+
+export async function updateBikeEquipmentAction(equipmentId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/equipment/${equipmentId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let equipment;
+  try {
+    equipment = await client.updateBikeEquipment(equipmentId, toBikeEquipmentUpdatePayload(formData));
+  } catch {
+    redirect(`/equipment/${equipmentId}/edit?status=save-error`);
+  }
+
+  revalidatePath("/equipment");
+  revalidatePath(`/equipment/${equipment.id}`);
+  redirect(`/equipment/${equipment.id}?status=updated`);
+}
+
+export async function removeBikeEquipmentAction(equipmentId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/equipment/${equipmentId}?status=mock-removed`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let equipment;
+  try {
+    equipment = await client.removeBikeEquipment(equipmentId, toBikeEquipmentRemovePayload(formData));
+  } catch {
+    redirect(`/equipment/${equipmentId}?status=remove-error`);
+  }
+
+  revalidatePath("/equipment");
+  revalidatePath(`/equipment/${equipment.id}`);
+  redirect(`/equipment/${equipment.id}?status=removed`);
+}

--- a/development/front-admin-web/app/equipment/new/page.tsx
+++ b/development/front-admin-web/app/equipment/new/page.tsx
@@ -1,0 +1,20 @@
+import { createBikeEquipmentAction } from "@/app/equipment/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { BikeEquipmentForm } from "@/components/equipment/BikeEquipmentForm";
+import { loadEquipmentFormOptions } from "@/lib/services/equipment-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "바이크 장비 저장에 실패했습니다. 선택값, 날짜, 중복 시리얼, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewBikeEquipmentPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, options] = await Promise.all([searchParams, loadEquipmentFormOptions()]);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="바이크 장비 등록" description="차량과 장비 종류는 선택 UI로 연결합니다. DB/FK ID는 직접 입력하지 않습니다." />
+      {options.notice ? <p className="notice">{options.notice}</p> : null}
+      <BikeEquipmentForm action={createBikeEquipmentAction} equipmentTypes={options.equipmentTypes} statusMessage={status ? statusMessage[status] : null} vehicles={options.vehicles} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/equipment/page.tsx
+++ b/development/front-admin-web/app/equipment/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadEquipmentData } from "@/lib/services/equipment-data";
+import type { BikeEquipment } from "@/types/domain";
+
+const statusMessage: Record<string, string> = {
+  created: "장비가 등록되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  removed: "바이크 장비가 제거 처리되었습니다.",
+  updated: "장비 정보가 수정되었습니다."
+};
+
+export default async function EquipmentPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadEquipmentData()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref="/equipment/new"
+        actionLabel="바이크 장비 등록"
+        description="바이크별 장비와 관리 기한을 service-ops API 기준으로 관리합니다."
+        title="장비 관리"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <section className="content-grid">
+        <div>
+          <div className="table-card">
+            {data.bikeEquipments.length ? (
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>차량</th>
+                    <th>장비</th>
+                    <th>모델/시리얼</th>
+                    <th>관리 기한</th>
+                    <th>상태</th>
+                    <th>상세</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.bikeEquipments.map((equipment) => (
+                    <tr key={equipment.slug}>
+                      <td>{equipment.bikeLabel}</td>
+                      <td>{equipment.equipmentLabel}<br /><span className="muted-text">{equipment.equipmentTypeName}</span></td>
+                      <td>{equipment.modelName ?? "모델 미지정"}<br /><span className="muted-text">{equipment.serialNumber ?? "시리얼 미입력"}</span></td>
+                      <td>{equipment.managementDueDate}</td>
+                      <td><Badge tone={equipmentTone(equipment)}>{equipment.managementStatus}</Badge></td>
+                      <td><Link className="button-secondary" href={`/equipment/${equipment.slug}`}>보기</Link></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <EmptyState
+                actionLabel="바이크 장비 등록"
+                description="아직 등록된 바이크 장비가 없습니다. 차량번호와 장비 종류 선택부터 등록합니다."
+                href="/equipment/new"
+                title="바이크 장비 없음"
+              />
+            )}
+          </div>
+        </div>
+        <aside className="detail-panel">
+          <h2>장비 종류</h2>
+          <p>장비 종류는 운영자가 직접 만들고, 바이크 장비 등록 시 선택 UI로 연결합니다.</p>
+          <div className="form-actions" style={{ marginTop: 12 }}>
+            <Link className="button-primary" href="/equipment/types/new">장비 종류 등록</Link>
+          </div>
+          <div className="detail-list" style={{ marginTop: 16 }}>
+            {data.equipmentTypes.map((type) => (
+              <div className="detail-row" key={type.slug}>
+                <span>{type.name}</span>
+                <Link className="button-secondary" href={`/equipment/types/${type.slug}`}>{type.enabled ? "사용" : "비활성"}</Link>
+              </div>
+            ))}
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function equipmentTone(equipment: BikeEquipment): "active" | "muted" | "outline" {
+  if (equipment.managementStatus === "정상") {
+    return "active";
+  }
+
+  return equipment.managementStatus === "제거됨" ? "muted" : "outline";
+}

--- a/development/front-admin-web/app/equipment/types/[slug]/page.tsx
+++ b/development/front-admin-web/app/equipment/types/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { updateEquipmentTypeAction } from "@/app/equipment/actions";
+import { EquipmentTypeForm } from "@/components/equipment/EquipmentTypeForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { loadEquipmentTypeDetail } from "@/lib/services/equipment-data";
+
+const statusMessage: Record<string, string> = {
+  created: "장비 종류가 등록되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 장비 종류 화면으로 돌아왔습니다.",
+  "save-error": "장비 종류 수정에 실패했습니다. 이름 중복 또는 백엔드 연결 상태를 확인하세요.",
+  updated: "장비 종류가 수정되었습니다."
+};
+
+export default async function EquipmentTypeDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadEquipmentTypeDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const equipmentType = detail.equipmentType;
+  const updateAction = updateEquipmentTypeAction.bind(null, equipmentType.slug);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader title={equipmentType.name} description="장비 종류 상세와 수정 화면입니다." />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>장비 종류 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>사용 상태</span><Badge tone={equipmentType.enabled ? "active" : "muted"}>{equipmentType.enabled ? "사용" : "비활성"}</Badge></div>
+            <div className="detail-row"><span>설명</span><strong>{equipmentType.description ?? "없음"}</strong></div>
+            <div className="detail-row"><span>표시 순번</span><strong>{equipmentType.idx ?? "mock"}</strong></div>
+          </div>
+          <div className="form-actions"><Link className="button-secondary" href="/equipment">목록</Link></div>
+        </div>
+        <EquipmentTypeForm
+          action={updateAction}
+          cancelHref="/equipment"
+          defaultValues={{ description: equipmentType.description, enabled: equipmentType.enabled, name: equipmentType.name }}
+          mode="수정"
+          statusMessage={status === "save-error" ? statusMessage[status] : null}
+        />
+      </section>
+    </div>
+  );
+}

--- a/development/front-admin-web/app/equipment/types/new/page.tsx
+++ b/development/front-admin-web/app/equipment/types/new/page.tsx
@@ -1,0 +1,18 @@
+import { createEquipmentTypeAction } from "@/app/equipment/actions";
+import { EquipmentTypeForm } from "@/components/equipment/EquipmentTypeForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "장비 종류 저장에 실패했습니다. 이름 중복 또는 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewEquipmentTypePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="장비 종류 등록" description="장비 종류 ID는 DB가 자동 생성합니다. 운영자는 이름, 설명, 사용 상태만 입력합니다." />
+      <EquipmentTypeForm action={createEquipmentTypeAction} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/components/equipment/BikeEquipmentForm.tsx
+++ b/development/front-admin-web/components/equipment/BikeEquipmentForm.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { BikeEquipment, EquipmentType } from "@/types/domain";
+import type { FrontendVehicle } from "@/lib/services/service-ops-api";
+
+type BikeEquipmentFormValues = Pick<
+  BikeEquipment,
+  | "equipmentLabel"
+  | "managementDueDate"
+  | "managementNote"
+  | "memo"
+  | "modelName"
+  | "serialNumber"
+> & { installedAt?: string };
+
+type BikeEquipmentFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<BikeEquipmentFormValues>;
+  equipmentTypes?: EquipmentType[];
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+  vehicles?: Array<Pick<FrontendVehicle, "model" | "plateNumber" | "slug" | "status">>;
+};
+
+export function BikeEquipmentForm({
+  action,
+  cancelHref = "/equipment",
+  defaultValues,
+  equipmentTypes = [],
+  mode = "등록",
+  statusMessage,
+  vehicles = []
+}: BikeEquipmentFormProps) {
+  const isCreateMode = mode === "등록";
+
+  return (
+    <form action={action} className="card" aria-label={`바이크 장비 ${mode} 폼`}>
+      <div className="form-grid">
+        {isCreateMode ? (
+          <>
+            <Field label="차량 선택" hint="차량번호와 모델 기준으로 선택합니다. DB ID를 직접 입력하지 않습니다.">
+              <select className="select" name="bikeSelection" required>
+                <option value="">차량 선택</option>
+                {vehicles.map((vehicle) => (
+                  <option key={vehicle.slug} value={vehicle.slug}>{vehicle.plateNumber} · {vehicle.model} · {vehicle.status}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="장비 종류 선택" hint="장비 종류명 기준으로 선택합니다. FK ID를 직접 입력하지 않습니다.">
+              <select className="select" name="equipmentTypeSelection" required>
+                <option value="">장비 종류 선택</option>
+                {equipmentTypes.map((type) => (
+                  <option key={type.id ?? type.slug} value={type.id ?? type.slug}>{type.name}{type.enabled ? "" : " · 비활성"}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="설치일시"><input className="input" defaultValue={defaultValues?.installedAt ?? ""} name="installedAt" required type="datetime-local" /></Field>
+          </>
+        ) : null}
+        <Field label="장비 표시명"><input className="input" defaultValue={defaultValues?.equipmentLabel ?? ""} maxLength={100} name="equipmentLabel" placeholder="예: 전륜 브레이크 패드" /></Field>
+        <Field label="모델명"><input className="input" defaultValue={defaultValues?.modelName ?? ""} maxLength={100} name="modelName" placeholder="예: BP-Urban-01" /></Field>
+        <Field label="시리얼 번호"><input className="input" defaultValue={defaultValues?.serialNumber ?? ""} maxLength={100} name="serialNumber" placeholder="제조사 시리얼" /></Field>
+        <Field label="관리 기한"><input className="input" defaultValue={defaultValues?.managementDueDate ?? ""} name="managementDueDate" required type="date" /></Field>
+      </div>
+      <br />
+      <Field label="관리 메모"><textarea className="input" defaultValue={defaultValues?.managementNote ?? ""} name="managementNote" placeholder="기한 관리 기준 또는 점검 메모" rows={3} /></Field>
+      <br />
+      <Field label="운영 메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={3} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>바이크 장비 ID는 DB가 자동 생성합니다. 차량과 장비 종류는 사람이 읽을 수 있는 선택 UI로 연결합니다.</p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">바이크 장비 {mode}</button>
+      </div>
+    </form>
+  );
+}

--- a/development/front-admin-web/components/equipment/EquipmentTypeForm.tsx
+++ b/development/front-admin-web/components/equipment/EquipmentTypeForm.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { EquipmentType } from "@/types/domain";
+
+type EquipmentTypeFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<Pick<EquipmentType, "description" | "enabled" | "name">>;
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+};
+
+export function EquipmentTypeForm({ action, cancelHref = "/equipment", defaultValues, mode = "등록", statusMessage }: EquipmentTypeFormProps) {
+  return (
+    <form action={action} className="card" aria-label={`장비 종류 ${mode} 폼`}>
+      <div className="form-grid">
+        <Field label="장비 종류명">
+          <input className="input" defaultValue={defaultValues?.name ?? ""} maxLength={100} name="name" placeholder="예: 브레이크 패드" required />
+        </Field>
+        <Field label="사용 상태">
+          <select className="select" defaultValue={String(defaultValues?.enabled ?? true)} name="enabled">
+            <option value="true">사용</option>
+            <option value="false">비활성</option>
+          </select>
+        </Field>
+      </div>
+      <br />
+      <Field label="설명"><textarea className="input" defaultValue={defaultValues?.description ?? ""} name="description" placeholder="운영자가 구분할 수 있는 장비 종류 설명" rows={3} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>장비 종류 ID는 DB가 자동 생성합니다. 운영자는 종류명, 설명, 사용 상태만 관리합니다.</p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">장비 종류 {mode}</button>
+      </div>
+    </form>
+  );
+}

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -10,7 +10,8 @@ const operationsItems = [
   { href: "/riders", label: "라이더 관리", icon: "R" },
   { href: "/contracts", label: "계약 관리", icon: "C" },
   { href: "/insurance", label: "보험 관리", icon: "I" },
-  { href: "/stations", label: "스테이션 관리", icon: "S" }
+  { href: "/stations", label: "스테이션 관리", icon: "S" },
+  { href: "/equipment", label: "장비 관리", icon: "E" }
 ];
 
 export async function AppShell({ children }: { children: ReactNode }) {

--- a/development/front-admin-web/lib/services/equipment-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/equipment-command-payload.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EquipmentCommandPayloadError,
+  toBikeEquipmentCreatePayload,
+  toBikeEquipmentRemovePayload,
+  toBikeEquipmentUpdatePayload,
+  toEquipmentTypeCreatePayload,
+  toEquipmentTypeUpdatePayload
+} from "./equipment-command-payload.ts";
+
+test("equipment type payloads keep operator fields only", () => {
+  const formData = new FormData();
+  formData.set("name", "브레이크 패드");
+  formData.set("description", "제동계 소모품");
+  formData.set("enabled", "true");
+  formData.set("equipmentTypeId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toEquipmentTypeCreatePayload(formData), {
+    description: "제동계 소모품",
+    enabled: true,
+    name: "브레이크 패드"
+  });
+  assert.deepEqual(toEquipmentTypeUpdatePayload(formData), {
+    description: "제동계 소모품",
+    enabled: true,
+    name: "브레이크 패드"
+  });
+});
+
+test("equipment type update payload preserves blank description as clear command", () => {
+  const formData = new FormData();
+  formData.set("name", "브레이크 패드");
+  formData.set("description", "");
+  formData.set("enabled", "true");
+
+  assert.deepEqual(toEquipmentTypeUpdatePayload(formData), {
+    description: "",
+    enabled: true,
+    name: "브레이크 패드"
+  });
+});
+
+test("bike equipment create payload uses selector fields and ignores direct raw ID field names", () => {
+  const formData = new FormData();
+  formData.set("bikeSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("equipmentTypeSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("equipmentLabel", "전륜 브레이크 패드");
+  formData.set("modelName", "BP-Urban-01");
+  formData.set("serialNumber", "BP-001");
+  formData.set("installedAt", "2026-04-30T10:30");
+  formData.set("managementDueDate", "2026-05-30");
+  formData.set("managementNote", "정기 점검");
+  formData.set("memo", "운영 메모");
+  formData.set("bikeId", "99999999-9999-4999-8999-999999999999");
+  formData.set("equipmentTypeId", "99999999-9999-4999-8999-999999999999");
+  formData.set("equipmentId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBikeEquipmentCreatePayload(formData), {
+    bikeId: "11111111-1111-4111-8111-111111111111",
+    equipmentLabel: "전륜 브레이크 패드",
+    equipmentTypeId: "22222222-2222-4222-8222-222222222222",
+    installedAt: "2026-04-30T01:30:00.000Z",
+    managementDueDate: "2026-05-30",
+    managementNote: "정기 점검",
+    memo: "운영 메모",
+    modelName: "BP-Urban-01",
+    serialNumber: "BP-001"
+  });
+});
+
+test("bike equipment update and remove payloads do not include relationship fields", () => {
+  const updateData = new FormData();
+  updateData.set("equipmentLabel", "후륜 브레이크 패드");
+  updateData.set("modelName", "BP-Urban-02");
+  updateData.set("serialNumber", "BP-002");
+  updateData.set("managementDueDate", "2026-06-30");
+  updateData.set("managementNote", "교체 예정");
+  updateData.set("memo", "수정 메모");
+  updateData.set("bikeSelection", "11111111-1111-4111-8111-111111111111");
+  updateData.set("equipmentTypeSelection", "22222222-2222-4222-8222-222222222222");
+
+  assert.deepEqual(toBikeEquipmentUpdatePayload(updateData), {
+    equipmentLabel: "후륜 브레이크 패드",
+    managementDueDate: "2026-06-30",
+    managementNote: "교체 예정",
+    memo: "수정 메모",
+    modelName: "BP-Urban-02",
+    serialNumber: "BP-002"
+  });
+
+  const removeData = new FormData();
+  removeData.set("removedAt", "2026-05-01T12:00");
+  removeData.set("memo", "교체 완료");
+  removeData.set("equipmentId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBikeEquipmentRemovePayload(removeData), {
+    memo: "교체 완료",
+    removedAt: "2026-05-01T03:00:00.000Z"
+  });
+});
+
+test("bike equipment update and remove payloads preserve blank text as clear commands", () => {
+  const updateData = new FormData();
+  updateData.set("equipmentLabel", "");
+  updateData.set("modelName", "");
+  updateData.set("serialNumber", "");
+  updateData.set("managementDueDate", "");
+  updateData.set("managementNote", "");
+  updateData.set("memo", "");
+
+  assert.deepEqual(toBikeEquipmentUpdatePayload(updateData), {
+    equipmentLabel: "",
+    managementDueDate: null,
+    managementNote: "",
+    memo: "",
+    modelName: "",
+    serialNumber: ""
+  });
+
+  const removeData = new FormData();
+  removeData.set("removedAt", "");
+  removeData.set("memo", "");
+
+  assert.deepEqual(toBikeEquipmentRemovePayload(removeData), {
+    memo: "",
+    removedAt: null
+  });
+});
+
+test("bike equipment payloads reject blank selectors and invalid dates", () => {
+  const formData = new FormData();
+  formData.set("bikeSelection", "서울바4821");
+  formData.set("equipmentTypeSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("installedAt", "2026-04-30T10:30");
+  formData.set("managementDueDate", "2026-05-30");
+
+  assert.throws(() => toBikeEquipmentCreatePayload(formData), EquipmentCommandPayloadError);
+
+  formData.set("bikeSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("managementDueDate", "2026-5-30");
+  assert.throws(() => toBikeEquipmentCreatePayload(formData), EquipmentCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/equipment-command-payload.ts
+++ b/development/front-admin-web/lib/services/equipment-command-payload.ts
@@ -1,0 +1,172 @@
+import type {
+  BikeEquipmentCreateInput,
+  BikeEquipmentRemoveInput,
+  BikeEquipmentUpdateInput,
+  EquipmentTypeCreateInput,
+  EquipmentTypeUpdateInput
+} from "./service-ops-api";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SEOUL_OFFSET = "+09:00";
+
+export class EquipmentCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EquipmentCommandPayloadError";
+  }
+}
+
+export function toEquipmentTypeCreatePayload(formData: FormData): EquipmentTypeCreateInput {
+  return {
+    description: optionalText(formData.get("description")),
+    enabled: toEnabled(formData.get("enabled"), true),
+    name: requiredText(formData.get("name"), "Equipment type name is required.")
+  };
+}
+
+export function toEquipmentTypeUpdatePayload(formData: FormData): EquipmentTypeUpdateInput {
+  return {
+    description: clearableText(formData.get("description")),
+    enabled: toEnabled(formData.get("enabled"), true),
+    name: requiredText(formData.get("name"), "Equipment type name is required.")
+  };
+}
+
+export function toBikeEquipmentCreatePayload(formData: FormData): BikeEquipmentCreateInput {
+  return {
+    bikeId: requiredUuid(formData.get("bikeSelection"), "Vehicle selection is required."),
+    equipmentLabel: optionalText(formData.get("equipmentLabel")),
+    equipmentTypeId: requiredUuid(formData.get("equipmentTypeSelection"), "Equipment type selection is required."),
+    installedAt: toServiceInstant(formData.get("installedAt"), "Installed date/time is required."),
+    managementDueDate: toServiceDate(formData.get("managementDueDate"), "Management due date is required."),
+    managementNote: optionalText(formData.get("managementNote")),
+    memo: optionalText(formData.get("memo")),
+    modelName: optionalText(formData.get("modelName")),
+    serialNumber: optionalText(formData.get("serialNumber"))
+  };
+}
+
+export function toBikeEquipmentUpdatePayload(formData: FormData): BikeEquipmentUpdateInput {
+  return {
+    equipmentLabel: clearableText(formData.get("equipmentLabel")),
+    managementDueDate: toOptionalServiceDate(formData.get("managementDueDate")),
+    managementNote: clearableText(formData.get("managementNote")),
+    memo: clearableText(formData.get("memo")),
+    modelName: clearableText(formData.get("modelName")),
+    serialNumber: clearableText(formData.get("serialNumber"))
+  };
+}
+
+export function toBikeEquipmentRemovePayload(formData: FormData): BikeEquipmentRemoveInput {
+  return {
+    memo: clearableText(formData.get("memo")),
+    removedAt: toOptionalServiceInstant(formData.get("removedAt"))
+  };
+}
+
+function requiredUuid(value: FormDataEntryValue | null, message: string): string {
+  const text = requiredText(value, message);
+  if (!UUID_PATTERN.test(text)) {
+    throw new EquipmentCommandPayloadError("Invalid selector token. Use the provided vehicle and equipment type selection controls.");
+  }
+
+  return text;
+}
+
+function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (!text) {
+    return fallback;
+  }
+
+  if (["true", "1", "on", "enabled"].includes(text)) {
+    return true;
+  }
+
+  if (["false", "0", "off", "disabled"].includes(text)) {
+    return false;
+  }
+
+  throw new EquipmentCommandPayloadError("Invalid enabled status.");
+}
+
+function toOptionalServiceDate(value: FormDataEntryValue | null): string | null {
+  const text = optionalText(value);
+  if (!text) {
+    return null;
+  }
+
+  return toServiceDate(text, "Management due date is required.");
+}
+
+function toServiceDate(value: FormDataEntryValue | string | null, message: string): string {
+  const text = requiredText(value, message);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    throw new EquipmentCommandPayloadError("Invalid management due date.");
+  }
+
+  return text;
+}
+
+function toOptionalServiceInstant(value: FormDataEntryValue | null): string | null {
+  const text = optionalText(value);
+  if (!text) {
+    return null;
+  }
+
+  return toServiceInstant(text, "Removal date/time is required.");
+}
+
+function toServiceInstant(value: FormDataEntryValue | string | null, message: string): string {
+  const text = requiredText(value, message);
+  const normalized = normalizeDateTimeInput(text);
+  const date = new Date(normalized);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new EquipmentCommandPayloadError("Invalid equipment date/time.");
+  }
+
+  return date.toISOString();
+}
+
+function normalizeDateTimeInput(value: string): string {
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(value)) {
+    return value;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+    return `${value}:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+    return `${value}${SEOUL_OFFSET}`;
+  }
+
+  return value;
+}
+
+function requiredText(value: FormDataEntryValue | string | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new EquipmentCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | string | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function clearableText(value: FormDataEntryValue | string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return String(value).trim();
+}

--- a/development/front-admin-web/lib/services/equipment-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/equipment-data-core.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mockBikeEquipmentUnavailableServiceDetail,
+  mockEquipmentTypeUnavailableServiceDetail,
+  toFrontendBikeEquipment,
+  toFrontendManagementStatus
+} from "./equipment-data-core.ts";
+
+const lookup = {
+  equipmentTypes: new Map([["22222222-2222-4222-8222-222222222222", { name: "브레이크 패드" }]]),
+  vehicles: new Map([["11111111-1111-4111-8111-111111111111", { model: "Thunder M1", plateNumber: "서울바4821", status: "대기" }]])
+};
+
+const mockTypes = [{ description: "제동계", enabled: true, name: "브레이크 패드", slug: "brake-pad" }];
+const mockEquipments = [
+  {
+    bikeLabel: "서울바4821 · Thunder M1",
+    equipmentLabel: "전륜 브레이크 패드",
+    equipmentTypeName: "브레이크 패드",
+    installedAt: "2026-04-30T10:30:00+09:00",
+    managementDueDate: "2026-05-30",
+    managementStatus: "정상",
+    slug: "equip-brake"
+  }
+];
+
+test("toFrontendBikeEquipment hydrates vehicle/type labels and management status", () => {
+  const equipment = toFrontendBikeEquipment(
+    {
+      bikeId: "11111111-1111-4111-8111-111111111111",
+      createdAt: "2026-04-30T00:00:00Z",
+      equipmentLabel: "전륜 브레이크 패드",
+      equipmentTypeId: "22222222-2222-4222-8222-222222222222",
+      id: "33333333-3333-4333-8333-333333333333",
+      idx: 3,
+      installedAt: "2026-04-30T01:30:00Z",
+      managementDueDate: "2026-05-30",
+      managementNote: "정기 점검",
+      managementStatus: "DUE_SOON",
+      memo: "운영 메모",
+      modelName: "BP-Urban-01",
+      removedAt: null,
+      serialNumber: "BP-001",
+      updatedAt: "2026-04-30T00:00:00Z"
+    },
+    lookup
+  );
+
+  assert.equal(equipment.bikeLabel, "서울바4821 · Thunder M1");
+  assert.equal(equipment.equipmentTypeName, "브레이크 패드");
+  assert.equal(equipment.managementStatus, "관리 예정");
+  assert.equal(equipment.slug, "33333333-3333-4333-8333-333333333333");
+});
+
+test("removed bike equipment displays removed status", () => {
+  const equipment = toFrontendBikeEquipment(
+    {
+      bikeId: "11111111-1111-4111-8111-111111111111",
+      createdAt: "2026-04-30T00:00:00Z",
+      equipmentLabel: "전륜 브레이크 패드",
+      equipmentTypeId: "22222222-2222-4222-8222-222222222222",
+      id: "33333333-3333-4333-8333-333333333333",
+      idx: 3,
+      installedAt: "2026-04-30T01:30:00Z",
+      managementDueDate: "2026-05-30",
+      managementNote: null,
+      managementStatus: "NORMAL",
+      memo: null,
+      modelName: null,
+      removedAt: "2026-05-01T00:00:00Z",
+      serialNumber: null,
+      updatedAt: "2026-04-30T00:00:00Z"
+    },
+    lookup
+  );
+
+  assert.equal(equipment.managementStatus, "제거됨");
+});
+
+test("management status label mapping is explicit", () => {
+  assert.equal(toFrontendManagementStatus("NORMAL"), "정상");
+  assert.equal(toFrontendManagementStatus("DUE_SOON"), "관리 예정");
+  assert.equal(toFrontendManagementStatus("OVERDUE"), "기한 초과");
+});
+
+test("UUID equipment detail falls back to visible mock detail when service API is unavailable", () => {
+  const missingEquipment = mockBikeEquipmentUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    mockEquipments,
+    "서비스 API 세션 쿠키가 없어 mock 장비 상세를 표시합니다."
+  );
+  const missingType = mockEquipmentTypeUnavailableServiceDetail(
+    "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    mockTypes,
+    "서비스 API 세션 쿠키가 없어 mock 장비 종류 상세를 표시합니다."
+  );
+
+  assert.equal(missingEquipment?.source, "mock");
+  assert.equal(missingEquipment?.equipment.slug, "equip-brake");
+  assert.equal(missingType?.source, "mock");
+  assert.equal(missingType?.equipmentType.slug, "brake-pad");
+});

--- a/development/front-admin-web/lib/services/equipment-data-core.ts
+++ b/development/front-admin-web/lib/services/equipment-data-core.ts
@@ -1,0 +1,194 @@
+import type { BikeEquipment, EquipmentManagementStatus, EquipmentType } from "@/types/domain";
+import type {
+  FrontendVehicle,
+  ServiceOpsBikeEquipment,
+  ServiceOpsBikeEquipmentManagementStatus,
+  ServiceOpsEquipmentType
+} from "./service-ops-api";
+
+export type EquipmentDataResult = {
+  source: "mock" | "service-ops";
+  equipmentTypes: EquipmentType[];
+  bikeEquipments: BikeEquipment[];
+  notice?: string;
+};
+
+export type BikeEquipmentDetailResult = {
+  source: "mock" | "service-ops";
+  equipment: BikeEquipment;
+  notice?: string;
+};
+
+export type EquipmentTypeDetailResult = {
+  source: "mock" | "service-ops";
+  equipmentType: EquipmentType;
+  notice?: string;
+};
+
+export type EquipmentFormOptions = {
+  source: "mock" | "service-ops";
+  vehicles: Array<Pick<FrontendVehicle, "model" | "plateNumber" | "slug" | "status">>;
+  equipmentTypes: EquipmentType[];
+  notice?: string;
+};
+
+export type EquipmentLookup = {
+  vehicles: Map<string, Pick<FrontendVehicle, "model" | "plateNumber" | "status">>;
+  equipmentTypes: Map<string, Pick<EquipmentType, "name">>;
+};
+
+export function toFrontendBikeEquipment(equipment: ServiceOpsBikeEquipment, lookup: EquipmentLookup): BikeEquipment {
+  const vehicle = lookup.vehicles.get(equipment.bikeId);
+  const type = lookup.equipmentTypes.get(equipment.equipmentTypeId);
+  const equipmentTypeName = type?.name ?? "장비 종류 연결 확인 필요";
+
+  return {
+    bikeId: equipment.bikeId,
+    bikeLabel: vehicle ? `${vehicle.plateNumber} · ${vehicle.model}` : "차량 연결 확인 필요",
+    equipmentLabel: equipment.equipmentLabel ?? equipmentTypeName,
+    equipmentTypeId: equipment.equipmentTypeId,
+    equipmentTypeName,
+    id: equipment.id,
+    idx: equipment.idx,
+    installedAt: toDateTimeLabel(equipment.installedAt),
+    managementDueDate: equipment.managementDueDate,
+    managementNote: equipment.managementNote,
+    managementStatus: equipment.removedAt ? "제거됨" : toFrontendManagementStatus(equipment.managementStatus),
+    managementStatusCode: equipment.managementStatus,
+    memo: equipment.memo,
+    modelName: equipment.modelName,
+    removedAt: equipment.removedAt,
+    serialNumber: equipment.serialNumber,
+    slug: equipment.id,
+    source: "service-ops"
+  };
+}
+
+export function toFrontendManagementStatus(status: ServiceOpsBikeEquipmentManagementStatus): EquipmentManagementStatus {
+  switch (status) {
+    case "NORMAL":
+      return "정상";
+    case "DUE_SOON":
+      return "관리 예정";
+    case "OVERDUE":
+      return "기한 초과";
+  }
+}
+
+export function toEquipmentTypeList(types: ServiceOpsEquipmentType[]): EquipmentType[] {
+  return types.map((type) => ({
+    createdAt: type.createdAt,
+    description: type.description,
+    enabled: type.enabled,
+    id: type.id,
+    idx: type.idx,
+    name: type.name,
+    slug: type.id,
+    source: "service-ops" as const,
+    updatedAt: type.updatedAt
+  }));
+}
+
+export function mockEquipmentData(mockTypes: EquipmentType[], mockEquipments: BikeEquipment[]): EquipmentDataResult {
+  return {
+    bikeEquipments: mockEquipments.map((equipment) => ({ ...equipment, source: "mock" as const })),
+    equipmentTypes: mockTypes.map((type) => ({ ...type, source: "mock" as const })),
+    source: "mock"
+  };
+}
+
+export function mockBikeEquipmentDetail(slug: string, mockEquipments: BikeEquipment[]): BikeEquipmentDetailResult | null {
+  const equipment = mockEquipments.find((candidate) => candidate.slug === slug);
+  if (!equipment) {
+    return null;
+  }
+
+  return {
+    equipment: { ...equipment, source: "mock" },
+    source: "mock"
+  };
+}
+
+export function mockEquipmentTypeDetail(slug: string, mockTypes: EquipmentType[]): EquipmentTypeDetailResult | null {
+  const equipmentType = mockTypes.find((candidate) => candidate.slug === slug);
+  if (!equipmentType) {
+    return null;
+  }
+
+  return {
+    equipmentType: { ...equipmentType, source: "mock" },
+    source: "mock"
+  };
+}
+
+export function mockBikeEquipmentUnavailableServiceDetail(
+  slug: string,
+  mockEquipments: BikeEquipment[],
+  notice: string
+): BikeEquipmentDetailResult | null {
+  const exactFallback = mockBikeEquipmentDetail(slug, mockEquipments);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockEquipments.length) {
+    return null;
+  }
+
+  return {
+    equipment: { ...mockEquipments[0], source: "mock" },
+    notice,
+    source: "mock"
+  };
+}
+
+export function mockEquipmentTypeUnavailableServiceDetail(
+  slug: string,
+  mockTypes: EquipmentType[],
+  notice: string
+): EquipmentTypeDetailResult | null {
+  const exactFallback = mockEquipmentTypeDetail(slug, mockTypes);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockTypes.length) {
+    return null;
+  }
+
+  return {
+    equipmentType: { ...mockTypes[0], source: "mock" },
+    notice,
+    source: "mock"
+  };
+}
+
+export function mockEquipmentFormOptions(
+  vehicles: Array<Pick<FrontendVehicle, "model" | "plateNumber" | "slug" | "status">>,
+  equipmentTypes: EquipmentType[],
+  notice?: string
+): EquipmentFormOptions {
+  return {
+    equipmentTypes: equipmentTypes.map((type) => ({ ...type, source: "mock" as const })),
+    notice,
+    source: "mock",
+    vehicles: vehicles.map((vehicle) => ({ ...vehicle }))
+  };
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function toDateTimeLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Seoul"
+  }).format(date);
+}

--- a/development/front-admin-web/lib/services/equipment-data.ts
+++ b/development/front-admin-web/lib/services/equipment-data.ts
@@ -1,0 +1,206 @@
+import {
+  type FrontendVehicle,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import type { EquipmentType } from "@/types/domain";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  bikeEquipments as mockBikeEquipments,
+  equipmentTypes as mockEquipmentTypes,
+  vehicles as mockVehicles
+} from "@/lib/services/mock-data";
+import {
+  type BikeEquipmentDetailResult,
+  type EquipmentDataResult,
+  type EquipmentFormOptions,
+  type EquipmentLookup,
+  type EquipmentTypeDetailResult,
+  isUuidLike,
+  mockBikeEquipmentDetail,
+  mockBikeEquipmentUnavailableServiceDetail,
+  mockEquipmentData,
+  mockEquipmentFormOptions,
+  mockEquipmentTypeDetail,
+  mockEquipmentTypeUnavailableServiceDetail,
+  toEquipmentTypeList,
+  toFrontendBikeEquipment
+} from "@/lib/services/equipment-data-core";
+
+export async function loadEquipmentData(): Promise<EquipmentDataResult> {
+  const fallback = mockEquipmentData(mockEquipmentTypes, mockBikeEquipments);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 장비 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 장비 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const [equipmentTypesPage, bikeEquipmentsPage, vehiclesPage] = await Promise.all([
+      client.listEquipmentTypes({ page: 0, size: 100 }),
+      client.listBikeEquipments({ page: 0, size: 100 }),
+      client.listVehicles({ page: 0, size: 100 })
+    ]);
+    const equipmentTypes = toEquipmentTypeList(equipmentTypesPage.items);
+    const lookup = toEquipmentLookup(vehiclesPage.items, equipmentTypes);
+
+    return {
+      bikeEquipments: bikeEquipmentsPage.items.map((equipment) => toFrontendBikeEquipment(equipment, lookup)),
+      equipmentTypes,
+      source: "service-ops"
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 장비 조회 실패로 mock 장비 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadBikeEquipmentDetail(slug: string): Promise<BikeEquipmentDetailResult | null> {
+  const fallback = mockBikeEquipmentDetail(slug, mockBikeEquipments);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockBikeEquipmentUnavailableServiceDetail(
+      slug,
+      mockBikeEquipments,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 장비 상세를 표시합니다. 백엔드 연결 후 실제 장비 상세로 전환됩니다."
+    );
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockBikeEquipmentUnavailableServiceDetail(
+        slug,
+        mockBikeEquipments,
+        "서비스 API 세션 쿠키가 없어 mock 장비 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const [equipment, equipmentTypesPage, vehiclesPage] = await Promise.all([
+        client.getBikeEquipment(slug),
+        client.listEquipmentTypes({ page: 0, size: 100 }),
+        client.listVehicles({ page: 0, size: 100 })
+      ]);
+      const equipmentTypes = toEquipmentTypeList(equipmentTypesPage.items);
+      const lookup = toEquipmentLookup(vehiclesPage.items, equipmentTypes);
+      return { equipment: toFrontendBikeEquipment(equipment, lookup), source: "service-ops" };
+    } catch (error) {
+      return mockBikeEquipmentUnavailableServiceDetail(
+        slug,
+        mockBikeEquipments,
+        `서비스 API 장비 상세 조회 실패로 mock 장비 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadEquipmentTypeDetail(slug: string): Promise<EquipmentTypeDetailResult | null> {
+  const fallback = mockEquipmentTypeDetail(slug, mockEquipmentTypes);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockEquipmentTypeUnavailableServiceDetail(
+      slug,
+      mockEquipmentTypes,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 장비 종류 상세를 표시합니다. 백엔드 연결 후 실제 장비 종류 상세로 전환됩니다."
+    );
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockEquipmentTypeUnavailableServiceDetail(
+        slug,
+        mockEquipmentTypes,
+        "서비스 API 세션 쿠키가 없어 mock 장비 종류 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const equipmentType = await client.getEquipmentType(slug);
+      return { equipmentType: toEquipmentTypeList([equipmentType])[0], source: "service-ops" };
+    } catch (error) {
+      return mockEquipmentTypeUnavailableServiceDetail(
+        slug,
+        mockEquipmentTypes,
+        `서비스 API 장비 종류 상세 조회 실패로 mock 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadEquipmentFormOptions(): Promise<EquipmentFormOptions> {
+  const fallback = mockEquipmentFormOptions(mockVehicles, mockEquipmentTypes);
+
+  if (!serviceOpsApiConfigured()) {
+    return mockEquipmentFormOptions(
+      mockVehicles,
+      mockEquipmentTypes,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 차량/장비 종류 선택지를 표시합니다."
+    );
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return mockEquipmentFormOptions(
+      mockVehicles,
+      mockEquipmentTypes,
+      "서비스 API 세션 쿠키가 없어 mock 차량/장비 종류 선택지를 표시합니다."
+    );
+  }
+
+  try {
+    const [vehiclesPage, typesPage] = await Promise.all([
+      client.listVehicles({ page: 0, size: 100 }),
+      client.listEquipmentTypes({ page: 0, size: 100 })
+    ]);
+    return {
+      equipmentTypes: toEquipmentTypeList(typesPage.items).filter((type) => type.enabled),
+      source: "service-ops",
+      vehicles: vehiclesPage.items
+    };
+  } catch (error) {
+    return mockEquipmentFormOptions(
+      mockVehicles,
+      mockEquipmentTypes,
+      `서비스 API 선택지 조회 실패로 mock 선택지를 표시합니다.${formatServiceOpsError(error)}`
+    );
+  }
+}
+
+function toEquipmentLookup(
+  vehicles: FrontendVehicle[],
+  equipmentTypes: EquipmentType[]
+): EquipmentLookup {
+  return {
+    equipmentTypes: new Map(equipmentTypes.map((type) => [type.id ?? type.slug, { name: type.name }])),
+    vehicles: new Map(vehicles.map((vehicle) => [vehicle.id ?? vehicle.slug, { model: vehicle.model, plateNumber: vehicle.plateNumber, status: vehicle.status }]))
+  };
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/mock-data.ts
+++ b/development/front-admin-web/lib/services/mock-data.ts
@@ -1,4 +1,4 @@
-import type { BatteryStation, InsurancePolicy, Rider, RiderContract, Vehicle } from "@/types/domain";
+import type { BatteryStation, BikeEquipment, EquipmentType, InsurancePolicy, Rider, RiderContract, Vehicle } from "@/types/domain";
 
 export const riders: Rider[] = [
   { slug: "kim-minjun", name: "김민준", phone: "010-2411-9021", team: "강남 1팀", area: "강남/역삼", status: "활동", joinedAt: "2026-01-12" },
@@ -28,6 +28,41 @@ export const stations: BatteryStation[] = [
   { slug: "gangnam-station", name: "강남 교체 스테이션", address: "서울 강남구 테헤란로 152", status: "운영 중", batteryCount: 48, replaceableCount: 31, latitude: 37.5007, longitude: 127.0364 },
   { slug: "seocho-station", name: "서초 물류 스테이션", address: "서울 서초구 사임당로 174", status: "운영 중", batteryCount: 35, replaceableCount: 19, latitude: 37.4921, longitude: 127.0242 },
   { slug: "songpa-station", name: "송파 점검 스테이션", address: "서울 송파구 올림픽로 300", status: "점검 중", batteryCount: 22, replaceableCount: 4, latitude: 37.5145, longitude: 127.1059 }
+];
+
+export const equipmentTypes: EquipmentType[] = [
+  { slug: "brake-pad", name: "브레이크 패드", description: "제동계 소모품", enabled: true },
+  { slug: "controller", name: "컨트롤러", description: "전기 이륜차 구동 제어 장치", enabled: true },
+  { slug: "tire", name: "타이어", description: "전후륜 타이어", enabled: true }
+];
+
+export const bikeEquipments: BikeEquipment[] = [
+  {
+    slug: "equip-seoul-ba-4821-brake",
+    bikeLabel: "서울바4821 · NIU NQi Cargo",
+    equipmentTypeName: "브레이크 패드",
+    equipmentLabel: "전륜 브레이크 패드",
+    modelName: "BP-Urban-01",
+    serialNumber: "BP-4821-F",
+    installedAt: "2026-01-15T09:00:00+09:00",
+    managementDueDate: "2026-05-15",
+    managementStatus: "관리 예정",
+    managementNote: "5월 정기점검 때 교체 여부 확인",
+    memo: "강남 운영 차량"
+  },
+  {
+    slug: "equip-seoul-ba-7390-controller",
+    bikeLabel: "서울바7390 · Gogoro 2 Utility",
+    equipmentTypeName: "컨트롤러",
+    equipmentLabel: "메인 컨트롤러",
+    modelName: "CTRL-G2",
+    serialNumber: "CTRL-7390-M",
+    installedAt: "2025-11-20T10:30:00+09:00",
+    managementDueDate: "2026-04-20",
+    managementStatus: "기한 초과",
+    managementNote: "점검 입고 필요",
+    memo: "점검 필요 차량"
+  }
 ];
 
 export const dashboardMetrics = [

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -871,3 +871,146 @@ test("invalid backend station status does not display as active", () => {
       error.message.includes("Unsupported battery station status")
   );
 });
+
+test("equipment type list/create/update/delete use dedicated backend endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify(
+          init?.method === "GET"
+            ? {
+                items: [
+                  {
+                    id: "11111111-1111-4111-8111-111111111111",
+                    idx: 1,
+                    name: "브레이크 패드",
+                    description: "제동계 소모품",
+                    enabled: true,
+                    createdAt: "2026-04-30T00:00:00Z",
+                    updatedAt: "2026-04-30T00:00:00Z"
+                  }
+                ],
+                page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+              }
+            : {
+                id: "11111111-1111-4111-8111-111111111111",
+                idx: 1,
+                name: body.name,
+                description: body.description ?? null,
+                enabled: body.enabled ?? true,
+                createdAt: "2026-04-30T00:00:00Z",
+                updatedAt: "2026-04-30T00:00:00Z"
+              }
+        ),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.listEquipmentTypes({ page: 0, size: 20 });
+  await client.createEquipmentType({ description: "제동계 소모품", enabled: true, name: "브레이크 패드" });
+  await client.updateEquipmentType("11111111-1111-4111-8111-111111111111", { description: "수정", enabled: false, name: "브레이크 패드" });
+  await client.deleteEquipmentType("11111111-1111-4111-8111-111111111111");
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/equipment-types",
+    "/api/v1/equipment-types",
+    "/api/v1/equipment-types/11111111-1111-4111-8111-111111111111",
+    "/api/v1/equipment-types/11111111-1111-4111-8111-111111111111"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["GET", "POST", "PATCH", "DELETE"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[1].init?.body))).sort(), ["description", "enabled", "name"]);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("bike equipment create/update/remove use selector-backed lifecycle endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          id: "22222222-2222-4222-8222-222222222222",
+          idx: 2,
+          bikeId: body.bikeId ?? "33333333-3333-4333-8333-333333333333",
+          equipmentTypeId: body.equipmentTypeId ?? "44444444-4444-4444-8444-444444444444",
+          equipmentLabel: body.equipmentLabel ?? "전륜 브레이크 패드",
+          modelName: body.modelName ?? "BP-Urban-01",
+          serialNumber: body.serialNumber ?? "BP-001",
+          installedAt: body.installedAt ?? "2026-04-30T00:00:00Z",
+          removedAt: body.removedAt ?? null,
+          managementDueDate: body.managementDueDate ?? "2026-05-30",
+          managementStatus: "NORMAL",
+          managementNote: body.managementNote ?? null,
+          memo: body.memo ?? null,
+          createdAt: "2026-04-30T00:00:00Z",
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.createBikeEquipment({
+    bikeId: "33333333-3333-4333-8333-333333333333",
+    equipmentLabel: "전륜 브레이크 패드",
+    equipmentTypeId: "44444444-4444-4444-8444-444444444444",
+    installedAt: "2026-04-30T00:00:00Z",
+    managementDueDate: "2026-05-30",
+    managementNote: "정기 점검",
+    memo: "운영 메모",
+    modelName: "BP-Urban-01",
+    serialNumber: "BP-001"
+  });
+  await client.updateBikeEquipment("22222222-2222-4222-8222-222222222222", {
+    equipmentLabel: "후륜 브레이크 패드",
+    managementDueDate: "2026-06-30",
+    managementNote: "교체 예정",
+    memo: "수정 메모",
+    modelName: "BP-Urban-02",
+    serialNumber: "BP-002"
+  });
+  await client.removeBikeEquipment("22222222-2222-4222-8222-222222222222", {
+    memo: "교체 완료",
+    removedAt: "2026-05-01T00:00:00Z"
+  });
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/bike-equipments",
+    "/api/v1/bike-equipments/22222222-2222-4222-8222-222222222222",
+    "/api/v1/bike-equipments/22222222-2222-4222-8222-222222222222/remove"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["POST", "PATCH", "PATCH"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), [
+    "bikeId",
+    "equipmentLabel",
+    "equipmentTypeId",
+    "installedAt",
+    "managementDueDate",
+    "managementNote",
+    "memo",
+    "modelName",
+    "serialNumber"
+  ]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[1].init?.body))).sort(), [
+    "equipmentLabel",
+    "managementDueDate",
+    "managementNote",
+    "memo",
+    "modelName",
+    "serialNumber"
+  ]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["memo", "removedAt"]);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1,4 +1,4 @@
-import type { BatteryStation } from "@/types/domain";
+import type { BatteryStation, EquipmentType } from "@/types/domain";
 
 export type ServiceOpsFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
@@ -256,6 +256,74 @@ export type BatteryStationCountUpdateInput = {
   memo?: string | null;
 };
 
+export type ServiceOpsEquipmentType = {
+  id: string;
+  idx: number | null;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type EquipmentTypeCreateInput = {
+  name: string;
+  description?: string | null;
+  enabled?: boolean | null;
+};
+
+export type EquipmentTypeUpdateInput = {
+  name?: string | null;
+  description?: string | null;
+  enabled?: boolean | null;
+};
+
+export type ServiceOpsBikeEquipmentManagementStatus = "NORMAL" | "DUE_SOON" | "OVERDUE";
+
+export type ServiceOpsBikeEquipment = {
+  id: string;
+  idx: number | null;
+  bikeId: string;
+  equipmentTypeId: string;
+  equipmentLabel: string | null;
+  modelName: string | null;
+  serialNumber: string | null;
+  installedAt: string;
+  removedAt: string | null;
+  managementDueDate: string;
+  managementStatus: ServiceOpsBikeEquipmentManagementStatus;
+  managementNote: string | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BikeEquipmentCreateInput = {
+  bikeId: string;
+  equipmentTypeId: string;
+  equipmentLabel?: string | null;
+  modelName?: string | null;
+  serialNumber?: string | null;
+  installedAt: string;
+  managementDueDate: string;
+  managementNote?: string | null;
+  memo?: string | null;
+};
+
+export type BikeEquipmentUpdateInput = {
+  equipmentLabel?: string | null;
+  modelName?: string | null;
+  serialNumber?: string | null;
+  managementDueDate?: string | null;
+  managementNote?: string | null;
+  memo?: string | null;
+};
+
+export type BikeEquipmentRemoveInput = {
+  removedAt?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -361,6 +429,16 @@ export type ServiceOpsApiClient = {
   createBatteryStation: (request: BatteryStationCreateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStation: (id: string, request: BatteryStationUpdateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStationCounts: (id: string, request: BatteryStationCountUpdateInput) => Promise<FrontendBatteryStation>;
+  listEquipmentTypes: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsEquipmentType>>;
+  getEquipmentType: (id: string) => Promise<ServiceOpsEquipmentType>;
+  createEquipmentType: (request: EquipmentTypeCreateInput) => Promise<ServiceOpsEquipmentType>;
+  updateEquipmentType: (id: string, request: EquipmentTypeUpdateInput) => Promise<ServiceOpsEquipmentType>;
+  deleteEquipmentType: (id: string) => Promise<void>;
+  listBikeEquipments: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsBikeEquipment>>;
+  getBikeEquipment: (id: string) => Promise<ServiceOpsBikeEquipment>;
+  createBikeEquipment: (request: BikeEquipmentCreateInput) => Promise<ServiceOpsBikeEquipment>;
+  updateBikeEquipment: (id: string, request: BikeEquipmentUpdateInput) => Promise<ServiceOpsBikeEquipment>;
+  removeBikeEquipment: (id: string, request: BikeEquipmentRemoveInput) => Promise<ServiceOpsBikeEquipment>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -588,6 +666,42 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    listEquipmentTypes: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsEquipmentType>>("/equipment-types", { method: "GET" }, { page, size, sort }),
+    getEquipmentType: (id) =>
+      request<ServiceOpsEquipmentType>(`/equipment-types/${encodeURIComponent(id)}`, { method: "GET" }),
+    createEquipmentType: (createRequest) =>
+      request<ServiceOpsEquipmentType>("/equipment-types", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateEquipmentType: (id, updateRequest) =>
+      request<ServiceOpsEquipmentType>(`/equipment-types/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
+        method: "PATCH"
+      }),
+    deleteEquipmentType: async (id) => {
+      await request<void>(`/equipment-types/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
+    listBikeEquipments: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsBikeEquipment>>("/bike-equipments", { method: "GET" }, { page, size, sort }),
+    getBikeEquipment: (id) =>
+      request<ServiceOpsBikeEquipment>(`/bike-equipments/${encodeURIComponent(id)}`, { method: "GET" }),
+    createBikeEquipment: (createRequest) =>
+      request<ServiceOpsBikeEquipment>("/bike-equipments", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateBikeEquipment: (id, updateRequest) =>
+      request<ServiceOpsBikeEquipment>(`/bike-equipments/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
+        method: "PATCH"
+      }),
+    removeBikeEquipment: (id, removeRequest) =>
+      request<ServiceOpsBikeEquipment>(`/bike-equipments/${encodeURIComponent(id)}/remove`, {
+        body: JSON.stringify(removeRequest),
+        method: "PATCH"
+      }),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {
@@ -736,6 +850,20 @@ export function toFrontendStationStatus(status: ServiceOpsStationStatus): Fronte
   throw new ServiceOpsApiError("Unsupported battery station status returned by service ops API.", 0, "SERVICE_OPS_UNSUPPORTED_STATION_STATUS", {
     status
   });
+}
+
+export function toFrontendEquipmentType(type: ServiceOpsEquipmentType): EquipmentType {
+  return {
+    createdAt: type.createdAt,
+    description: type.description,
+    enabled: type.enabled,
+    id: type.id,
+    idx: type.idx,
+    name: type.name,
+    slug: type.id,
+    source: "service-ops",
+    updatedAt: type.updatedAt
+  };
 }
 
 function parseResponseBody(responseText: string): unknown {

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -48,3 +48,21 @@ export const stationSchema = z.object({
   message: "현재 보유 수량은 교체 가능 수량보다 작을 수 없습니다.",
   path: ["availableBatteryCount"]
 });
+
+export const equipmentTypeSchema = z.object({
+  name: z.string().min(1, "장비 종류명을 입력하세요.").max(100),
+  description: z.string().optional(),
+  enabled: z.enum(["true", "false"])
+});
+
+export const bikeEquipmentSchema = z.object({
+  bikeSelection: z.string().min(1, "차량을 선택하세요."),
+  equipmentTypeSelection: z.string().min(1, "장비 종류를 선택하세요."),
+  equipmentLabel: z.string().max(100).optional(),
+  modelName: z.string().max(100).optional(),
+  serialNumber: z.string().max(100).optional(),
+  installedAt: z.string().min(1, "설치일시를 선택하세요."),
+  managementDueDate: z.string().min(1, "관리 기한을 선택하세요."),
+  managementNote: z.string().optional(),
+  memo: z.string().optional()
+});

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -3,6 +3,7 @@ export type AssignmentStatus = "배정됨" | "미배정" | "교대 예정";
 export type ContractStatus = "활성" | "만료 예정" | "종료" | "초안";
 export type InsuranceStatus = "정상" | "만료 예정" | "만료" | "비활성";
 export type StationStatus = "운영 중" | "점검 중" | "운영 중지";
+export type EquipmentManagementStatus = "정상" | "관리 예정" | "기한 초과" | "제거됨";
 
 export type Rider = {
   slug: string;
@@ -100,5 +101,38 @@ export type BatteryStation = {
   memo?: string | null;
   createdAt?: string;
   updatedAt?: string;
+  source?: "mock" | "service-ops";
+};
+
+export type EquipmentType = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  name: string;
+  description?: string | null;
+  enabled: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
+};
+
+export type BikeEquipment = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  bikeId?: string;
+  bikeLabel: string;
+  equipmentTypeId?: string;
+  equipmentTypeName: string;
+  equipmentLabel: string;
+  modelName?: string | null;
+  serialNumber?: string | null;
+  installedAt: string;
+  removedAt?: string | null;
+  managementDueDate: string;
+  managementStatus: EquipmentManagementStatus;
+  managementStatusCode?: "NORMAL" | "DUE_SOON" | "OVERDUE";
+  managementNote?: string | null;
+  memo?: string | null;
   source?: "mock" | "service-ops";
 };

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -770,3 +770,30 @@ Verification:
 
 - TDD red observed on frontend service-ops station tests before implementation because station API client methods and station command/data helpers did not exist.
 - Frontend service-ops tests cover battery-station list mapping, create/update/count endpoint shape, system-ID field exclusion, status/coordinate/count validation, available `n/m` label preservation, and UUID mock fallback.
+
+## Frontend bike equipment admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#83
+- Target issue: EVNSolution/thundercrew-domain#73
+- Branch: `cc-83-equipment-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires a new Next.js equipment management surface to existing service-ops-api equipment-type and bike-equipment endpoints.
+- Included work is a frontend equipment client/data adapter, equipment type create/update actions, bike-equipment create/update/remove actions, pages/forms, service-ops tests, and docs updates.
+- Telemetry/current-state, real map provider/API integration, backend schema/API changes, hard delete/restore/bulk flows, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Equipment type commands expose only name, description, and enabled status; IDs and idx remain server-owned.
+- Bike equipment create uses human-readable select controls for vehicle and equipment type; operators do not type raw `bikeId`, `equipmentTypeId`, `equipmentId`, `vehicle_id`, or FK fields.
+- Bike equipment update is metadata/due-date only, matching the existing backend DTO; vehicle/type relationship changes remain a separate lifecycle operation.
+- Remove is modeled as a history-preserving state transition through `/bike-equipments/{id}/remove`, not hard delete.
+- Missing config/session/API failure falls back to explicit mock equipment data with a visible notice, including service UUID detail routes.
+
+Verification:
+
+- TDD red observed on frontend service-ops equipment tests before implementation because equipment API client methods and equipment command/data helpers did not exist.
+- Frontend service-ops tests cover equipment-type endpoint request shape, bike-equipment create/update/remove endpoint shape, selector-only payload conversion, management status label derivation, removed-status display, and UUID mock fallback.


### PR DESCRIPTION
## Summary
- Adds the frontend admin equipment management surface under 운영 관리.
- Connects equipment type and bike equipment pages/actions to existing service-ops endpoints.
- Keeps vehicle/equipment relationships selector-backed and prevents direct raw ID/FK input fields.
- Preserves blank optional update/remove text values as explicit clear commands.

## Scope
- Change-control: EVNSolution/clever-change-control#83
- Closes EVNSolution/thundercrew-domain#73
- Excludes telemetry/current-state, real map provider/API integration, backend schema/API changes, and production env mutation.

## Validation
- git diff --check
- npm run check:workspace
- npm run lint
- npm run test:service-ops
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew test)
- (cd development/service-ops-api && ./gradlew build)
- code-reviewer PASS
