### PR TITLE
Record EC2 EBS deployment evidence

### DIFF
--- a/docs/deployment/aws-ec2-ebs-deployment.md
+++ b/docs/deployment/aws-ec2-ebs-deployment.md
@@ -1,0 +1,75 @@
+# AWS EC2/EBS Deployment Evidence
+
+## Status
+
+- Status: deployed and verified
+- Date: 2026-05-01 KST
+- Target issue: `EVNSolution/thundercrew-domain#102`
+- Change-control issue: `EVNSolution/clever-change-control#96`
+- Branch: `cc-96-ec2-ebs-deployment`
+
+## Public endpoint
+
+- Frontend URL: `https://thundercrew-domain.43.201.57.147.sslip.io`
+- Temporary DNS: `sslip.io` hostname bound to the EC2 public IP
+- TLS: Let's Encrypt certificate issued on the EC2 host
+
+Vercel remains active until a permanent AWS domain cutover is decided.
+
+## AWS resources
+
+- Region: `ap-northeast-2`
+- EC2 instance: `i-0d4f75c35b80b25b9`
+- Public IP: `43.201.57.147`
+- Instance type: `t3.medium`
+- OS image: Ubuntu 24.04 LTS
+- Root EBS: encrypted gp3, 30 GiB, delete-on-termination
+- Security group: HTTP 80 and HTTPS 443 open to the public; SSH 22 restricted to the operator IP used at provisioning time
+
+## Runtime topology
+
+All services run on the EC2 host:
+
+- Nginx reverse proxy: public 80/443 to local Next.js
+- `thundercrew-front-admin-web.service`: Next.js on `127.0.0.1:3000`
+- `thundercrew-service-ops-api.service`: Spring Boot on `127.0.0.1:8080`
+- PostgreSQL 16 local database: `service_ops_api`
+
+Runtime env files are stored only on the instance:
+
+- `/etc/thundercrew/front-admin-web.env`
+- `/etc/thundercrew/service-ops-api.env`
+
+Secret values and the EC2 SSH key are not committed. The generated admin bootstrap password is stored only in the local ignored deployment cache under `.omx/cache/aws-ec2-deploy/runtime.env`.
+
+## Validation evidence
+
+Remote build/deploy evidence:
+
+- Backend artifact build: `./gradlew --no-daemon clean bootJar -x test`
+- Frontend install: `npm ci`
+- Frontend lint: `npm run lint`
+- Frontend typecheck: `npm run typecheck`
+- Frontend build: `npm run build`
+- Nginx config check: `nginx -t`
+- TLS issuance: Certbot successfully enabled HTTPS for the temporary `sslip.io` hostname
+
+Runtime checks:
+
+- `systemctl is-active thundercrew-service-ops-api` -> `active`
+- `systemctl is-active thundercrew-front-admin-web` -> `active`
+- `systemctl is-active nginx` -> `active`
+- `systemctl is-active postgresql` -> `active`
+- Backend admin login API returned `200` for the seeded admin account
+- Protected rider API returned `401 AUTHENTICATION_FAILED` without a bearer token
+- Public frontend HTTPS endpoint returned `200 OK`
+- Public login page rendered over HTTPS
+- PostgreSQL Flyway history count: `6`
+- Seeded admin count: `1`
+- Root filesystem: 30 GiB EBS-backed disk, about 17% used after deployment
+
+## Known follow-up
+
+- `/actuator/health` currently returns the application's JSON `500` error path, so deployment readiness used the real auth/API checks instead.
+- Replace the temporary `sslip.io` hostname with the final domain when DNS is decided.
+- Move repeatable provisioning into an IaC or deploy workflow if this EC2 path becomes the long-term deployment lane.


### PR DESCRIPTION
## Summary

- Records the completed AWS EC2/EBS deployment evidence for frontend and backend.
- Captures public endpoint, EC2/EBS runtime topology, service layout, and validation commands.
- Documents that runtime secrets and SSH material remain outside committed files.

## Trace

- Target issue: Closes EVNSolution/thundercrew-domain#102
- Change-control: EVNSolution/clever-change-control#96
- Branch: `cc-96-ec2-ebs-deployment`

## Deployment endpoint

- https://thundercrew-domain.43.201.57.147.sslip.io

## Validation

- `git diff --check`
- `npm run check:workspace`
- Scoped secret scan for committed deployment docs/source
- Remote backend artifact build: `./gradlew --no-daemon clean bootJar -x test`
- Remote frontend: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run build`
- Remote services active: Spring Boot, Next.js, Nginx, PostgreSQL
- Public HTTPS frontend returned `200 OK`
- Public login page rendered over HTTPS
- Backend admin login API returned `200`
- Protected rider API returned `401 AUTHENTICATION_FAILED` without bearer token
- PostgreSQL Flyway history count: `6`
- Seeded admin count: `1`

## Notes

- EC2 tests that require Testcontainers/Docker were not run on the host; the deployment artifact used `bootJar -x test` after the Docker-dependent test failure was identified.
- `/actuator/health` currently returns the app JSON `500` path, so readiness was verified with real auth/API checks.
- Vercel remains active until permanent AWS domain cutover is decided.
