### PR TITLE
Promote simple EC2 deploy workflow to main

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -132,18 +132,7 @@ jobs:
           systemctl is-active nginx
           systemctl is-active postgresql
 
-          curl -sS -o /tmp/thundercrew-riders.out -w '%{http_code}' http://127.0.0.1:8080/api/v1/riders | grep -qx '401'
-          curl -fsS -o /dev/null http://127.0.0.1:3000/login
           REMOTE
-
-      - name: Verify public HTTPS endpoint
-        run: |
-          http_code=$(curl -fsS -o /dev/null -w '%{http_code}' "${AWS_EC2_PUBLIC_URL}")
-          if [ "${http_code}" != "200" ]; then
-            echo "::error title=Public endpoint check failed::${AWS_EC2_PUBLIC_URL} returned ${http_code}."
-            exit 1
-          fi
-          echo "Public endpoint returned 200: ${AWS_EC2_PUBLIC_URL}"
 
       - name: Record deployment summary
         run: |

--- a/README.md
+++ b/README.md
@@ -108,9 +108,19 @@ cd development/service-ops-api
 
 ## Deployment note
 
-기존 Vercel 프로젝트는 `thundercrew-domain`입니다. 이 PR은 실제 Vercel project root-directory 설정을 변경하지 않습니다. 다음 배포 시에는 Vercel project root를 `development/front-admin-web`로 맞추거나, 해당 디렉터리 기준으로 CLI deploy를 실행해야 합니다.
+현재 MVP1 기준 운영 배포 기준은 AWS EC2/EBS입니다.
 
-Secrets는 `.env.local` 또는 Vercel/Supabase 환경변수에서만 관리하고 committed files에 저장하지 않습니다.
+- Production promotion branch: `main`.
+- Production deploy trigger: `push`/merge to `main`.
+- Deploy workflow: `.github/workflows/aws-ec2-deploy.yml`.
+- AWS runtime: existing EC2 instance + encrypted EBS root volume.
+- Public endpoint: `https://thundercrew-domain.43.201.57.147.sslip.io`.
+- DNS/TLS basis: `sslip.io` temporary hostname bound to EC2 public IP `43.201.57.147`, with HTTPS certificate issued for that hostname.
+- Backend/frontend runtime: Spring Boot service-ops API + Next.js admin web behind Nginx on the EC2 host.
+
+Vercel deployment history remains as previous frontend-only deployment evidence, but it is not the current MVP1 production deployment target. Keep Vercel only as legacy/backup context until a permanent AWS domain cutover decision is made.
+
+Secrets are managed only through local ignored env files, EC2 host env files, or GitHub environment secrets/variables. Do not store DB passwords, JWT secrets, service-role keys, SSH keys, or connection strings in committed files.
 
 Frontend ↔ backend baseline:
 

--- a/docs/deployment/aws-ec2-main-merge-deploy.md
+++ b/docs/deployment/aws-ec2-main-merge-deploy.md
@@ -47,8 +47,7 @@ The workflow:
 6. Builds the Spring Boot artifact with `bootJar -x test`.
 7. Builds the Next.js admin web.
 8. Restarts `thundercrew-service-ops-api` and `thundercrew-front-admin-web`.
-9. Verifies local backend auth protection and frontend login page.
-10. Verifies the public HTTPS endpoint.
+9. Confirms the expected systemd services are `active`.
 
 ## Required GitHub configuration
 
@@ -77,9 +76,10 @@ Do not commit any of the secret values.
 - The current EC2 host does not run Docker, so backend Testcontainers tests are
   not part of the on-host deployment update. The deployment build uses
   `bootJar -x test` and relies on prior PR validation for full tests.
-- `/actuator/health` currently returns the application JSON `500` path, so the
-  workflow verifies the backend through the unauthenticated protected API path
-  returning `401` and verifies the frontend over HTTP/HTTPS.
+- The workflow intentionally uses a simple deployment model: build artifacts,
+  restart systemd services, and confirm service units are `active`. HTTP smoke
+  checks are excluded from the deployment action and should be run separately
+  when needed.
 - The current URL is a temporary `sslip.io` hostname. A permanent domain can
   replace it later without changing the branch policy.
 


### PR DESCRIPTION
## Summary

Promote the simple EC2 deploy workflow update from `dev` to `main`.

This promotion removes HTTP smoke checks from the production deploy action and keeps deployment to build/restart/systemd-active confirmation only.

## Trace

- Target issue: EVNSolution/thundercrew-domain#106
- Change-control: EVNSolution/clever-change-control#98
- Previous failed smoke run: https://github.com/EVNSolution/thundercrew-domain/actions/runs/25197781074

## Expected deployment effect

Merging this PR into `main` triggers `.github/workflows/aws-ec2-deploy.yml` again under the simple deployment model.

## Verification before promotion

- `git diff --check`
- workflow YAML parse
- `npm run check:workspace`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
