### PR TITLE
Simplify EC2 deploy workflow checks

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -132,18 +132,7 @@ jobs:
           systemctl is-active nginx
           systemctl is-active postgresql
 
-          curl -sS -o /tmp/thundercrew-riders.out -w '%{http_code}' http://127.0.0.1:8080/api/v1/riders | grep -qx '401'
-          curl -fsS -o /dev/null http://127.0.0.1:3000/login
           REMOTE
-
-      - name: Verify public HTTPS endpoint
-        run: |
-          http_code=$(curl -fsS -o /dev/null -w '%{http_code}' "${AWS_EC2_PUBLIC_URL}")
-          if [ "${http_code}" != "200" ]; then
-            echo "::error title=Public endpoint check failed::${AWS_EC2_PUBLIC_URL} returned ${http_code}."
-            exit 1
-          fi
-          echo "Public endpoint returned 200: ${AWS_EC2_PUBLIC_URL}"
 
       - name: Record deployment summary
         run: |

--- a/docs/deployment/aws-ec2-main-merge-deploy.md
+++ b/docs/deployment/aws-ec2-main-merge-deploy.md
@@ -47,8 +47,7 @@ The workflow:
 6. Builds the Spring Boot artifact with `bootJar -x test`.
 7. Builds the Next.js admin web.
 8. Restarts `thundercrew-service-ops-api` and `thundercrew-front-admin-web`.
-9. Verifies local backend auth protection and frontend login page.
-10. Verifies the public HTTPS endpoint.
+9. Confirms the expected systemd services are `active`.
 
 ## Required GitHub configuration
 
@@ -77,9 +76,10 @@ Do not commit any of the secret values.
 - The current EC2 host does not run Docker, so backend Testcontainers tests are
   not part of the on-host deployment update. The deployment build uses
   `bootJar -x test` and relies on prior PR validation for full tests.
-- `/actuator/health` currently returns the application JSON `500` path, so the
-  workflow verifies the backend through the unauthenticated protected API path
-  returning `401` and verifies the frontend over HTTP/HTTPS.
+- The workflow intentionally uses a simple deployment model: build artifacts,
+  restart systemd services, and confirm service units are `active`. HTTP smoke
+  checks are excluded from the deployment action and should be run separately
+  when needed.
 - The current URL is a temporary `sslip.io` hostname. A permanent domain can
   replace it later without changing the branch policy.
 


### PR DESCRIPTION
## Summary

- Removes HTTP smoke checks from the AWS EC2 production deploy workflow.
- Keeps production deploy as simple build/restart/systemd-active confirmation.
- Updates deployment docs to state smoke checks are separate from deploy.

## Trace

- Target issue: EVNSolution/thundercrew-domain#106
- Change-control: EVNSolution/clever-change-control#98
- Previous failed run: https://github.com/EVNSolution/thundercrew-domain/actions/runs/25197781074

## Verification

- `git diff --check`
- workflow YAML parse
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Next after merge

- Promote `dev` to `main` again.
- Verify the AWS EC2 production deploy run succeeds under the simple deploy model.
