### PR TITLE
Keep AWS OIDC smoke evidence current

### DIFF
--- a/docs/deployment/aws-deployment-readiness.md
+++ b/docs/deployment/aws-deployment-readiness.md
@@ -35,9 +35,9 @@ It does not create, update, or delete AWS resources.
 
 ## Latest smoke result
 
-Run: `25194769461` on branch `dev` at `2026-05-01` KST.
+Run: `25194839786` on branch `dev` at `2026-05-01` KST after the smoke job was aligned to GitHub environment `prod`.
 
-Result: **failed before AWS STS** because `vars.PROD_AWS_ROLE_ARN` was empty in the workflow environment. This means the GitHub organization variable is not visible to `EVNSolution/thundercrew-domain`, is not set, or is restricted away from this repository.
+Result: **failed before AWS STS** because `vars.PROD_AWS_ROLE_ARN` was empty in the workflow environment. This means the GitHub organization, repository, or `prod` environment variable is not visible to `EVNSolution/thundercrew-domain`, is not set, or is restricted away from this repository/job.
 
 AWS-side read-only checks showed that the account has a GitHub Actions OIDC provider and deploy-related IAM roles, but no Amplify app exists in `ap-northeast-2`. Exact production role ARNs should remain in GitHub organization variables, not in committed files.
 


### PR DESCRIPTION
## Summary

- Updates AWS deployment readiness notes to reference the second smoke run after the workflow was aligned to GitHub environment `prod`.
- Records that `PROD_AWS_ROLE_ARN` remains unavailable in the workflow environment, so AWS STS was still not reached.

## Trace

- Target issue: EVNSolution/thundercrew-domain#95
- Change-control: EVNSolution/clever-change-control#94
- Prior readiness PRs: EVNSolution/thundercrew-domain#96, EVNSolution/thundercrew-domain#97
- Branch: `cc-94-aws-oidc-smoke-rerun-result`
- Parallel work decision: `allowed-with-non-overlap`
  - Active target PRs checked: none open at check time.
  - Non-overlap reason: documentation-only latest evidence update.

## Validation

- `git diff --check -- docs/deployment/aws-deployment-readiness.md`
- `npm run check:workspace`
- Scoped secret and role-arn scan over `docs/deployment`
- `gh run watch 25194839786 --repo EVNSolution/thundercrew-domain --exit-status`

## Result captured

Run `25194839786` failed with `PROD_AWS_ROLE_ARN` empty in the workflow environment. AWS STS was not reached.
