### PR TITLE
Frontend integrity reference-check admin read UI baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd development/service-ops-api
 관리자 웹 앱 문서는 `development/front-admin-web/README.md`에 있습니다.
 
 - 핵심 화면: 지도 관제
-- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비, 단말
+- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비, 단말, 무결성 점검
 - 디자인 기준: `development/front-admin-web/DESIGN.md`
 - Supabase MVP migration/seed: `development/front-admin-web/supabase/`
 
@@ -103,6 +103,7 @@ Frontend ↔ backend baseline:
 - 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.
+- 무결성 점검은 같은 service-ops 세션으로 `GET /api/v1/integrity/reference-checks`를 읽어 read-only로 표시하며, telemetry/current-state 항목은 화면 표시에서 제외합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어
   summary, bike pins, station pins를 렌더링합니다.
 - 값이 없거나 placeholder이면 프론트는 명시적 notice와 함께 mock 데이터를 사용합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -1,6 +1,6 @@
 # ThunderCrew Front Admin Web
 
-전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비·단말 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
+전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비·단말·무결성 점검 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
 
 ## 기술 스택
 
@@ -21,6 +21,7 @@
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
 - 장비: `bikeId`, `equipmentTypeId`, `equipmentId` 직접 입력 금지 → 차량번호/장비 종류명 기준 선택
 - 단말 설치: `bikeId`, `deviceId`, `installationId` 직접 입력 금지 → 차량번호/단말 UID 기준 선택
+- 무결성 점검: read-only 결과 표시만 제공, DB ID/FK 수정 입력 금지
 
 DB PK/FK는 backend/Postgres에서 자동 생성·관리합니다. 화면 route에 backend UUID가 쓰이더라도 사용자가 직접 입력하거나 수정하는 필드로 노출하지 않습니다.
 
@@ -86,6 +87,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거는 server action/server component에서 `/api/v1/equipment-types`와 `/api/v1/bike-equipments`를 호출합니다.
 - 바이크 장비 등록 폼은 차량과 장비 종류를 select로 고르게 하며 `bikeId`, `equipmentTypeId`, `equipmentId` 같은 직접 입력 필드를 만들지 않습니다.
 - 단말 등록/수정은 단말 자체 UID와 제조사/모델/상태만 다루고, 차량 단말 설치 폼은 차량과 단말을 select로 고르게 하며 `bikeId`, `deviceId`, `installationId` 같은 직접 입력 필드를 만들지 않습니다.
+- 무결성 점검 화면은 `/api/v1/integrity/reference-checks`를 read-only로 표시하고, repair/scheduler/write 입력을 제공하지 않습니다. Telemetry/current-state 소스 테이블은 이번 범위에서 화면 표시 제외합니다.
 - 지도 관제 대시보드는 server component에서 `GET /api/v1/dashboard/map-state`를 호출해 summary, bike pins, station pins를 표시합니다.
 - `SERVICE_OPS_API_BASE_URL`이 없거나 placeholder이면 mock fallback을 명시 notice로 표시합니다.
 - 라이더 route slug는 backend 응답 UUID를 내부 route 식별자로 사용하지만, form에는 `id`, `riderId`, `appAccountId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -125,6 +127,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/devices/[slug]/edit` 단말 기본 정보 수정
 - `/devices/installations/new` 차량 단말 설치
 - `/devices/installations/[slug]` 차량 단말 설치 상세 + 제거 처리
+- `/integrity` 무-FK 참조 무결성 점검 read-only 화면
 - `/settings` 연결 설정 확인
 
 ## Supabase

