### PR TITLE
Remove public generated UUID exposure

### DIFF
--- a/development/front-admin-web/app/integrity/page.tsx
+++ b/development/front-admin-web/app/integrity/page.tsx
@@ -78,11 +78,11 @@ function FindingsTable({ findings }: { findings: IntegrityFinding[] }) {
       </thead>
       <tbody>
         {findings.map((finding) => (
-          <tr key={`${finding.sourceTable}:${finding.sourceId}:${finding.referenceField}:${finding.referenceId}`}>
+          <tr key={finding.rowKey}>
             <td><Badge tone={finding.severity === "danger" ? "outline" : "muted"}>{finding.categoryLabel}</Badge></td>
             <td>{finding.sourceLabel}<br /><span className="muted-text">IDX {finding.sourceIdx ?? "-"}</span></td>
             <td>{finding.referenceFieldLabel}</td>
-            <td>{finding.targetLabel}<br /><span className="muted-text">{finding.referenceId}</span></td>
+            <td>{finding.targetLabel}</td>
             <td>{finding.message}</td>
           </tr>
         ))}

--- a/development/front-admin-web/lib/services/device-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/device-data-core.test.mjs
@@ -62,7 +62,8 @@ test("toFrontendBikeDeviceInstallation hydrates vehicle and device labels", () =
   assert.equal(installation.status, "설치 중");
 });
 
