### PR TITLE
Make production deployment a main-merge action

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -1,0 +1,158 @@
+name: AWS EC2 production deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-ec2-production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-existing-ec2:
+    name: Deploy existing EC2 host
+    runs-on: ubuntu-latest
+    environment: prod
+    timeout-minutes: 45
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      AWS_EC2_INSTANCE_ID: ${{ vars.AWS_EC2_INSTANCE_ID }}
+      AWS_EC2_HOST: ${{ vars.AWS_EC2_HOST }}
+      AWS_EC2_USER: ${{ vars.AWS_EC2_USER || 'ubuntu' }}
+      AWS_EC2_DEPLOY_PATH: ${{ vars.AWS_EC2_DEPLOY_PATH || '/opt/thundercrew/current' }}
+      AWS_EC2_PUBLIC_URL: ${{ vars.AWS_EC2_PUBLIC_URL }}
+    steps:
+      - name: Validate deployment configuration
+        env:
+          PROD_AWS_ROLE_ARN: ${{ vars.PROD_AWS_ROLE_ARN }}
+          AWS_EC2_SSH_PRIVATE_KEY_PRESENT: ${{ secrets.AWS_EC2_SSH_PRIVATE_KEY != '' }}
+          AWS_EC2_KNOWN_HOSTS_PRESENT: ${{ secrets.AWS_EC2_KNOWN_HOSTS != '' }}
+        run: |
+          missing=0
+          for name in PROD_AWS_ROLE_ARN AWS_EC2_INSTANCE_ID AWS_EC2_HOST AWS_EC2_PUBLIC_URL; do
+            if [ -z "${!name}" ]; then
+              echo "::error title=Missing ${name}::Set ${name} as a GitHub variable for the prod environment or repository."
+              missing=1
+            fi
+          done
+
+          if [ "${AWS_EC2_SSH_PRIVATE_KEY_PRESENT}" != "true" ]; then
+            echo "::error title=Missing AWS_EC2_SSH_PRIVATE_KEY::Set the EC2 SSH private key as a GitHub secret for prod deployment."
+            missing=1
+          fi
+
+          if [ "${AWS_EC2_KNOWN_HOSTS_PRESENT}" != "true" ]; then
+            echo "::error title=Missing AWS_EC2_KNOWN_HOSTS::Set the EC2 SSH known_hosts entry as a GitHub secret to keep StrictHostKeyChecking enabled."
+            missing=1
+          fi
+
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "::add-mask::${PROD_AWS_ROLE_ARN}"
+          echo "Deployment configuration is present."
+
+      - name: Enforce production branch for manual dispatch
+        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'main'
+        run: |
+          echo "::error title=Invalid manual deploy ref::Manual production deployment must be dispatched from main. Current ref is ${GITHUB_REF_NAME}."
+          exit 1
+
+      - name: Check out deployment ref
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.PROD_AWS_ROLE_ARN }}
+          role-session-name: thundercrew-domain-ec2-deploy
+
+      - name: Verify target EC2 instance
+        run: |
+          state=$(aws ec2 describe-instances \
+            --instance-ids "${AWS_EC2_INSTANCE_ID}" \
+            --query 'Reservations[0].Instances[0].State.Name' \
+            --output text)
+
+          if [ "${state}" != "running" ]; then
+            echo "::error title=EC2 instance is not running::${AWS_EC2_INSTANCE_ID} state is ${state}."
+            exit 1
+          fi
+
+          echo "Target EC2 instance ${AWS_EC2_INSTANCE_ID} is running."
+
+      - name: Prepare SSH key
+        env:
+          AWS_EC2_SSH_PRIVATE_KEY: ${{ secrets.AWS_EC2_SSH_PRIVATE_KEY }}
+          AWS_EC2_KNOWN_HOSTS: ${{ secrets.AWS_EC2_KNOWN_HOSTS }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${AWS_EC2_SSH_PRIVATE_KEY}" > ~/.ssh/thundercrew_ec2_key
+          chmod 600 ~/.ssh/thundercrew_ec2_key
+          printf '%s\n' "${AWS_EC2_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy application on EC2
+        run: |
+          ssh -i ~/.ssh/thundercrew_ec2_key \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            "${AWS_EC2_USER}@${AWS_EC2_HOST}" \
+            "DEPLOY_SHA='${GITHUB_SHA}' DEPLOY_PATH='${AWS_EC2_DEPLOY_PATH}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          cd "${DEPLOY_PATH}"
+          git fetch --prune origin main
+          git checkout --force "${DEPLOY_SHA}"
+          git reset --hard "${DEPLOY_SHA}"
+
+          ./development/service-ops-api/gradlew --project-dir development/service-ops-api --no-daemon clean bootJar -x test
+
+          npm ci
+          npm run lint
+          npm run typecheck
+          npm run build
+
+          sudo systemctl daemon-reload
+          sudo systemctl restart thundercrew-service-ops-api
+          sleep 8
+          sudo systemctl restart thundercrew-front-admin-web
+          sudo systemctl reload nginx
+
+          systemctl is-active thundercrew-service-ops-api
+          systemctl is-active thundercrew-front-admin-web
+          systemctl is-active nginx
+          systemctl is-active postgresql
+
+          curl -sS -o /tmp/thundercrew-riders.out -w '%{http_code}' http://127.0.0.1:8080/api/v1/riders | grep -qx '401'
+          curl -fsS -o /dev/null http://127.0.0.1:3000/login
+          REMOTE
+
+      - name: Verify public HTTPS endpoint
+        run: |
+          http_code=$(curl -fsS -o /dev/null -w '%{http_code}' "${AWS_EC2_PUBLIC_URL}")
+          if [ "${http_code}" != "200" ]; then
+            echo "::error title=Public endpoint check failed::${AWS_EC2_PUBLIC_URL} returned ${http_code}."
+            exit 1
+          fi
+          echo "Public endpoint returned 200: ${AWS_EC2_PUBLIC_URL}"
+
+      - name: Record deployment summary
+        run: |
+          {
+            echo "## AWS EC2 production deployment"
+            echo "- Repository: ${GITHUB_REPOSITORY}"
+            echo "- Ref: ${GITHUB_REF_NAME}"
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- EC2 instance: ${AWS_EC2_INSTANCE_ID}"
+            echo "- Public URL: ${AWS_EC2_PUBLIC_URL}"
+            echo "- Branch policy: push to main deploys production; dev remains integration."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Change-control 기반 메타데이터는 각 이슈 루프의 일부로 유지�
 Local memory의 deployment metadata는 기록일 뿐 source of truth가 아닙니다.
 Vercel/Supabase의 현재 상태를 말할 때는 CLI/API로 다시 확인합니다.
 
+
+### AWS production deployment
+
+Current production promotion policy:
+
+- `dev` is the integration branch for normal issue/PR work.
+- `main` is the production promotion branch.
+- A push/merge to `main` runs `.github/workflows/aws-ec2-deploy.yml`.
+- The workflow uses GitHub OIDC to assume the production AWS role and updates the existing EC2/EBS host.
+- The workflow does not create EC2/EBS resources; it rebuilds the app on the host and restarts the systemd services.
+- Required runtime secrets stay in GitHub Actions secrets or on the EC2 host, never in committed files.
+
+See `docs/deployment/aws-ec2-main-merge-deploy.md` for the exact variables, secrets, and verification behavior.
+
 ## Root commands
 
 루트 명령은 현재 frontend workspace로 위임됩니다.

--- a/docs/deployment/aws-deployment-readiness.md
+++ b/docs/deployment/aws-deployment-readiness.md
@@ -47,8 +47,8 @@ Required next actions before AWS deployment can run:
 
 1. Choose and create the AWS hosting target, such as Amplify Hosting compute or an OpenNext/SST-managed stack.
 2. Configure AWS-side runtime environment variables for frontend/backend as needed.
-3. Add an actual deploy workflow that uses the now-verified OIDC role.
-4. Keep Vercel as the active frontend deployment until the AWS target has a verified public URL.
+3. Add an actual deploy workflow that uses the now-verified OIDC role. **Done:** `.github/workflows/aws-ec2-deploy.yml` updates the existing EC2 host on `main` pushes.
+4. Keep Vercel as the active frontend deployment until the AWS target has a verified public URL. **Current:** AWS EC2 is verified at the temporary `sslip.io` URL; Vercel remains active until final cutover.
 
 The smoke workflow now runs under GitHub environment `prod` so a production OIDC trust policy can target `repo:EVNSolution/thundercrew-domain:environment:prod`.
 

--- a/docs/deployment/aws-ec2-main-merge-deploy.md
+++ b/docs/deployment/aws-ec2-main-merge-deploy.md
@@ -1,0 +1,84 @@
+# AWS EC2 Main-Merge Deployment
+
+## Status
+
+- Target issue: `EVNSolution/thundercrew-domain#104`
+- Change-control issue: `EVNSolution/clever-change-control#97`
+- Branch: `cc-97-main-merge-ec2-deploy`
+- Deployment model: update the existing EC2/EBS host when `main` receives a push.
+
+This change does not create EC2, EBS, network, DNS, or database resources. It only
+adds the workflow needed to update the application on the already-provisioned
+host.
+
+## Branch policy
+
+| Branch | Role | Deployment effect |
+| --- | --- | --- |
+| `dev` | integration branch for issue/PR work | no production deploy |
+| `main` | production promotion branch | `push` to `main` runs AWS EC2 deploy |
+| `cc-<change-control>-<slug>` | scoped work branch | no production deploy |
+
+The normal flow is:
+
+```text
+issue/change-control
+→ cc-* branch
+→ PR into dev
+→ verify dev
+→ promotion PR/merge into main
+→ GitHub Actions deploys the existing EC2 host
+```
+
+## Workflow
+
+`.github/workflows/aws-ec2-deploy.yml` runs on:
+
+- `push` to `main`
+- manual `workflow_dispatch` from `main` only
+
+The workflow:
+
+1. Validates required GitHub variables/secrets.
+2. Assumes the production AWS role with GitHub OIDC.
+3. Confirms the configured EC2 instance is running.
+4. SSHes into the existing EC2 host.
+5. Checks out the deployed commit under `/opt/thundercrew/current`.
+6. Builds the Spring Boot artifact with `bootJar -x test`.
+7. Builds the Next.js admin web.
+8. Restarts `thundercrew-service-ops-api` and `thundercrew-front-admin-web`.
+9. Verifies local backend auth protection and frontend login page.
+10. Verifies the public HTTPS endpoint.
+
+## Required GitHub configuration
+
+The workflow uses GitHub environment `prod` and expects these values to be
+available from organization/repository/environment variables or secrets.
+
+Variables:
+
+- `PROD_AWS_ROLE_ARN` — AWS role assumed through OIDC.
+- `AWS_REGION` — currently `ap-northeast-2`.
+- `AWS_EC2_INSTANCE_ID` — currently `i-0d4f75c35b80b25b9`.
+- `AWS_EC2_HOST` — EC2 SSH host, currently the public IP.
+- `AWS_EC2_USER` — currently `ubuntu`.
+- `AWS_EC2_DEPLOY_PATH` — currently `/opt/thundercrew/current`.
+- `AWS_EC2_PUBLIC_URL` — currently `https://thundercrew-domain.43.201.57.147.sslip.io`.
+
+Secrets:
+
+- `AWS_EC2_SSH_PRIVATE_KEY` — private key for the EC2 deploy user.
+- `AWS_EC2_KNOWN_HOSTS` — pinned SSH host key entry for StrictHostKeyChecking.
+
+Do not commit any of the secret values.
+
+## Known constraints
+
+- The current EC2 host does not run Docker, so backend Testcontainers tests are
+  not part of the on-host deployment update. The deployment build uses
+  `bootJar -x test` and relies on prior PR validation for full tests.
+- `/actuator/health` currently returns the application JSON `500` path, so the
+  workflow verifies the backend through the unauthenticated protected API path
+  returning `401` and verifies the frontend over HTTP/HTTPS.
+- The current URL is a temporary `sslip.io` hostname. A permanent domain can
+  replace it later without changing the branch policy.

--- a/docs/process/framework-and-process.md
+++ b/docs/process/framework-and-process.md
@@ -42,9 +42,13 @@ Every non-trivial implementation or durable process change follows this loop:
 
 | Branch | Meaning |
 | --- | --- |
-| `main` | deploy/promotion branch; not normal day-to-day work |
-| `dev` | target repository integration branch |
-| `cc-<change-control-issue>-<slug>` | scoped trace branch for a concrete issue |
+| `main` | production deploy/promotion branch; push/merge to this branch runs AWS EC2 deployment |
+| `dev` | target repository integration branch; normal issue PRs merge here first |
+| `cc-<change-control-issue>-<slug>` | scoped trace branch for a concrete issue; never a production deploy trigger |
+
+### Production promotion rule
+
+Do not treat `dev` merges as production deployments. Promote to production by merging the already-verified integration state into `main`. The `main` push is the deployment trigger and must only contain work that is accepted for the current production update.
 
 ## Change-control metadata maintenance
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/aws-ec2-deploy.yml` for production deployment on `main` pushes.
- Uses GitHub OIDC to assume the production AWS role before updating the existing EC2 host.
- Reuses the current EC2/EBS deployment target; this PR does not create infrastructure.
- Documents the branch policy: `dev` is integration, `main` is production promotion/deploy.
- Configures required GitHub prod variable/secret names for the existing EC2 host without committing secret values.

## Trace

- Closes EVNSolution/thundercrew-domain#104
- Change-control: EVNSolution/clever-change-control#97
- Branch: `cc-97-main-merge-ec2-deploy`

## Concurrent work decision

- Decision: `allowed-with-non-overlap`
- Current open PRs were checked before PR creation: none.
- Scope is limited to deployment workflow/docs for the existing EC2 host.

## Verification

- `git diff --check HEAD^ HEAD`
- Ruby YAML parse for `.github/workflows/aws-ec2-deploy.yml`
- `npm run check:workspace`
- GitHub prod variable/secret name presence check

## Not tested in this PR

- Actual `main` push deployment. This branch intentionally targets `dev`; production deployment should happen only when verified `dev` state is promoted to `main`.
