### PR TITLE
Frontend operations audit log read panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Frontend ↔ backend baseline:
 - 사이드바 로그아웃은 `POST /api/v1/auth/logout` 호출을 시도한 뒤, API 실패 여부와
   관계없이 로컬 HTTP-only 쿠키를 제거합니다.
 - 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
-- 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 상세는 `/api/v1/bike-operation-status-histories`를 read-only 이력 패널로 표시합니다. 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
 - 계약 양식 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 시스템 양식은 읽기 전용으로 보호합니다.
 - 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 보험 항목 폼에는 DB/FK ID 입력칸을 두지 않습니다.
-- 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 상세는 `/api/v1/station-battery-count-logs`를 read-only 이력 패널로 표시합니다. 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.
 - 무결성 점검은 같은 service-ops 세션으로 `GET /api/v1/integrity/reference-checks`를 읽어 read-only로 표시하며, telemetry/current-state 항목은 화면 표시에서 제외합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -78,7 +78,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - access-token cookie가 없고 refresh-token cookie가 남아 있는 server action은 `/api/v1/auth/refresh`로 cookie를 회전할 수 있습니다.
 - 좌측 sidebar의 관리자 로그아웃은 `/api/v1/auth/logout`을 Bearer access token으로 호출하고, backend 호출 실패 시에도 local HTTP-only cookie를 삭제합니다.
 - 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
-- 차량 목록/상세/등록/수정/차체 상태 변경은 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경은 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다. 차량 상세의 차체 상태 변경 이력은 `/api/v1/bike-operation-status-histories`를 read-only로 조회합니다.
 - 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료는 server action/server component에서 `/api/v1/contract-templates`와 `/api/v1/rider-bike-contracts`를 호출합니다.
 - 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
@@ -86,7 +86,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 보험 목록/상세/등록/수정은 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/insurance-items`를 호출합니다. 활성 라이더 보험 연결이 있으면 삭제는 백엔드 정책에 따라 거부됩니다.
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
-- 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다. 스테이션 상세의 재고 변경 이력은 `/api/v1/station-battery-count-logs`를 read-only로 조회합니다.
 - 스테이션 폼은 이름, 주소, 좌표, 운영 상태, 수량만 다루며 `stationId`, `station_id`, `batteryStationId` 같은 직접 입력 필드를 만들지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거는 server action/server component에서 `/api/v1/equipment-types`와 `/api/v1/bike-equipments`를 호출합니다.
 - 바이크 장비 등록 폼은 차량과 장비 종류를 select로 고르게 하며 `bikeId`, `equipmentTypeId`, `equipmentId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -103,7 +103,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/dashboard` 지도 기반 관제 화면(현재 빈 지도 배경)
 - `/vehicles` 차량 목록
 - `/vehicles/new` 차량 등록
-- `/vehicles/[slug]` 차량 상세
+- `/vehicles/[slug]` 차량 상세 + 차체 상태 변경 이력
 - `/vehicles/[slug]/edit` 차량 수정
 - `/riders` 라이더 목록
 - `/riders/new` 라이더 등록
@@ -125,7 +125,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/insurance/items/[slug]/edit` 보험 항목 수정
 - `/stations` 배터리 스테이션 목록 + mock 지도 영역
 - `/stations/new` 스테이션 등록
-- `/stations/[slug]` 스테이션 상세 + 재고 수량 변경
+- `/stations/[slug]` 스테이션 상세 + 재고 수량 변경 + 재고 변경 이력
 - `/stations/[slug]/edit` 스테이션 기본 정보 수정
 - `/equipment` 장비 목록 + 장비 종류 관리
 - `/equipment/new` 바이크 장비 등록

