### PR TITLE
AWS OIDC deploy readiness smoke

### DIFF
--- a/.github/workflows/aws-oidc-smoke.yml
+++ b/.github/workflows/aws-oidc-smoke.yml
@@ -1,0 +1,56 @@
+name: AWS OIDC smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      aws-region:
+        description: AWS region to use for the OIDC assume-role smoke check.
+        required: true
+        default: ap-northeast-2
+        type: string
+
+permissions:
+  contents: none
+  id-token: write
+
+jobs:
+  assume-prod-role:
+    name: Assume production AWS role
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate organization role variable
+        env:
+          PROD_AWS_ROLE_ARN: ${{ vars.PROD_AWS_ROLE_ARN }}
+        run: |
+          if [ -z "${PROD_AWS_ROLE_ARN}" ]; then
+            echo "::error title=Missing PROD_AWS_ROLE_ARN::The organization variable PROD_AWS_ROLE_ARN is not visible to this repository or is not set."
+            exit 1
+          fi
+
+          echo "::add-mask::${PROD_AWS_ROLE_ARN}"
+          echo "PROD_AWS_ROLE_ARN is visible to this workflow."
+
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ vars.PROD_AWS_ROLE_ARN }}
+          role-session-name: thundercrew-domain-oidc-smoke
+
+      - name: Verify assumed AWS identity
+        run: |
+          aws sts get-caller-identity --query '{Account:Account,Arn:Arn}' --output json
+
+      - name: Record readiness summary
+        run: |
+          {
+            echo "## AWS OIDC smoke result"
+            echo "- Repository: $GITHUB_REPOSITORY"
+            echo "- Ref: $GITHUB_REF_NAME"
+            echo "- Region: ${{ inputs.aws-region }}"
+            echo "- Role variable: PROD_AWS_ROLE_ARN visible"
+            echo "- STS assume-role: verified"
+            echo ""
+            echo "This workflow does not create or update AWS resources."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deployment/aws-deployment-readiness.md
+++ b/docs/deployment/aws-deployment-readiness.md
@@ -1,0 +1,65 @@
+# AWS Deployment Readiness
+
+## Current status
+
+- Frontend production is still on Vercel: `https://thundercrew-domain.vercel.app`.
+- AWS CLI local login is available for account `902837199612`.
+- `ap-northeast-2` currently has no Amplify apps for this account at the time of the readiness check.
+- GitHub repository Actions are enabled.
+- Repository-level GitHub Actions variables/secrets are empty.
+- The organization variable `PROD_AWS_ROLE_ARN` cannot be read through the current local GitHub token because org Actions variable read requires org admin or fine-grained actions variable permission.
+
+## What `PROD_AWS_ROLE_ARN` proves
+
+`PROD_AWS_ROLE_ARN` is the role ARN that a GitHub Actions workflow can try to assume through OIDC. By itself it does not deploy the application.
+
+The minimum deploy chain still needs:
+
+1. GitHub Actions workflow permission `id-token: write`.
+2. `aws-actions/configure-aws-credentials` with `role-to-assume: ${{ vars.PROD_AWS_ROLE_ARN }}`.
+3. AWS IAM role trust policy allowing this repository/ref/environment as the OIDC subject.
+4. AWS region and a concrete hosting target.
+5. AWS-side runtime environment variables for the frontend/backend.
+
+## Smoke workflow
+
+`.github/workflows/aws-oidc-smoke.yml` is a manual, non-deploying smoke test.
+
+It checks:
+
+- whether `vars.PROD_AWS_ROLE_ARN` is visible to this repository workflow;
+- whether GitHub OIDC can assume that role;
+- whether `aws sts get-caller-identity` succeeds after assumption.
+
+It does not create, update, or delete AWS resources.
+
+## Frontend hosting recommendation
+
+The current frontend has dynamic/server-rendered Next.js routes, server actions, and server-side API calls. Therefore S3-only static hosting is not a direct replacement for Vercel unless the app is converted to static export.
+
+Recommended AWS paths:
+
+1. **AWS Amplify Hosting compute** for the frontend Next.js app.
+2. **OpenNext/SST-style AWS deployment** if we want infrastructure-as-code ownership and Lambda/CloudFront resources.
+
+Do not remove Vercel production until one AWS path is deployed and verified.
+
+## Environment variable ownership
+
+Shareable metadata:
+
+- AWS account ID
+- AWS region
+- frontend public URL
+- non-secret deployment IDs
+- environment variable names
+
+Do not commit or print secret values:
+
+- database URLs/passwords
+- service-role keys
+- JWT secrets
+- admin passwords
+- token values
+
+`PROD_AWS_ROLE_ARN` is not a password, but it is deployment authority metadata. Keep it in GitHub organization variables rather than committed files.


### PR DESCRIPTION
## Summary

- Adds a manual, non-deploying AWS OIDC smoke workflow.
- Documents current AWS/Vercel deployment readiness and what `PROD_AWS_ROLE_ARN` proves.
- Keeps Vercel production unchanged while AWS hosting target remains undecided.

## Trace

- Target issue: EVNSolution/thundercrew-domain#95
- Change-control: EVNSolution/clever-change-control#94
- Branch: `cc-94-aws-oidc-deploy-readiness`
- Parallel work decision: `allowed-with-non-overlap`
  - Active target PRs checked: none open at check time.
  - Non-overlap reason: workflow/docs-only readiness check; no frontend/backend/database/Vercel/AWS resource mutation.

## Validation

- `git diff --check -- .github/workflows/aws-oidc-smoke.yml docs/deployment/aws-deployment-readiness.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-oidc-smoke.yml"); puts "workflow yaml parse ok"'`
- `npm run check:workspace`
- Scoped secret scan over `.github/workflows` and `docs/deployment`
- `aws sts get-caller-identity`
- `aws amplify list-apps --region ap-northeast-2 --query 'apps[].{name:name,appId:appId,defaultDomain:defaultDomain}' --output json`
- security-reviewer review: least-privilege finding fixed by removing checkout and setting `contents: none`.

## Notes

The new workflow is `workflow_dispatch` only and does not create, update, or delete AWS resources. It can be used after merge to check whether the organization variable `PROD_AWS_ROLE_ARN` is visible to this repository and assumable through GitHub OIDC.
