### PR TITLE
Frontend soft-delete operation actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Frontend ↔ backend baseline:
   `POST /api/v1/auth/refresh`로 세션 쿠키를 회전할 수 있습니다.
 - 사이드바 로그아웃은 `POST /api/v1/auth/logout` 호출을 시도한 뒤, API 실패 여부와
   관계없이 로컬 HTTP-only 쿠키를 제거합니다.
-- 라이더 목록/상세/등록/수정 server action은 해당 쿠키에서 Bearer token을 붙입니다.
-- 차량 목록/상세/등록/수정/차체 상태 변경 server action도 같은 service-ops 세션을 사용하며, 차량 상세는 `/api/v1/bike-operation-status-histories`를 read-only 이력 패널로 표시합니다. 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
+- 라이더 목록/상세/등록/수정/비활성 삭제 server action은 해당 쿠키에서 Bearer token을 붙입니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 차량 상세는 `/api/v1/bike-operation-status-histories`를 read-only 이력 패널로 표시합니다. 차량 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료 server action도 같은 service-ops 세션을 사용하며, 계약 폼은 라이더/차량/계약양식을 사람이 읽을 수 있는 select로 연결합니다.
 - 계약 양식 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 시스템 양식은 읽기 전용으로 보호합니다.
-- 보험 목록/상세/등록/수정 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
+- 보험 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 보험 항목 폼에는 DB/FK ID 입력칸을 두지 않습니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 상세는 `/api/v1/station-battery-count-logs`를 read-only 이력 패널로 표시합니다. 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -77,13 +77,13 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - access/refresh token은 localStorage, URL, rendered HTML, editable form field에 두지 않고 HTTP-only cookie로 저장합니다.
 - access-token cookie가 없고 refresh-token cookie가 남아 있는 server action은 `/api/v1/auth/refresh`로 cookie를 회전할 수 있습니다.
 - 좌측 sidebar의 관리자 로그아웃은 `/api/v1/auth/logout`을 Bearer access token으로 호출하고, backend 호출 실패 시에도 local HTTP-only cookie를 삭제합니다.
-- 라이더 목록/상세/등록/수정은 server action/server component에서 `/api/v1/riders`를 호출합니다.
-- 차량 목록/상세/등록/수정/차체 상태 변경은 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다. 차량 상세의 차체 상태 변경 이력은 `/api/v1/bike-operation-status-histories`를 read-only로 조회합니다.
+- 라이더 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/riders`를 호출합니다.
+- 차량 목록/상세/등록/수정/차체 상태 변경/비활성 삭제는 server action/server component에서 `/api/v1/bikes`와 `/api/v1/bikes/{id}/operation-status`를 호출합니다. 차량 상세의 차체 상태 변경 이력은 `/api/v1/bike-operation-status-histories`를 read-only로 조회합니다.
 - 차량 기본 정보 폼은 차량번호, VIN, 모델, 메모와 상태 선택만 다루며 `bikeId`, `vehicle_id`, `riderId`, `deviceId` 같은 직접 입력 필드를 만들지 않습니다.
 - 계약 목록/상세/등록/메모 수정/종료는 server action/server component에서 `/api/v1/contract-templates`와 `/api/v1/rider-bike-contracts`를 호출합니다.
 - 계약 등록 폼은 라이더, 차량, 계약 양식을 select로 고르게 하며 `contractId`, `riderId`, `bikeId`, `contractTemplateId` 같은 직접 입력 필드를 만들지 않습니다. 종료일은 선택한 계약 양식의 기간으로 백엔드가 계산합니다.
 - 계약 양식 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/contract-templates`를 호출합니다. 시스템 계약 양식은 UI에서 읽기 전용으로 보호합니다.
-- 보험 목록/상세/등록/수정은 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
+- 보험 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/insurance-items`를 호출합니다. 활성 라이더 보험 연결이 있으면 삭제는 백엔드 정책에 따라 거부됩니다.
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
 - 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다. 스테이션 상세의 재고 변경 이력은 `/api/v1/station-battery-count-logs`를 read-only로 조회합니다.
@@ -103,11 +103,11 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/dashboard` 지도 기반 관제 화면(현재 빈 지도 배경)
 - `/vehicles` 차량 목록
 - `/vehicles/new` 차량 등록
