### PR TITLE
Frontend station soft-delete action

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Frontend ↔ backend baseline:
 - 계약 양식 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 시스템 양식은 읽기 전용으로 보호합니다.
 - 보험 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 보험 폼은 라이더와 보험 항목을 사람이 읽을 수 있는 select로 연결합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 보험 항목 폼에는 DB/FK ID 입력칸을 두지 않습니다.
-- 배터리 스테이션 목록/상세/등록/수정/재고 변경 server action도 같은 service-ops 세션을 사용하며, 스테이션 상세는 `/api/v1/station-battery-count-logs`를 read-only 이력 패널로 표시합니다. 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경/비활성 삭제 server action도 같은 service-ops 세션을 사용하며, 스테이션 상세는 `/api/v1/station-battery-count-logs`를 read-only 이력 패널로 표시합니다. 스테이션 폼에는 DB ID 입력칸을 두지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거 server action도 같은 service-ops 세션을 사용하며, 차량과 장비 종류 연결은 사람이 읽을 수 있는 select로 처리합니다.
 - 무결성 점검은 같은 service-ops 세션으로 `GET /api/v1/integrity/reference-checks`를 읽어 read-only로 표시하며, telemetry/current-state 항목은 화면 표시에서 제외합니다.
 - 지도 관제는 같은 쿠키 세션으로 `GET /api/v1/dashboard/map-state`를 읽어