--- a/development/front-admin-web/app/stations/[slug]/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/page.tsx
@@ -34,6 +34,7 @@ export default async function StationDetailPage({
   const station = detail.station;
   const message = status ? statusMessage[status] : null;
   const updateCountsAction = updateStationBatteryCountsAction.bind(null, station.slug);
+  const countLogs = detail.countLogs;
 
   return (
     <div className="page-container">
@@ -72,6 +73,42 @@ export default async function StationDetailPage({
           <h2>위치 카드</h2>
           <p>지도 API 없이 주소, 위도/경도, 핀 라벨({station.name} {availableLabel(station)})을 우선 준비합니다.</p>
         </aside>
+      </section>
+      <section className="card">
+        <h2>재고 변경 이력</h2>
+        {countLogs.length ? (
+          <div className="table-card">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>변경일시</th>
+                  <th>최대</th>
+                  <th>현재</th>
+                  <th>교체 가능</th>
+                  <th>사유</th>
+                  <th>메모</th>
+                </tr>
+              </thead>
+              <tbody>
+                {countLogs.map((row) => (
+                  <tr key={`${row.changedAt}-${row.availableChange}-${row.reason}`}>
+                    <td>{row.changedAt}</td>
+                    <td>{row.maxChange}</td>
+                    <td>{row.currentChange}</td>
+                    <td>{row.availableChange}</td>
+                    <td>{row.reason}</td>
+                    <td>{row.memo}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <div className="empty-state-icon">LOG</div>
+            <p>이 스테이션에 표시할 재고 변경 이력이 아직 없습니다.</p>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/development/front-admin-web/app/vehicles/[slug]/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/page.tsx
@@ -34,6 +34,7 @@ export default async function VehicleDetailPage({
   const vehicle = detail.vehicle;
   const message = status ? statusMessage[status] : null;
   const changeStatusAction = changeVehicleOperationStatusAction.bind(null, vehicle.slug);
+  const operationHistory = detail.operationHistory;
 
   return (
     <div className="page-container">
@@ -74,6 +75,40 @@ export default async function VehicleDetailPage({
             </div>
           </form>
         </aside>
+      </section>
+      <section className="card">
+        <h2>차체 상태 변경 이력</h2>
+        {operationHistory.length ? (
+          <div className="table-card">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>시작</th>
+                  <th>종료</th>
+                  <th>상태</th>
+                  <th>사유</th>
+                  <th>메모</th>
+                </tr>
+              </thead>
+              <tbody>
+                {operationHistory.map((row) => (
+                  <tr key={`${row.startedAt}-${row.statusLabel}-${row.reason}`}>
+                    <td>{row.startedAt}</td>
+                    <td>{row.endedAt}</td>
+                    <td><Badge>{row.statusLabel}</Badge></td>
+                    <td>{row.reason}</td>
+                    <td>{row.memo}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <div className="empty-state-icon">LOG</div>
+            <p>이 차량에 표시할 차체 상태 변경 이력이 아직 없습니다.</p>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -326,6 +326,50 @@ test("changeVehicleOperationStatus uses dedicated status endpoint", async () => 
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
 
+test("bike operation status history list request uses read-only history endpoint", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "99999999-9999-4999-8999-999999999999",
+              idx: 99,
+              bikeId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+              operationStatus: "INSPECTION_REQUIRED",
+              startedAt: "2026-04-30T01:00:00Z",
+              endedAt: null,
+              reason: "운영자 확인",
+              memo: "브레이크 점검",
+              changedBy: "11111111-1111-4111-8111-111111111111",
+              createdAt: "2026-04-30T01:00:00Z",
+              updatedAt: "2026-04-30T01:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listVehicleOperationStatusHistories({ page: 0, size: 20 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/bike-operation-status-histories");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "20");
+  assert.equal(calls[0].init?.method, "GET");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].bikeId, "cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+  assert.equal(page.items[0].operationStatus, "INSPECTION_REQUIRED");
+});
+
 test("contract template list request uses backend path and bearer token", async () => {
   const calls = [];
   const client = createServiceOpsApiClient({
@@ -956,6 +1000,54 @@ test("battery station create/update/count methods use dedicated backend endpoint
   assert.deepEqual(Object.keys(JSON.parse(String(calls[1].init?.body))).sort(), ["address", "latitude", "longitude", "memo", "name", "status"]);
   assert.deepEqual(Object.keys(JSON.parse(String(calls[2].init?.body))).sort(), ["availableBatteryCount", "currentBatteryCount", "maxBatteryCapacity", "memo", "reason"]);
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("station battery count log list request uses read-only count-log endpoint", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              idx: 101,
+              stationId: "55555555-5555-4555-8555-555555555555",
+              beforeMaxBatteryCapacity: 48,
+              afterMaxBatteryCapacity: 48,
+              beforeCurrentBatteryCount: 41,
+              afterCurrentBatteryCount: 38,
+              beforeAvailableBatteryCount: 31,
+              afterAvailableBatteryCount: 28,
+              reason: "출고",
+              memo: "재고 보정",
+              changedAt: "2026-04-30T02:00:00Z",
+              changedBy: "11111111-1111-4111-8111-111111111111",
+              createdAt: "2026-04-30T02:00:00Z",
+              updatedAt: "2026-04-30T02:00:00Z"
+            }
+          ],
+          page: { number: 0, size: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrevious: false }
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 }
+      );
+    }
+  });
+
+  const page = await client.listStationBatteryCountLogs({ page: 0, size: 20 });
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/station-battery-count-logs");
+  assert.equal(url.searchParams.get("page"), "0");
+  assert.equal(url.searchParams.get("size"), "20");
+  assert.equal(calls[0].init?.method, "GET");
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+  assert.equal(page.items[0].stationId, "55555555-5555-4555-8555-555555555555");
+  assert.equal(page.items[0].afterAvailableBatteryCount, 28);
 });
 
 test("invalid backend station status does not display as active", () => {

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -127,6 +127,20 @@ export type VehicleOperationStatusChangeInput = {
   memo?: string | null;
 };
 
+export type ServiceOpsBikeOperationStatusHistory = {
+  id: string;
+  idx: number | null;
+  bikeId: string;
+  operationStatus: ServiceOpsBikeOperationStatus;
+  startedAt: string;
+  endedAt: string | null;
+  reason: string | null;
+  memo: string | null;
+  changedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type ServiceOpsContractTemplate = {
   id: string;
   idx: number | null;
@@ -280,6 +294,24 @@ export type BatteryStationCountUpdateInput = {
   availableBatteryCount: number;
   reason?: string | null;
   memo?: string | null;
+};
+
+export type ServiceOpsStationBatteryCountLog = {
+  id: string;
+  idx: number | null;
+  stationId: string;
+  beforeMaxBatteryCapacity: number;
+  afterMaxBatteryCapacity: number;
+  beforeCurrentBatteryCount: number;
+  afterCurrentBatteryCount: number;
+  beforeAvailableBatteryCount: number;
+  afterAvailableBatteryCount: number;
+  reason: string | null;
+  memo: string | null;
+  changedAt: string;
+  changedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type ServiceOpsEquipmentType = {
@@ -515,6 +547,8 @@ export type ServiceOpsApiClient = {
   createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
   updateVehicle: (id: string, request: VehicleUpdateInput) => Promise<FrontendVehicle>;
   changeVehicleOperationStatus: (id: string, request: VehicleOperationStatusChangeInput) => Promise<FrontendVehicle>;
+  listVehicleOperationStatusHistories: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsBikeOperationStatusHistory>>;
+  getVehicleOperationStatusHistory: (id: string) => Promise<ServiceOpsBikeOperationStatusHistory>;
   listContractTemplates: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsContractTemplate>>;
   getContractTemplate: (id: string) => Promise<ServiceOpsContractTemplate>;
   createContractTemplate: (request: ContractTemplateCreateInput) => Promise<ServiceOpsContractTemplate>;
@@ -539,6 +573,8 @@ export type ServiceOpsApiClient = {
   createBatteryStation: (request: BatteryStationCreateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStation: (id: string, request: BatteryStationUpdateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStationCounts: (id: string, request: BatteryStationCountUpdateInput) => Promise<FrontendBatteryStation>;
+  listStationBatteryCountLogs: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsStationBatteryCountLog>>;
+  getStationBatteryCountLog: (id: string) => Promise<ServiceOpsStationBatteryCountLog>;
   listEquipmentTypes: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsEquipmentType>>;
   getEquipmentType: (id: string) => Promise<ServiceOpsEquipmentType>;
   createEquipmentType: (request: EquipmentTypeCreateInput) => Promise<ServiceOpsEquipmentType>;
@@ -712,6 +748,14 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    listVehicleOperationStatusHistories: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsBikeOperationStatusHistory>>(
+        "/bike-operation-status-histories",
+        { method: "GET" },
+        { page, size, sort }
+      ),
+    getVehicleOperationStatusHistory: (id) =>
+      request<ServiceOpsBikeOperationStatusHistory>(`/bike-operation-status-histories/${encodeURIComponent(id)}`, { method: "GET" }),
     listContractTemplates: ({ page = 0, size = 20, sort } = {}) =>
       request<ServiceOpsPage<ServiceOpsContractTemplate>>("/contract-templates", { method: "GET" }, { page, size, sort }),
     getContractTemplate: (id) =>
@@ -813,6 +857,14 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    listStationBatteryCountLogs: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsStationBatteryCountLog>>(
+        "/station-battery-count-logs",
+        { method: "GET" },
+        { page, size, sort }
+      ),
+    getStationBatteryCountLog: (id) =>
+      request<ServiceOpsStationBatteryCountLog>(`/station-battery-count-logs/${encodeURIComponent(id)}`, { method: "GET" }),
     listEquipmentTypes: ({ page = 0, size = 20, sort } = {}) =>
       request<ServiceOpsPage<ServiceOpsEquipmentType>>("/equipment-types", { method: "GET" }, { page, size, sort }),
     getEquipmentType: (id) =>

--- a/development/front-admin-web/lib/services/station-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/station-data-core.test.mjs
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  loadStationBatteryCountLogRows,
   mockStationUnconfiguredServiceDetail,
   mockStationUnavailableServiceDetail,
-  normalizeMockStation
+  normalizeMockStation,
+  toStationBatteryCountLogRows
 } from "./station-data-core.ts";
 
 const mockStations = [
@@ -42,4 +44,124 @@ test("UUID station detail falls back to visible mock detail when service API is 
   assert.equal(missingSession?.source, "mock");
   assert.equal(missingSession?.station.slug, "gangnam-station");
   assert.match(missingBaseUrl?.notice ?? "", /SERVICE_OPS_API_BASE_URL/);
+});
+
+test("station battery count log rows are filtered by internal station id without exposing raw ids", () => {
+  const rows = toStationBatteryCountLogRows(
+    [
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        idx: 101,
+        stationId: "55555555-5555-4555-8555-555555555555",
+        beforeMaxBatteryCapacity: 48,
+        afterMaxBatteryCapacity: 48,
+        beforeCurrentBatteryCount: 41,
+        afterCurrentBatteryCount: 38,
+        beforeAvailableBatteryCount: 31,
+        afterAvailableBatteryCount: 28,
+        reason: "출고",
+        memo: "재고 보정",
+        changedAt: "2026-04-30T02:00:00Z",
+        changedBy: "11111111-1111-4111-8111-111111111111",
+        createdAt: "2026-04-30T02:00:00Z",
+        updatedAt: "2026-04-30T02:00:00Z"
+      },
+      {
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        idx: 102,
+        stationId: "66666666-6666-4666-8666-666666666666",
+        beforeMaxBatteryCapacity: 20,
+        afterMaxBatteryCapacity: 20,
+        beforeCurrentBatteryCount: 10,
+        afterCurrentBatteryCount: 9,
+        beforeAvailableBatteryCount: 5,
+        afterAvailableBatteryCount: 4,
+        reason: "다른 스테이션",
+        memo: null,
+        changedAt: "2026-04-30T03:00:00Z",
+        changedBy: null,
+        createdAt: "2026-04-30T03:00:00Z",
+        updatedAt: "2026-04-30T03:00:00Z"
+      }
+    ],
+    "55555555-5555-4555-8555-555555555555"
+  );
+
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], {
+    availableChange: "31 → 28",
+    changedAt: "2026-04-30 11:00",
+    currentChange: "41 → 38",
+    maxChange: "48 → 48",
+    memo: "재고 보정",
+    reason: "출고"
+  });
+  assert.equal("id" in rows[0], false);
+  assert.equal("idx" in rows[0], false);
+  assert.equal("stationId" in rows[0], false);
+  assert.equal("changedBy" in rows[0], false);
+});
+
+test("station battery count log loader scans later pages before declaring empty history", async () => {
+  const requests = [];
+  const rows = await loadStationBatteryCountLogRows(
+    async (params) => {
+      requests.push(params);
+      if (params.page === 0) {
+        return {
+          items: [
+            {
+              id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+              idx: 102,
+              stationId: "66666666-6666-4666-8666-666666666666",
+              beforeMaxBatteryCapacity: 20,
+              afterMaxBatteryCapacity: 20,
+              beforeCurrentBatteryCount: 10,
+              afterCurrentBatteryCount: 9,
+              beforeAvailableBatteryCount: 5,
+              afterAvailableBatteryCount: 4,
+              reason: "다른 스테이션",
+              memo: null,
+              changedAt: "2026-04-30T03:00:00Z",
+              changedBy: null,
+              createdAt: "2026-04-30T03:00:00Z",
+              updatedAt: "2026-04-30T03:00:00Z"
+            }
+          ],
+          page: { hasNext: true, hasPrevious: false, number: 0, size: 100, totalItems: 2, totalPages: 2 }
+        };
+      }
+
+      return {
+        items: [
+          {
+            id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            idx: 101,
+            stationId: "55555555-5555-4555-8555-555555555555",
+            beforeMaxBatteryCapacity: 48,
+            afterMaxBatteryCapacity: 48,
+            beforeCurrentBatteryCount: 41,
+            afterCurrentBatteryCount: 38,
+            beforeAvailableBatteryCount: 31,
+            afterAvailableBatteryCount: 28,
+            reason: "출고",
+            memo: "재고 보정",
+            changedAt: "2026-04-30T02:00:00Z",
+            changedBy: null,
+            createdAt: "2026-04-30T02:00:00Z",
+            updatedAt: "2026-04-30T02:00:00Z"
+          }
+        ],
+        page: { hasNext: false, hasPrevious: true, number: 1, size: 100, totalItems: 2, totalPages: 2 }
+      };
+    },
+    "55555555-5555-4555-8555-555555555555"
+  );
+
+  assert.deepEqual(requests, [
+    { page: 0, size: 100, sort: "idx,desc" },
+    { page: 1, size: 100, sort: "idx,desc" }
+  ]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].availableChange, "31 → 28");
 });

--- a/development/front-admin-web/lib/services/station-data-core.ts
+++ b/development/front-admin-web/lib/services/station-data-core.ts
@@ -1,4 +1,24 @@
 import type { BatteryStation } from "@/types/domain";
+import type { ServiceOpsPage, ServiceOpsStationBatteryCountLog } from "./service-ops-api";
+
+const AUDIT_LOG_PAGE_SIZE = 100;
+const AUDIT_LOG_ROW_LIMIT = 20;
+const AUDIT_LOG_SORT = "idx,desc";
+
+type StationBatteryCountLogPageLoader = (params: {
+  page: number;
+  size: number;
+  sort: string;
+}) => Promise<ServiceOpsPage<ServiceOpsStationBatteryCountLog>>;
+
+export type StationBatteryCountLogRow = {
+  changedAt: string;
+  maxChange: string;
+  currentChange: string;
+  availableChange: string;
+  reason: string;
+  memo: string;
+};
 
 export type StationDataResult = {
   source: "mock" | "service-ops";
@@ -9,6 +29,7 @@ export type StationDataResult = {
 export type StationDetailResult = {
   source: "mock" | "service-ops";
   station: BatteryStation;
+  countLogs: StationBatteryCountLogRow[];
   notice?: string;
 };
 
@@ -27,6 +48,7 @@ export function mockStationDetail(slug: string, mockStations: BatteryStation[]):
 
   return {
     source: "mock",
+    countLogs: [],
     station: normalizeMockStation(station)
   };
 }
@@ -46,6 +68,7 @@ export function mockStationUnavailableServiceDetail(
   }
 
   return {
+    countLogs: [],
     notice,
     source: "mock",
     station: normalizeMockStation(mockStations[0])
@@ -88,4 +111,60 @@ function calculateCapacityPercentage(currentBatteryCount: number, maxBatteryCapa
   }
 
   return Math.round((currentBatteryCount * 100) / maxBatteryCapacity);
+}
+
+export function toStationBatteryCountLogRows(
+  logs: ServiceOpsStationBatteryCountLog[],
+  stationId: string
+): StationBatteryCountLogRow[] {
+  return logs
+    .filter((log) => log.stationId === stationId)
+    .sort((left, right) => Date.parse(right.changedAt) - Date.parse(left.changedAt))
+    .map((log) => ({
+      availableChange: formatCountChange(log.beforeAvailableBatteryCount, log.afterAvailableBatteryCount),
+      changedAt: formatKstMinute(log.changedAt),
+      currentChange: formatCountChange(log.beforeCurrentBatteryCount, log.afterCurrentBatteryCount),
+      maxChange: formatCountChange(log.beforeMaxBatteryCapacity, log.afterMaxBatteryCapacity),
+      memo: log.memo?.trim() || "없음",
+      reason: log.reason?.trim() || "사유 없음"
+    }));
+}
+
+export async function loadStationBatteryCountLogRows(
+  loadPage: StationBatteryCountLogPageLoader,
+  stationId: string,
+  limit = AUDIT_LOG_ROW_LIMIT
+): Promise<StationBatteryCountLogRow[]> {
+  const rows: StationBatteryCountLogRow[] = [];
+  let page = 0;
+
+  while (rows.length < limit) {
+    const response = await loadPage({
+      page,
+      size: AUDIT_LOG_PAGE_SIZE,
+      sort: AUDIT_LOG_SORT
+    });
+    rows.push(...toStationBatteryCountLogRows(response.items, stationId));
+
+    if (!response.page.hasNext) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return rows.slice(0, limit);
+}
+
+function formatCountChange(before: number, after: number): string {
+  return `${before} → ${after}`;
+}
+
+function formatKstMinute(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Date(date.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 16).replace("T", " ");
 }

--- a/development/front-admin-web/lib/services/station-data.ts
+++ b/development/front-admin-web/lib/services/station-data.ts
@@ -8,6 +8,7 @@ import {
   type StationDataResult,
   type StationDetailResult,
   isUuidLike,
+  loadStationBatteryCountLogRows,
   mockStationDetail,
   mockStationList,
   mockStationUnconfiguredServiceDetail,
@@ -63,7 +64,20 @@ export async function loadStationDetail(slug: string): Promise<StationDetailResu
 
     try {
       const station = await client.getBatteryStation(slug);
-      return { source: "service-ops", station };
+      try {
+        return {
+          countLogs: await loadStationBatteryCountLogRows(client.listStationBatteryCountLogs, station.id ?? station.slug),
+          source: "service-ops",
+          station
+        };
+      } catch (error) {
+        return {
+          countLogs: [],
+          notice: `서비스 API 스테이션 상세는 조회했지만 재고 이력 조회에 실패했습니다.${formatServiceOpsError(error)}`,
+          source: "service-ops",
+          station
+        };
+      }
     } catch (error) {
       return mockStationUnavailableServiceDetail(
         slug,

--- a/development/front-admin-web/lib/services/vehicle-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/vehicle-data-core.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { mockVehicleUnconfiguredServiceDetail, mockVehicleUnavailableServiceDetail } from "./vehicle-data-core.ts";
+import {
+  loadVehicleOperationHistoryRows,
+  mockVehicleUnconfiguredServiceDetail,
+  mockVehicleUnavailableServiceDetail,
+  toVehicleOperationHistoryRows
+} from "./vehicle-data-core.ts";
 
 const mockVehicles = [
   {
@@ -38,4 +43,107 @@ test("UUID vehicle detail falls back to visible mock detail when service API bas
 
 test("non-UUID missing vehicle detail does not fabricate a fallback", () => {
   assert.equal(mockVehicleUnavailableServiceDetail("missing-slug", mockVehicles, "notice"), null);
+});
+
+test("vehicle operation history rows are filtered by internal bike id without exposing raw ids", () => {
+  const rows = toVehicleOperationHistoryRows(
+    [
+      {
+        id: "99999999-9999-4999-8999-999999999999",
+        idx: 99,
+        bikeId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        operationStatus: "INSPECTION_REQUIRED",
+        startedAt: "2026-04-30T01:00:00Z",
+        endedAt: null,
+        reason: "운영자 확인",
+        memo: "브레이크 점검",
+        changedBy: "11111111-1111-4111-8111-111111111111",
+        createdAt: "2026-04-30T01:00:00Z",
+        updatedAt: "2026-04-30T01:00:00Z"
+      },
+      {
+        id: "88888888-8888-4888-8888-888888888888",
+        idx: 100,
+        bikeId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        operationStatus: "READY",
+        startedAt: "2026-04-29T01:00:00Z",
+        endedAt: "2026-04-29T02:00:00Z",
+        reason: "다른 차량",
+        memo: null,
+        changedBy: null,
+        createdAt: "2026-04-29T01:00:00Z",
+        updatedAt: "2026-04-29T02:00:00Z"
+      }
+    ],
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  );
+
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], {
+    endedAt: "진행 중",
+    memo: "브레이크 점검",
+    reason: "운영자 확인",
+    startedAt: "2026-04-30 10:00",
+    statusLabel: "점검 필요"
+  });
+  assert.equal("id" in rows[0], false);
+  assert.equal("idx" in rows[0], false);
+  assert.equal("bikeId" in rows[0], false);
+  assert.equal("changedBy" in rows[0], false);
+});
+
+test("vehicle operation history loader scans later pages before declaring empty history", async () => {
+  const requests = [];
+  const rows = await loadVehicleOperationHistoryRows(
+    async (params) => {
+      requests.push(params);
+      if (params.page === 0) {
+        return {
+          items: [
+            {
+              id: "88888888-8888-4888-8888-888888888888",
+              idx: 100,
+              bikeId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+              operationStatus: "READY",
+              startedAt: "2026-04-29T01:00:00Z",
+              endedAt: null,
+              reason: "다른 차량",
+              memo: null,
+              changedBy: null,
+              createdAt: "2026-04-29T01:00:00Z",
+              updatedAt: "2026-04-29T01:00:00Z"
+            }
+          ],
+          page: { hasNext: true, hasPrevious: false, number: 0, size: 100, totalItems: 2, totalPages: 2 }
+        };
+      }
+
+      return {
+        items: [
+          {
+            id: "99999999-9999-4999-8999-999999999999",
+            idx: 99,
+            bikeId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            operationStatus: "IN_SERVICE",
+            startedAt: "2026-04-30T00:00:00Z",
+            endedAt: null,
+            reason: "운영 투입",
+            memo: "오전 교대",
+            changedBy: null,
+            createdAt: "2026-04-30T00:00:00Z",
+            updatedAt: "2026-04-30T00:00:00Z"
+          }
+        ],
+        page: { hasNext: false, hasPrevious: true, number: 1, size: 100, totalItems: 2, totalPages: 2 }
+      };
+    },
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  );
+
+  assert.deepEqual(requests, [
+    { page: 0, size: 100, sort: "idx,desc" },
+    { page: 1, size: 100, sort: "idx,desc" }
+  ]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].statusLabel, "운행 중");
 });

--- a/development/front-admin-web/lib/services/vehicle-data-core.ts
+++ b/development/front-admin-web/lib/services/vehicle-data-core.ts
@@ -1,4 +1,27 @@
-import type { FrontendVehicle } from "./service-ops-api";
+import type {
+  FrontendVehicle,
+  ServiceOpsBikeOperationStatus,
+  ServiceOpsBikeOperationStatusHistory,
+  ServiceOpsPage
+} from "./service-ops-api";
+
+const AUDIT_HISTORY_PAGE_SIZE = 100;
+const AUDIT_HISTORY_ROW_LIMIT = 20;
+const AUDIT_HISTORY_SORT = "idx,desc";
+
+type VehicleOperationHistoryPageLoader = (params: {
+  page: number;
+  size: number;
+  sort: string;
+}) => Promise<ServiceOpsPage<ServiceOpsBikeOperationStatusHistory>>;
+
+export type VehicleOperationHistoryRow = {
+  statusLabel: FrontendVehicle["status"];
+  startedAt: string;
+  endedAt: string;
+  reason: string;
+  memo: string;
+};
 
 export type VehicleDataResult = {
   source: "mock" | "service-ops";
@@ -9,6 +32,7 @@ export type VehicleDataResult = {
 export type VehicleDetailResult = {
   source: "mock" | "service-ops";
   vehicle: FrontendVehicle;
+  operationHistory: VehicleOperationHistoryRow[];
   notice?: string;
 };
 
@@ -28,6 +52,7 @@ export function mockVehicleDetail(slug: string, mockVehicles: FrontendVehicle[])
 
   return {
     source: "mock",
+    operationHistory: [],
     vehicle: { ...vehicle, source: "mock" }
   };
 }
@@ -48,6 +73,7 @@ export function mockVehicleUnavailableServiceDetail(
 
   return {
     notice,
+    operationHistory: [],
     source: "mock",
     vehicle: { ...mockVehicles[0], source: "mock" }
   };
@@ -63,4 +89,68 @@ export function mockVehicleUnconfiguredServiceDetail(slug: string, mockVehicles:
 
 export function isUuidLike(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function toVehicleOperationHistoryRows(
+  histories: ServiceOpsBikeOperationStatusHistory[],
+  vehicleId: string
+): VehicleOperationHistoryRow[] {
+  return histories
+    .filter((history) => history.bikeId === vehicleId)
+    .sort((left, right) => Date.parse(right.startedAt) - Date.parse(left.startedAt))
+    .map((history) => ({
+      endedAt: history.endedAt ? formatKstMinute(history.endedAt) : "진행 중",
+      memo: history.memo?.trim() || "없음",
+      reason: history.reason?.trim() || "사유 없음",
+      startedAt: formatKstMinute(history.startedAt),
+      statusLabel: toVehicleStatusLabel(history.operationStatus)
+    }));
+}
+
+export async function loadVehicleOperationHistoryRows(
+  loadPage: VehicleOperationHistoryPageLoader,
+  vehicleId: string,
+  limit = AUDIT_HISTORY_ROW_LIMIT
+): Promise<VehicleOperationHistoryRow[]> {
+  const rows: VehicleOperationHistoryRow[] = [];
+  let page = 0;
+
+  while (rows.length < limit) {
+    const response = await loadPage({
+      page,
+      size: AUDIT_HISTORY_PAGE_SIZE,
+      sort: AUDIT_HISTORY_SORT
+    });
+    rows.push(...toVehicleOperationHistoryRows(response.items, vehicleId));
+
+    if (!response.page.hasNext) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return rows.slice(0, limit);
+}
+
+function toVehicleStatusLabel(status: ServiceOpsBikeOperationStatus): FrontendVehicle["status"] {
+  switch (status) {
+    case "IN_SERVICE":
+      return "운행 중";
+    case "REPAIRING":
+      return "수리";
+    case "INSPECTION_REQUIRED":
+      return "점검 필요";
+    case "READY":
+      return "대기";
+  }
+}
+
+function formatKstMinute(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Date(date.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 16).replace("T", " ");
 }

--- a/development/front-admin-web/lib/services/vehicle-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-data.ts
@@ -8,6 +8,7 @@ import {
   type VehicleDataResult,
   type VehicleDetailResult,
   isUuidLike,
+  loadVehicleOperationHistoryRows,
   mockVehicleDetail,
   mockVehicleList,
   mockVehicleUnconfiguredServiceDetail,
@@ -63,7 +64,20 @@ export async function loadVehicleDetail(slug: string): Promise<VehicleDetailResu
 
     try {
       const vehicle = await client.getVehicle(slug);
-      return { source: "service-ops", vehicle };
+      try {
+        return {
+          operationHistory: await loadVehicleOperationHistoryRows(client.listVehicleOperationStatusHistories, vehicle.id ?? vehicle.slug),
+          source: "service-ops",
+          vehicle
+        };
+      } catch (error) {
+        return {
+          notice: `서비스 API 차량 상세는 조회했지만 상태 이력 조회에 실패했습니다.${formatServiceOpsError(error)}`,
+          operationHistory: [],
+          source: "service-ops",
+          vehicle
+        };
+      }
     } catch (error) {
       return mockVehicleUnavailableServiceDetail(
         slug,

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -906,3 +906,32 @@ Add a dedicated admin UI for insurance item management on top of the existing se
 - Insurance item IDs and DB idx values are never operator input fields.
 - Operators manage only name, description, and enabled state.
 - Soft-delete is exposed as 비활성 삭제 and backend active-link protection remains authoritative.
+
+## Frontend operations audit log read panels
+
+- Date: 2026-04-30
+- Change-control issue: EVNSolution/clever-change-control#88
+- Target issue: EVNSolution/thundercrew-domain#83
+- Branch: `cc-88-operations-audit-log-panels`
+
+### Decision
+
+Expose existing service-ops read-only operational history APIs on the relevant admin detail pages.
+
+### Included
+
+- Frontend service client read methods for `/api/v1/bike-operation-status-histories` and `/api/v1/station-battery-count-logs`.
+- Vehicle detail read-only 차체 상태 변경 이력 panel.
+- Battery station detail read-only 재고 변경 이력 panel.
+- Data helpers/tests that filter by the current internal UUID while returning display rows that omit raw IDs, DB `idx`, and actor UUID fields.
+- README updates for the frontend/backend bridge metadata.
+
+### Excluded
+
+- Telemetry/current-state work, real map provider/API work, device API sync logs, new backend schema/API changes, new write commands, and production env mutation remain out of scope.
+
+### Guardrails
+
+- History UUIDs, FK UUIDs, DB `idx`, and `changedBy` are service-owned metadata and are not displayed or editable in the panels.
+- History loaders request deterministic `idx,desc` pages and keep scanning until 20 matching rows are collected or the backend reports no next page, so the first global page cannot silently hide later matching rows.
+- If the detail entity is available but the history endpoint fails, the detail page remains usable with an explicit notice and an empty read-only history panel.


### PR DESCRIPTION
## Summary

- Add read-only vehicle operation-status history on vehicle detail.
- Add read-only station battery-count log history on station detail.
- Add service-ops client methods and data helpers for the existing history endpoints.
- Scan deterministic `idx,desc` pages until enough matching rows are collected so later-page rows are not silently missed.

## Change-control

- Change-control: EVNSolution/clever-change-control#88
- Target: Closes EVNSolution/thundercrew-domain#83

## Scope boundaries

- Excludes telemetry/current-state, real map provider/API, device API sync logs, backend schema/API changes, and new write commands.
- Does not display/edit raw history UUIDs, FK UUIDs, DB idx, or changedBy in audit rows.

## Verification

- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (100/100)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- code-reviewer re-review PASS
