### PR TITLE
Allow shared SSH deployment and align search panel width

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -242,7 +242,7 @@ textarea { padding-top: 10px; min-height: 96px; }
   width: min(420px, calc(100% - 48px));
   transform: none;
 }
-.map-search-panel-top.is-collapsed { width: min(320px, calc(100% - 48px)); }
+.map-search-panel-top.is-collapsed { width: min(420px, calc(100% - 48px)); }
 .map-search-header { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; }
 .map-search-header strong { display: block; font-size: 16px; }
 .map-search-body { display: grid; gap: 10px; }

--- a/docs/deployment/aws-ec2-main-merge-deploy.md
+++ b/docs/deployment/aws-ec2-main-merge-deploy.md
@@ -82,3 +82,13 @@ Do not commit any of the secret values.
   returning `401` and verifies the frontend over HTTP/HTTPS.
 - The current URL is a temporary `sslip.io` hostname. A permanent domain can
   replace it later without changing the branch policy.
+
+## Temporary SSH access policy
+
+Current temporary operations decision: the EC2 security group allows TCP/22 from
+`0.0.0.0/0` so GitHub-hosted runners and multiple operators can deploy without
+per-run source IP changes.
+
+This is an explicit temporary compromise. Keep SSH key access restricted through
+GitHub/environment secrets and replace this with a narrower deploy access model
+when the team settles the permanent operations path.


### PR DESCRIPTION
## Summary

- Documents the temporary EC2 SSH security group posture requested for shared deployment access: TCP/22 open to `0.0.0.0/0`.
- Keeps the deploy workflow on the simple existing-EC2 SSH update path.
- Aligns the dashboard search panel collapsed width with the expanded width.

## Trace

- Target issue: EVNSolution/thundercrew-domain#106
- Change-control: EVNSolution/clever-change-control#98
- Previous failed main deploy run: https://github.com/EVNSolution/thundercrew-domain/actions/runs/25197573099

## Verification

- `git diff --check`
- workflow YAML parse
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- AWS SG ingress check shows `0.0.0.0/0` on TCP/22

## Next after merge

- Promote `dev` to `main` again.
- Verify the AWS EC2 production deploy run succeeds.
