### PR TITLE
Frontend contract template management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd development/service-ops-api
 관리자 웹 앱 문서는 `development/front-admin-web/README.md`에 있습니다.
 
 - 핵심 화면: 지도 관제
-- 운영관리 하위 화면: 차량, 라이더, 계약, 보험, 배터리 스테이션, 장비, 단말, 무결성 점검
+- 운영관리 하위 화면: 차량, 라이더, 계약, 계약 양식, 보험, 배터리 스테이션, 장비, 단말, 무결성 점검
 - 디자인 기준: `development/front-admin-web/DESIGN.md`
 - Supabase MVP migration/seed: `development/front-admin-web/supabase/`
 
@@ -100,6 +100,7 @@ Frontend ↔ backend baseline:
 - 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
 - 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
+- 계약 양식 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 시스템 양식은 읽기 전용으로 보호합니다.
 - 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -1,6 +1,6 @@
 # ThunderCrew Front Admin Web
 
-전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·보험·스테이션·장비·단말·무결성 점검 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
+전기 이륜차 운영을 위한 지도 기반 관제/관리 웹 서비스 MVP입니다. 핵심 화면은 지도 관제이며, 차량·라이더·계약·계약 양식·보험·스테이션·장비·단말·무결성 점검 테이블 화면은 좌측 사이드바의 `운영 관리` 하위 메뉴로 둡니다.
 
 ## 기술 스택
 
@@ -17,6 +17,7 @@
 - 차량: `vehicle_id` 입력 금지 → 차량번호/모델/상태/위치와 라이더 선택
 - 라이더: `rider_id` 입력 금지 → 이름/연락처/소속/구역 입력
 - 계약: `contract_id`, `rider_id`, `vehicle_id`, `contract_template_id` 입력 금지 → 라이더 이름/연락처, 차량번호, 계약 양식 선택
+- 계약 양식: `contract_template_id`, `idx`, `systemTemplate` 입력 금지 → 양식명, 기간, 설명, 사용 상태만 관리
 - 보험: `insurance_id`, `rider_id`, `vehicle_id`, `insurance_item_id` 입력 금지 → 라이더 이름/연락처와 보험 항목 선택
 - 스테이션: `station_id` 입력 금지 → 이름/주소/운영 상태/재고 입력
 - 장비: `bikeId`, `equipmentTypeId`, `equipmentId` 직접 입력 금지 → 차량번호/장비 종류명 기준 선택
@@ -80,6 +81,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료는 server action/server component에서 `/api/v1/contract-templates`와 `/api/v1/rider-bike-contracts`를 호출합니다.
 - 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
+- 계약 양식 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/contract-templates`를 호출합니다. 시스템 계약 양식은 UI에서 읽기 전용으로 보호합니다.
 - 보험 목록/상세/등록/수정은 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다.
@@ -108,6 +110,10 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/contracts` 계약 목록
 - `/contracts/new` 계약 등록
 - `/contracts/[slug]` 계약 상세
+- `/contract-templates` 계약 양식 목록
+- `/contract-templates/new` 계약 양식 등록
+- `/contract-templates/[slug]` 계약 양식 상세 + 비활성 삭제
+- `/contract-templates/[slug]/edit` 계약 양식 수정
 - `/insurance` 보험 목록
 - `/insurance/new` 보험 등록
 - `/insurance/[slug]` 보험 상세

