### PR TITLE
Admin management tab trim and back links

### DIFF
--- a/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { updateContractTemplateAction } from "@/app/contract-templates/actions";
 import { ContractTemplateForm } from "@/components/contract-templates/ContractTemplateForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadContractTemplateDetail } from "@/lib/services/contract-template-data";
 
 const statusMessage: Record<string, string> = {
@@ -30,6 +31,7 @@ export default async function EditContractTemplatePage({
   if (template.systemTemplate) {
     return (
       <div className="page-container">
+        <BackToListLink href="/contract-templates" />
         <PageHeader title="시스템 계약 양식" description="시스템 양식은 보호되어 수정할 수 없습니다." />
         <div className="card">
           <p className="notice">{template.name}은 백엔드 정책상 수정/삭제할 수 없는 시스템 계약 양식입니다.</p>
@@ -44,6 +46,7 @@ export default async function EditContractTemplatePage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/contract-templates" />
       <PageHeader title="계약 양식 수정" description="계약 양식명, 기간, 설명, 사용 상태만 수정합니다. 계약 양식 ID는 입력받지 않습니다." />
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}
       <ContractTemplateForm

--- a/development/front-admin-web/app/contract-templates/[slug]/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteContractTemplateAction } from "@/app/contract-templates/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadContractTemplateDetail } from "@/lib/services/contract-template-data";
 
@@ -34,6 +35,7 @@ export default async function ContractTemplateDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/contract-templates" />
       <PageHeader
         actionHref={template.systemTemplate ? undefined : `/contract-templates/${template.slug}/edit`}
         actionLabel={template.systemTemplate ? undefined : "수정"}

--- a/development/front-admin-web/app/contract-templates/new/page.tsx
+++ b/development/front-admin-web/app/contract-templates/new/page.tsx
@@ -1,6 +1,7 @@
 import { createContractTemplateAction } from "@/app/contract-templates/actions";
 import { ContractTemplateForm } from "@/components/contract-templates/ContractTemplateForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 
 const statusMessage: Record<string, string> = {
   "save-error": "계약 양식 저장에 실패했습니다. 이름 중복, 기간 입력, 백엔드 연결 상태를 확인하세요."
@@ -11,6 +12,7 @@ export default async function NewContractTemplatePage({ searchParams }: { search
 
   return (
     <div className="page-container">
+      <BackToListLink href="/contract-templates" />
       <PageHeader title="계약 양식 등록" description="계약 양식 ID는 DB가 자동 생성합니다. 운영자는 사람이 읽을 수 있는 이름과 기간만 입력합니다." />
       <ContractTemplateForm action={createContractTemplateAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/contracts/[slug]/page.tsx
+++ b/development/front-admin-web/app/contracts/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { terminateContractAction, updateContractMemoAction } from "@/app/contracts/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
 import { loadContractDetail } from "@/lib/services/contract-data";
@@ -38,6 +39,7 @@ export default async function ContractDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/contracts" />
       <PageHeader title={contract.contractType} description={`${contract.riderName} 계약 상세`} />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/contracts/new/page.tsx
+++ b/development/front-admin-web/app/contracts/new/page.tsx
@@ -1,5 +1,6 @@
 import { createContractAction } from "@/app/contracts/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { ContractForm } from "@/components/contracts/ContractForm";
 import { loadContractFormOptions } from "@/lib/services/contract-data";
 
@@ -12,6 +13,7 @@ export default async function NewContractPage({ searchParams }: { searchParams: 
 
   return (
     <div className="page-container">
+      <BackToListLink href="/contracts" />
       <PageHeader title="계약 등록" description="계약 ID는 DB에서 자동 생성합니다. 계약 대상 라이더, 차량, 계약 양식은 사람이 읽을 수 있는 선택 UI로 연결합니다." />
       {options.notice ? <p className="notice">{options.notice}</p> : null}
       <ContractForm action={createContractAction} options={options} statusMessage={status ? statusMessage[status] : null} />

--- a/development/front-admin-web/app/devices/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/devices/[slug]/edit/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { updateDeviceAction } from "@/app/devices/actions";
 import { DeviceForm } from "@/components/devices/DeviceForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadDeviceDetail } from "@/lib/services/device-data";
 
 const statusMessage: Record<string, string> = {
@@ -27,6 +28,7 @@ export default async function EditDevicePage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/devices" />
       <PageHeader title="단말 수정" description="단말 UID, 제조사, 모델, 사용 상태와 메모만 수정합니다. 차량 설치 연결은 별도 설치/제거 흐름으로 분리합니다." />
       <DeviceForm
         action={updateAction}

--- a/development/front-admin-web/app/devices/[slug]/page.tsx
+++ b/development/front-admin-web/app/devices/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteDeviceAction } from "@/app/devices/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadDeviceDetail } from "@/lib/services/device-data";
 import { deviceLabel } from "@/lib/services/device-data-core";
@@ -35,6 +36,7 @@ export default async function DeviceDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/devices" />
       <PageHeader title={device.deviceUid} description={deviceLabel(device)} actionHref={`/devices/${device.slug}/edit`} actionLabel="수정" />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/devices/installations/[slug]/page.tsx
+++ b/development/front-admin-web/app/devices/installations/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { removeBikeDeviceInstallationAction } from "@/app/devices/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
 import { loadBikeDeviceInstallationDetail } from "@/lib/services/device-data";
@@ -34,6 +35,7 @@ export default async function BikeDeviceInstallationDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/devices" />
       <PageHeader title="차량 단말 설치 상세" description={`${installation.bikeLabel} · ${installation.deviceLabel}`} />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/devices/installations/new/page.tsx
+++ b/development/front-admin-web/app/devices/installations/new/page.tsx
@@ -1,6 +1,7 @@
 import { createBikeDeviceInstallationAction } from "@/app/devices/actions";
 import { BikeDeviceInstallationForm } from "@/components/devices/BikeDeviceInstallationForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadDeviceFormOptions } from "@/lib/services/device-data";
 
 const statusMessage: Record<string, string> = {
@@ -12,6 +13,7 @@ export default async function NewBikeDeviceInstallationPage({ searchParams }: { 
 
   return (
     <div className="page-container">
+      <BackToListLink href="/devices" />
       <PageHeader title="차량 단말 설치" description="차량번호와 단말 UID 선택으로 설치/교체합니다. DB ID/FK는 직접 입력하지 않습니다." />
       {options.notice ? <p className="notice">{options.notice}</p> : null}
       <BikeDeviceInstallationForm

--- a/development/front-admin-web/app/devices/new/page.tsx
+++ b/development/front-admin-web/app/devices/new/page.tsx
@@ -1,6 +1,7 @@
 import { createDeviceAction } from "@/app/devices/actions";
 import { DeviceForm } from "@/components/devices/DeviceForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 
 const statusMessage: Record<string, string> = {
   "save-error": "단말 등록에 실패했습니다. 단말 UID 중복 또는 백엔드 연결 상태를 확인하세요."
@@ -11,6 +12,7 @@ export default async function NewDevicePage({ searchParams }: { searchParams: Pr
 
   return (
     <div className="page-container">
+      <BackToListLink href="/devices" />
       <PageHeader title="단말 등록" description="단말 자체 UID와 제조사/모델/사용 상태를 등록합니다. DB ID는 직접 입력하지 않습니다." />
       <DeviceForm action={createDeviceAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/equipment/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/equipment/[slug]/edit/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { updateBikeEquipmentAction } from "@/app/equipment/actions";
 import { BikeEquipmentForm } from "@/components/equipment/BikeEquipmentForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadBikeEquipmentDetail } from "@/lib/services/equipment-data";
 
 const statusMessage: Record<string, string> = {
@@ -27,6 +28,7 @@ export default async function EditBikeEquipmentPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/equipment" />
       <PageHeader title="바이크 장비 수정" description="장비 표시명, 모델, 시리얼, 관리 기한과 메모만 수정합니다. 차량/장비 종류 변경은 별도 재등록 흐름으로 분리합니다." />
       <BikeEquipmentForm
         action={updateAction}

--- a/development/front-admin-web/app/equipment/[slug]/page.tsx
+++ b/development/front-admin-web/app/equipment/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { removeBikeEquipmentAction } from "@/app/equipment/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
 import { loadBikeEquipmentDetail } from "@/lib/services/equipment-data";
@@ -37,6 +38,7 @@ export default async function BikeEquipmentDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/equipment" />
       <PageHeader title={equipment.equipmentLabel} description={`${equipment.bikeLabel} · ${equipment.equipmentTypeName}`} actionHref={`/equipment/${equipment.slug}/edit`} actionLabel="수정" />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/equipment/new/page.tsx
+++ b/development/front-admin-web/app/equipment/new/page.tsx
@@ -1,5 +1,6 @@
 import { createBikeEquipmentAction } from "@/app/equipment/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { BikeEquipmentForm } from "@/components/equipment/BikeEquipmentForm";
 import { loadEquipmentFormOptions } from "@/lib/services/equipment-data";
 
@@ -12,6 +13,7 @@ export default async function NewBikeEquipmentPage({ searchParams }: { searchPar
 
   return (
     <div className="page-container">
+      <BackToListLink href="/equipment" />
       <PageHeader title="바이크 장비 등록" description="차량과 장비 종류는 선택 UI로 연결합니다. DB/FK ID는 직접 입력하지 않습니다." />
       {options.notice ? <p className="notice">{options.notice}</p> : null}
       <BikeEquipmentForm action={createBikeEquipmentAction} equipmentTypes={options.equipmentTypes} statusMessage={status ? statusMessage[status] : null} vehicles={options.vehicles} />

--- a/development/front-admin-web/app/equipment/types/[slug]/page.tsx
+++ b/development/front-admin-web/app/equipment/types/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { updateEquipmentTypeAction } from "@/app/equipment/actions";
 import { EquipmentTypeForm } from "@/components/equipment/EquipmentTypeForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadEquipmentTypeDetail } from "@/lib/services/equipment-data";
 
@@ -34,6 +35,7 @@ export default async function EquipmentTypeDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/equipment" />
       <PageHeader title={equipmentType.name} description="장비 종류 상세와 수정 화면입니다." />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/equipment/types/new/page.tsx
+++ b/development/front-admin-web/app/equipment/types/new/page.tsx
@@ -1,6 +1,7 @@
 import { createEquipmentTypeAction } from "@/app/equipment/actions";
 import { EquipmentTypeForm } from "@/components/equipment/EquipmentTypeForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 
 const statusMessage: Record<string, string> = {
   "save-error": "장비 종류 저장에 실패했습니다. 이름 중복 또는 백엔드 연결 상태를 확인하세요."
@@ -11,6 +12,7 @@ export default async function NewEquipmentTypePage({ searchParams }: { searchPar
 
   return (
     <div className="page-container">
+      <BackToListLink href="/equipment" />
       <PageHeader title="장비 종류 등록" description="장비 종류 ID는 DB가 자동 생성합니다. 운영자는 이름, 설명, 사용 상태만 입력합니다." />
       <EquipmentTypeForm action={createEquipmentTypeAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -82,6 +82,8 @@ button, input, select, textarea { font: inherit; }
 .management-subnav-link { display: inline-flex; align-items: center; min-height: 34px; padding: 0 12px; border-radius: 999px; background: var(--color-surface); color: var(--color-text-secondary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-weight: 800; }
 .management-subnav-link:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .management-subnav-link.is-active { background: var(--mint-12); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--mint-20), inset 0 -2px 0 var(--baemin-mint); }
+.page-back-link { display: inline-flex; align-items: center; gap: 6px; min-height: 34px; margin: 20px 0 -18px; color: var(--color-text-secondary); font-size: 13px; font-weight: 800; }
+.page-back-link:hover { color: var(--color-text-primary); }
 
 .button-primary, .button-secondary, .button-ghost-mint { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 40px; padding: 0 16px; border: 0; border-radius: 8px; font-size: 14px; font-weight: 700; cursor: pointer; }
 .button-primary { background: var(--baemin-mint); color: var(--color-text-on-mint); box-shadow: 0 0 0 1px rgba(0,0,0,.06); }

--- a/development/front-admin-web/app/insurance/[slug]/page.tsx
+++ b/development/front-admin-web/app/insurance/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteInsuranceAction, updateInsuranceAction } from "@/app/insurance/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
 import { loadInsuranceDetail } from "@/lib/services/insurance-data";
@@ -37,6 +38,7 @@ export default async function InsuranceDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/insurance" />
       <PageHeader title={`${policy.provider} 보험`} description={policy.holderLabel} />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/insurance/items/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/insurance/items/[slug]/edit/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { updateInsuranceItemAction } from "@/app/insurance/items/actions";
 import { InsuranceItemForm } from "@/components/insurance-items/InsuranceItemForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadInsuranceItemDetail } from "@/lib/services/insurance-item-data";
 
 const statusMessage: Record<string, string> = {
@@ -28,6 +29,7 @@ export default async function EditInsuranceItemPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/insurance/items" />
       <PageHeader title="보험 항목 수정" description="보험 항목명, 설명, 사용 상태만 수정합니다. 보험 항목 ID는 입력받지 않습니다." />
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}
       <InsuranceItemForm

--- a/development/front-admin-web/app/insurance/items/[slug]/page.tsx
+++ b/development/front-admin-web/app/insurance/items/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteInsuranceItemAction } from "@/app/insurance/items/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadInsuranceItemDetail } from "@/lib/services/insurance-item-data";
 
@@ -34,6 +35,7 @@ export default async function InsuranceItemDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/insurance/items" />
       <PageHeader actionHref={`/insurance/items/${item.slug}/edit`} actionLabel="수정" description="라이더 보험 등록 화면에서 선택되는 보험 항목 상세입니다." title={item.name} />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/insurance/items/new/page.tsx
+++ b/development/front-admin-web/app/insurance/items/new/page.tsx
@@ -1,6 +1,7 @@
 import { createInsuranceItemAction } from "@/app/insurance/items/actions";
 import { InsuranceItemForm } from "@/components/insurance-items/InsuranceItemForm";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 
 const statusMessage: Record<string, string> = {
   "save-error": "보험 항목 저장에 실패했습니다. 이름 중복 또는 백엔드 연결 상태를 확인하세요."
@@ -11,6 +12,7 @@ export default async function NewInsuranceItemPage({ searchParams }: { searchPar
 
   return (
     <div className="page-container">
+      <BackToListLink href="/insurance/items" />
       <PageHeader title="보험 항목 등록" description="보험 항목 ID는 DB가 자동 생성합니다. 운영자는 사람이 읽을 수 있는 보험명과 설명만 입력합니다." />
       <InsuranceItemForm action={createInsuranceItemAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/insurance/new/page.tsx
+++ b/development/front-admin-web/app/insurance/new/page.tsx
@@ -1,5 +1,6 @@
 import { createInsuranceAction } from "@/app/insurance/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { InsuranceForm } from "@/components/insurance/InsuranceForm";
 import { loadInsuranceFormOptions } from "@/lib/services/insurance-data";
 
@@ -12,6 +13,7 @@ export default async function NewInsurancePage({ searchParams }: { searchParams:
 
   return (
     <div className="page-container">
+      <BackToListLink href="/insurance" />
       <PageHeader title="보험 등록" description="보험 ID는 자동 생성합니다. 라이더와 보험 항목은 사람이 읽을 수 있는 선택 UI로 연결합니다." />
       {options.notice ? <p className="notice">{options.notice}</p> : null}
       <InsuranceForm action={createInsuranceAction} options={options} statusMessage={status ? statusMessage[status] : null} />

--- a/development/front-admin-web/app/riders/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { updateRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { RiderForm } from "@/components/riders/RiderForm";
 import { loadRiderDetail } from "@/lib/services/rider-data";
 
@@ -27,6 +28,7 @@ export default async function EditRiderPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/riders" />
       <PageHeader title="라이더 수정" description="소속, 구역, 앱 계정 연결 상태를 선택/조회형 입력 중심으로 수정합니다." />
       <RiderForm
         action={updateAction}

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadRiderDetail } from "@/lib/services/rider-data";
 
@@ -34,6 +35,7 @@ export default async function RiderDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/riders" />
       <PageHeader
         actionHref={`/riders/${rider.slug}/edit`}
         actionLabel="수정"

--- a/development/front-admin-web/app/riders/new/page.tsx
+++ b/development/front-admin-web/app/riders/new/page.tsx
@@ -1,4 +1,5 @@
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { RiderForm } from "@/components/riders/RiderForm";
 import { createRiderAction } from "@/app/riders/actions";
 
@@ -11,6 +12,7 @@ export default async function NewRiderPage({ searchParams }: { searchParams: Pro
 
   return (
     <div className="page-container">
+      <BackToListLink href="/riders" />
       <PageHeader title="라이더 등록" description="라이더 ID는 DB에서 자동 생성합니다. 사용자는 이름, 연락처, 소속과 담당 구역만 입력합니다." />
       <RiderForm action={createRiderAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/stations/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { updateStationAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { StationForm } from "@/components/stations/StationForm";
 import { loadStationDetail } from "@/lib/services/station-data";
 
@@ -27,6 +28,7 @@ export default async function EditStationPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/stations" />
       <PageHeader title="스테이션 수정" description="스테이션 기본 정보만 수정합니다. 재고 수량 변경은 상세 화면의 전용 영역을 사용합니다." />
       <StationForm
         action={updateAction}

--- a/development/front-admin-web/app/stations/[slug]/page.tsx
+++ b/development/front-admin-web/app/stations/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteStationAction, updateStationBatteryCountsAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
 import { loadStationDetail } from "@/lib/services/station-data";
@@ -41,6 +42,7 @@ export default async function StationDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/stations" />
       <PageHeader title={station.name} description={station.address} actionHref={`/stations/${station.slug}/edit`} actionLabel="수정" />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/stations/new/page.tsx
+++ b/development/front-admin-web/app/stations/new/page.tsx
@@ -1,5 +1,6 @@
 import { createStationAction } from "@/app/stations/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { StationForm } from "@/components/stations/StationForm";
 
 const statusMessage: Record<string, string> = {
@@ -11,6 +12,7 @@ export default async function NewStationPage({ searchParams }: { searchParams: P
 
   return (
     <div className="page-container">
+      <BackToListLink href="/stations" />
       <PageHeader title="스테이션 등록" description="스테이션 ID는 DB가 자동 생성합니다. 운영자는 이름, 주소, 좌표, 상태와 재고 수량만 입력합니다." />
       <StationForm action={createStationAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/app/vehicles/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { updateVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { VehicleForm } from "@/components/vehicles/VehicleForm";
 import { loadVehicleDetail } from "@/lib/services/vehicle-data";
 
@@ -27,6 +28,7 @@ export default async function EditVehiclePage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/vehicles" />
       <PageHeader title="차량 수정" description="차량 기본 정보만 수정합니다. 차체 상태 변경은 상세 화면의 전용 상태 변경 영역을 사용합니다." />
       <VehicleForm
         action={updateAction}

--- a/development/front-admin-web/app/vehicles/[slug]/page.tsx
+++ b/development/front-admin-web/app/vehicles/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { changeVehicleOperationStatusAction, deleteVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { vehicleStatusOptions } from "@/components/vehicles/VehicleForm";
 import { Badge } from "@/components/ui/Badge";
 import { Field } from "@/components/ui/FormField";
@@ -41,6 +42,7 @@ export default async function VehicleDetailPage({
 
   return (
     <div className="page-container">
+      <BackToListLink href="/vehicles" />
       <PageHeader title={vehicle.plateNumber} description="차량 상세, 기본 정보와 차체 상태 변경 화면입니다." actionHref={`/vehicles/${vehicle.slug}/edit`} actionLabel="수정" />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}

--- a/development/front-admin-web/app/vehicles/new/page.tsx
+++ b/development/front-admin-web/app/vehicles/new/page.tsx
@@ -1,5 +1,6 @@
 import { createVehicleAction } from "@/app/vehicles/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { BackToListLink } from "@/components/layout/BackToListLink";
 import { VehicleForm } from "@/components/vehicles/VehicleForm";
 
 const statusMessage: Record<string, string> = {
@@ -11,6 +12,7 @@ export default async function NewVehiclePage({ searchParams }: { searchParams: P
 
   return (
     <div className="page-container">
+      <BackToListLink href="/vehicles" />
       <PageHeader title="차량 등록" description="차량 ID는 DB가 자동 생성합니다. 사용자는 차량번호, VIN, 모델, 초기 차체 상태만 입력합니다." />
       <VehicleForm action={createVehicleAction} statusMessage={status ? statusMessage[status] : null} />
     </div>

--- a/development/front-admin-web/components/layout/BackToListLink.tsx
+++ b/development/front-admin-web/components/layout/BackToListLink.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export function BackToListLink({ href, label = "목록으로" }: { href: string; label?: string }) {
+  return (
+    <Link aria-label={label} className="page-back-link" href={href}>
+      <span aria-hidden="true">←</span>
+      <span>{label}</span>
+    </Link>
+  );
+}

--- a/development/front-admin-web/lib/navigation/management-navigation.test.mjs
+++ b/development/front-admin-web/lib/navigation/management-navigation.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -12,11 +13,11 @@ test("sidebar exposes only four management groups", () => {
   assert.deepEqual(sidebarManagementItems.map((item) => item.href), ["/vehicles", "/riders", "/contracts", "/stations"]);
 });
 
-test("management groups keep former flat entries as sub-pages", () => {
-  assert.deepEqual(managementGroups.vehicles.items.map((item) => item.href), ["/vehicles", "/vehicles/new", "/equipment", "/equipment/types/new", "/devices", "/devices/installations/new"]);
-  assert.deepEqual(managementGroups.riders.items.map((item) => item.href), ["/riders", "/riders/new", "/insurance", "/insurance/items"]);
-  assert.deepEqual(managementGroups.contracts.items.map((item) => item.href), ["/contracts", "/contracts/new", "/contract-templates"]);
-  assert.deepEqual(managementGroups.stations.items.map((item) => item.href), ["/stations", "/stations/new"]);
+test("management groups keep only list-level sub-pages", () => {
+  assert.deepEqual(managementGroups.vehicles.items.map((item) => item.href), ["/vehicles", "/equipment", "/devices"]);
+  assert.deepEqual(managementGroups.riders.items.map((item) => item.href), ["/riders", "/insurance", "/insurance/items"]);
+  assert.deepEqual(managementGroups.contracts.items.map((item) => item.href), ["/contracts", "/contract-templates"]);
+  assert.deepEqual(managementGroups.stations.items.map((item) => item.href), ["/stations"]);
 });
 
 test("known child routes resolve to their parent management group", () => {
@@ -25,4 +26,49 @@ test("known child routes resolve to their parent management group", () => {
   assert.equal(resolveManagementGroupForHref("/insurance/items"), "riders");
   assert.equal(resolveManagementGroupForHref("/contract-templates"), "contracts");
   assert.equal(resolveManagementGroupForHref("/stations/new"), "stations");
+  assert.equal(resolveManagementGroupForHref("/vehicles/new"), "vehicles");
+  assert.equal(resolveManagementGroupForHref("/contracts/new"), "contracts");
+});
+
+test("non-list management pages expose a list-return link", () => {
+  const pages = [
+    ["app/vehicles/new/page.tsx", "/vehicles"],
+    ["app/vehicles/[slug]/page.tsx", "/vehicles"],
+    ["app/vehicles/[slug]/edit/page.tsx", "/vehicles"],
+    ["app/equipment/new/page.tsx", "/equipment"],
+    ["app/equipment/[slug]/page.tsx", "/equipment"],
+    ["app/equipment/[slug]/edit/page.tsx", "/equipment"],
+    ["app/equipment/types/new/page.tsx", "/equipment"],
+    ["app/equipment/types/[slug]/page.tsx", "/equipment"],
+    ["app/devices/new/page.tsx", "/devices"],
+    ["app/devices/[slug]/page.tsx", "/devices"],
+    ["app/devices/[slug]/edit/page.tsx", "/devices"],
+    ["app/devices/installations/new/page.tsx", "/devices"],
+    ["app/devices/installations/[slug]/page.tsx", "/devices"],
+    ["app/riders/new/page.tsx", "/riders"],
+    ["app/riders/[slug]/page.tsx", "/riders"],
+    ["app/riders/[slug]/edit/page.tsx", "/riders"],
+    ["app/insurance/new/page.tsx", "/insurance"],
+    ["app/insurance/[slug]/page.tsx", "/insurance"],
+    ["app/insurance/items/new/page.tsx", "/insurance/items"],
+    ["app/insurance/items/[slug]/page.tsx", "/insurance/items"],
+    ["app/insurance/items/[slug]/edit/page.tsx", "/insurance/items"],
+    ["app/contracts/new/page.tsx", "/contracts"],
+    ["app/contracts/[slug]/page.tsx", "/contracts"],
+    ["app/contract-templates/new/page.tsx", "/contract-templates"],
+    ["app/contract-templates/[slug]/page.tsx", "/contract-templates"],
+    ["app/contract-templates/[slug]/edit/page.tsx", "/contract-templates"],
+    ["app/stations/new/page.tsx", "/stations"],
+    ["app/stations/[slug]/page.tsx", "/stations"],
+    ["app/stations/[slug]/edit/page.tsx", "/stations"]
+  ];
+
+  for (const [page, href] of pages) {
+    const source = readFileSync(page, "utf8");
+    const renderedPageContainers = source.match(/<div className="page-container">/gu) ?? [];
+    const renderedBackLinks = source.match(new RegExp(`<BackToListLink href="${href}" />`, "gu")) ?? [];
+
+    assert.ok(source.includes('import { BackToListLink } from "@/components/layout/BackToListLink";'), page);
+    assert.equal(renderedBackLinks.length, renderedPageContainers.length, page);
+  }
 });

--- a/development/front-admin-web/lib/navigation/management-navigation.ts
+++ b/development/front-admin-web/lib/navigation/management-navigation.ts
@@ -21,11 +21,8 @@ export const managementGroups = {
     icon: "EV",
     items: [
       { href: "/vehicles", label: "차량" },
-      { href: "/vehicles/new", label: "차량 등록" },
       { href: "/equipment", label: "장비" },
-      { href: "/equipment/types/new", label: "장비 종류" },
-      { href: "/devices", label: "단말" },
-      { href: "/devices/installations/new", label: "단말 설치" }
+      { href: "/devices", label: "단말" }
     ],
     key: "vehicles",
     label: "차량 관리",
@@ -36,7 +33,6 @@ export const managementGroups = {
     icon: "R",
     items: [
       { href: "/riders", label: "라이더" },
-      { href: "/riders/new", label: "라이더 등록" },
       { href: "/insurance", label: "보험 연결" },
       { href: "/insurance/items", label: "보험 항목" }
     ],
@@ -49,7 +45,6 @@ export const managementGroups = {
     icon: "C",
     items: [
       { href: "/contracts", label: "계약" },
-      { href: "/contracts/new", label: "계약 등록" },
       { href: "/contract-templates", label: "계약 양식" }
     ],
     key: "contracts",
@@ -59,10 +54,7 @@ export const managementGroups = {
   stations: {
     href: "/stations",
     icon: "S",
-    items: [
-      { href: "/stations", label: "스테이션" },
-      { href: "/stations/new", label: "스테이션 등록" }
-    ],
+    items: [{ href: "/stations", label: "스테이션" }],
     key: "stations",
     label: "스테이션 관리",
     routePrefixes: ["/stations"]

--- a/docs/frontend/01-admin-navigation-grouping.md
+++ b/docs/frontend/01-admin-navigation-grouping.md
@@ -1,35 +1,30 @@
 # Admin Navigation Grouping Plan
 
 ## Goal
-Reduce the admin sidebar from a flat operations list into four management areas while keeping existing routes intact.
+Reduce the admin sidebar from a flat operations list into four management areas while keeping existing routes intact. Management sub-navigation should stay list-level only; create/type/install flows remain page action buttons.
 
 ## Grouping
 - 차량 관리
   - 차량
-  - 차량 등록
   - 장비
-  - 장비 종류
   - 단말
-  - 단말 설치
 - 라이더 관리
   - 라이더
-  - 라이더 등록
   - 보험 연결
   - 보험 항목
 - 계약 관리
   - 계약
-  - 계약 등록
   - 계약 양식
 - 스테이션 관리
   - 스테이션
-  - 스테이션 등록
 
 ## Implementation sequence
 1. Centralize management navigation data.
 2. Replace the sidebar operations list with the four top-level groups.
 3. Add compact group sub-navigation to grouped list pages.
 4. Keep create/detail/edit routes unchanged.
-5. Verify locally, merge through PR, then redeploy the frontend to Vercel.
+5. Add a top-left `목록으로` return link to non-list management pages.
+6. Verify locally, merge through PR, then redeploy the frontend to Vercel.
 
 ## Out of scope
 - Backend/API/schema changes.


### PR DESCRIPTION
## Summary
- Remove create/type/action-only destinations from the management subnav.
- Add a reusable top-left `목록으로` link to non-list management pages.
- Update navigation grouping docs and tests to enforce list-level tabs and back-link coverage.

## Trace
- Target issue: fixes EVNSolution/thundercrew-domain#93
- Change-control: EVNSolution/clever-change-control#93
- Root project-start: EVNSolution/clever-change-control#44
- Branch: `cc-93-admin-nav-tab-trim-backlinks`

## Concurrent work gate
Decision: allowed-with-non-overlap
Evidence:
- Open target issues before #93: none.
- Open target PRs before this PR: none.
- Active branches at start: `dev`, `main`, `origin/dev`, `origin/main`.
Reason: no active overlapping target work existed for this admin navigation/UI scope.

## Validation
- `git diff --check` pass
- `npm run check:workspace` pass
- `npm run lint` pass
- `npm run test:service-ops` pass (109 tests)
- `npm run typecheck` pass
- `npm run build` pass
- `(cd development/service-ops-api && ./gradlew test)` pass
- `(cd development/service-ops-api && ./gradlew build)` pass
- code-reviewer subagent PASS after fixing the contract-template edit branch

## Non-scope
- Backend/schema changes
- Telemetry/map API work
- New explanatory UI copy
