### PR TITLE
Capture AWS OIDC smoke blocker evidence

### DIFF
--- a/.github/workflows/aws-oidc-smoke.yml
+++ b/.github/workflows/aws-oidc-smoke.yml
@@ -17,6 +17,7 @@ jobs:
   assume-prod-role:
     name: Assume production AWS role
     runs-on: ubuntu-latest
+    environment: prod
     timeout-minutes: 10
     steps:
       - name: Validate organization role variable

--- a/docs/deployment/aws-deployment-readiness.md
+++ b/docs/deployment/aws-deployment-readiness.md
@@ -33,6 +33,23 @@ It checks:
 
 It does not create, update, or delete AWS resources.
 
+## Latest smoke result
+
+Run: `25194769461` on branch `dev` at `2026-05-01` KST.
+
+Result: **failed before AWS STS** because `vars.PROD_AWS_ROLE_ARN` was empty in the workflow environment. This means the GitHub organization variable is not visible to `EVNSolution/thundercrew-domain`, is not set, or is restricted away from this repository.
+
+AWS-side read-only checks showed that the account has a GitHub Actions OIDC provider and deploy-related IAM roles, but no Amplify app exists in `ap-northeast-2`. Exact production role ARNs should remain in GitHub organization variables, not in committed files.
+
+Required next actions before AWS deployment can run:
+
+1. Expose organization variable `PROD_AWS_ROLE_ARN` to `EVNSolution/thundercrew-domain`.
+2. Confirm the referenced IAM role trust policy allows this repository and production environment subject.
+3. Choose and create the AWS hosting target, such as Amplify Hosting compute or an OpenNext/SST-managed stack.
+4. Keep Vercel as the active frontend deployment until the AWS target has a verified public URL.
+
+The smoke workflow now runs under GitHub environment `prod` so a production OIDC trust policy can target `repo:EVNSolution/thundercrew-domain:environment:prod`.
+
 ## Frontend hosting recommendation
 
 The current frontend has dynamic/server-rendered Next.js routes, server actions, and server-side API calls. Therefore S3-only static hosting is not a direct replacement for Vercel unless the app is converted to static export.


### PR DESCRIPTION
## Summary

- Records the first `AWS OIDC smoke` run result from `dev`.
- Documents that the run failed before AWS STS because `vars.PROD_AWS_ROLE_ARN` was empty.
- Aligns the smoke job with GitHub environment `prod` so future production OIDC trust policies can match `repo:EVNSolution/thundercrew-domain:environment:prod`.

## Trace

- Target issue: EVNSolution/thundercrew-domain#95
- Change-control: EVNSolution/clever-change-control#94
- Prior readiness PR: EVNSolution/thundercrew-domain#96
- Branch: `cc-94-aws-oidc-smoke-result`
- Parallel work decision: `allowed-with-non-overlap`
  - Active target PRs checked: none open at check time.
  - Non-overlap reason: workflow/docs-only evidence update; no AWS/Vercel/frontend/backend/DB mutation.

## Validation

- `git diff --check -- .github/workflows/aws-oidc-smoke.yml docs/deployment/aws-deployment-readiness.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aws-oidc-smoke.yml"); puts "workflow yaml parse ok"'`
- `npm run check:workspace`
- Scoped secret and role-arn scan over `.github/workflows` and `docs/deployment`
- `gh run view 25194769461 --repo EVNSolution/thundercrew-domain --log-failed`

## Result captured

Run `25194769461` failed with `PROD_AWS_ROLE_ARN` empty in the workflow environment. AWS STS was not reached.