-- `/vehicles/[slug]` 차량 상세 + 차체 상태 변경 이력
+- `/vehicles/[slug]` 차량 상세 + 차체 상태 변경 이력 + 비활성 삭제
 - `/vehicles/[slug]/edit` 차량 수정
 - `/riders` 라이더 목록
 - `/riders/new` 라이더 등록
-- `/riders/[slug]` 라이더 상세
+- `/riders/[slug]` 라이더 상세 + 비활성 삭제
 - `/riders/[slug]/edit` 라이더 수정
 - `/contracts` 계약 목록
 - `/contracts/new` 계약 등록
@@ -118,7 +118,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/contract-templates/[slug]/edit` 계약 양식 수정
 - `/insurance` 보험 목록
 - `/insurance/new` 보험 등록
-- `/insurance/[slug]` 보험 상세
+- `/insurance/[slug]` 보험 상세 + 비활성 삭제
 - `/insurance/items` 보험 항목 목록
 - `/insurance/items/new` 보험 항목 등록
 - `/insurance/items/[slug]` 보험 항목 상세 + 비활성 삭제

--- a/development/front-admin-web/app/insurance/[slug]/page.tsx
+++ b/development/front-admin-web/app/insurance/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { updateInsuranceAction } from "@/app/insurance/actions";
+import { deleteInsuranceAction, updateInsuranceAction } from "@/app/insurance/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
@@ -9,6 +9,8 @@ import { loadInsuranceDetail } from "@/lib/services/insurance-data";
 
 const statusMessage: Record<string, string> = {
   created: "보험 연결이 등록되었습니다.",
+  "delete-error": "보험 연결 비활성 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-updated": "서비스 API가 연결되지 않아 보험 수정 요청을 mock 피드백으로만 처리했습니다.",
   "save-error": "보험 수정에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
   updated: "보험 연결 정보가 수정되었습니다."
@@ -31,6 +33,7 @@ export default async function InsuranceDetailPage({
   const policy = detail.policy;
   const message = status ? statusMessage[status] : null;
   const updateAction = updateInsuranceAction.bind(null, slug);
+  const deleteAction = deleteInsuranceAction.bind(null, slug);
 
   return (
     <div className="page-container">
@@ -67,6 +70,11 @@ export default async function InsuranceDetailPage({
             <p className="notice">보험 연결 수정은 현재 상세 대상에만 적용됩니다. 라이더/보험 항목 ID를 직접 입력하지 않습니다.</p>
             <div className="form-actions">
               <button className="button-primary" type="submit">변경 저장</button>
+            </div>
+          </form>
+          <form action={deleteAction} className="action-panel">
+            <div className="form-actions">
+              <button className="button-secondary" type="submit">보험 연결 비활성 삭제</button>
             </div>
           </form>
         </aside>

--- a/development/front-admin-web/app/insurance/actions.ts
+++ b/development/front-admin-web/app/insurance/actions.ts
@@ -52,3 +52,23 @@ export async function updateInsuranceAction(policyId: string, formData: FormData
   revalidatePath(`/insurance/${policy.id}`);
   redirect(`/insurance/${policy.id}?status=updated`);
 }
+
+export async function deleteInsuranceAction(policyId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/insurance/${policyId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteRiderInsurance(policyId);
+  } catch {
+    redirect(`/insurance/${policyId}?status=delete-error`);
+  }
+
+  revalidatePath("/insurance");
+  redirect("/insurance?status=deleted");
+}

--- a/development/front-admin-web/app/insurance/page.tsx
+++ b/development/front-admin-web/app/insurance/page.tsx
@@ -7,6 +7,7 @@ import { loadInsuranceList } from "@/lib/services/insurance-data";
 
 const statusMessage: Record<string, string> = {
   created: "보험 연결이 등록되었습니다.",
+  deleted: "보험 연결이 비활성 삭제 처리되었습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
   updated: "보험 연결 정보가 수정되었습니다."
 };

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -1,12 +1,15 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { deleteRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
 import { loadRiderDetail } from "@/lib/services/rider-data";
 
 const statusMessage: Record<string, string> = {
   created: "라이더가 등록되었습니다.",
+  "delete-error": "라이더 비활성 삭제에 실패했습니다. 활성 계약/보험 연결이나 백엔드 연결 상태를 확인하세요.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 없이 mock 상세로 돌아왔습니다.",
   updated: "라이더 정보가 수정되었습니다."
 };
@@ -25,8 +28,9 @@ export default async function RiderDetailPage({
     notFound();
   }
 
-  const { contracts, insurance, notice, rider, source } = detail;
+  const { contracts, insurance, notice, rider } = detail;
   const message = status ? statusMessage[status] : null;
+  const deleteAction = deleteRiderAction.bind(null, rider.slug);
 
   return (
     <div className="page-container">
@@ -57,9 +61,12 @@ export default async function RiderDetailPage({
           </div>
         </div>
         <aside className="detail-panel">
-          <h2>연결 방식</h2>
-          <p>계약/보험 연결은 라이더 이름과 연락처 기준 선택 UI를 통해 진행합니다. rider_id 입력 필드는 만들지 않습니다.</p>
-          <p className="notice">현재 데이터 소스: {source === "service-ops" ? "service-ops-api" : "mock"}</p>
+          <h2>작업</h2>
+          <form action={deleteAction} className="action-panel">
+            <div className="form-actions">
+              <button className="button-secondary" type="submit">라이더 비활성 삭제</button>
+            </div>
+          </form>
         </aside>
       </section>
     </div>

--- a/development/front-admin-web/app/riders/actions.ts
+++ b/development/front-admin-web/app/riders/actions.ts
@@ -49,6 +49,26 @@ export async function updateRiderAction(riderId: string, formData: FormData): Pr
   redirect(`/riders/${rider.slug}?status=updated`);
 }
 
+export async function deleteRiderAction(riderId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteRider(riderId);
+  } catch {
+    redirect(`/riders/${riderId}?status=delete-error`);
+  }
+
+  revalidatePath("/riders");
+  redirect("/riders?status=deleted");
+}
+
 function toRiderPayload(formData: FormData): RiderCreateInput {
   return {
     areaName: optionalText(formData.get("areaName")),

--- a/development/front-admin-web/app/riders/page.tsx
+++ b/development/front-admin-web/app/riders/page.tsx
@@ -8,6 +8,7 @@ import { mockRiderConnections, loadRiderList } from "@/lib/services/rider-data";
 const statusMessage: Record<string, string> = {
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
   created: "라이더가 등록되었습니다.",
+  deleted: "라이더가 비활성 삭제 처리되었습니다.",
   updated: "라이더 정보가 수정되었습니다."
 };
 

--- a/development/front-admin-web/app/vehicles/[slug]/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { changeVehicleOperationStatusAction } from "@/app/vehicles/actions";
+import { changeVehicleOperationStatusAction, deleteVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { vehicleStatusOptions } from "@/components/vehicles/VehicleForm";
 import { Badge } from "@/components/ui/Badge";
@@ -10,6 +10,8 @@ import { loadVehicleDetail } from "@/lib/services/vehicle-data";
 
 const statusMessage: Record<string, string> = {
   created: "차량이 등록되었습니다.",
+  "delete-error": "차량 비활성 삭제에 실패했습니다. 활성 배정/장비/단말 연결이나 백엔드 연결 상태를 확인하세요.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   updated: "차량 기본 정보가 수정되었습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 mock 차량 화면으로 돌아왔습니다.",
   "mock-status-updated": "서비스 API가 연결되지 않아 상태 변경을 mock 피드백으로만 처리했습니다.",
@@ -34,6 +36,7 @@ export default async function VehicleDetailPage({
   const vehicle = detail.vehicle;
   const message = status ? statusMessage[status] : null;
   const changeStatusAction = changeVehicleOperationStatusAction.bind(null, vehicle.slug);
+  const deleteAction = deleteVehicleAction.bind(null, vehicle.slug);
   const operationHistory = detail.operationHistory;
 
   return (
@@ -74,6 +77,14 @@ export default async function VehicleDetailPage({
               <button className="button-primary" type="submit">상태 변경</button>
             </div>
           </form>
+          <div className="detail-section">
+            <h2>비활성 삭제</h2>
+            <form action={deleteAction} className="action-panel">
+              <div className="form-actions">
+                <button className="button-secondary" type="submit">차량 비활성 삭제</button>
+              </div>
+            </form>
+          </div>
         </aside>
       </section>
       <section className="card">

--- a/development/front-admin-web/app/vehicles/actions.ts
+++ b/development/front-admin-web/app/vehicles/actions.ts
@@ -56,6 +56,26 @@ export async function updateVehicleAction(vehicleId: string, formData: FormData)
   redirect(`/vehicles/${vehicle.slug}?status=updated`);
 }
 
+export async function deleteVehicleAction(vehicleId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/vehicles/${vehicleId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteVehicle(vehicleId);
+  } catch {
+    redirect(`/vehicles/${vehicleId}?status=delete-error`);
+  }
+
+  revalidatePath("/vehicles");
+  redirect("/vehicles?status=deleted");
+}
+
 export async function changeVehicleOperationStatusAction(vehicleId: string, formData: FormData): Promise<void> {
   if (!serviceOpsApiConfigured()) {
     redirect(`/vehicles/${vehicleId}?status=mock-status-updated`);

--- a/development/front-admin-web/app/vehicles/page.tsx
+++ b/development/front-admin-web/app/vehicles/page.tsx
@@ -8,6 +8,7 @@ import { loadVehicleList } from "@/lib/services/vehicle-data";
 const statusMessage: Record<string, string> = {
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
   created: "차량이 등록되었습니다.",
+  deleted: "차량이 비활성 삭제 처리되었습니다.",
   updated: "차량 기본 정보가 수정되었습니다.",
   "status-updated": "차량 차체 상태가 변경되었습니다."
 };

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -110,6 +110,27 @@ test("createRider sends only operator-editable fields", async () => {
   assert.deepEqual(Object.keys(requestBody).sort(), ["areaName", "memo", "name", "phoneNumber", "teamName"]);
 });
 
+test("deleteRider uses soft-delete endpoint without request body", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }
+  });
+
+  await client.deleteRider("55555555-5555-4555-8555-555555555555");
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/riders/55555555-5555-4555-8555-555555555555");
+  assert.equal(calls[0].init?.method, "DELETE");
+  assert.equal("body" in calls[0].init, false);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
 test("HTTP error responses throw ServiceOpsApiError with status and backend code", async () => {
   const client = createServiceOpsApiClient({
     baseUrl: "http://localhost:8080",
@@ -237,6 +258,27 @@ test("createVehicle sends only operator-editable bike fields", async () => {
   assert.equal("bikeId" in requestBody, false);
   assert.equal("riderId" in requestBody, false);
   assert.equal("deviceId" in requestBody, false);
+});
+
+test("deleteVehicle uses bike soft-delete endpoint without relationship fields", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }
+  });
+
+  await client.deleteVehicle("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/bikes/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  assert.equal(calls[0].init?.method, "DELETE");
+  assert.equal("body" in calls[0].init, false);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
 
 
@@ -869,6 +911,27 @@ test("rider insurance create/update use dedicated insurance endpoints", async ()
   assert.deepEqual(calls.map((call) => call.init?.method), ["POST", "PATCH"]);
   assert.deepEqual(Object.keys(JSON.parse(String(calls[0].init?.body))).sort(), ["enabled", "insuranceItemId", "memo", "riderId"]);
   assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { enabled: false, memo: "비활성 전환" });
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
+test("deleteRiderInsurance uses dedicated soft-delete endpoint without selector ids", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }
+  });
+
+  await client.deleteRiderInsurance("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/rider-insurances/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+  assert.equal(calls[0].init?.method, "DELETE");
+  assert.equal("body" in calls[0].init, false);
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
 

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -546,6 +546,7 @@ export type ServiceOpsApiClient = {
   getVehicle: (id: string) => Promise<FrontendVehicle>;
   createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
   updateVehicle: (id: string, request: VehicleUpdateInput) => Promise<FrontendVehicle>;
+  deleteVehicle: (id: string) => Promise<void>;
   changeVehicleOperationStatus: (id: string, request: VehicleOperationStatusChangeInput) => Promise<FrontendVehicle>;
   listVehicleOperationStatusHistories: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsBikeOperationStatusHistory>>;
   getVehicleOperationStatusHistory: (id: string) => Promise<ServiceOpsBikeOperationStatusHistory>;
@@ -568,6 +569,7 @@ export type ServiceOpsApiClient = {
   getRiderInsurance: (id: string) => Promise<ServiceOpsRiderInsurance>;
   createRiderInsurance: (request: RiderInsuranceCreateInput) => Promise<ServiceOpsRiderInsurance>;
   updateRiderInsurance: (id: string, request: RiderInsuranceUpdateInput) => Promise<ServiceOpsRiderInsurance>;
+  deleteRiderInsurance: (id: string) => Promise<void>;
   listBatteryStations: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendBatteryStation>>;
   getBatteryStation: (id: string) => Promise<FrontendBatteryStation>;
   createBatteryStation: (request: BatteryStationCreateInput) => Promise<FrontendBatteryStation>;
@@ -598,6 +600,7 @@ export type ServiceOpsApiClient = {
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
   updateRider: (id: string, request: RiderUpdateInput) => Promise<FrontendRider>;
+  deleteRider: (id: string) => Promise<void>;
 };
 
 type ServiceOpsApiOptions = {
@@ -741,6 +744,9 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    deleteVehicle: async (id) => {
+      await request<void>(`/bikes/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     changeVehicleOperationStatus: async (id, statusRequest) =>
       toFrontendVehicle(
         await request<ServiceOpsBike>(`/bikes/${encodeURIComponent(id)}/operation-status`, {
@@ -823,6 +829,9 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify(updateRequest),
         method: "PATCH"
       }),
+    deleteRiderInsurance: async (id) => {
+      await request<void>(`/rider-insurances/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     listBatteryStations: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsBatteryStation>>(
         "/battery-stations",
@@ -953,7 +962,10 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           body: JSON.stringify(updateRequest),
           method: "PATCH"
         })
-      )
+      ),
+    deleteRider: async (id) => {
+      await request<void>(`/riders/${encodeURIComponent(id)}`, { method: "DELETE" });
+    }
   };
 }
 

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -935,3 +935,32 @@ Expose existing service-ops read-only operational history APIs on the relevant a
 - History UUIDs, FK UUIDs, DB `idx`, and `changedBy` are service-owned metadata and are not displayed or editable in the panels.
 - History loaders request deterministic `idx,desc` pages and keep scanning until 20 matching rows are collected or the backend reports no next page, so the first global page cannot silently hide later matching rows.
 - If the detail entity is available but the history endpoint fails, the detail page remains usable with an explicit notice and an empty read-only history panel.
+
+## Frontend soft-delete operation actions
+
+- Date: 2026-04-30
+- Change-control issue: EVNSolution/clever-change-control#89
+- Target issue: EVNSolution/thundercrew-domain#85
+- Branch: `cc-89-frontend-soft-delete-actions`
+
+### Decision
+
+Expose existing service-ops soft-delete commands from the relevant admin detail pages without adding backend schema/API scope.
+
+### Included
+
+- Frontend service client delete methods for `/api/v1/riders/{id}`, `/api/v1/bikes/{id}`, and `/api/v1/rider-insurances/{id}`.
+- Rider, vehicle, and rider-insurance detail server actions and action buttons for 비활성 삭제.
+- List/detail feedback states for successful, mock, and failed delete attempts.
+- Service-ops client tests for DELETE request shape, bearer token forwarding, and no request body.
+
+### Excluded
+
+- Telemetry/current-state work, real map provider/API work, device sync logs, backend schema/API changes, station delete UI, production env mutation, and rider app-account link/unlink remain out of scope.
+- Rider app-account link/unlink is deferred until a selector/lookup API avoids operator-entered raw `appAccountId` UUIDs.
+
+### Guardrails
+
+- Detail pages expose buttons only; explanatory implementation text stays in docs/README rather than cluttering the web UI.
+- Delete commands use route slugs from selected records and do not introduce editable raw DB ID/FK fields.
+- Soft-delete wording is used consistently as 비활성 삭제; backend reference-protection remains authoritative.


### PR DESCRIPTION
## Summary
- Add service-ops frontend DELETE client methods for riders, bikes, and rider-insurances.
- Add detail-page server actions/buttons for rider, vehicle, and insurance 비활성 삭제.
- Keep web UI terse after review feedback: action buttons and feedback only; implementation/lifecycle detail stays in docs.
- Update README and backend change ledger for change-control metadata.

## Trace
- Change-control: EVNSolution/clever-change-control#89
- Target issue: Closes #85
- Branch: `cc-89-frontend-soft-delete-actions`

## Guardrails
- No raw DB/FK ID input fields added.
- No telemetry/current-state, real map provider/API, device sync, backend schema/API, production env, or app-account link work included.
- Rider app-account link/unlink remains deferred until a selector/lookup API avoids operator-entered raw `appAccountId` UUIDs.

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (103/103)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- code-reviewer PASS

## Not tested
- Live backend soft-delete against deployed service-ops API.