-test("removed bike-device installation displays removed status", () => {
+test("removed bike-device installation displays removed status without UUID fragments", () => {
+  const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
   const installation = toFrontendBikeDeviceInstallation(
     {
       id: "22222222-2222-4222-8222-222222222222",
@@ -79,16 +80,24 @@ test("removed bike-device installation displays removed status", () => {
   );
 
   assert.equal(installation.status, "제거됨");
-  assert.match(installation.bikeLabel, /알 수 없는 차량/);
-  assert.match(installation.deviceLabel, /알 수 없는 단말/);
+  assert.equal(installation.bikeLabel, "알 수 없는 차량");
+  assert.equal(installation.deviceLabel, "알 수 없는 단말");
+  assert.doesNotMatch(installation.bikeLabel, uuidPattern);
+  assert.doesNotMatch(installation.deviceLabel, uuidPattern);
+  assert.doesNotMatch(installation.bikeLabel, /33333333/);
+  assert.doesNotMatch(installation.deviceLabel, /44444444/);
 });
 
-test("UUID service detail fallback remains visible when API is unavailable", () => {
+test("UUID service detail fallback keeps internal slugs but hides UUID-derived device UID", () => {
+  const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
   const device = mockDeviceUnavailableServiceDetail("11111111-1111-4111-8111-111111111111", [], "no service");
   const installation = mockBikeDeviceInstallationUnavailableServiceDetail("22222222-2222-4222-8222-222222222222", [], "no service");
 
   assert.equal(device.device.slug, "11111111-1111-4111-8111-111111111111");
   assert.equal(device.notice, "no service");
+  assert.equal(device.device.deviceUid, "서비스 연결 필요 단말");
+  assert.doesNotMatch(device.device.deviceUid, uuidPattern);
+  assert.doesNotMatch(device.device.deviceUid, /11111111/);
   assert.equal(installation.installation.slug, "22222222-2222-4222-8222-222222222222");
   assert.equal(installation.notice, "no service");
 });

--- a/development/front-admin-web/lib/services/device-data-core.ts
+++ b/development/front-admin-web/lib/services/device-data-core.ts
@@ -62,10 +62,10 @@ export function toFrontendBikeDeviceInstallation(
 
   return {
     bikeId: installation.bikeId,
-    bikeLabel: vehicle ? `${vehicle.plateNumber} · ${vehicle.model}` : `알 수 없는 차량 (${shortId(installation.bikeId)})`,
+    bikeLabel: vehicle ? `${vehicle.plateNumber} · ${vehicle.model}` : "알 수 없는 차량",
     createdAt: installation.createdAt,
     deviceId: installation.deviceId,
-    deviceLabel: device?.label ?? `알 수 없는 단말 (${shortId(installation.deviceId)})`,
+    deviceLabel: device?.label ?? "알 수 없는 단말",
     deviceUid: device?.deviceUid,
     id: installation.id,
     idx: installation.idx,
@@ -94,7 +94,7 @@ export function mockDeviceDetail(slug: string, devices: Device[]): DeviceDetailR
 
 export function mockDeviceUnavailableServiceDetail(slug: string, devices: Device[], notice: string): DeviceDetailResult {
   const fallback = devices[0] ?? {
-    deviceUid: `SERVICE-DEVICE-${shortId(slug).toUpperCase()}`,
+    deviceUid: "서비스 연결 필요 단말",
     enabled: false,
     manufacturer: "서비스 연결 필요",
     memo: notice,
@@ -160,8 +160,4 @@ export function deviceLabel(device: Device): string {
 
 export function isUuidLike(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
-}
-
-function shortId(value: string): string {
-  return value.slice(0, 8);
 }

--- a/development/front-admin-web/lib/services/integrity-data-core.test.mjs
+++ b/development/front-admin-web/lib/services/integrity-data-core.test.mjs
@@ -63,3 +63,28 @@ test("category labels are explicit and mock fallback is visible", () => {
   assert.equal(data.source, "mock");
   assert.equal(data.visibleFindingCount, 2);
 });
+
+test("integrity findings do not expose generated UUIDs in the frontend display model", () => {
+  const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+  const data = toFrontendIntegrityData({
+    generatedAt: "2026-04-30T00:00:00Z",
+    totalFindings: 1,
+    summary: [{ category: "REFERENCE_NOT_FOUND", count: 1 }],
+    findings: [
+      {
+        category: "REFERENCE_NOT_FOUND",
+        message: "missing rider 11111111-1111-4111-8111-111111111111",
+        referenceField: "rider_id",
+        referenceId: "11111111-1111-4111-8111-111111111111",
+        sourceId: "22222222-2222-4222-8222-222222222222",
+        sourceIdx: 7,
+        sourceTable: "rider_bike_contracts",
+        targetTable: "riders"
+      }
+    ]
+  });
+
+  assert.equal(Object.hasOwn(data.findings[0], "sourceId"), false);
+  assert.equal(Object.hasOwn(data.findings[0], "referenceId"), false);
+  assert.doesNotMatch(JSON.stringify(data.findings), uuidPattern);
+});

--- a/development/front-admin-web/lib/services/integrity-data-core.ts
+++ b/development/front-admin-web/lib/services/integrity-data-core.ts
@@ -7,12 +7,19 @@ import type {
 
 const EXCLUDED_SOURCE_TABLES = new Set(["bike_recent_states", "bike_current_states"]);
 
-export type IntegrityFinding = ServiceOpsIntegrityFinding & {
+export type IntegrityFinding = {
+  category: ServiceOpsIntegrityFindingCategory;
   categoryLabel: string;
-  sourceLabel: string;
-  targetLabel: string;
+  message: string;
+  referenceField: string;
   referenceFieldLabel: string;
+  rowKey: string;
   severity: "warning" | "danger";
+  sourceIdx: number | null;
+  sourceLabel: string;
+  sourceTable: string;
+  targetLabel: string;
+  targetTable: string;
 };
 
 export type IntegritySummaryItem = {
@@ -55,8 +62,8 @@ export function mockIntegrityData(notice?: string): IntegrityDataResult {
           category: "REFERENCE_NOT_FOUND",
           message: "rider_bike_contracts.bike_id references missing bikes",
           referenceField: "bike_id",
-          referenceId: "11111111-1111-4111-8111-111111111111",
-          sourceId: "22222222-2222-4222-8222-222222222222",
+          referenceId: "mock-missing-bike",
+          sourceId: "mock-rider-contract",
           sourceIdx: 2,
           sourceTable: "rider_bike_contracts",
           targetTable: "bikes"
@@ -65,8 +72,8 @@ export function mockIntegrityData(notice?: string): IntegrityDataResult {
           category: "REFERENCE_DELETED",
           message: "bike_equipments.equipment_type_id references deleted equipment_types",
           referenceField: "equipment_type_id",
-          referenceId: "33333333-3333-4333-8333-333333333333",
-          sourceId: "44444444-4444-4444-8444-444444444444",
+          referenceId: "mock-deleted-equipment-type",
+          sourceId: "mock-bike-equipment",
           sourceIdx: 4,
           sourceTable: "bike_equipments",
           targetTable: "equipment_types"
@@ -92,14 +99,20 @@ export function toCategoryLabel(category: ServiceOpsIntegrityFindingCategory): s
   }
 }
 
-function toFrontendIntegrityFinding(finding: ServiceOpsIntegrityFinding): IntegrityFinding {
+function toFrontendIntegrityFinding(finding: ServiceOpsIntegrityFinding, index: number): IntegrityFinding {
   return {
-    ...finding,
+    category: finding.category,
     categoryLabel: toCategoryLabel(finding.category),
+    message: redactGeneratedUuid(finding.message),
+    referenceField: finding.referenceField,
     referenceFieldLabel: toDisplayLabel(finding.referenceField),
+    rowKey: [finding.sourceTable, finding.sourceIdx ?? `row-${index}`, finding.referenceField, finding.targetTable, finding.category].join(":"),
     severity: finding.category === "REFERENCE_NOT_FOUND" ? "danger" : "warning",
+    sourceIdx: finding.sourceIdx,
     sourceLabel: tableLabel(finding.sourceTable),
-    targetLabel: tableLabel(finding.targetTable)
+    sourceTable: finding.sourceTable,
+    targetLabel: tableLabel(finding.targetTable),
+    targetTable: finding.targetTable
   };
 }
 
@@ -124,6 +137,10 @@ function summarizeVisibleFindings(
   return order
     .filter((category) => counts.has(category))
     .map((category) => ({ category, categoryLabel: toCategoryLabel(category), count: counts.get(category) ?? 0 }));
+}
+
+function redactGeneratedUuid(value: string): string {
+  return value.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, "비공개 ID");
 }
 
 function tableLabel(table: string): string {


### PR DESCRIPTION
## Summary
- remove generated UUID/source-reference rendering from the integrity check table
- strip generated UUIDs from integrity finding display messages/model fields
- replace unknown vehicle/device fallback labels with neutral text while preserving real device UID display

## Trace
- Change-control: EVNSolution/clever-change-control#91
- Target issue: EVNSolution/thundercrew-domain#89
- Branch: `cc-91-public-uuid-exposure-cleanup`
- Concurrent work decision: allowed-with-non-overlap. No open target PRs/issues at creation time; older soft-delete branches are already merged and non-overlapping.

## Validation
- `git diff --check`
- `npm run check:workspace`
- `npm run lint`
- `npm run test:service-ops` (105/105)
- `npm run typecheck`
- `npm run build`
- `(cd development/service-ops-api && ./gradlew test)`
- `(cd development/service-ops-api && ./gradlew build)`
- code-reviewer subagent: PASS

Closes EVNSolution/thundercrew-domain#89
Refs EVNSolution/clever-change-control#91