--- a/development/front-admin-web/README.md
+++ b/development/front-admin-web/README.md
@@ -86,7 +86,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - 보험 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/insurance-items`와 `/api/v1/rider-insurances`를 호출합니다.
 - 보험 항목 목록/상세/등록/수정/비활성 삭제는 server action/server component에서 `/api/v1/insurance-items`를 호출합니다. 활성 라이더 보험 연결이 있으면 삭제는 백엔드 정책에 따라 거부됩니다.
 - 보험 등록 폼은 라이더와 보험 항목을 select로 고르게 하며 `insuranceId`, `riderId`, `insuranceItemId`, `vehicle_id` 같은 직접 입력 필드를 만들지 않습니다. 현재 backend 범위는 라이더 보험 연결이며 증권번호/보험기간/차량 보험은 후속 확장 범위입니다.
-- 배터리 스테이션 목록/상세/등록/수정/재고 변경은 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다. 스테이션 상세의 재고 변경 이력은 `/api/v1/station-battery-count-logs`를 read-only로 조회합니다.
+- 배터리 스테이션 목록/상세/등록/수정/재고 변경/비활성 삭제는 server action/server component에서 `/api/v1/battery-stations`와 `/api/v1/battery-stations/{id}/battery-counts`를 호출합니다. 스테이션 상세의 재고 변경 이력은 `/api/v1/station-battery-count-logs`를 read-only로 조회합니다.
 - 스테이션 폼은 이름, 주소, 좌표, 운영 상태, 수량만 다루며 `stationId`, `station_id`, `batteryStationId` 같은 직접 입력 필드를 만들지 않습니다.
 - 장비 종류와 바이크 장비 목록/상세/등록/수정/제거는 server action/server component에서 `/api/v1/equipment-types`와 `/api/v1/bike-equipments`를 호출합니다.
 - 바이크 장비 등록 폼은 차량과 장비 종류를 select로 고르게 하며 `bikeId`, `equipmentTypeId`, `equipmentId` 같은 직접 입력 필드를 만들지 않습니다.
@@ -125,7 +125,7 @@ secret은 코드, README, `.omx/project-memory.json`, `.omx/notepad.md`에 저�
 - `/insurance/items/[slug]/edit` 보험 항목 수정
 - `/stations` 배터리 스테이션 목록 + mock 지도 영역
 - `/stations/new` 스테이션 등록
-- `/stations/[slug]` 스테이션 상세 + 재고 수량 변경 + 재고 변경 이력
+- `/stations/[slug]` 스테이션 상세 + 재고 수량 변경 + 재고 변경 이력 + 비활성 삭제
 - `/stations/[slug]/edit` 스테이션 기본 정보 수정
 - `/equipment` 장비 목록 + 장비 종류 관리
 - `/equipment/new` 바이크 장비 등록

--- a/development/front-admin-web/app/stations/[slug]/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { updateStationBatteryCountsAction } from "@/app/stations/actions";
+import { deleteStationAction, updateStationBatteryCountsAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
@@ -12,7 +12,9 @@ const statusMessage: Record<string, string> = {
   "count-error": "재고 수량 변경에 실패했습니다. 수량 규칙과 백엔드 연결 상태를 확인하세요.",
   "count-updated": "스테이션 재고 수량이 변경되었습니다.",
   created: "스테이션이 등록되었습니다.",
+  "delete-error": "스테이션 비활성 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
   "mock-count-updated": "서비스 API가 연결되지 않아 재고 변경을 mock 피드백으로만 처리했습니다.",
+  "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 mock 스테이션 화면으로 돌아왔습니다.",
   updated: "스테이션 기본 정보가 수정되었습니다."
 };
@@ -34,6 +36,7 @@ export default async function StationDetailPage({
   const station = detail.station;
   const message = status ? statusMessage[status] : null;
   const updateCountsAction = updateStationBatteryCountsAction.bind(null, station.slug);
+  const deleteAction = deleteStationAction.bind(null, station.slug);
   const countLogs = detail.countLogs;
 
   return (
@@ -66,12 +69,16 @@ export default async function StationDetailPage({
             <Field label="교체 가능 수량"><input className="input" defaultValue={station.availableBatteryCount ?? station.replaceableCount} min="0" name="availableBatteryCount" required type="number" /></Field>
             <Field label="변경 사유"><input className="input" maxLength={100} name="reason" placeholder="예: 입고, 출고, 점검 차감" /></Field>
             <Field label="재고 메모"><textarea className="input" name="memo" placeholder="재고 변경 관련 메모" rows={3} /></Field>
-            <p className="notice">수량 규칙: 최대 보관 수량 ≥ 현재 보유 수량 ≥ 교체 가능 수량. 이력은 backend 재고 로그로 남깁니다.</p>
             <div className="form-actions"><button className="button-primary" type="submit">재고 변경</button></div>
           </form>
-          <br />
-          <h2>위치 카드</h2>
-          <p>지도 API 없이 주소, 위도/경도, 핀 라벨({station.name} {availableLabel(station)})을 우선 준비합니다.</p>
+          <div className="detail-section">
+            <h2>비활성 삭제</h2>
+            <form action={deleteAction} className="action-panel">
+              <div className="form-actions">
+                <button className="button-secondary" type="submit">스테이션 비활성 삭제</button>
+              </div>
+            </form>
+          </div>
         </aside>
       </section>
       <section className="card">

--- a/development/front-admin-web/app/stations/actions.ts
+++ b/development/front-admin-web/app/stations/actions.ts
@@ -56,6 +56,26 @@ export async function updateStationAction(stationId: string, formData: FormData)
   redirect(`/stations/${station.slug}?status=updated`);
 }
 
+export async function deleteStationAction(stationId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/stations/${stationId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteBatteryStation(stationId);
+  } catch {
+    redirect(`/stations/${stationId}?status=delete-error`);
+  }
+
+  revalidatePath("/stations");
+  redirect("/stations?status=deleted");
+}
+
 export async function updateStationBatteryCountsAction(stationId: string, formData: FormData): Promise<void> {
   if (!serviceOpsApiConfigured()) {
     redirect(`/stations/${stationId}?status=mock-count-updated`);

--- a/development/front-admin-web/app/stations/page.tsx
+++ b/development/front-admin-web/app/stations/page.tsx
@@ -9,6 +9,7 @@ import type { BatteryStation } from "@/types/domain";
 const statusMessage: Record<string, string> = {
   "count-updated": "스테이션 재고 수량이 변경되었습니다.",
   created: "스테이션이 등록되었습니다.",
+  deleted: "스테이션이 비활성 삭제 처리되었습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 대신 mock 화면으로 돌아왔습니다.",
   updated: "스테이션 기본 정보가 수정되었습니다."
 };
@@ -80,8 +81,12 @@ export default async function StationsPage({ searchParams }: { searchParams: Pro
           </div>
         </div>
         <aside className="detail-panel">
-          <h2>지도 API 제외 범위</h2>
-          <p>이번 범위는 실제 지도 SDK/API를 붙이지 않습니다. 대신 좌표, 주소, 핀 라벨, 카드/리스트/상세 구조만 API 데이터로 준비합니다.</p>
+          <h2>요약</h2>
+          <div className="detail-list">
+            <div className="detail-row"><span>전체</span><strong>{data.stations.length}곳</strong></div>
+            <div className="detail-row"><span>운영 중</span><strong>{data.stations.filter((station) => station.status === "운영 중").length}곳</strong></div>
+            <div className="detail-row"><span>교체 가능</span><strong>{data.stations.reduce((total, station) => total + (station.availableBatteryCount ?? station.replaceableCount), 0)}개</strong></div>
+          </div>
         </aside>
       </section>
     </div>

--- a/development/front-admin-web/lib/services/service-ops-api.test.mjs
+++ b/development/front-admin-web/lib/services/service-ops-api.test.mjs
@@ -1065,6 +1065,27 @@ test("battery station create/update/count methods use dedicated backend endpoint
   assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
 });
 
+test("deleteBatteryStation uses station soft-delete endpoint without request body", async () => {
+  const calls = [];
+  const client = createServiceOpsApiClient({
+    accessToken: "access-token",
+    baseUrl: "http://localhost:8080",
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }
+  });
+
+  await client.deleteBatteryStation("55555555-5555-4555-8555-555555555555");
+
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/battery-stations/55555555-5555-4555-8555-555555555555");
+  assert.equal(calls[0].init?.method, "DELETE");
+  assert.equal("body" in calls[0].init, false);
+  assert.equal(new Headers(calls[0].init?.headers).get("authorization"), "Bearer access-token");
+});
+
 test("station battery count log list request uses read-only count-log endpoint", async () => {
   const calls = [];
   const client = createServiceOpsApiClient({

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -575,6 +575,7 @@ export type ServiceOpsApiClient = {
   createBatteryStation: (request: BatteryStationCreateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStation: (id: string, request: BatteryStationUpdateInput) => Promise<FrontendBatteryStation>;
   updateBatteryStationCounts: (id: string, request: BatteryStationCountUpdateInput) => Promise<FrontendBatteryStation>;
+  deleteBatteryStation: (id: string) => Promise<void>;
   listStationBatteryCountLogs: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsStationBatteryCountLog>>;
   getStationBatteryCountLog: (id: string) => Promise<ServiceOpsStationBatteryCountLog>;
   listEquipmentTypes: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsEquipmentType>>;
@@ -866,6 +867,9 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           method: "PATCH"
         })
       ),
+    deleteBatteryStation: async (id) => {
+      await request<void>(`/battery-stations/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     listStationBatteryCountLogs: ({ page = 0, size = 20, sort } = {}) =>
       request<ServiceOpsPage<ServiceOpsStationBatteryCountLog>>(
         "/station-battery-count-logs",

--- a/docs/backend/00-change-ledger.md
+++ b/docs/backend/00-change-ledger.md
@@ -964,3 +964,32 @@ Expose existing service-ops soft-delete commands from the relevant admin detail 
 - Detail pages expose buttons only; explanatory implementation text stays in docs/README rather than cluttering the web UI.
 - Delete commands use route slugs from selected records and do not introduce editable raw DB ID/FK fields.
 - Soft-delete wording is used consistently as 비활성 삭제; backend reference-protection remains authoritative.
+
+## Frontend station soft-delete action
+
+- Date: 2026-04-30
+- Change-control issue: EVNSolution/clever-change-control#90
+- Target issue: EVNSolution/thundercrew-domain#87
+- Branch: `cc-90-station-soft-delete-action`
+
+### Decision
+
+Expose the existing service-ops battery-station soft-delete command from the station detail page without adding backend or map-provider scope.
+
+### Included
+
+- Frontend service client delete method for `/api/v1/battery-stations/{id}`.
+- Station detail server action and terse 비활성 삭제 button.
+- Station list/detail feedback states for successful, mock, and failed delete attempts.
+- Service-ops client test for DELETE request shape, bearer token forwarding, and no request body.
+- Removal of implementation-explanation text from the station UI touched by this slice.
+
+### Excluded
+
+- Telemetry/current-state work, real map provider/API work, backend schema/API changes, device sync logs, production env mutation, and app-account link/unlink remain out of scope.
+
+### Guardrails
+
+- The web UI exposes only useful operations and data; implementation explanations stay in docs/README.
+- Delete commands use selected route slugs and do not introduce editable raw DB ID/FK fields.
+- Soft-delete wording is kept as 비활성 삭제; backend reference-protection remains authoritative.


### PR DESCRIPTION
## Summary
- Add frontend service client DELETE support for battery stations.
- Add station detail 비활성 삭제 server action/button with terse UI.
- Add station list/detail feedback and service-ops DELETE request-shape test.
- Update README/change ledger metadata.

## Trace
- Change-control: EVNSolution/clever-change-control#90
- Target issue: Closes #87
- Branch: `cc-90-station-soft-delete-action`

## Guardrails
- No raw DB/FK ID input fields added.
- No telemetry/current-state, real map provider/API, device sync, backend schema/API, production env, or app-account link work included.
- No implementation explanation text added to the web UI.

## Verification
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (104/104)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- code-reviewer PASS

## Not tested
- Live backend station soft-delete against deployed service-ops API.
