### PR TITLE
Promote shared SSH deploy fix to main

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -242,7 +242,7 @@ textarea { padding-top: 10px; min-height: 96px; }
   width: min(420px, calc(100% - 48px));
   transform: none;
 }
-.map-search-panel-top.is-collapsed { width: min(320px, calc(100% - 48px)); }
+.map-search-panel-top.is-collapsed { width: min(420px, calc(100% - 48px)); }
 .map-search-header { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; }
 .map-search-header strong { display: block; font-size: 16px; }
 .map-search-body { display: grid; gap: 10px; }

--- a/docs/deployment/aws-ec2-main-merge-deploy.md
+++ b/docs/deployment/aws-ec2-main-merge-deploy.md
@@ -82,3 +82,13 @@ Do not commit any of the secret values.
   returning `401` and verifies the frontend over HTTP/HTTPS.
 - The current URL is a temporary `sslip.io` hostname. A permanent domain can
   replace it later without changing the branch policy.
+
+## Temporary SSH access policy
+
+Current temporary operations decision: the EC2 security group allows TCP/22 from
+`0.0.0.0/0` so GitHub-hosted runners and multiple operators can deploy without
+per-run source IP changes.
+
+This is an explicit temporary compromise. Keep SSH key access restricted through
+GitHub/environment secrets and replace this with a narrower deploy access model
+when the team settles the permanent operations path.


### PR DESCRIPTION
## Summary

Promote the post-run fix from `dev` to `main` after the first main deployment run proved the workflow trigger but failed at SSH access.

This promotion includes:
- temporary shared SSH SG documentation for the current EC2 deployment path
- dashboard search panel collapsed/expanded width alignment

## Trace

- Target issue: EVNSolution/thundercrew-domain#106
- Change-control: EVNSolution/clever-change-control#98
- Previous failed main deploy run: https://github.com/EVNSolution/thundercrew-domain/actions/runs/25197573099

## Expected deployment effect

Merging this PR into `main` should trigger `.github/workflows/aws-ec2-deploy.yml` again. EC2 TCP/22 is now temporarily open to `0.0.0.0/0` by explicit operations decision, so GitHub-hosted runner SSH should connect.

## Verification before promotion

- `git diff --check`
- workflow YAML parse
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- AWS SG ingress check shows `0.0.0.0/0` on TCP/22