--- a/development/front-admin-web/app/integrity/page.tsx
+++ b/development/front-admin-web/app/integrity/page.tsx
@@ -1,0 +1,101 @@
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadIntegrityReferenceChecks } from "@/lib/services/integrity-data";
+import type { IntegrityFinding } from "@/lib/services/integrity-data-core";
+
+export default async function IntegrityPage() {
+  const data = await loadIntegrityReferenceChecks();
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        description="외래키를 강제하지 않는 운영 테이블의 참조 깨짐을 읽기 전용으로 점검합니다. telemetry/current-state 테이블은 이번 범위에서 제외합니다."
+        title="무결성 점검"
+      />
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <section className="metric-grid">
+        <article className="metric-card">
+          <span>전체 발견</span>
+          <strong>{data.totalFindings}</strong>
+          <small>backend reference-check 원본</small>
+        </article>
+        <article className="metric-card">
+          <span>표시 대상</span>
+          <strong>{data.visibleFindingCount}</strong>
+          <small>telemetry/current-state 제외</small>
+        </article>
+        <article className="metric-card">
+          <span>제외됨</span>
+          <strong>{data.excludedFindingCount}</strong>
+          <small>bike_recent/current_states</small>
+        </article>
+        <article className="metric-card">
+          <span>생성 시각</span>
+          <strong style={{ fontSize: 18 }}>{formatDateTime(data.generatedAt)}</strong>
+          <small>{data.source}</small>
+        </article>
+      </section>
+      <section className="content-grid">
+        <div className="table-card">
+          {data.findings.length ? <FindingsTable findings={data.findings} /> : (
+            <EmptyState
+              actionLabel="대시보드로 이동"
+              description="표시 대상 운영 참조 깨짐이 없습니다. 이 화면은 수정 기능 없이 조회만 제공합니다."
+              href="/dashboard"
+              title="무결성 이상 없음"
+            />
+          )}
+        </div>
+        <aside className="detail-panel">
+          <h2>요약</h2>
+          <p>자동 복구나 스케줄러는 후속 이슈 범위입니다. 여기서는 관리자 확인을 위한 read-only 결과만 표시합니다.</p>
+          <div className="detail-list" style={{ marginTop: 16 }}>
+            {data.summary.length ? data.summary.map((item) => (
+              <div className="detail-row" key={item.category}>
+                <span>{item.categoryLabel}</span>
+                <strong>{item.count}</strong>
+              </div>
+            )) : <div className="detail-row"><span>표시 대상 findings</span><strong>0</strong></div>}
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function FindingsTable({ findings }: { findings: IntegrityFinding[] }) {
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <th>분류</th>
+          <th>소스</th>
+          <th>참조 필드</th>
+          <th>참조 대상</th>
+          <th>메시지</th>
+        </tr>
+      </thead>
+      <tbody>
+        {findings.map((finding) => (
+          <tr key={`${finding.sourceTable}:${finding.sourceId}:${finding.referenceField}:${finding.referenceId}`}>
+            <td><Badge tone={finding.severity === "danger" ? "outline" : "muted"}>{finding.categoryLabel}</Badge></td>
+            <td>{finding.sourceLabel}<br /><span className="muted-text">IDX {finding.sourceIdx ?? "-"}</span></td>
+            <td>{finding.referenceFieldLabel}</td>
+            <td>{finding.targetLabel}<br /><span className="muted-text">{finding.referenceId}</span></td>
+            <td>{finding.message}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString("ko-KR", { dateStyle: "short", timeStyle: "short", timeZone: "Asia/Seoul" });
+}

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -12,7 +12,8 @@ const operationsItems = [
   { href: "/insurance", label: "보험 관리", icon: "I" },
   { href: "/stations", label: "스테이션 관리", icon: "S" },
   { href: "/equipment", label: "장비 관리", icon: "E" },
-  { href: "/devices", label: "단말 관리", icon: "D" }
+  { href: "/devices", label: "단말 관리", icon: "D" },
+  { href: "/integrity", label: "무결성 점검", icon: "Q" }
 ];
 
 export async function AppShell({ children }: { children: ReactNode }) {

--- a/development/front-admin-web/lib/services/integrity-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/integrity-data-core.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mockIntegrityData, toCategoryLabel, toFrontendIntegrityData } from "./integrity-data-core.ts";
+
+test("toFrontendIntegrityData maps labels and recalculates visible summary", () => {
+  const data = toFrontendIntegrityData({
+    generatedAt: "2026-04-30T00:00:00Z",
+    totalFindings: 3,
+    summary: [
+      { category: "REFERENCE_NOT_FOUND", count: 2 },
+      { category: "REFERENCE_DELETED", count: 1 }
+    ],
+    findings: [
+      {
+        category: "REFERENCE_NOT_FOUND",
+        message: "missing bike",
+        referenceField: "bike_id",
+        referenceId: "11111111-1111-4111-8111-111111111111",
+        sourceId: "22222222-2222-4222-8222-222222222222",
+        sourceIdx: 2,
+        sourceTable: "rider_bike_contracts",
+        targetTable: "bikes"
+      },
+      {
+        category: "REFERENCE_DELETED",
+        message: "deleted station",
+        referenceField: "station_id",
+        referenceId: "33333333-3333-4333-8333-333333333333",
+        sourceId: "44444444-4444-4444-8444-444444444444",
+        sourceIdx: 4,
+        sourceTable: "station_battery_count_logs",
+        targetTable: "battery_stations"
+      },
+      {
+        category: "REFERENCE_NOT_FOUND",
+        message: "excluded current state",
+        referenceField: "bike_id",
+        referenceId: "55555555-5555-4555-8555-555555555555",
+        sourceId: "55555555-5555-4555-8555-555555555555",
+        sourceIdx: null,
+        sourceTable: "bike_current_states",
+        targetTable: "bikes"
+      }
+    ]
+  });
+
+  assert.equal(data.totalFindings, 3);
+  assert.equal(data.visibleFindingCount, 2);
+  assert.equal(data.excludedFindingCount, 1);
+  assert.deepEqual(data.summary.map((item) => [item.categoryLabel, item.count]), [["대상 없음", 1], ["삭제 대상 참조", 1]]);
+  assert.equal(data.findings[0].sourceLabel, "라이더-차량 계약");
+  assert.equal(data.findings[0].targetLabel, "차량");
+  assert.equal(data.findings[0].severity, "danger");
+});
+
+test("category labels are explicit and mock fallback is visible", () => {
+  assert.equal(toCategoryLabel("REFERENCE_NOT_FOUND"), "대상 없음");
+  assert.equal(toCategoryLabel("REFERENCE_DELETED"), "삭제 대상 참조");
+
+  const data = mockIntegrityData("no service");
+  assert.equal(data.notice, "no service");
+  assert.equal(data.source, "mock");
+  assert.equal(data.visibleFindingCount, 2);
+});

--- a/development/front-admin-web/lib/services/integrity-data-core.ts
+++ b/development/front-admin-web/lib/services/integrity-data-core.ts
@@ -1,0 +1,150 @@
+import type {
+  ServiceOpsIntegrityFinding,
+  ServiceOpsIntegrityFindingCategory,
+  ServiceOpsIntegrityScan,
+  ServiceOpsIntegritySummary
+} from "./service-ops-api";
+
+const EXCLUDED_SOURCE_TABLES = new Set(["bike_recent_states", "bike_current_states"]);
+
+export type IntegrityFinding = ServiceOpsIntegrityFinding & {
+  categoryLabel: string;
+  sourceLabel: string;
+  targetLabel: string;
+  referenceFieldLabel: string;
+  severity: "warning" | "danger";
+};
+
+export type IntegritySummaryItem = {
+  category: ServiceOpsIntegrityFindingCategory;
+  categoryLabel: string;
+  count: number;
+};
+
+export type IntegrityDataResult = {
+  excludedFindingCount: number;
+  findings: IntegrityFinding[];
+  generatedAt: string;
+  notice?: string;
+  source: "mock" | "service-ops";
+  summary: IntegritySummaryItem[];
+  totalFindings: number;
+  visibleFindingCount: number;
+};
+
+export function toFrontendIntegrityData(scan: ServiceOpsIntegrityScan, source: "mock" | "service-ops" = "service-ops"): IntegrityDataResult {
+  const visibleFindings = scan.findings.filter((finding) => !EXCLUDED_SOURCE_TABLES.has(finding.sourceTable));
+  const excludedFindingCount = scan.findings.length - visibleFindings.length;
+
+  return {
+    excludedFindingCount,
+    findings: visibleFindings.map(toFrontendIntegrityFinding),
+    generatedAt: scan.generatedAt,
+    source,
+    summary: summarizeVisibleFindings(visibleFindings, scan.summary),
+    totalFindings: scan.totalFindings,
+    visibleFindingCount: visibleFindings.length
+  };
+}
+
+export function mockIntegrityData(notice?: string): IntegrityDataResult {
+  return {
+    ...toFrontendIntegrityData({
+      findings: [
+        {
+          category: "REFERENCE_NOT_FOUND",
+          message: "rider_bike_contracts.bike_id references missing bikes",
+          referenceField: "bike_id",
+          referenceId: "11111111-1111-4111-8111-111111111111",
+          sourceId: "22222222-2222-4222-8222-222222222222",
+          sourceIdx: 2,
+          sourceTable: "rider_bike_contracts",
+          targetTable: "bikes"
+        },
+        {
+          category: "REFERENCE_DELETED",
+          message: "bike_equipments.equipment_type_id references deleted equipment_types",
+          referenceField: "equipment_type_id",
+          referenceId: "33333333-3333-4333-8333-333333333333",
+          sourceId: "44444444-4444-4444-8444-444444444444",
+          sourceIdx: 4,
+          sourceTable: "bike_equipments",
+          targetTable: "equipment_types"
+        }
+      ],
+      generatedAt: "2026-04-30T00:00:00Z",
+      summary: [
+        { category: "REFERENCE_NOT_FOUND", count: 1 },
+        { category: "REFERENCE_DELETED", count: 1 }
+      ],
+      totalFindings: 2
+    }, "mock"),
+    notice
+  };
+}
+
+export function toCategoryLabel(category: ServiceOpsIntegrityFindingCategory): string {
+  switch (category) {
+    case "REFERENCE_NOT_FOUND":
+      return "대상 없음";
+    case "REFERENCE_DELETED":
+      return "삭제 대상 참조";
+  }
+}
+
+function toFrontendIntegrityFinding(finding: ServiceOpsIntegrityFinding): IntegrityFinding {
+  return {
+    ...finding,
+    categoryLabel: toCategoryLabel(finding.category),
+    referenceFieldLabel: toDisplayLabel(finding.referenceField),
+    severity: finding.category === "REFERENCE_NOT_FOUND" ? "danger" : "warning",
+    sourceLabel: tableLabel(finding.sourceTable),
+    targetLabel: tableLabel(finding.targetTable)
+  };
+}
+
+function summarizeVisibleFindings(
+  findings: ServiceOpsIntegrityFinding[],
+  fallbackSummary: ServiceOpsIntegritySummary[]
+): IntegritySummaryItem[] {
+  if (!findings.length) {
+    return [];
+  }
+
+  const counts = new Map<ServiceOpsIntegrityFindingCategory, number>();
+  findings.forEach((finding) => counts.set(finding.category, (counts.get(finding.category) ?? 0) + 1));
+
+  const order = fallbackSummary.map((item) => item.category);
+  (["REFERENCE_NOT_FOUND", "REFERENCE_DELETED"] as const).forEach((category) => {
+    if (!order.includes(category)) {
+      order.push(category);
+    }
+  });
+
+  return order
+    .filter((category) => counts.has(category))
+    .map((category) => ({ category, categoryLabel: toCategoryLabel(category), count: counts.get(category) ?? 0 }));
+}
+
+function tableLabel(table: string): string {
+  const labels: Record<string, string> = {
+    battery_stations: "배터리 스테이션",
+    bike_device_installations: "차량 단말 설치",
+    bike_equipments: "바이크 장비",
+    bikes: "차량",
+    contract_templates: "계약 양식",
+    devices: "단말",
+    equipment_types: "장비 종류",
+    insurance_items: "보험 항목",
+    rider_bike_contracts: "라이더-차량 계약",
+    rider_insurances: "라이더 보험",
+    riders: "라이더",
+    station_battery_count_logs: "스테이션 수량 로그"
+  };
+
+  return labels[table] ?? toDisplayLabel(table);
+}
+
+function toDisplayLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}

--- a/development/front-admin-web/lib/services/integrity-data.ts
+++ b/development/front-admin-web/lib/services/integrity-data.ts
@@ -1,0 +1,34 @@
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  type IntegrityDataResult,
+  mockIntegrityData,
+  toFrontendIntegrityData
+} from "@/lib/services/integrity-data-core";
+import { type ServiceOpsApiError, serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+
+export async function loadIntegrityReferenceChecks(): Promise<IntegrityDataResult> {
+  if (!serviceOpsApiConfigured()) {
+    return mockIntegrityData("SERVICE_OPS_API_BASE_URL이 없어 mock 무결성 점검 데이터를 표시합니다. 백엔드 연결 후 실제 reference check로 전환됩니다.");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return mockIntegrityData("서비스 API 세션 쿠키가 없어 mock 무결성 점검 데이터를 표시합니다. 관리자 로그인 후 실제 점검 결과로 전환됩니다.");
+  }
+
+  try {
+    const scan = await client.getIntegrityReferenceChecks();
+    return toFrontendIntegrityData(scan, "service-ops");
+  } catch (error) {
+    return mockIntegrityData(`서비스 API 무결성 점검 조회 실패로 mock 데이터를 표시합니다.${formatServiceOpsError(error)}`);
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -1131,3 +1131,45 @@ test("bike-device installation lifecycle uses selector-backed endpoints", async 
   assert.equal("deleteBikeDeviceInstallation" in client, false);
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
+
+
+test("integrity reference-check request uses backend path and bearer token", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          generatedAt: "2026-04-30T00:00:00Z",
+          totalFindings: 1,
+          summary: [{ category: "REFERENCE_NOT_FOUND", count: 1 }],
+          findings: [
+            {
+              category: "REFERENCE_NOT_FOUND",
+              sourceTable: "rider_bike_contracts",
+              sourceId: "11111111-1111-4111-8111-111111111111",
+              sourceIdx: 1,
+              referenceField: "bike_id",
+              referenceId: "22222222-2222-4222-8222-222222222222",
+              targetTable: "bikes",
+              message: "rider_bike_contracts.bike_id references missing bikes"
+            }
+          ]
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const scan = await client.getIntegrityReferenceChecks();
+
+  assert.equal(calls.length, 1);
+  assert.equal(new URL(calls[0].url).pathname, "/api/v1/integrity/reference-checks");
+  assert.equal(calls[0].init?.method, "GET");
+  assert.equal(calls[0].init?.cache, "no-store");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(scan.totalFindings, 1);
+  assert.equal(scan.findings[0].sourceTable, "rider_bike_contracts");
+});

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -432,6 +432,31 @@ export type ServiceOpsDashboardMapState = {
   stationPins: ServiceOpsDashboardStationPin[];
 };
 
+export type ServiceOpsIntegrityFindingCategory = "REFERENCE_NOT_FOUND" | "REFERENCE_DELETED";
+
+export type ServiceOpsIntegritySummary = {
+  category: ServiceOpsIntegrityFindingCategory;
+  count: number;
+};
+
+export type ServiceOpsIntegrityFinding = {
+  category: ServiceOpsIntegrityFindingCategory;
+  sourceTable: string;
+  sourceId: string;
+  sourceIdx: number | null;
+  referenceField: string;
+  referenceId: string;
+  targetTable: string;
+  message: string;
+};
+
+export type ServiceOpsIntegrityScan = {
+  generatedAt: string;
+  totalFindings: number;
+  summary: ServiceOpsIntegritySummary[];
+  findings: ServiceOpsIntegrityFinding[];
+};
+
 export type FrontendDashboardBikePin = Omit<ServiceOpsDashboardBikePin, "latitude" | "longitude" | "speedKph" | "batteryPercent"> & {
   slug: string;
   latitude: number;
@@ -458,6 +483,7 @@ export type ServiceOpsApiClient = {
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
   getDashboardMapState: () => Promise<FrontendDashboardMapState>;
+  getIntegrityReferenceChecks: () => Promise<ServiceOpsIntegrityScan>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
   createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
@@ -623,6 +649,8 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     },
     getDashboardMapState: async () =>
       toFrontendDashboardMapState(await request<ServiceOpsDashboardMapState>("/dashboard/map-state", { method: "GET" })),
+    getIntegrityReferenceChecks: () =>
+      request<ServiceOpsIntegrityScan>("/integrity/reference-checks", { method: "GET" }),
     listVehicles: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsBike>>("/bikes", { method: "GET" }, { page, size, sort });
       return {

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs lib/services/device-command-payload.test.mjs lib/services/device-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs lib/services/device-command-payload.test.mjs lib/services/device-data-core.test.mjs lib/services/integrity-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -824,3 +824,29 @@ Verification:
 
 - TDD red observed on frontend service-ops device tests before implementation because device API client coverage and device command/data helpers did not exist.
 - Frontend service-ops tests cover device endpoint request shape, bike-device install/remove endpoint shape, selector-only payload conversion, label hydration, removed-status display, and UUID mock fallback.
+
+
+## Frontend integrity reference-check admin read UI baseline
+
+Trace:
+
+- Change request: EVNSolution/clever-change-control#85
+- Target issue: EVNSolution/thundercrew-domain#77
+- Branch: `cc-85-integrity-admin-read-ui`
+
+Issue-size decision:
+
+- This slice wires a read-only Next.js admin page to the existing service-ops-api integrity/reference-check endpoint.
+- Included work is a frontend integrity client method, data adapter, read-only page, service-ops tests, and docs updates.
+- Telemetry/current-state UI, real map provider/API integration, backend schema/API changes, repair/scheduler/write commands, and production env mutation remain out of scope.
+
+Boundary decision:
+
+- The UI displays summary and finding rows only; no DB ID/FK repair inputs or write actions are introduced.
+- Because the backend reference-check endpoint can include `bike_recent_states` and `bike_current_states`, the frontend adapter excludes those telemetry/current-state source tables from visible rows for this slice and reports the excluded count.
+- Missing config/session/API failure falls back to explicit mock integrity data with a visible notice.
+
+Verification:
+
+- TDD red observed on frontend service-ops integrity tests before implementation because integrity API client coverage and integrity data helpers did not exist.
+- Frontend service-ops tests cover integrity endpoint request shape, label mapping, visible summary recalculation, telemetry/current-state source exclusion, and mock fallback.


### PR DESCRIPTION
## Summary
- Adds a read-only `/integrity` admin page for service-ops reference-check results.
- Calls existing `GET /api/v1/integrity/reference-checks` with the service-ops session.
- Displays summary/finding rows while filtering telemetry/current-state source tables from visible results for this scope.
- Adds service client and adapter tests plus docs/change-ledger updates.

## Scope
- Change-control: EVNSolution/clever-change-control#85
- Closes EVNSolution/thundercrew-domain#77
- Excludes telemetry/current-state UI, real map provider/API integration, backend schema/API changes, repair/scheduler/write commands, and production env mutation.

## Validation
- git diff --check
- npm run check:workspace
- npm run lint
- npm run test:service-ops
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew test)
- (cd development/service-ops-api && ./gradlew build)
- code-reviewer PASS