--- a/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { updateContractTemplateAction } from "@/app/contract-templates/actions";
+import { ContractTemplateForm } from "@/components/contract-templates/ContractTemplateForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { loadContractTemplateDetail } from "@/lib/services/contract-template-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "계약 양식 수정에 실패했습니다. 이름 중복, 기간 입력, 시스템 양식 여부, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditContractTemplatePage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadContractTemplateDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const template = detail.template;
+  const updateAction = updateContractTemplateAction.bind(null, template.slug);
+
+  if (template.systemTemplate) {
+    return (
+      <div className="page-container">
+        <PageHeader title="시스템 계약 양식" description="시스템 양식은 보호되어 수정할 수 없습니다." />
+        <div className="card">
+          <p className="notice">{template.name}은 백엔드 정책상 수정/삭제할 수 없는 시스템 계약 양식입니다.</p>
+          <div className="form-actions">
+            <Link className="button-secondary" href={`/contract-templates/${template.slug}`}>상세로 돌아가기</Link>
+            <Link className="button-primary" href="/contract-templates/new">운영자 양식 등록</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-container">
+      <PageHeader title="계약 양식 수정" description="계약 양식명, 기간, 설명, 사용 상태만 수정합니다. 계약 양식 ID는 입력받지 않습니다." />
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <ContractTemplateForm
+        action={updateAction}
+        cancelHref={`/contract-templates/${template.slug}`}
+        defaultValues={{
+          description: template.description,
+          durationMinutes: template.durationMinutes,
+          enabled: template.enabled,
+          name: template.name,
+          unlimited: template.unlimited
+        }}
+        mode="수정"
+        statusMessage={status ? statusMessage[status] : null}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/contract-templates/[slug]/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { deleteContractTemplateAction } from "@/app/contract-templates/actions";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { loadContractTemplateDetail } from "@/lib/services/contract-template-data";
+
+const statusMessage: Record<string, string> = {
+  created: "계약 양식이 등록되었습니다.",
+  "delete-error": "계약 양식 삭제 처리에 실패했습니다. 시스템 양식이거나 백엔드 연결 상태를 확인하세요.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 mock 계약 양식 화면으로 돌아왔습니다.",
+  updated: "계약 양식이 수정되었습니다."
+};
+
+export default async function ContractTemplateDetailPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadContractTemplateDetail(slug);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const template = detail.template;
+  const message = status ? statusMessage[status] : null;
+  const deleteAction = deleteContractTemplateAction.bind(null, template.slug);
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref={template.systemTemplate ? undefined : `/contract-templates/${template.slug}/edit`}
+        actionLabel={template.systemTemplate ? undefined : "수정"}
+        description="계약 등록 화면에서 선택되는 계약 양식 상세입니다. 시스템 양식은 보호되어 수정/삭제하지 않습니다."
+        title={template.name}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {detail.notice ? <p className="notice">{detail.notice}</p> : null}
+      <section className="content-grid">
+        <div className="card">
+          <h2>계약 양식 정보</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>기간</span><strong>{template.durationLabel}</strong></div>
+            <div className="detail-row"><span>사용 상태</span><Badge tone={template.enabled ? "active" : "muted"}>{template.enabled ? "사용" : "비활성"}</Badge></div>
+            <div className="detail-row"><span>보호 상태</span><Badge tone={template.systemTemplate ? "outline" : "muted"}>{template.systemTemplate ? "시스템 보호" : "운영자 관리"}</Badge></div>
+            <div className="detail-row"><span>설명</span><strong>{template.description ?? "없음"}</strong></div>
+            <div className="detail-row"><span>표시 순번</span><strong>{template.idx ?? "mock"}</strong></div>
+            {template.createdAt ? <div className="detail-row"><span>생성일시</span><strong>{template.createdAt}</strong></div> : null}
+            {template.updatedAt ? <div className="detail-row"><span>수정일시</span><strong>{template.updatedAt}</strong></div> : null}
+          </div>
+          <div className="form-actions">
+            <Link className="button-secondary" href="/contract-templates">목록</Link>
+            {template.systemTemplate ? null : <Link className="button-secondary" href={`/contract-templates/${template.slug}/edit`}>기본 정보 수정</Link>}
+          </div>
+        </div>
+        <aside className="detail-panel">
+          <h2>계약 양식 작업</h2>
+          {template.systemTemplate ? (
+            <p className="notice">시스템 계약 양식은 백엔드 정책상 수정/삭제할 수 없습니다. 운영자용 양식을 새로 만들어 계약 등록 화면에서 선택하세요.</p>
+          ) : (
+            <form action={deleteAction} className="action-panel">
+              <p>이 작업은 hard delete가 아니라 백엔드의 soft-delete 흐름입니다. 기존 계약 이력은 보존하고, 새 계약 등록 선택지에서 제외합니다.</p>
+              <div className="form-actions">
+                <Link className="button-secondary" href={`/contract-templates/${template.slug}/edit`}>수정</Link>
+                <button className="button-secondary" type="submit">비활성 삭제</button>
+              </div>
+            </form>
+          )}
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/development/front-admin-web/app/contract-templates/actions.ts
+++ b/development/front-admin-web/app/contract-templates/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  toContractTemplateCreatePayload,
+  toContractTemplateUpdatePayload
+} from "@/lib/services/contract-template-command-payload";
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export async function createContractTemplateAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/contract-templates?status=mock-saved");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let template;
+  try {
+    template = await client.createContractTemplate(toContractTemplateCreatePayload(formData));
+  } catch {
+    redirect("/contract-templates/new?status=save-error");
+  }
+
+  revalidatePath("/contract-templates");
+  revalidatePath("/contracts/new");
+  redirect(`/contract-templates/${template.id}?status=created`);
+}
+
+export async function updateContractTemplateAction(templateId: string, formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/contract-templates/${templateId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let template;
+  try {
+    template = await client.updateContractTemplate(templateId, toContractTemplateUpdatePayload(formData));
+  } catch {
+    redirect(`/contract-templates/${templateId}/edit?status=save-error`);
+  }
+
+  revalidatePath("/contract-templates");
+  revalidatePath("/contracts/new");
+  revalidatePath(`/contract-templates/${template.id}`);
+  redirect(`/contract-templates/${template.id}?status=updated`);
+}
+
+export async function deleteContractTemplateAction(templateId: string, _formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/contract-templates/${templateId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteContractTemplate(templateId);
+  } catch {
+    redirect(`/contract-templates/${templateId}?status=delete-error`);
+  }
+
+  revalidatePath("/contract-templates");
+  revalidatePath("/contracts/new");
+  redirect("/contract-templates?status=deleted");
+}

--- a/development/front-admin-web/app/contract-templates/new/page.tsx
+++ b/development/front-admin-web/app/contract-templates/new/page.tsx
@@ -1,0 +1,18 @@
+import { createContractTemplateAction } from "@/app/contract-templates/actions";
+import { ContractTemplateForm } from "@/components/contract-templates/ContractTemplateForm";
+import { PageHeader } from "@/components/layout/PageHeader";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "계약 양식 저장에 실패했습니다. 이름 중복, 기간 입력, 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function NewContractTemplatePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="page-container">
+      <PageHeader title="계약 양식 등록" description="계약 양식 ID는 DB가 자동 생성합니다. 운영자는 사람이 읽을 수 있는 이름과 기간만 입력합니다." />
+      <ContractTemplateForm action={createContractTemplateAction} statusMessage={status ? statusMessage[status] : null} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/contract-templates/page.tsx
+++ b/development/front-admin-web/app/contract-templates/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { loadContractTemplateList } from "@/lib/services/contract-template-data";
+
+const statusMessage: Record<string, string> = {
+  created: "계약 양식이 등록되었습니다.",
+  deleted: "계약 양식이 비활성 삭제 처리되었습니다.",
+  "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 목록으로 돌아왔습니다.",
+  updated: "계약 양식이 수정되었습니다."
+};
+
+export default async function ContractTemplatesPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const [{ status }, data] = await Promise.all([searchParams, loadContractTemplateList()]);
+  const message = status ? statusMessage[status] : null;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        actionHref="/contract-templates/new"
+        actionLabel="계약 양식 등록"
+        description="운영자가 계약 양식을 만들고, 계약 등록 시 선택 UI로 연결합니다. 계약 양식 ID는 입력받지 않습니다."
+        title="계약 양식 관리"
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {data.notice ? <p className="notice">{data.notice}</p> : null}
+      <div className="table-card">
+        {data.templates.length ? (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>양식명</th>
+                <th>기간</th>
+                <th>사용 상태</th>
+                <th>보호</th>
+                <th>표시 순번</th>
+                <th>상세</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.templates.map((template) => (
+                <tr key={template.slug}>
+                  <td>{template.name}<br /><span className="muted-text">{template.description ?? "설명 없음"}</span></td>
+                  <td>{template.durationLabel}</td>
+                  <td><Badge tone={template.enabled ? "active" : "muted"}>{template.enabled ? "사용" : "비활성"}</Badge></td>
+                  <td><Badge tone={template.systemTemplate ? "outline" : "muted"}>{template.systemTemplate ? "시스템" : "운영자"}</Badge></td>
+                  <td>{template.idx ?? "mock"}</td>
+                  <td><Link className="button-secondary" href={`/contract-templates/${template.slug}`}>보기</Link></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <EmptyState
+            actionLabel="계약 양식 등록"
+            description="아직 등록된 계약 양식이 없습니다. 이름과 기간만 먼저 정의할 수 있습니다."
+            href="/contract-templates/new"
+            title="계약 양식 없음"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/development/front-admin-web/components/contract-templates/ContractTemplateForm.tsx
+++ b/development/front-admin-web/components/contract-templates/ContractTemplateForm.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { ContractTemplate } from "@/types/domain";
+
+type ContractTemplateFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  cancelHref?: string;
+  defaultValues?: Partial<Pick<ContractTemplate, "description" | "durationMinutes" | "enabled" | "name" | "unlimited">>;
+  mode?: "등록" | "수정";
+  statusMessage?: string | null;
+};
+
+export function ContractTemplateForm({
+  action,
+  cancelHref = "/contract-templates",
+  defaultValues,
+  mode = "등록",
+  statusMessage
+}: ContractTemplateFormProps) {
+  const duration = splitDuration(defaultValues?.durationMinutes ?? null);
+  const durationMode = defaultValues?.unlimited || defaultValues?.durationMinutes === null ? "unlimited" : "limited";
+
+  return (
+    <form action={action} className="card" aria-label={`계약 양식 ${mode} 폼`}>
+      <div className="form-grid">
+        <Field label="계약 양식명">
+          <input className="input" defaultValue={defaultValues?.name ?? ""} maxLength={100} name="name" placeholder="예: 표준 12일" required />
+        </Field>
+        <Field label="사용 상태">
+          <select className="select" defaultValue={String(defaultValues?.enabled ?? true)} name="enabled">
+            <option value="true">사용</option>
+            <option value="false">비활성</option>
+          </select>
+        </Field>
+        <Field label="기간 방식" hint="무제한은 종료일 없이 운영자가 별도 종료할 때까지 유지합니다.">
+          <select className="select" defaultValue={durationMode} name="durationMode">
+            <option value="limited">기간 지정</option>
+            <option value="unlimited">무제한</option>
+          </select>
+        </Field>
+        <Field label="기간 · 일">
+          <input className="input" defaultValue={duration.days || ""} min={0} name="durationDays" placeholder="예: 12" type="number" />
+        </Field>
+        <Field label="기간 · 시간">
+          <input className="input" defaultValue={duration.hours || ""} min={0} name="durationHours" placeholder="예: 6" type="number" />
+        </Field>
+        <Field label="기간 · 분">
+          <input className="input" defaultValue={duration.minutes || ""} min={0} name="durationMinutesPart" placeholder="예: 30" type="number" />
+        </Field>
+      </div>
+      <br />
+      <Field label="설명"><textarea className="input" defaultValue={defaultValues?.description ?? ""} name="description" placeholder="운영자가 구분할 수 있는 계약 양식 설명" rows={3} /></Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        계약 양식 ID는 DB가 자동 생성합니다. 운영자는 양식명, 기간, 설명, 사용 상태만 입력합니다. 라이더/차량 연결은 계약 등록 화면에서 선택 UI로 처리합니다.
+      </p>
+      {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
+      <div className="form-actions">
+        <Link className="button-secondary" href={cancelHref}>취소</Link>
+        <button className="button-primary" type="submit">계약 양식 {mode}</button>
+      </div>
+    </form>
+  );
+}
+
+function splitDuration(durationMinutes: number | null): { days: number; hours: number; minutes: number } {
+  if (!durationMinutes) {
+    return { days: 0, hours: 0, minutes: 0 };
+  }
+
+  return {
+    days: Math.floor(durationMinutes / 1440),
+    hours: Math.floor((durationMinutes % 1440) / 60),
+    minutes: durationMinutes % 60
+  };
+}

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ const operationsItems = [
   { href: "/vehicles", label: "차량 관리", icon: "EV" },
   { href: "/riders", label: "라이더 관리", icon: "R" },
   { href: "/contracts", label: "계약 관리", icon: "C" },
+  { href: "/contract-templates", label: "계약 양식", icon: "T" },
   { href: "/insurance", label: "보험 관리", icon: "I" },
   { href: "/stations", label: "스테이션 관리", icon: "S" },
   { href: "/equipment", label: "장비 관리", icon: "E" },

--- a/development/front-admin-web/lib/services/contract-data.ts
+++ b/development/front-admin-web/lib/services/contract-data.ts
@@ -8,7 +8,7 @@ import type {
 } from "@/lib/services/service-ops-api";
 import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
-import { contracts as mockContracts, riders as mockRiders, vehicles as mockVehicles } from "@/lib/services/mock-data";
+import { contractTemplates as mockContractTemplates, contracts as mockContracts, riders as mockRiders, vehicles as mockVehicles } from "@/lib/services/mock-data";
 import {
   type ContractDataResult,
   type ContractDetailResult,
@@ -178,8 +178,6 @@ async function loadContractLookup(client: ServiceOpsApiClient): Promise<Contract
 }
 
 function mockContractFormOptions(): ContractFormOptionsResult {
-  const templateNames = Array.from(new Set(mockContracts.map((contract) => contract.contractType)));
-
   return {
     riders: mockRiders.map((rider) => ({
       helper: `${rider.team} · ${rider.area}`,
@@ -187,11 +185,13 @@ function mockContractFormOptions(): ContractFormOptionsResult {
       value: rider.slug
     })),
     source: "mock",
-    templates: templateNames.map((templateName) => ({
-      helper: "mock 계약 양식",
-      label: templateName,
-      value: templateName
-    })),
+    templates: mockContractTemplates
+      .filter((template) => template.enabled)
+      .map((template) => ({
+        helper: template.description ?? undefined,
+        label: `${template.name} · ${template.durationLabel}`,
+        value: template.slug
+      })),
     vehicles: mockVehicles.map((vehicle) => ({
       helper: vehicle.status,
       label: `${vehicle.plateNumber} · ${vehicle.model}`,

--- a/development/front-admin-web/lib/services/contract-template-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/contract-template-command-payload.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ContractTemplateCommandPayloadError,
+  toContractTemplateCreatePayload,
+  toContractTemplateUpdatePayload
+} from "./contract-template-command-payload.ts";
+
+test("contract template create payload keeps operator fields only and ignores direct ids", () => {
+  const formData = new FormData();
+  formData.set("name", "표준 12일 6시간");
+  formData.set("durationMode", "limited");
+  formData.set("durationDays", "12");
+  formData.set("durationHours", "6");
+  formData.set("durationMinutesPart", "30");
+  formData.set("description", "운영자 생성 양식");
+  formData.set("enabled", "true");
+  formData.set("id", "99999999-9999-4999-8999-999999999999");
+  formData.set("idx", "999");
+  formData.set("contractTemplateId", "99999999-9999-4999-8999-999999999999");
+  formData.set("systemTemplate", "true");
+
+  assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    description: "운영자 생성 양식",
+    durationMinutes: 17670,
+    enabled: true,
+    name: "표준 12일 6시간"
+  });
+});
+
+test("contract template payload supports unlimited duration", () => {
+  const formData = new FormData();
+  formData.set("name", "무제한 현장 계약");
+  formData.set("durationMode", "unlimited");
+  formData.set("durationDays", "12");
+  formData.set("durationHours", "3");
+  formData.set("description", "");
+  formData.set("enabled", "false");
+
+  assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    description: null,
+    durationMinutes: null,
+    enabled: false,
+    name: "무제한 현장 계약"
+  });
+});
+
+test("contract template update preserves blank description as clear command", () => {
+  const formData = new FormData();
+  formData.set("name", "표준 13일");
+  formData.set("durationMode", "limited");
+  formData.set("durationDays", "13");
+  formData.set("durationHours", "0");
+  formData.set("durationMinutesPart", "0");
+  formData.set("description", "");
+  formData.set("enabled", "false");
+
+  assert.deepEqual(toContractTemplateUpdatePayload(formData), {
+    description: "",
+    durationMinutes: 18720,
+    enabled: false,
+    name: "표준 13일"
+  });
+});
+
+test("contract template payload rejects blank name, zero duration, and invalid enabled state", () => {
+  const formData = new FormData();
+  formData.set("name", "");
+  formData.set("durationMode", "limited");
+  formData.set("durationDays", "12");
+
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
+
+  formData.set("name", "0분 계약");
+  formData.set("durationDays", "0");
+  formData.set("durationHours", "0");
+  formData.set("durationMinutesPart", "0");
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
+
+  formData.set("durationMinutesPart", "30");
+  formData.set("enabled", "maybe");
+  assert.throws(() => toContractTemplateUpdatePayload(formData), ContractTemplateCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/contract-template-command-payload.ts
+++ b/development/front-admin-web/lib/services/contract-template-command-payload.ts
@@ -1,0 +1,96 @@
+import type { ContractTemplateCreateInput, ContractTemplateUpdateInput } from "./service-ops-api";
+
+export class ContractTemplateCommandPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContractTemplateCommandPayloadError";
+  }
+}
+
+export function toContractTemplateCreatePayload(formData: FormData): ContractTemplateCreateInput {
+  return {
+    description: optionalText(formData.get("description")),
+    durationMinutes: toDurationMinutes(formData),
+    enabled: toEnabled(formData.get("enabled"), true),
+    name: requiredText(formData.get("name"), "Contract template name is required.")
+  };
+}
+
+export function toContractTemplateUpdatePayload(formData: FormData): ContractTemplateUpdateInput {
+  return {
+    description: clearableText(formData.get("description")),
+    durationMinutes: toDurationMinutes(formData),
+    enabled: toEnabled(formData.get("enabled"), true),
+    name: requiredText(formData.get("name"), "Contract template name is required.")
+  };
+}
+
+function toDurationMinutes(formData: FormData): number | null {
+  const mode = String(formData.get("durationMode") ?? "limited").trim();
+  if (mode === "unlimited") {
+    return null;
+  }
+
+  if (mode !== "limited") {
+    throw new ContractTemplateCommandPayloadError("Invalid contract template duration mode.");
+  }
+
+  const days = toNonNegativeInteger(formData.get("durationDays"), "Duration days must be a non-negative integer.");
+  const hours = toNonNegativeInteger(formData.get("durationHours"), "Duration hours must be a non-negative integer.");
+  const minutes = toNonNegativeInteger(formData.get("durationMinutesPart"), "Duration minutes must be a non-negative integer.");
+  const total = (days * 1440) + (hours * 60) + minutes;
+
+  if (total <= 0) {
+    throw new ContractTemplateCommandPayloadError("Limited contract duration must be greater than zero.");
+  }
+
+  return total;
+}
+
+function toNonNegativeInteger(value: FormDataEntryValue | null, message: string): number {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    return 0;
+  }
+
+  if (!/^\d+$/.test(text)) {
+    throw new ContractTemplateCommandPayloadError(message);
+  }
+
+  return Number(text);
+}
+
+function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (!text) {
+    return fallback;
+  }
+
+  if (["true", "1", "on", "enabled"].includes(text)) {
+    return true;
+  }
+
+  if (["false", "0", "off", "disabled"].includes(text)) {
+    return false;
+  }
+
+  throw new ContractTemplateCommandPayloadError("Invalid enabled status.");
+}
+
+function requiredText(value: FormDataEntryValue | null, message: string): string {
+  const text = optionalText(value);
+  if (!text) {
+    throw new ContractTemplateCommandPayloadError(message);
+  }
+
+  return text;
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function clearableText(value: FormDataEntryValue | null): string {
+  return String(value ?? "").trim();
+}

--- a/development/front-admin-web/lib/services/contract-template-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/contract-template-data-core.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mockContractTemplateUnavailableServiceDetail,
+  toContractTemplateDurationLabel,
+  toFrontendContractTemplate
+} from "./contract-template-data-core.ts";
+
+test("toFrontendContractTemplate preserves system flags and readable duration label", () => {
+  const template = toFrontendContractTemplate({
+    createdAt: "2026-04-30T00:00:00Z",
+    description: "12일 운영 계약",
+    durationMinutes: 17280,
+    enabled: true,
+    id: "11111111-1111-4111-8111-111111111111",
+    idx: 12,
+    name: "표준 12일",
+    systemTemplate: false,
+    unlimited: false,
+    updatedAt: "2026-04-30T00:00:00Z"
+  });
+
+  assert.equal(template.slug, "11111111-1111-4111-8111-111111111111");
+  assert.equal(template.durationLabel, "12일");
+  assert.equal(template.systemTemplate, false);
+  assert.equal(template.source, "service-ops");
+});
+
+test("duration labels support unlimited and mixed day/hour/minute values", () => {
+  assert.equal(toContractTemplateDurationLabel(null, true), "무제한");
+  assert.equal(toContractTemplateDurationLabel(1500, false), "1일 1시간");
+  assert.equal(toContractTemplateDurationLabel(90, false), "1시간 30분");
+  assert.equal(toContractTemplateDurationLabel(35, false), "35분");
+});
+
+test("UUID contract template detail falls back to visible mock detail when service API is unavailable", () => {
+  const detail = mockContractTemplateUnavailableServiceDetail(
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    [
+      {
+        description: "기간 제한 없음",
+        durationLabel: "무제한",
+        durationMinutes: null,
+        enabled: true,
+        name: "무제한 계약",
+        slug: "unlimited-contract",
+        systemTemplate: true,
+        unlimited: true
+      }
+    ],
+    "서비스 API 세션 쿠키가 없어 mock 계약 양식 상세를 표시합니다."
+  );
+
+  assert.equal(detail?.source, "mock");
+  assert.equal(detail?.template.slug, "unlimited-contract");
+  assert.equal(detail?.template.systemTemplate, true);
+});

--- a/development/front-admin-web/lib/services/contract-template-data-core.ts
+++ b/development/front-admin-web/lib/services/contract-template-data-core.ts
@@ -1,0 +1,93 @@
+import type { ContractTemplate } from "@/types/domain";
+import type { ServiceOpsContractTemplate } from "./service-ops-api";
+
+export type ContractTemplateDataResult = {
+  source: "mock" | "service-ops";
+  templates: ContractTemplate[];
+  notice?: string;
+};
+
+export type ContractTemplateDetailResult = {
+  source: "mock" | "service-ops";
+  template: ContractTemplate;
+  notice?: string;
+};
+
+export function toFrontendContractTemplate(template: ServiceOpsContractTemplate): ContractTemplate {
+  return {
+    createdAt: template.createdAt,
+    description: template.description,
+    durationLabel: toContractTemplateDurationLabel(template.durationMinutes, template.unlimited),
+    durationMinutes: template.durationMinutes,
+    enabled: template.enabled,
+    id: template.id,
+    idx: template.idx,
+    name: template.name,
+    slug: template.id,
+    source: "service-ops",
+    systemTemplate: template.systemTemplate,
+    unlimited: template.unlimited,
+    updatedAt: template.updatedAt
+  };
+}
+
+export function toContractTemplateDurationLabel(durationMinutes: number | null, unlimited = durationMinutes === null): string {
+  if (unlimited || durationMinutes === null) {
+    return "무제한";
+  }
+
+  const days = Math.floor(durationMinutes / 1440);
+  const hours = Math.floor((durationMinutes % 1440) / 60);
+  const minutes = durationMinutes % 60;
+  const parts = [
+    days ? `${days}일` : null,
+    hours ? `${hours}시간` : null,
+    minutes ? `${minutes}분` : null
+  ].filter(Boolean);
+
+  return parts.length ? parts.join(" ") : `${durationMinutes}분`;
+}
+
+export function mockContractTemplateList(mockTemplates: ContractTemplate[]): ContractTemplateDataResult {
+  return {
+    source: "mock",
+    templates: mockTemplates.map((template) => ({ ...template, source: "mock" as const }))
+  };
+}
+
+export function mockContractTemplateDetail(slug: string, mockTemplates: ContractTemplate[]): ContractTemplateDetailResult | null {
+  const template = mockTemplates.find((candidate) => candidate.slug === slug);
+  if (!template) {
+    return null;
+  }
+
+  return {
+    source: "mock",
+    template: { ...template, source: "mock" }
+  };
+}
+
+export function mockContractTemplateUnavailableServiceDetail(
+  slug: string,
+  mockTemplates: ContractTemplate[],
+  notice: string
+): ContractTemplateDetailResult | null {
+  const exactFallback = mockContractTemplateDetail(slug, mockTemplates);
+  if (exactFallback) {
+    return { ...exactFallback, notice };
+  }
+
+  if (!isUuidLike(slug) || !mockTemplates.length) {
+    return null;
+  }
+
+  return {
+    notice,
+    source: "mock",
+    template: { ...mockTemplates[0], source: "mock" }
+  };
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}

--- a/development/front-admin-web/lib/services/contract-template-data.ts
+++ b/development/front-admin-web/lib/services/contract-template-data.ts
@@ -1,0 +1,92 @@
+import { contractTemplates as mockContractTemplates } from "@/lib/services/mock-data";
+import { serviceOpsApiConfigured, type ServiceOpsApiError } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import {
+  type ContractTemplateDataResult,
+  type ContractTemplateDetailResult,
+  isUuidLike,
+  mockContractTemplateDetail,
+  mockContractTemplateList,
+  mockContractTemplateUnavailableServiceDetail,
+  toFrontendContractTemplate
+} from "@/lib/services/contract-template-data-core";
+
+export async function loadContractTemplateList(): Promise<ContractTemplateDataResult> {
+  const fallback = mockContractTemplateList(mockContractTemplates);
+
+  if (!serviceOpsApiConfigured()) {
+    return {
+      ...fallback,
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 mock 계약 양식을 표시합니다. 백엔드 연결 시 실제 API 목록으로 전환됩니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      ...fallback,
+      notice: "서비스 API 세션 쿠키가 없어 mock 계약 양식을 표시합니다. 관리자 로그인 후 실제 백엔드 목록으로 전환됩니다."
+    };
+  }
+
+  try {
+    const page = await client.listContractTemplates({ page: 0, size: 100 });
+    return {
+      source: "service-ops",
+      templates: page.items.map(toFrontendContractTemplate)
+    };
+  } catch (error) {
+    return {
+      ...fallback,
+      notice: `서비스 API 계약 양식 조회 실패로 mock 계약 양식을 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+export async function loadContractTemplateDetail(slug: string): Promise<ContractTemplateDetailResult | null> {
+  const fallback = mockContractTemplateDetail(slug, mockContractTemplates);
+
+  if (!serviceOpsApiConfigured() && isUuidLike(slug)) {
+    return mockContractTemplateUnavailableServiceDetail(
+      slug,
+      mockContractTemplates,
+      "SERVICE_OPS_API_BASE_URL이 없어 mock 계약 양식 상세를 표시합니다. 백엔드 연결 후 실제 상세로 전환됩니다."
+    );
+  }
+
+  if (serviceOpsApiConfigured() && isUuidLike(slug)) {
+    const client = await createAuthenticatedServiceOpsApiClient();
+
+    if (!client) {
+      return mockContractTemplateUnavailableServiceDetail(
+        slug,
+        mockContractTemplates,
+        "서비스 API 세션 쿠키가 없어 mock 계약 양식 상세를 표시합니다. 관리자 로그인 후 실제 상세로 전환됩니다."
+      );
+    }
+
+    try {
+      return {
+        source: "service-ops",
+        template: toFrontendContractTemplate(await client.getContractTemplate(slug))
+      };
+    } catch (error) {
+      return mockContractTemplateUnavailableServiceDetail(
+        slug,
+        mockContractTemplates,
+        `서비스 API 계약 양식 상세 조회 실패로 mock 계약 양식 상세를 표시합니다.${formatServiceOpsError(error)}`
+      );
+    }
+  }
+
+  return fallback;
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const serviceError = error as Partial<ServiceOpsApiError>;
+  if (serviceError?.status) {
+    return ` (${serviceError.status}${serviceError.code ? `/${serviceError.code}` : ""})`;
+  }
+
+  return "";
+}

--- a/development/front-admin-web/lib/services/mock-data.ts
+++ b/development/front-admin-web/lib/services/mock-data.ts
@@ -2,6 +2,7 @@ import type {
   BatteryStation,
   BikeDeviceInstallation,
   BikeEquipment,
+  ContractTemplate,
   Device,
   EquipmentType,
   InsurancePolicy,
@@ -20,6 +21,40 @@ export const vehicles: Vehicle[] = [
   { slug: "seoul-ba-4821", plateNumber: "서울바4821", model: "NIU NQi Cargo", status: "운행 중", assignmentStatus: "배정됨", batteryPercent: 78, riderName: "김민준", locationLabel: "강남역 11번 출구", lastSeenAt: "3분 전" },
   { slug: "seoul-ba-7390", plateNumber: "서울바7390", model: "Gogoro 2 Utility", status: "점검 필요", assignmentStatus: "미배정", batteryPercent: 21, locationLabel: "역삼 정비 거점", lastSeenAt: "18분 전" },
   { slug: "seoul-ba-1168", plateNumber: "서울바1168", model: "Thundercrew E2", status: "대기", assignmentStatus: "교대 예정", batteryPercent: 94, riderName: "이하나", locationLabel: "서초 스테이션", lastSeenAt: "8분 전" }
+];
+
+
+export const contractTemplates: ContractTemplate[] = [
+  {
+    slug: "unlimited-contract",
+    name: "무제한 계약",
+    durationMinutes: null,
+    unlimited: true,
+    durationLabel: "무제한",
+    description: "기간 제한 없이 운영자가 별도 종료할 때까지 유지",
+    enabled: true,
+    systemTemplate: true
+  },
+  {
+    slug: "standard-12-days",
+    name: "표준 12일",
+    durationMinutes: 17280,
+    unlimited: false,
+    durationLabel: "12일",
+    description: "12일 단위 바이크 이용 계약",
+    enabled: true,
+    systemTemplate: false
+  },
+  {
+    slug: "trial-3-days",
+    name: "체험 3일",
+    durationMinutes: 4320,
+    unlimited: false,
+    durationLabel: "3일",
+    description: "단기 체험 운영 계약",
+    enabled: false,
+    systemTemplate: false
+  }
 ];
 
 export const contracts: RiderContract[] = [

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -368,6 +368,74 @@ test("contract template list request uses backend path and bearer token", async 
   assert.equal(page.items[0].unlimited, true);
 });
 
+test("contract template command requests use backend path and bearer token", async () => {
+  const calls = [];
+  const templateId = "11111111-1111-4111-8111-111111111111";
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          createdAt: "2026-04-30T00:00:00Z",
+          description: body.description ?? null,
+          durationMinutes: body.durationMinutes ?? null,
+          enabled: body.enabled ?? true,
+          id: templateId,
+          idx: 1,
+          name: body.name ?? "무제한 계약",
+          systemTemplate: false,
+          unlimited: body.durationMinutes === null,
+          updatedAt: "2026-04-30T00:00:00Z"
+        }),
+        { headers: { "content-type": "application/json" }, status: init?.method === "POST" ? 201 : 200 }
+      );
+    }
+  });
+
+  await client.createContractTemplate({
+    description: "12일 운영",
+    durationMinutes: 17280,
+    enabled: true,
+    name: "표준 12일"
+  });
+  await client.updateContractTemplate(templateId, {
+    description: "",
+    durationMinutes: null,
+    enabled: false,
+    name: "무제한 운영"
+  });
+  await client.deleteContractTemplate(templateId);
+
+  assert.equal(calls.length, 3);
+  assert.equal(new URL(calls[0].url).pathname, "/api/v1/contract-templates");
+  assert.equal(calls[0].init?.method, "POST");
+  assert.deepEqual(JSON.parse(String(calls[0].init?.body)), {
+    description: "12일 운영",
+    durationMinutes: 17280,
+    enabled: true,
+    name: "표준 12일"
+  });
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(new URL(calls[1].url).pathname, `/api/v1/contract-templates/${templateId}`);
+  assert.equal(calls[1].init?.method, "PATCH");
+  assert.deepEqual(JSON.parse(String(calls[1].init?.body)), {
+    description: "",
+    durationMinutes: null,
+    enabled: false,
+    name: "무제한 운영"
+  });
+  assert.equal(new URL(calls[2].url).pathname, `/api/v1/contract-templates/${templateId}`);
+  assert.equal(calls[2].init?.method, "DELETE");
+});
+
+
 test("rider-bike contract create/update/terminate use dedicated contract endpoints", async () => {
   const calls = [];
   const client = createServiceOpsApiClient({

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -140,6 +140,20 @@ export type ServiceOpsContractTemplate = {
   updatedAt: string;
 };
 
+export type ContractTemplateCreateInput = {
+  name: string;
+  durationMinutes?: number | null;
+  description?: string | null;
+  enabled?: boolean | null;
+};
+
+export type ContractTemplateUpdateInput = {
+  name?: string | null;
+  durationMinutes?: number | null;
+  description?: string | null;
+  enabled?: boolean | null;
+};
+
 export type ServiceOpsRiderBikeContract = {
   id: string;
   idx: number | null;
@@ -491,6 +505,9 @@ export type ServiceOpsApiClient = {
   changeVehicleOperationStatus: (id: string, request: VehicleOperationStatusChangeInput) => Promise<FrontendVehicle>;
   listContractTemplates: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsContractTemplate>>;
   getContractTemplate: (id: string) => Promise<ServiceOpsContractTemplate>;
+  createContractTemplate: (request: ContractTemplateCreateInput) => Promise<ServiceOpsContractTemplate>;
+  updateContractTemplate: (id: string, request: ContractTemplateUpdateInput) => Promise<ServiceOpsContractTemplate>;
+  deleteContractTemplate: (id: string) => Promise<void>;
   listRiderBikeContracts: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsRiderBikeContract>>;
   getRiderBikeContract: (id: string) => Promise<ServiceOpsRiderBikeContract>;
   createRiderBikeContract: (request: RiderBikeContractCreateInput) => Promise<ServiceOpsRiderBikeContract>;
@@ -684,6 +701,19 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       request<ServiceOpsPage<ServiceOpsContractTemplate>>("/contract-templates", { method: "GET" }, { page, size, sort }),
     getContractTemplate: (id) =>
       request<ServiceOpsContractTemplate>(`/contract-templates/${encodeURIComponent(id)}`, { method: "GET" }),
+    createContractTemplate: (createRequest) =>
+      request<ServiceOpsContractTemplate>("/contract-templates", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    updateContractTemplate: (id, updateRequest) =>
+      request<ServiceOpsContractTemplate>(`/contract-templates/${encodeURIComponent(id)}`, {
+        body: JSON.stringify(updateRequest),
+        method: "PATCH"
+      }),
+    deleteContractTemplate: async (id) => {
+      await request<void>(`/contract-templates/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     listRiderBikeContracts: ({ page = 0, size = 20, sort } = {}) =>
       request<ServiceOpsPage<ServiceOpsRiderBikeContract>>("/rider-bike-contracts", { method: "GET" }, { page, size, sort }),
     getRiderBikeContract: (id) =>

--- a/development/front-admin-web/package.json
+++ b/development/front-admin-web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs lib/services/device-command-payload.test.mjs lib/services/device-data-core.test.mjs lib/services/integrity-data-core.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/vehicle-command-payload.test.mjs lib/services/vehicle-data-core.test.mjs lib/services/contract-command-payload.test.mjs lib/services/contract-data-core.test.mjs lib/services/contract-template-command-payload.test.mjs lib/services/contract-template-data-core.test.mjs lib/services/insurance-command-payload.test.mjs lib/services/insurance-data-core.test.mjs lib/services/station-command-payload.test.mjs lib/services/station-data-core.test.mjs lib/services/equipment-command-payload.test.mjs lib/services/equipment-data-core.test.mjs lib/services/device-command-payload.test.mjs lib/services/device-data-core.test.mjs lib/services/integrity-data-core.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -36,6 +36,23 @@ export type Vehicle = {
   source?: "mock" | "service-ops";
 };
 
+
+export type ContractTemplate = {
+  slug: string;
+  id?: string;
+  idx?: number | null;
+  name: string;
+  durationMinutes: number | null;
+  unlimited: boolean;
+  durationLabel: string;
+  description?: string | null;
+  enabled: boolean;
+  systemTemplate: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  source?: "mock" | "service-ops";
+};
+
 export type RiderContract = {
   slug: string;
   id?: string;

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -850,3 +850,31 @@ Verification:
 
 - TDD red observed on frontend service-ops integrity tests before implementation because integrity API client coverage and integrity data helpers did not exist.
 - Frontend service-ops tests cover integrity endpoint request shape, label mapping, visible summary recalculation, telemetry/current-state source exclusion, and mock fallback.
+
+## Frontend contract template management UI
+
+- Date: 2026-04-30
+- Change-control issue: EVNSolution/clever-change-control#86
+- Target issue: EVNSolution/thundercrew-domain#79
+- Branch: `cc-86-contract-template-admin-ui`
+
+### Decision
+
+Add a dedicated admin UI for contract template management on top of the existing service-ops contract-template API.
+
+### Included
+
+- Frontend service client command methods for `/api/v1/contract-templates`.
+- Contract template list/detail/new/edit pages and server actions.
+- Payload/data helpers and service-ops tests for duration conversion, unlimited templates, mock fallback, and command endpoint shapes.
+- Sidebar/README updates so contract templates are an explicit operations sub-menu.
+
+### Excluded
+
+- Telemetry/current-state work, real map provider/API work, backend schema changes, contract reassignment/correction flows, hard delete/restore, bulk import/export, and production env mutation remain out of scope.
+
+### Guardrails
+
+- Contract template IDs, DB idx values, and system-template flags are never operator input fields.
+- Operators manage only name, duration/unlimited mode, description, and enabled state.
+- System templates are displayed read-only and do not expose edit/delete controls.


### PR DESCRIPTION
## Summary
- Add contract-template admin list/detail/new/edit pages and sidebar entry.
- Add service-ops client create/update/delete methods plus payload/data helpers and tests.
- Protect system templates as read-only and keep operator forms limited to human-readable fields.

## Scope controls
- Excludes telemetry/current-state and real map provider/API work.
- Does not add backend schema/API changes.
- Does not expose raw `contractTemplateId`, DB `idx`, or `systemTemplate` editable inputs.

## Validation
- git diff --check
- npm run check:workspace
- npm run lint
- npm run test:service-ops
- npm run typecheck
- npm run build
- (cd development/service-ops-api && ./gradlew test)
- (cd development/service-ops-api && ./gradlew build)
- code-reviewer PASS

Closes #79
Change-control: EVNSolution/clever-change-control#86
