### PR TITLE
Frontend device registry and bike-device installation admin API integration baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd development/service-ops-api
 관리자 웹 앱 문서는 `development/front-admin-web/README.md`에 있습니다.
 
 - 핵심 화면: 지도 관제
-- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비
+- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비, 단말
 - 디자인 기준: `development/front-admin-web/DESIGN.md`
 - Supabase MVP migration/seed: `development/front-admin-web/supabase/`
 

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -1,6 +1,6 @@
 # ThunderCrew Front Admin Web
 
-전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
+전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비·단말 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
 
 ## 기술 스택
 
@@ -20,6 +20,7 @@
 - 보험: `insurance_id`, `rider_id`, `vehicle_id`, `insurance_item_id` 입력 금지 → 라이더 이름/연락처와 보험 항목 선택
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
 - 장비: `bikeId`, `equipmentTypeId`, `equipmentId` 직접 입력 금지 → 차량번호/장비 종류명 기준 선택
+- 단말 설치: `bikeId`, `deviceId`, `installationId` 직접 입력 금지 → 차량번호/단말 UID 기준 선택
 
 DB PK/FK는 backend/Postgres에서 자동 생성·관리합니다. 화면 route에 backend UUID가 쓰이더라도 사용자가 직접 입력하거나 수정하는 필드로 노출하지 않습니다.
 
@@ -84,6 +85,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 스테이션 폼은 이름, 주소, 좌표, 운영 상태, 수량만 다루며 `stationId`, `station_id`, `batteryStationId` 같은 직접 입력 필드를 만들지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거는 server action/server component에서 `/api/v1/equipment-types`와 `/api/v1/bike-equipments`를 호출합니다.
 - 바이크 장비 등록 폼은 차량과 장비 종류를 select로 고르게 하며 `bikeId`, `equipmentTypeId`, `equipmentId` 같은 직접 입력 필드를 만들지 않습니다.
+- 단말 등록/수정은 단말 자체 UID와 제조사/모델/상태만 다루고, 차량 단말 설치 폼은 차량과 단말을 select로 고르게 하며 `bikeId`, `deviceId`, `installationId` 같은 직접 입력 필드를 만들지 않습니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -117,6 +119,12 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/equipment/[slug]/edit` 바이크 장비 수정
 - `/equipment/types/new` 장비 종류 등록
 - `/equipment/types/[slug]` 장비 종류 상세/수정
+- `/devices` 단말 목록 + 차량 단말 설치 이력
+- `/devices/new` 단말 등록
+- `/devices/[slug]` 단말 상세 + 비활성 삭제
+- `/devices/[slug]/edit` 단말 기본 정보 수정
+- `/devices/installations/new` 차량 단말 설치
+- `/devices/installations/[slug]` 차량 단말 설치 상세 + 제거 처리
 - `/settings` 연결 설정 확인
 
 ## Supabase

--- a/development/front-admin-web/app/devices/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/devices/[slug]/edit/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from "next/navigation";
+
+import { updateDeviceAction } from "@/app/devices/actions";
+import { DeviceForm } from "@/components/devices/DeviceForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { loadDeviceDetail } from "@/lib/services/device-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "단말 수정에 실패했습니다. 단말 UID 중복 또는 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditDevicePage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadDeviceDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const updateAction = updateDeviceAction.bind(null, slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="단말 수정" description="단말 UID, 제조사, 모델, 사용 상태와 메모만 수정합니다. 차량 설치 연결은 별도 설치/제거 흐름으로 분리합니다." />
+      <DeviceForm
+        action={updateAction}
+        cancelHref={`/devices/${slug}`}
+        defaultValues={{
+          deviceUid: detail.device.deviceUid,
+          enabled: detail.device.enabled,
+          manufacturer: detail.device.manufacturer,
+          memo: detail.device.memo,
+          modelName: detail.device.modelName
+        }}
+        mode="수정"
+        statusMessage={status ? statusMessage[status] : null}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/devices/[slug]/page.tsx
+++ b/development/front-admin-web/app/devices/[slug]/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { deleteDeviceAction } from "@/app/devices/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { loadDeviceDetail } from "@/lib/services/device-data";
+import { deviceLabel } from "@/lib/services/device-data-core";
+
+const statusMessage: Record<string, string> = {
+  created: "단말이 등록되었습니다.",
+  "delete-error": "단말 비활성 삭제에 실패했습니다. 활성 차량 설치가 있는지 확인하세요.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 단말 화면으로 돌아왔습니다.",
+  updated: "단말 정보가 수정되었습니다."
+};
+
+export default async function DeviceDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadDeviceDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const device = detail.device;
+  const message = status ? statusMessage[status] : null;
+  const deleteAction = deleteDeviceAction.bind(null, device.slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title={device.deviceUid} description={deviceLabel(device)} actionHref={`/devices/${device.slug}/edit`} actionLabel="수정" />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>단말 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>단말 UID</span><strong>{device.deviceUid}</strong></div>
+            <div className="detail-row"><span>제조사</span><strong>{device.manufacturer ?? "미입력"}</strong></div>
+            <div className="detail-row"><span>모델명</span><strong>{device.modelName ?? "미입력"}</strong></div>
+            <div className="detail-row"><span>사용 상태</span><Badge tone={device.enabled ? "active" : "muted"}>{device.enabled ? "사용" : "비활성"}</Badge></div>
+            <div className="detail-row"><span>운영 메모</span><strong>{device.memo ?? "없음"}</strong></div>
+          </div>
+          <div className="form-actions">
+            <Link className="button-secondary" href="/devices">목록</Link>
+            <Link className="button-secondary" href={`/devices/${device.slug}/edit`}>기본 정보 수정</Link>
+          </div>
+        </div>
+        <aside className="detail-panel">
+          <h2>비활성 삭제</h2>
+          <p>활성 차량 설치가 없는 단말만 이력 보존 soft-delete로 비활성 처리합니다.</p>
+          <form action={deleteAction} className="action-panel">
+            <div className="form-actions"><button className="button-primary" type="submit">단말 비활성 삭제</button></div>
+          </form>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/development/front-admin-web/app/devices/actions.ts
+++ b/development/front-admin-web/app/devices/actions.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  toBikeDeviceInstallationCreatePayload,
+  toBikeDeviceInstallationRemovePayload,
+  toDeviceCreatePayload,
+  toDeviceUpdatePayload
+} from "@/lib/services/device-command-payload";
+
+export async function createDeviceAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/devices?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let device;
+  try {
+    device = await client.createDevice(toDeviceCreatePayload(formData));
+  } catch {
+    redirect("/devices/new?status=save-error");
+  }
+
+  revalidatePath("/devices");
+  redirect(`/devices/${device.id}?status=created`);
+}
+
+export async function updateDeviceAction(deviceId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/devices/${deviceId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let device;
+  try {
+    device = await client.updateDevice(deviceId, toDeviceUpdatePayload(formData));
+  } catch {
+    redirect(`/devices/${deviceId}/edit?status=save-error`);
+  }
+
+  revalidatePath("/devices");
+  revalidatePath(`/devices/${device.id}`);
+  redirect(`/devices/${device.id}?status=updated`);
+}
+
+export async function deleteDeviceAction(deviceId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/devices/${deviceId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteDevice(deviceId);
+  } catch {
+    redirect(`/devices/${deviceId}?status=delete-error`);
+  }
+
+  revalidatePath("/devices");
+  redirect("/devices?status=deleted");
+}
+
+export async function createBikeDeviceInstallationAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/devices?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let installation;
+  try {
+    installation = await client.createBikeDeviceInstallation(toBikeDeviceInstallationCreatePayload(formData));
+  } catch {
+    redirect("/devices/installations/new?status=save-error");
+  }
+
+  revalidatePath("/devices");
+  redirect(`/devices/installations/${installation.id}?status=created`);
+}
+
+export async function removeBikeDeviceInstallationAction(installationId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/devices/installations/${installationId}?status=mock-removed`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let installation;
+  try {
+    installation = await client.removeBikeDeviceInstallation(installationId, toBikeDeviceInstallationRemovePayload(formData));
+  } catch {
+    redirect(`/devices/installations/${installationId}?status=remove-error`);
+  }
+
+  revalidatePath("/devices");
+  revalidatePath(`/devices/installations/${installation.id}`);
+  redirect(`/devices/installations/${installation.id}?status=removed`);
+}

--- a/development/front-admin-web/app/devices/installations/[slug]/page.tsx
+++ b/development/front-admin-web/app/devices/installations/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { removeBikeDeviceInstallationAction } from "@/app/devices/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { Field } from "@/components/ui/FormField";
+import { loadBikeDeviceInstallationDetail } from "@/lib/services/device-data";
+
+const statusMessage: Record<string, string> = {
+  created: "차량 단말 설치가 등록되었습니다.",
+  "mock-removed": "서비스 API가 연결되지 않아 제거 처리를 mock 피드백으로만 처리했습니다.",
+  "remove-error": "차량 단말 설치 제거에 실패했습니다. 이미 제거되었거나 제거일시가 설치일시보다 빠른지 확인하세요.",
+  removed: "차량 단말 설치가 제거 처리되었습니다."
+};
+
+export default async function BikeDeviceInstallationDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadBikeDeviceInstallationDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const installation = detail.installation;
+  const message = status ? statusMessage[status] : null;
+  const removeAction = removeBikeDeviceInstallationAction.bind(null, installation.slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="차량 단말 설치 상세" description={`${installation.bikeLabel} · ${installation.deviceLabel}`} />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>설치 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>차량</span><strong>{installation.bikeLabel}</strong></div>
+            <div className="detail-row"><span>단말</span><strong>{installation.deviceLabel}</strong></div>
+            <div className="detail-row"><span>설치일시</span><strong>{installation.installedAt}</strong></div>
+            <div className="detail-row"><span>제거일시</span><strong>{installation.removedAt ?? "설치 중"}</strong></div>
+            <div className="detail-row"><span>상태</span><Badge tone={installation.status === "설치 중" ? "active" : "muted"}>{installation.status}</Badge></div>
+            <div className="detail-row"><span>운영 메모</span><strong>{installation.memo ?? "없음"}</strong></div>
+          </div>
+          <div className="form-actions"><Link className="button-secondary" href="/devices">목록</Link></div>
+        </div>
+        <aside className="detail-panel">
+          <h2>설치 제거 처리</h2>
+          <form action={removeAction} className="action-panel">
+            <Field label="제거일시"><input className="input" name="removedAt" type="datetime-local" /></Field>
+            <Field label="제거 메모"><textarea className="input" name="memo" placeholder="교체/탈거 사유" rows={3} /></Field>
+            <p className="notice">제거는 이력 보존을 위한 상태 전환입니다. hard delete를 수행하지 않습니다.</p>
+            <div className="form-actions"><button className="button-primary" type="submit">설치 제거</button></div>
+          </form>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/development/front-admin-web/app/devices/installations/new/page.tsx
+++ b/development/front-admin-web/app/devices/installations/new/page.tsx
@@ -1,0 +1,25 @@
+import { createBikeDeviceInstallationAction } from "@/app/devices/actions";
+import { BikeDeviceInstallationForm } from "@/components/devices/BikeDeviceInstallationForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { loadDeviceFormOptions } from "@/lib/services/device-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "차량 단말 설치에 실패했습니다. 차량/단말 선택, 설치일시, 중복 설치 상태를 확인하세요."
+};
+
+export default async function NewBikeDeviceInstallationPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, options] = await Promise.all([searchParams, loadDeviceFormOptions()]);
+
+  return (
+    <div className="page-container">
+      <PageHeader title="차량 단말 설치" description="차량번호와 단말 UID 선택으로 설치/교체합니다. DB ID/FK는 직접 입력하지 않습니다." />
+      {options.notice ? <p className="notice">{options.notice}</p> : null}
+      <BikeDeviceInstallationForm
+        action={createBikeDeviceInstallationAction}
+        devices={options.devices}
+        statusMessage={status ? statusMessage[status] : null}
+        vehicles={options.vehicles}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/devices/new/page.tsx
+++ b/development/front-admin-web/app/devices/new/page.tsx
@@ -1,0 +1,18 @@
+import { createDeviceAction } from "@/app/devices/actions";
+import { DeviceForm } from "@/components/devices/DeviceForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "단말 등록에 실패했습니다. 단말 UID 중복 또는 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewDevicePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="단말 등록" description="단말 자체 UID와 제조사/모델/사용 상태를 등록합니다. DB ID는 직접 입력하지 않습니다." />
+      <DeviceForm action={createDeviceAction} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/devices/page.tsx
+++ b/development/front-admin-web/app/devices/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { deviceLabel, type DeviceDataResult } from "@/lib/services/device-data-core";
+import { loadDeviceData } from "@/lib/services/device-data";
+import type { BikeDeviceInstallation } from "@/types/domain";
+
+const statusMessage: Record<string, string> = {
+  created: "차량 단말 설치가 등록되었습니다.",
+  deleted: "단말이 비활성 삭제 처리되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
+  removed: "차량 단말 설치가 제거 처리되었습니다.",
+  updated: "단말 정보가 수정되었습니다."
+};
+
+export default async function DevicesPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadDeviceData()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref="/devices/new"
+        actionLabel="단말 등록"
+        description="차량 단말과 바이크 설치 이력을 service-ops API 기준으로 관리합니다. 텔레메트리/current-state는 이 범위에서 제외합니다."
+        title="단말 관리"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <section className="content-grid">
+        <div>
+          <DeviceTable data={data} />
+        </div>
+        <aside className="detail-panel">
+          <h2>차량 단말 설치</h2>
+          <p>차량번호와 단말 UID 기준 선택으로 설치/교체합니다. raw DB ID나 FK 값을 직접 입력하지 않습니다.</p>
+          <div className="form-actions" style={{ marginTop: 12 }}>
+            <Link className="button-primary" href="/devices/installations/new">차량 단말 설치</Link>
+          </div>
+          <div className="detail-list" style={{ marginTop: 16 }}>
+            {data.installations.map((installation) => (
+              <div className="detail-row" key={installation.slug}>
+                <span>{installation.bikeLabel}</span>
+                <Link className="button-secondary" href={`/devices/installations/${installation.slug}`}>{installation.status}</Link>
+              </div>
+            ))}
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function DeviceTable({ data }: { data: DeviceDataResult }) {
+  if (!data.devices.length) {
+    return (
+      <EmptyState
+        actionLabel="단말 등록"
+        description="아직 등록된 단말이 없습니다. 단말 자체 UID부터 등록합니다."
+        href="/devices/new"
+        title="단말 없음"
+      />
+    );
+  }
+
+  return (
+    <div className="table-card">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>단말 UID</th>
+            <th>제조사/모델</th>
+            <th>상태</th>
+            <th>메모</th>
+            <th>상세</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.devices.map((device) => (
+            <tr key={device.slug}>
+              <td>{device.deviceUid}</td>
+              <td>{deviceLabel(device)}</td>
+              <td><Badge tone={device.enabled ? "active" : "muted"}>{device.enabled ? "사용" : "비활성"}</Badge></td>
+              <td>{device.memo ?? "-"}</td>
+              <td><Link className="button-secondary" href={`/devices/${device.slug}`}>보기</Link></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function installationTone(installation: BikeDeviceInstallation): "active" | "muted" | "outline" {
+  return installation.status === "설치 중" ? "active" : "muted";
+}

--- a/development/front-admin-web/components/devices/BikeDeviceInstallationForm.tsx
+++ b/development/front-admin-web/components/devices/BikeDeviceInstallationForm.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { Device, Vehicle } from "@/types/domain";
+import { deviceLabel } from "@/lib/services/device-data-core";
+
+type BikeDeviceInstallationFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  devices?: Device[];
+  statusMessage?: string | null;
+  vehicles?: Array<Pick<Vehicle, "model" | "plateNumber" | "slug" | "status">>;
+};
+
+export function BikeDeviceInstallationForm({
+  action,
+  cancelHref = "/devices",
+  devices = [],
+  statusMessage,
+  vehicles = []
+}: BikeDeviceInstallationFormProps) {
+  return (
+    <form action={action} className="card" aria-label="차량 단말 설치 폼">
+      <div className="form-grid">
+        <Field label="차량 선택" hint="차량번호와 모델 기준으로 선택합니다. DB ID를 직접 입력하지 않습니다.">
+          <select className="select" name="vehicleSelection" required>
+            <option value="">차량 선택</option>
+            {vehicles.map((vehicle) => (
+              <option key={vehicle.slug} value={vehicle.slug}>{vehicle.plateNumber} · {vehicle.model} · {vehicle.status}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="단말 선택" hint="단말 UID와 모델 기준으로 선택합니다. FK ID를 직접 입력하지 않습니다.">
+          <select className="select" name="deviceSelection" required>
+            <option value="">단말 선택</option>
+            {devices.map((device) => (
+              <option key={device.id ?? device.slug} value={device.id ?? device.slug}>{deviceLabel(device)}{device.enabled ? "" : " · 비활성"}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="설치일시"><input className="input" name="installedAt" required type="datetime-local" /></Field>
+      </div>
+      <br />
+      <Field label="설치 메모"><textarea className="input" name="memo" placeholder="설치/교체 사유 또는 운영 메모" rows={3} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>설치 ID는 DB가 자동 생성합니다. 동일 차량 또는 동일 단말의 기존 활성 설치는 backend lifecycle 규칙에 따라 이력 보존 후 교체됩니다.</p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">차량 단말 설치</button>
+      </div>
+    </form>
+  );
+}

--- a/development/front-admin-web/components/devices/DeviceForm.tsx
+++ b/development/front-admin-web/components/devices/DeviceForm.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { Device } from "@/types/domain";
+
+type DeviceFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<Pick<Device, "deviceUid" | "enabled" | "manufacturer" | "memo" | "modelName">>;
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+};
+
+export function DeviceForm({ action, cancelHref = "/devices", defaultValues, mode = "등록", statusMessage }: DeviceFormProps) {
+  return (
+    <form action={action} className="card" aria-label={`단말 ${mode} 폼`}>
+      <div className="form-grid">
+        <Field label="단말 UID" hint="단말기가 자체 보유한 유니크 ID를 입력합니다. DB ID가 아닙니다.">
+          <input className="input" defaultValue={defaultValues?.deviceUid ?? ""} maxLength={100} name="deviceUid" placeholder="예: TDEV-SEOUL-4821" required />
+        </Field>
+        <Field label="사용 상태">
+          <select className="select" defaultValue={String(defaultValues?.enabled ?? true)} name="enabled">
+            <option value="true">사용</option>
+            <option value="false">비활성</option>
+          </select>
+        </Field>
+        <Field label="제조사"><input className="input" defaultValue={defaultValues?.manufacturer ?? ""} maxLength={100} name="manufacturer" placeholder="예: ThunderDevice" /></Field>
+        <Field label="모델명"><input className="input" defaultValue={defaultValues?.modelName ?? ""} maxLength={100} name="modelName" placeholder="예: TD-100" /></Field>
+      </div>
+      <br />
+      <Field label="운영 메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={3} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>단말 DB ID는 서버가 자동 생성합니다. 설치 연결은 차량번호와 단말 UID 선택 UI에서만 처리합니다.</p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">단말 {mode}</button>
+      </div>
+    </form>
+  );
+}

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -11,7 +11,8 @@ const operationsItems = [
   { href: "/contracts", label: "계약 관리", icon: "C" },
   { href: "/insurance", label: "보험 관리", icon: "I" },
   { href: "/stations", label: "스테이션 관리", icon: "S" },
-  { href: "/equipment", label: "장비 관리", icon: "E" }
+  { href: "/equipment", label: "장비 관리", icon: "E" },
+  { href: "/devices", label: "단말 관리", icon: "D" }
 ];
 
 export async function AppShell({ children }: { children: ReactNode }) {

--- a/development/front-admin-web/lib/services/device-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/device-command-payload.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DeviceCommandPayloadError,
+  toBikeDeviceInstallationCreatePayload,
+  toBikeDeviceInstallationRemovePayload,
+  toDeviceCreatePayload,
+  toDeviceUpdatePayload
+} from "./device-command-payload.ts";
+
+test("device create/update payloads keep operator fields and ignore direct relationship ids", () => {
+  const formData = new FormData();
+  formData.set("deviceUid", "TDEV-SEOUL-4821");
+  formData.set("manufacturer", "ThunderDevice");
+  formData.set("modelName", "TD-100");
+  formData.set("enabled", "true");
+  formData.set("memo", "운영 단말");
+  formData.set("deviceId", "99999999-9999-4999-8999-999999999999");
+  formData.set("bikeId", "99999999-9999-4999-8999-999999999999");
+  formData.set("installationId", "99999999-9999-4999-8999-999999999999");
+
+  const expected = {
+    deviceUid: "TDEV-SEOUL-4821",
+    enabled: true,
+    manufacturer: "ThunderDevice",
+    memo: "운영 단말",
+    modelName: "TD-100"
+  };
+  assert.deepEqual(toDeviceCreatePayload(formData), expected);
+  assert.deepEqual(toDeviceUpdatePayload(formData), expected);
+});
+
+test("device update preserves blank optional strings as clear commands", () => {
+  const formData = new FormData();
+  formData.set("deviceUid", "TDEV-SEOUL-4821");
+  formData.set("manufacturer", "");
+  formData.set("modelName", "");
+  formData.set("memo", "");
+  formData.set("enabled", "false");
+
+  assert.deepEqual(toDeviceUpdatePayload(formData), {
+    deviceUid: "TDEV-SEOUL-4821",
+    enabled: false,
+    manufacturer: "",
+    memo: "",
+    modelName: ""
+  });
+});
+
+test("device create treats blank optional strings as null", () => {
+  const formData = new FormData();
+  formData.set("deviceUid", "TDEV-SEOUL-4821");
+  formData.set("manufacturer", "");
+  formData.set("modelName", "");
+  formData.set("memo", "");
+  formData.set("enabled", "true");
+
+  assert.deepEqual(toDeviceCreatePayload(formData), {
+    deviceUid: "TDEV-SEOUL-4821",
+    enabled: true,
+    manufacturer: null,
+    memo: null,
+    modelName: null
+  });
+});
+
+test("device payloads reject blank uid and invalid enabled value", () => {
+  const formData = new FormData();
+  formData.set("deviceUid", "");
+  formData.set("enabled", "true");
+
+  assert.throws(() => toDeviceCreatePayload(formData), DeviceCommandPayloadError);
+
+  formData.set("deviceUid", "TDEV-SEOUL-4821");
+  formData.set("enabled", "maybe");
+  assert.throws(() => toDeviceUpdatePayload(formData), DeviceCommandPayloadError);
+});
+
+test("bike-device installation create payload uses selector fields and ignores raw direct ID names", () => {
+  const formData = new FormData();
+  formData.set("vehicleSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("deviceSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("installedAt", "2026-04-30T10:30");
+  formData.set("memo", "설치 메모");
+  formData.set("bikeId", "99999999-9999-4999-8999-999999999999");
+  formData.set("deviceId", "99999999-9999-4999-8999-999999999999");
+  formData.set("installationId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBikeDeviceInstallationCreatePayload(formData), {
+    bikeId: "11111111-1111-4111-8111-111111111111",
+    deviceId: "22222222-2222-4222-8222-222222222222",
+    installedAt: "2026-04-30T01:30:00.000Z",
+    memo: "설치 메모"
+  });
+});
+
+test("bike-device installation remove payload preserves blank memo as clear command", () => {
+  const formData = new FormData();
+  formData.set("removedAt", "");
+  formData.set("memo", "");
+  formData.set("deviceId", "99999999-9999-4999-8999-999999999999");
+
+  assert.deepEqual(toBikeDeviceInstallationRemovePayload(formData), {
+    memo: "",
+    removedAt: null
+  });
+});
+
+test("bike-device installation payloads reject blank selectors and invalid dates", () => {
+  const formData = new FormData();
+  formData.set("vehicleSelection", "서울바4821");
+  formData.set("deviceSelection", "22222222-2222-4222-8222-222222222222");
+  formData.set("installedAt", "2026-04-30T10:30");
+
+  assert.throws(() => toBikeDeviceInstallationCreatePayload(formData), DeviceCommandPayloadError);
+
+  formData.set("vehicleSelection", "11111111-1111-4111-8111-111111111111");
+  formData.set("installedAt", "not-a-date");
+  assert.throws(() => toBikeDeviceInstallationCreatePayload(formData), DeviceCommandPayloadError);
+
+  formData.set("installedAt", "2026-04-30T10:30");
+  formData.set("deviceSelection", "");
+  assert.throws(() => toBikeDeviceInstallationCreatePayload(formData), DeviceCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/device-command-payload.ts
+++ b/development/front-admin-web/lib/services/device-command-payload.ts
@@ -1,0 +1,141 @@
+import type {
+  BikeDeviceInstallationCreateInput,
+  BikeDeviceInstallationRemoveInput,
+  DeviceCreateInput,
+  DeviceUpdateInput
+} from "./service-ops-api";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SEOUL_OFFSET = "+09:00";
+
+export class DeviceCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeviceCommandPayloadError";
+  }
+}
+
+export function toDeviceCreatePayload(formData: FormData): DeviceCreateInput {
+  return {
+    deviceUid: requiredText(formData.get("deviceUid"), "Device UID is required."),
+    enabled: toEnabled(formData.get("enabled"), true),
+    manufacturer: optionalText(formData.get("manufacturer")),
+    memo: optionalText(formData.get("memo")),
+    modelName: optionalText(formData.get("modelName"))
+  };
+}
+
+export function toDeviceUpdatePayload(formData: FormData): DeviceUpdateInput {
+  return {
+    deviceUid: requiredText(formData.get("deviceUid"), "Device UID is required."),
+    enabled: toEnabled(formData.get("enabled"), true),
+    manufacturer: clearableText(formData.get("manufacturer")),
+    memo: clearableText(formData.get("memo")),
+    modelName: clearableText(formData.get("modelName"))
+  };
+}
+
+export function toBikeDeviceInstallationCreatePayload(formData: FormData): BikeDeviceInstallationCreateInput {
+  return {
+    bikeId: requiredUuid(formData.get("vehicleSelection"), "Vehicle selection is required."),
+    deviceId: requiredUuid(formData.get("deviceSelection"), "Device selection is required."),
+    installedAt: toServiceInstant(formData.get("installedAt"), "Installed date/time is required."),
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+export function toBikeDeviceInstallationRemovePayload(formData: FormData): BikeDeviceInstallationRemoveInput {
+  return {
+    memo: clearableText(formData.get("memo")),
+    removedAt: toOptionalServiceInstant(formData.get("removedAt"))
+  };
+}
+
+function requiredUuid(value: FormDataEntryValue | null, message: string): string {
+  const text = requiredText(value, message);
+  if (!UUID_PATTERN.test(text)) {
+    throw new DeviceCommandPayloadError("Invalid selector token. Use the provided vehicle and device selection controls.");
+  }
+
+  return text;
+}
+
+function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (!text) {
+    return fallback;
+  }
+
+  if (["true", "1", "on", "enabled"].includes(text)) {
+    return true;
+  }
+
+  if (["false", "0", "off", "disabled"].includes(text)) {
+    return false;
+  }
+
+  throw new DeviceCommandPayloadError("Invalid enabled status.");
+}
+
+function toOptionalServiceInstant(value: FormDataEntryValue | null): string | null {
+  const text = optionalText(value);
+  if (!text) {
+    return null;
+  }
+
+  return toServiceInstant(text, "Removal date/time is required.");
+}
+
+function toServiceInstant(value: FormDataEntryValue | string | null, message: string): string {
+  const text = requiredText(value, message);
+  const normalized = normalizeDateTimeInput(text);
+  const date = new Date(normalized);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new DeviceCommandPayloadError("Invalid device date/time.");
+  }
+
+  return date.toISOString();
+}
+
+function normalizeDateTimeInput(value: string): string {
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(value)) {
+    return value;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+    return `${value}:00${SEOUL_OFFSET}`;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+    return `${value}${SEOUL_OFFSET}`;
+  }
+
+  return value;
+}
+
+function requiredText(value: FormDataEntryValue | string | null, message: string): string {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new DeviceCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | string | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function clearableText(value: FormDataEntryValue | string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return String(value).trim();
+}

--- a/development/front-admin-web/lib/services/device-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/device-data-core.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mockBikeDeviceInstallationUnavailableServiceDetail,
+  mockDeviceUnavailableServiceDetail,
+  toDeviceList,
+  toFrontendBikeDeviceInstallation
+} from "./device-data-core.ts";
+
+test("toDeviceList maps service devices to frontend device models", () => {
+  const devices = toDeviceList([
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      idx: 1,
+      deviceUid: "TDEV-SEOUL-4821",
+      manufacturer: "ThunderDevice",
+      modelName: "TD-100",
+      enabled: true,
+      memo: "운영 단말",
+      createdAt: "2026-04-30T00:00:00Z",
+      updatedAt: "2026-04-30T00:00:00Z"
+    }
+  ]);
+
+  assert.deepEqual(devices[0], {
+    createdAt: "2026-04-30T00:00:00Z",
+    deviceUid: "TDEV-SEOUL-4821",
+    enabled: true,
+    id: "11111111-1111-4111-8111-111111111111",
+    idx: 1,
+    manufacturer: "ThunderDevice",
+    memo: "운영 단말",
+    modelName: "TD-100",
+    slug: "11111111-1111-4111-8111-111111111111",
+    source: "service-ops",
+    updatedAt: "2026-04-30T00:00:00Z"
+  });
+});
+
+test("toFrontendBikeDeviceInstallation hydrates vehicle and device labels", () => {
+  const installation = toFrontendBikeDeviceInstallation(
+    {
+      id: "22222222-2222-4222-8222-222222222222",
+      idx: 2,
+      bikeId: "33333333-3333-4333-8333-333333333333",
+      deviceId: "44444444-4444-4444-8444-444444444444",
+      installedAt: "2026-04-30T00:00:00Z",
+      removedAt: null,
+      memo: "설치",
+      createdAt: "2026-04-30T00:00:00Z",
+      updatedAt: "2026-04-30T00:00:00Z"
+    },
+    {
+      devices: new Map([["44444444-4444-4444-8444-444444444444", { deviceUid: "TDEV-001", label: "TDEV-001 · TD-100" }]]),
+      vehicles: new Map([["33333333-3333-4333-8333-333333333333", { model: "NIU NQi Cargo", plateNumber: "서울바4821", status: "대기" }]])
+    }
+  );
+
+  assert.equal(installation.bikeLabel, "서울바4821 · NIU NQi Cargo");
+  assert.equal(installation.deviceLabel, "TDEV-001 · TD-100");
+  assert.equal(installation.status, "설치 중");
+});
+
+test("removed bike-device installation displays removed status", () => {
+  const installation = toFrontendBikeDeviceInstallation(
+    {
+      id: "22222222-2222-4222-8222-222222222222",
+      idx: 2,
+      bikeId: "33333333-3333-4333-8333-333333333333",
+      deviceId: "44444444-4444-4444-8444-444444444444",
+      installedAt: "2026-04-30T00:00:00Z",
+      removedAt: "2026-05-01T00:00:00Z",
+      memo: null,
+      createdAt: "2026-04-30T00:00:00Z",
+      updatedAt: "2026-05-01T00:00:00Z"
+    },
+    { devices: new Map(), vehicles: new Map() }
+  );
+
+  assert.equal(installation.status, "제거됨");
+  assert.match(installation.bikeLabel, /알 수 없는 차량/);
+  assert.match(installation.deviceLabel, /알 수 없는 단말/);
+});
+
+test("UUID service detail fallback remains visible when API is unavailable", () => {
+  const device = mockDeviceUnavailableServiceDetail("11111111-1111-4111-8111-111111111111", [], "no service");
+  const installation = mockBikeDeviceInstallationUnavailableServiceDetail("22222222-2222-4222-8222-222222222222", [], "no service");
+
+  assert.equal(device.device.slug, "11111111-1111-4111-8111-111111111111");
+  assert.equal(device.notice, "no service");
+  assert.equal(installation.installation.slug, "22222222-2222-4222-8222-222222222222");
+  assert.equal(installation.notice, "no service");
+});

--- a/development/front-admin-web/lib/services/device-data-core.ts
+++ b/development/front-admin-web/lib/services/device-data-core.ts
@@ -1,0 +1,167 @@
+import type { BikeDeviceInstallation, Device, Vehicle } from "@/types/domain";
+import type { ServiceOpsBikeDeviceInstallation, ServiceOpsDevice } from "./service-ops-api";
+
+export type DeviceLookup = {
+  devices: Map<string, { deviceUid: string; label: string }>;
+  vehicles: Map<string, { model: string; plateNumber: string; status: Vehicle["status"] }>;
+};
+
+export type DeviceDataResult = {
+  devices: Device[];
+  installations: BikeDeviceInstallation[];
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type DeviceDetailResult = {
+  device: Device;
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type BikeDeviceInstallationDetailResult = {
+  installation: BikeDeviceInstallation;
+  notice?: string;
+  source: "mock" | "service-ops";
+};
+
+export type DeviceFormOptions = {
+  devices: Device[];
+  notice?: string;
+  source: "mock" | "service-ops";
+  vehicles: Array<Pick<Vehicle, "model" | "plateNumber" | "slug" | "status">>;
+};
+
+export function toDeviceList(devices: ServiceOpsDevice[]): Device[] {
+  return devices.map(toFrontendDeviceModel);
+}
+
+export function toFrontendDeviceModel(device: ServiceOpsDevice): Device {
+  return {
+    createdAt: device.createdAt,
+    deviceUid: device.deviceUid,
+    enabled: device.enabled,
+    id: device.id,
+    idx: device.idx,
+    manufacturer: device.manufacturer,
+    memo: device.memo,
+    modelName: device.modelName,
+    slug: device.id,
+    source: "service-ops",
+    updatedAt: device.updatedAt
+  };
+}
+
+export function toFrontendBikeDeviceInstallation(
+  installation: ServiceOpsBikeDeviceInstallation,
+  lookup: DeviceLookup
+): BikeDeviceInstallation {
+  const vehicle = lookup.vehicles.get(installation.bikeId);
+  const device = lookup.devices.get(installation.deviceId);
+  const removed = Boolean(installation.removedAt);
+
+  return {
+    bikeId: installation.bikeId,
+    bikeLabel: vehicle ? `${vehicle.plateNumber} · ${vehicle.model}` : `알 수 없는 차량 (${shortId(installation.bikeId)})`,
+    createdAt: installation.createdAt,
+    deviceId: installation.deviceId,
+    deviceLabel: device?.label ?? `알 수 없는 단말 (${shortId(installation.deviceId)})`,
+    deviceUid: device?.deviceUid,
+    id: installation.id,
+    idx: installation.idx,
+    installedAt: installation.installedAt,
+    memo: installation.memo,
+    removedAt: installation.removedAt,
+    slug: installation.id,
+    source: "service-ops",
+    status: removed ? "제거됨" : "설치 중",
+    updatedAt: installation.updatedAt
+  };
+}
+
+export function mockDeviceData(devices: Device[], installations: BikeDeviceInstallation[]): DeviceDataResult {
+  return {
+    devices,
+    installations,
+    source: "mock"
+  };
+}
+
+export function mockDeviceDetail(slug: string, devices: Device[]): DeviceDetailResult | null {
+  const device = devices.find((item) => item.slug === slug || item.id === slug);
+  return device ? { device, source: "mock" } : null;
+}
+
+export function mockDeviceUnavailableServiceDetail(slug: string, devices: Device[], notice: string): DeviceDetailResult {
+  const fallback = devices[0] ?? {
+    deviceUid: `SERVICE-DEVICE-${shortId(slug).toUpperCase()}`,
+    enabled: false,
+    manufacturer: "서비스 연결 필요",
+    memo: notice,
+    modelName: "-",
+    slug
+  };
+
+  return {
+    device: {
+      ...fallback,
+      id: slug,
+      slug,
+      source: "mock"
+    },
+    notice,
+    source: "mock"
+  };
+}
+
+export function mockBikeDeviceInstallationDetail(slug: string, installations: BikeDeviceInstallation[]): BikeDeviceInstallationDetailResult | null {
+  const installation = installations.find((item) => item.slug === slug || item.id === slug);
+  return installation ? { installation, source: "mock" } : null;
+}
+
+export function mockBikeDeviceInstallationUnavailableServiceDetail(
+  slug: string,
+  installations: BikeDeviceInstallation[],
+  notice: string
+): BikeDeviceInstallationDetailResult {
+  const fallback = installations[0] ?? {
+    bikeLabel: "서비스 연결 필요 차량",
+    deviceLabel: "서비스 연결 필요 단말",
+    installedAt: new Date(0).toISOString(),
+    memo: notice,
+    slug,
+    status: "제거됨" as const
+  };
+
+  return {
+    installation: {
+      ...fallback,
+      id: slug,
+      slug,
+      source: "mock"
+    },
+    notice,
+    source: "mock"
+  };
+}
+
+export function mockDeviceFormOptions(vehicles: Array<Pick<Vehicle, "model" | "plateNumber" | "slug" | "status">>, devices: Device[], notice?: string): DeviceFormOptions {
+  return {
+    devices: devices.filter((device) => device.enabled),
+    notice,
+    source: "mock",
+    vehicles
+  };
+}
+
+export function deviceLabel(device: Device): string {
+  return [device.deviceUid, device.modelName].filter(Boolean).join(" · ");
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function shortId(value: string): string {
+  return value.slice(0, 8);
+}

--- a/development/front-admin-web/lib/services/device-data.ts
+++ b/development/front-admin-web/lib/services/device-data.ts
@@ -1,0 +1,207 @@
+import {
+  type FrontendVehicle,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  bikeDeviceInstallations as mockBikeDeviceInstallations,
+  devices as mockDevices,
+  vehicles as mockVehicles
+} from "@/lib/services/mock-data";
+import type { Device } from "@/types/domain";
+import {
+  type BikeDeviceInstallationDetailResult,
+  type DeviceDataResult,
+  type DeviceDetailResult,
+  type DeviceFormOptions,
+  type DeviceLookup,
+  deviceLabel,
+  isUuidLike,
+  mockBikeDeviceInstallationDetail,
+  mockBikeDeviceInstallationUnavailableServiceDetail,
+  mockDeviceData,
+  mockDeviceDetail,
+  mockDeviceFormOptions,
+  mockDeviceUnavailableServiceDetail,
+  toDeviceList,
+  toFrontendBikeDeviceInstallation
+} from "@/lib/services/device-data-core";
+
+export async function loadDeviceData(): Promise<DeviceDataResult> {
+  const fallback = mockDeviceData(mockDevices, mockBikeDeviceInstallations);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 단말 데이터를 표시합니다. 백엔드 연결 시 서버 액션이 실제 API를 호출합니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 단말 데이터를 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const [devicesPage, installationsPage, vehiclesPage] = await Promise.all([
+      client.listDevices({ page: 0, size: 100 }),
+      client.listBikeDeviceInstallations({ page: 0, size: 100 }),
+      client.listVehicles({ page: 0, size: 100 })
+    ]);
+    const devices = toDeviceList(devicesPage.items);
+    const lookup = toDeviceLookup(vehiclesPage.items, devices);
+
+    return {
+      devices,
+      installations: installationsPage.items.map((installation) => toFrontendBikeDeviceInstallation(installation, lookup)),
+      source: "service-ops"
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 단말 조회 실패로 mock 단말 데이터를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadDeviceDetail(slug: string): Promise<DeviceDetailResult | null> {
+  const fallback = mockDeviceDetail(slug, mockDevices);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockDeviceUnavailableServiceDetail(
+      slug,
+      mockDevices,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 단말 상세를 표시합니다. 백엔드 연결 후 실제 단말 상세로 전환됩니다."
+    );
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockDeviceUnavailableServiceDetail(
+        slug,
+        mockDevices,
+        "서비스 API 세션 쿠키가 없어 mock 단말 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const device = await client.getDevice(slug);
+      return { device: toDeviceList([device])[0], source: "service-ops" };
+    } catch (error) {
+      return mockDeviceUnavailableServiceDetail(
+        slug,
+        mockDevices,
+        `서비스 API 단말 상세 조회 실패로 mock 단말 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadBikeDeviceInstallationDetail(slug: string): Promise<BikeDeviceInstallationDetailResult | null> {
+  const fallback = mockBikeDeviceInstallationDetail(slug, mockBikeDeviceInstallations);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockBikeDeviceInstallationUnavailableServiceDetail(
+      slug,
+      mockBikeDeviceInstallations,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 설치 상세를 표시합니다. 백엔드 연결 후 실제 설치 상세로 전환됩니다."
+    );
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockBikeDeviceInstallationUnavailableServiceDetail(
+        slug,
+        mockBikeDeviceInstallations,
+        "서비스 API 세션 쿠키가 없어 mock 설치 상세를 표시합니다. 관리자 로그인 후 실제 백엔드 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      const [installation, devicesPage, vehiclesPage] = await Promise.all([
+        client.getBikeDeviceInstallation(slug),
+        client.listDevices({ page: 0, size: 100 }),
+        client.listVehicles({ page: 0, size: 100 })
+      ]);
+      const devices = toDeviceList(devicesPage.items);
+      const lookup = toDeviceLookup(vehiclesPage.items, devices);
+      return { installation: toFrontendBikeDeviceInstallation(installation, lookup), source: "service-ops" };
+    } catch (error) {
+      return mockBikeDeviceInstallationUnavailableServiceDetail(
+        slug,
+        mockBikeDeviceInstallations,
+        `서비스 API 설치 상세 조회 실패로 mock 설치 데이터를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+export async function loadDeviceFormOptions(): Promise<DeviceFormOptions> {
+  const fallback = mockDeviceFormOptions(mockVehicles, mockDevices);
+
+  if (!serviceOpsApiConfigured()) {
+    return mockDeviceFormOptions(
+      mockVehicles,
+      mockDevices,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 차량/단말 선택지를 표시합니다."
+    );
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return mockDeviceFormOptions(
+      mockVehicles,
+      mockDevices,
+      "서비스 API 세션 쿠키가 없어 mock 차량/단말 선택지를 표시합니다."
+    );
+  }
+
+  try {
+    const [vehiclesPage, devicesPage] = await Promise.all([
+      client.listVehicles({ page: 0, size: 100 }),
+      client.listDevices({ page: 0, size: 100 })
+    ]);
+    return {
+      devices: toDeviceList(devicesPage.items).filter((device) => device.enabled),
+      source: "service-ops",
+      vehicles: vehiclesPage.items
+    };
+  } catch (error) {
+    return mockDeviceFormOptions(
+      mockVehicles,
+      mockDevices,
+      `서비스 API 선택지 조회 실패로 mock 선택지를 표시합니다.${formatServiceOpsError(error)}`
+    );
+  }
+}
+
+function toDeviceLookup(
+  vehicles: FrontendVehicle[],
+  devices: Device[]
+): DeviceLookup {
+  return {
+    devices: new Map(devices.map((device) => [device.id ?? device.slug, { deviceUid: device.deviceUid, label: deviceLabel(device) }])),
+    vehicles: new Map(vehicles.map((vehicle) => [vehicle.id ?? vehicle.slug, { model: vehicle.model, plateNumber: vehicle.plateNumber, status: vehicle.status }]))
+  };
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/mock-data.ts
+++ b/development/front-admin-web/lib/services/mock-data.ts
@@ -1,4 +1,14 @@
-import type { BatteryStation, BikeEquipment, EquipmentType, InsurancePolicy, Rider, RiderContract, Vehicle } from "@/types/domain";
+import type {
+  BatteryStation,
+  BikeDeviceInstallation,
+  BikeEquipment,
+  Device,
+  EquipmentType,
+  InsurancePolicy,
+  Rider,
+  RiderContract,
+  Vehicle
+} from "@/types/domain";
 
 export const riders: Rider[] = [
   { slug: "kim-minjun", name: "김민준", phone: "010-2411-9021", team: "강남 1팀", area: "강남/역삼", status: "활동", joinedAt: "2026-01-12" },
@@ -62,6 +72,55 @@ export const bikeEquipments: BikeEquipment[] = [
     managementStatus: "기한 초과",
     managementNote: "점검 입고 필요",
     memo: "점검 필요 차량"
+  }
+];
+
+export const devices: Device[] = [
+  {
+    slug: "dev-4821-main",
+    deviceUid: "TDEV-SEOUL-4821",
+    manufacturer: "ThunderDevice",
+    modelName: "TD-100",
+    enabled: true,
+    memo: "서울바4821 설치 단말"
+  },
+  {
+    slug: "dev-7390-spare",
+    deviceUid: "TDEV-SEOUL-7390",
+    manufacturer: "ThunderDevice",
+    modelName: "TD-100",
+    enabled: true,
+    memo: "점검 차량 예비 단말"
+  },
+  {
+    slug: "dev-disabled-001",
+    deviceUid: "TDEV-DISABLED-001",
+    manufacturer: "ThunderDevice",
+    modelName: "TD-050",
+    enabled: false,
+    memo: "설치 불가 비활성 단말"
+  }
+];
+
+export const bikeDeviceInstallations: BikeDeviceInstallation[] = [
+  {
+    slug: "install-seoul-ba-4821-main",
+    bikeLabel: "서울바4821 · NIU NQi Cargo",
+    deviceLabel: "TDEV-SEOUL-4821 · TD-100",
+    deviceUid: "TDEV-SEOUL-4821",
+    installedAt: "2026-04-01T09:00:00+09:00",
+    status: "설치 중",
+    memo: "운영 중 단말"
+  },
+  {
+    slug: "install-seoul-ba-7390-old",
+    bikeLabel: "서울바7390 · Gogoro 2 Utility",
+    deviceLabel: "TDEV-SEOUL-7390 · TD-100",
+    deviceUid: "TDEV-SEOUL-7390",
+    installedAt: "2026-03-15T10:30:00+09:00",
+    removedAt: "2026-04-20T11:00:00+09:00",
+    status: "제거됨",
+    memo: "점검 입고로 제거"
   }
 ];
 

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -1014,3 +1014,120 @@ test("bike equipment create/update/remove use selector-backed lifecycle endpoint
   assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["memo", "removedAt"]);
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
+
+
+test("device registry list/get/create/update/delete use dedicated backend endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const device = {
+        id: "11111111-1111-4111-8111-111111111111",
+        idx: 1,
+        deviceUid: body.deviceUid ?? "TDEV-SEOUL-4821",
+        manufacturer: body.manufacturer ?? "ThunderDevice",
+        modelName: body.modelName ?? "TD-100",
+        enabled: body.enabled ?? true,
+        memo: body.memo ?? null,
+        createdAt: "2026-04-30T00:00:00Z",
+        updatedAt: "2026-04-30T00:00:00Z"
+      };
+      return new Response(
+        JSON.stringify(
+          init?.method === "GET" && new URL(String(url)).pathname === "/api/v1/devices"
+            ? {
+                items: [device],
+                page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+              }
+            : device
+        ),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.listDevices({ page: 0, size: 20 });
+  await client.getDevice("11111111-1111-4111-8111-111111111111");
+  await client.createDevice({ deviceUid: "TDEV-SEOUL-4821", enabled: true, manufacturer: "ThunderDevice", memo: "운영", modelName: "TD-100" });
+  await client.updateDevice("11111111-1111-4111-8111-111111111111", { deviceUid: "TDEV-SEOUL-4822", enabled: false, manufacturer: "", memo: "", modelName: "" });
+  await client.deleteDevice("11111111-1111-4111-8111-111111111111");
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/devices",
+    "/api/v1/devices/11111111-1111-4111-8111-111111111111",
+    "/api/v1/devices",
+    "/api/v1/devices/11111111-1111-4111-8111-111111111111",
+    "/api/v1/devices/11111111-1111-4111-8111-111111111111"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["GET", "GET", "POST", "PATCH", "DELETE"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["deviceUid", "enabled", "manufacturer", "memo", "modelName"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[3].init?.body))).sort(), ["deviceUid", "enabled", "manufacturer", "memo", "modelName"]);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(calls[0].init?.cache, "no-store");
+});
+
+test("bike-device installation lifecycle uses selector-backed endpoints", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const installation = {
+        id: "22222222-2222-4222-8222-222222222222",
+        idx: 2,
+        bikeId: body.bikeId ?? "33333333-3333-4333-8333-333333333333",
+        deviceId: body.deviceId ?? "44444444-4444-4444-8444-444444444444",
+        installedAt: body.installedAt ?? "2026-04-30T00:00:00Z",
+        removedAt: body.removedAt ?? null,
+        memo: body.memo ?? null,
+        createdAt: "2026-04-30T00:00:00Z",
+        updatedAt: "2026-04-30T00:00:00Z"
+      };
+      return new Response(
+        JSON.stringify(
+          init?.method === "GET" && new URL(String(url)).pathname === "/api/v1/bike-device-installations"
+            ? {
+                items: [installation],
+                page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+              }
+            : installation
+        ),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.listBikeDeviceInstallations({ page: 0, size: 20 });
+  await client.getBikeDeviceInstallation("22222222-2222-4222-8222-222222222222");
+  await client.createBikeDeviceInstallation({
+    bikeId: "33333333-3333-4333-8333-333333333333",
+    deviceId: "44444444-4444-4444-8444-444444444444",
+    installedAt: "2026-04-30T00:00:00Z",
+    memo: "설치"
+  });
+  await client.removeBikeDeviceInstallation("22222222-2222-4222-8222-222222222222", {
+    memo: "제거",
+    removedAt: "2026-05-01T00:00:00Z"
+  });
+
+  assert.deepEqual(calls.map((call) => new URL(call.url).pathname), [
+    "/api/v1/bike-device-installations",
+    "/api/v1/bike-device-installations/22222222-2222-4222-8222-222222222222",
+    "/api/v1/bike-device-installations",
+    "/api/v1/bike-device-installations/22222222-2222-4222-8222-222222222222/remove"
+  ]);
+  assert.deepEqual(calls.map((call) => call.init?.method), ["GET", "GET", "POST", "PATCH"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["bikeId", "deviceId", "installedAt", "memo"]);
+  assert.deepEqual(Object.keys(JSON.parse(String(calls[3].init?.body))).sort(), ["memo", "removedAt"]);
+  assert.equal("updateBikeDeviceInstallation" in client, false);
+  assert.equal("deleteBikeDeviceInstallation" in client, false);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1,4 +1,4 @@
-import type { BatteryStation, EquipmentType } from "@/types/domain";
+import type { BatteryStation, Device, EquipmentType } from "@/types/domain";
 
 export type ServiceOpsFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
@@ -324,6 +324,58 @@ export type BikeEquipmentRemoveInput = {
   memo?: string | null;
 };
 
+export type ServiceOpsDevice = {
+  id: string;
+  idx: number | null;
+  deviceUid: string;
+  manufacturer: string | null;
+  modelName: string | null;
+  enabled: boolean;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DeviceCreateInput = {
+  deviceUid: string;
+  manufacturer?: string | null;
+  modelName?: string | null;
+  enabled?: boolean | null;
+  memo?: string | null;
+};
+
+export type DeviceUpdateInput = {
+  deviceUid?: string | null;
+  manufacturer?: string | null;
+  modelName?: string | null;
+  enabled?: boolean | null;
+  memo?: string | null;
+};
+
+export type ServiceOpsBikeDeviceInstallation = {
+  id: string;
+  idx: number | null;
+  bikeId: string;
+  deviceId: string;
+  installedAt: string;
+  removedAt: string | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BikeDeviceInstallationCreateInput = {
+  bikeId: string;
+  deviceId: string;
+  installedAt: string;
+  memo?: string | null;
+};
+
+export type BikeDeviceInstallationRemoveInput = {
+  removedAt?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsDashboardSummary = {
   totalBikes: number;
   bikePinCount: number;
@@ -439,6 +491,15 @@ export type ServiceOpsApiClient = {
   createBikeEquipment: (request: BikeEquipmentCreateInput) => Promise<ServiceOpsBikeEquipment>;
   updateBikeEquipment: (id: string, request: BikeEquipmentUpdateInput) => Promise<ServiceOpsBikeEquipment>;
   removeBikeEquipment: (id: string, request: BikeEquipmentRemoveInput) => Promise<ServiceOpsBikeEquipment>;
+  listDevices: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsDevice>>;
+  getDevice: (id: string) => Promise<ServiceOpsDevice>;
+  createDevice: (request: DeviceCreateInput) => Promise<ServiceOpsDevice>;
+  updateDevice: (id: string, request: DeviceUpdateInput) => Promise<ServiceOpsDevice>;
+  deleteDevice: (id: string) => Promise<void>;
+  listBikeDeviceInstallations: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsBikeDeviceInstallation>>;
+  getBikeDeviceInstallation: (id: string) => Promise<ServiceOpsBikeDeviceInstallation>;
+  createBikeDeviceInstallation: (request: BikeDeviceInstallationCreateInput) => Promise<ServiceOpsBikeDeviceInstallation>;
+  removeBikeDeviceInstallation: (id: string, request: BikeDeviceInstallationRemoveInput) => Promise<ServiceOpsBikeDeviceInstallation>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -702,6 +763,37 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify(removeRequest),
         method: "PATCH"
       }),
+    listDevices: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsDevice>>("/devices", { method: "GET" }, { page, size, sort }),
+    getDevice: (id) =>
+      request<ServiceOpsDevice>(`/devices/${encodeURIComponent(id)}`, { method: "GET" }),
+    createDevice: (createRequest) =>
+      request<ServiceOpsDevice>("/devices", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateDevice: (id, updateRequest) =>
+      request<ServiceOpsDevice>(`/devices/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
+        method: "PATCH"
+      }),
+    deleteDevice: async (id) => {
+      await request<void>(`/devices/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
+    listBikeDeviceInstallations: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsBikeDeviceInstallation>>("/bike-device-installations", { method: "GET" }, { page, size, sort }),
+    getBikeDeviceInstallation: (id) =>
+      request<ServiceOpsBikeDeviceInstallation>(`/bike-device-installations/${encodeURIComponent(id)}`, { method: "GET" }),
+    createBikeDeviceInstallation: (createRequest) =>
+      request<ServiceOpsBikeDeviceInstallation>("/bike-device-installations", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    removeBikeDeviceInstallation: (id, removeRequest) =>
+      request<ServiceOpsBikeDeviceInstallation>(`/bike-device-installations/${encodeURIComponent(id)}/remove`, {
+        body: JSON.stringify(removeRequest),
+        method: "PATCH"
+      }),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {
@@ -863,6 +955,22 @@ export function toFrontendEquipmentType(type: ServiceOpsEquipmentType): Equipmen
     slug: type.id,
     source: "service-ops",
     updatedAt: type.updatedAt
+  };
+}
+
+export function toFrontendDevice(device: ServiceOpsDevice): Device {
+  return {
+    createdAt: device.createdAt,
+    deviceUid: device.deviceUid,
+    enabled: device.enabled,
+    id: device.id,
+    idx: device.idx,
+    manufacturer: device.manufacturer,
+    memo: device.memo,
+    modelName: device.modelName,
+    slug: device.id,
+    source: "service-ops",
+    updatedAt: device.updatedAt
   };
 }
 

--- a/development/front-admin-web/lib/validations/domain.ts
+++ b/development/front-admin-web/lib/validations/domain.ts
@@ -66,3 +66,19 @@ export const bikeEquipmentSchema = z.object({
   managementNote: z.string().optional(),
   memo: z.string().optional()
 });
+
+
+export const deviceSchema = z.object({
+  deviceUid: z.string().min(1, "단말 UID를 입력하세요.").max(100),
+  manufacturer: z.string().max(100).optional(),
+  modelName: z.string().max(100).optional(),
+  enabled: z.enum(["true", "false"]),
+  memo: z.string().optional()
+});
+
+export const bikeDeviceInstallationSchema = z.object({
+  vehicleSelection: z.string().min(1, "차량을 선택하세요."),
+  deviceSelection: z.string().min(1, "단말을 선택하세요."),
+  installedAt: z.string().min(1, "설치일시를 선택하세요."),
+  memo: z.string().optional()
+});

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs lib/services/device-command-payload.test.mjs lib/services/device-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -4,6 +4,7 @@ export type ContractStatus = "활성" | "만료 예정" | "종료" | "초안";
 export type InsuranceStatus = "정상" | "만료 예정" | "만료" | "비활성";
 export type StationStatus = "운영 중" | "점검 중" | "운영 중지";
 export type EquipmentManagementStatus = "정상" | "관리 예정" | "기한 초과" | "제거됨";
+export type BikeDeviceInstallationStatus = "설치 중" | "제거됨";
 
 export type Rider = {
   slug: string;
@@ -134,5 +135,37 @@ export type BikeEquipment = {
   managementStatusCode?: "NORMAL" | "DUE_SOON" | "OVERDUE";
   managementNote?: string | null;
   memo?: string | null;
+  source?: "mock" | "service-ops";
+};
+
+export type Device = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  deviceUid: string;
+  manufacturer?: string | null;
+  modelName?: string | null;
+  enabled: boolean;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
+};
+
+export type BikeDeviceInstallation = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  bikeId?: string;
+  bikeLabel: string;
+  deviceId?: string;
+  deviceLabel: string;
+  deviceUid?: string;
+  installedAt: string;
+  removedAt?: string | null;
+  status: BikeDeviceInstallationStatus;
+  memo?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
   source?: "mock" | "service-ops";
 };

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -797,3 +797,30 @@ Verification:
 
 - TDD red observed on frontend service-ops equipment tests before implementation because equipment API client methods and equipment command/data helpers did not exist.
 - Frontend service-ops tests cover equipment-type endpoint request shape, bike-equipment create/update/remove endpoint shape, selector-only payload conversion, management status label derivation, removed-status display, and UUID mock fallback.
+
+
+## Frontend device registry and bike-device installation admin API integration baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#84
+- Target issue: EVNSolution/thundercrew-domain#75
+- Branch: `cc-84-device-admin-api-integration`
+
+Issue-size decision:
+
+- This slice wires a new Next.js device management surface to existing service-ops-api device registry and bike-device-installation endpoints.
+- Included work is a frontend device client/data adapter, device create/update/delete actions, bike-device install/remove actions, pages/forms, service-ops tests, and docs updates.
+- Telemetry/current-state, real map provider/API integration, backend schema/API changes, hard delete/restore/bulk flows beyond existing soft-delete endpoints, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- Device registry commands expose only device UID, manufacturer, model, enabled status, and memo; DB IDs and idx remain server-owned.
+- Bike-device installation create uses human-readable select controls for vehicle and device; operators do not type raw `bikeId`, `deviceId`, `installationId`, `vehicle_id`, or FK fields.
+- Installation removal is modeled as a history-preserving state transition through `/bike-device-installations/{id}/remove`, not hard delete.
+- Missing config/session/API failure falls back to explicit mock device data with a visible notice, including service UUID detail routes.
+
+Verification:
+
+- TDD red observed on frontend service-ops device tests before implementation because device API client coverage and device command/data helpers did not exist.
+- Frontend service-ops tests cover device endpoint request shape, bike-device install/remove endpoint shape, selector-only payload conversion, label hydration, removed-status display, and UUID mock fallback.


### PR DESCRIPTION
## Summary
- Adds the frontend admin device management surface under 운영 관리.
- Connects device registry list/detail/create/update/soft-delete to existing service-ops endpoints.
- Connects bike-device installation create/remove lifecycle to existing service-ops endpoints.
- Keeps vehicle/device relationship commands selector-backed and prevents direct raw ID/FK input fields.

## Scope
- Change-control: EVNSolution/clever-change-control#84
- Closes EVNSolution/thundercrew-domain#75
- Excludes telemetry/current-state, real map provider/API integration, backend schema/API changes, and production env mutation.

## Validation
- git diff --check
- npm run check:workspace
- npm run lint
- npm run test:service-ops
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew test)
- (cd development/service-ops-api && ./gradlew build)
- code-reviewer PASS
