### PR TITLE
Align AWS sslip deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See `docs/deployment/aws-ec2-main-merge-deploy.md` for the exact variables, secr
 
 | 항목 | 기준 이슈/PR | 현재 의미 | 정본 위치 | 비고 |
 | --- | --- | --- | --- | --- |
-| MVP 1 완료/운영 promotion anchor | `EVNSolution/thundercrew-domain#106`, `EVNSolution/clever-change-control#98` | MVP 1 완료 상태를 README/context에 고정하고 `dev` → `main` promotion으로 AWS 배포를 검증하는 최종 anchor | 이 README, `docs/deployment/aws-ec2-main-merge-deploy.md`, GitHub Actions run | 이 행은 main promotion 검증 후 완료 상태가 된다. |
+| MVP 1 완료/운영 promotion anchor | `EVNSolution/thundercrew-domain#106`, `EVNSolution/clever-change-control#98` | MVP 1 완료 상태를 README/context에 고정하고 `dev` → `main` promotion으로 AWS 배포를 검증하는 최종 anchor | 이 README, `docs/deployment/aws-ec2-main-merge-deploy.md`, GitHub Actions run | main promotion과 AWS 배포 검증 완료 상태다. |
 | AWS EC2/EBS MVP runtime baseline | `EVNSolution/thundercrew-domain#102`, `EVNSolution/clever-change-control#96`, PR `#103` | Next.js admin web + Spring Boot API + PostgreSQL을 단일 EC2/EBS 호스트에 배포한 baseline | `docs/deployment/aws-ec2-ebs-deployment.md` | secret 값은 문서/README에 저장하지 않는다. |
 | Main-merge deploy automation | `EVNSolution/thundercrew-domain#104`, `EVNSolution/clever-change-control#97`, PR `#105` | `main` push/merge 시 GitHub Actions가 기존 EC2 host를 업데이트하는 배포 구조 | `.github/workflows/aws-ec2-deploy.yml`, `docs/deployment/aws-ec2-main-merge-deploy.md` | EC2 생성/IaC는 범위 밖, 기존 host update만 수행. |
 | Template lineage | `Clever-OIDC-deploy`, `msa-template` | OIDC 기반 deploy authority와 MSA umbrella repo boundary를 따른다. 단, 현재 EC2 배포는 image-build-once가 아니라 기존 host update 방식의 runtime override다. | `clever-context-monorepo:docs/templates/index.md` | template을 맹신하지 않고 현재 서비스 제약에 맞춘 override를 명시한다. |
@@ -119,6 +119,12 @@ cd development/service-ops-api
 - Backend/frontend runtime: Spring Boot service-ops API + Next.js admin web behind Nginx on the EC2 host.
 
 Vercel deployment history remains as previous frontend-only deployment evidence, but it is not the current MVP1 production deployment target. Keep Vercel only as legacy/backup context until a permanent AWS domain cutover decision is made.
+
+AWS/sslip.io deployment notes are maintained as the current MVP1 production basis:
+
+- `docs/deployment/aws-ec2-ebs-deployment.md` records the provisioned EC2/EBS runtime and public `sslip.io` endpoint.
+- `docs/deployment/aws-ec2-main-merge-deploy.md` records the main-merge GitHub Actions update path for the existing host.
+- `docs/deployment/aws-deployment-readiness.md` is the historical OIDC/readiness note, now updated to point at the verified EC2/EBS path rather than Vercel as production.
 
 Secrets are managed only through local ignored env files, EC2 host env files, or GitHub environment secrets/variables. Do not store DB passwords, JWT secrets, service-role keys, SSH keys, or connection strings in committed files.
 

--- a/docs/deployment/aws-deployment-readiness.md
+++ b/docs/deployment/aws-deployment-readiness.md
@@ -2,28 +2,30 @@
 
 ## Current status
 
-- Frontend production is still on Vercel: `https://thundercrew-domain.vercel.app`.
-- AWS CLI local login is available for account `902837199612`.
-- `ap-northeast-2` currently has no Amplify apps for this account at the time of the readiness check.
-- GitHub repository Actions are enabled.
-- Repository-level GitHub Actions variables/secrets are empty.
-- The organization variable `PROD_AWS_ROLE_ARN` cannot be read through the current local GitHub token because org Actions variable read requires org admin or fine-grained actions variable permission.
+- MVP1 production basis is now AWS EC2/EBS, not Vercel.
+- Public endpoint: `https://thundercrew-domain.43.201.57.147.sslip.io`.
+- DNS/TLS basis: temporary `sslip.io` hostname bound to EC2 public IP `43.201.57.147`, with HTTPS certificate issued for that hostname.
+- Runtime topology: Nginx fronts the Next.js admin web and Spring Boot service-ops API on the existing EC2 host; PostgreSQL runs locally on the same host for the MVP baseline.
+- Deployment trigger: push/merge to `main` runs `.github/workflows/aws-ec2-deploy.yml`.
+- The deploy workflow uses GitHub OIDC via `PROD_AWS_ROLE_ARN` and updates the existing EC2/EBS host. It does not create EC2/EBS resources.
+- Vercel remains only historical frontend-only deployment evidence / legacy backup context until a permanent AWS domain is chosen.
 
 ## What `PROD_AWS_ROLE_ARN` proves
 
-`PROD_AWS_ROLE_ARN` is the role ARN that a GitHub Actions workflow can try to assume through OIDC. By itself it does not deploy the application.
+`PROD_AWS_ROLE_ARN` is the role ARN that a GitHub Actions workflow assumes through OIDC. By itself it does not deploy the application, but it is the authority link used by the current main-merge EC2 deploy workflow.
 
-The minimum deploy chain still needs:
+The active deploy chain is:
 
 1. GitHub Actions workflow permission `id-token: write`.
 2. `aws-actions/configure-aws-credentials` with `role-to-assume: ${{ vars.PROD_AWS_ROLE_ARN }}`.
-3. AWS IAM role trust policy allowing this repository/ref/environment as the OIDC subject.
-4. AWS region and a concrete hosting target.
-5. AWS-side runtime environment variables for the frontend/backend.
+3. AWS IAM role trust policy allowing this repository's production environment subject.
+4. Existing EC2 host metadata provided through GitHub variables.
+5. SSH private key and known-host data provided through GitHub environment secrets.
+6. On-host runtime env files and systemd units already provisioned on the EC2 instance.
 
-## Smoke workflow
+## OIDC smoke workflow
 
-`.github/workflows/aws-oidc-smoke.yml` is a manual, non-deploying smoke test.
+`.github/workflows/aws-oidc-smoke.yml` is a manual, non-deploying OIDC verification workflow.
 
 It checks:
 
@@ -33,35 +35,29 @@ It checks:
 
 It does not create, update, or delete AWS resources.
 
-## Latest smoke result
+Latest recorded OIDC smoke result: run `25195213443` on branch `dev` at `2026-05-01` KST passed. The workflow assumed the production deploy role through GitHub OIDC and `aws sts get-caller-identity` succeeded in account `902837199612`.
 
-Run: `25195213443` on branch `dev` at `2026-05-01` KST after the AWS IAM trust policy was updated for this repository's production environment subject.
+## Main-merge EC2 deployment
 
-Result: **passed**. The workflow sees `vars.PROD_AWS_ROLE_ARN`, assumes the production deploy role through GitHub OIDC, and `aws sts get-caller-identity` succeeds in account `902837199612`.
+`.github/workflows/aws-ec2-deploy.yml` is the active production update workflow.
 
-The role trust now allows the production environment subject `repo:EVNSolution/thundercrew-domain:environment:prod` with audience `sts.amazonaws.com`. Exact production role ARNs should remain in GitHub organization variables rather than committed files.
+- Trigger: `push` to `main` or manual `workflow_dispatch` from `main`.
+- Scope: update the existing EC2/EBS host only.
+- Deployment model: simple build/restart/systemd-active verification.
+- HTTP smoke checks are intentionally excluded from the deployment action and should be run separately when needed.
+- Current public URL: `https://thundercrew-domain.43.201.57.147.sslip.io`.
 
-AWS-side read-only checks still show no Amplify app for this service in `ap-northeast-2`, so OIDC readiness is complete but an AWS hosting target still needs to be chosen and created before replacing Vercel.
+## Temporary SSH access policy
 
-Required next actions before AWS deployment can run:
+Current temporary operations decision: the EC2 security group allows TCP/22 from `0.0.0.0/0` so GitHub-hosted runners and multiple operators can deploy without per-run source IP changes.
 
-1. Choose and create the AWS hosting target, such as Amplify Hosting compute or an OpenNext/SST-managed stack.
-2. Configure AWS-side runtime environment variables for frontend/backend as needed.
-3. Add an actual deploy workflow that uses the now-verified OIDC role. **Done:** `.github/workflows/aws-ec2-deploy.yml` updates the existing EC2 host on `main` pushes.
-4. Keep Vercel as the active frontend deployment until the AWS target has a verified public URL. **Current:** AWS EC2 is verified at the temporary `sslip.io` URL; Vercel remains active until final cutover.
+This is a deliberate temporary compromise. Keep SSH key access restricted through GitHub/environment secrets and replace the wide SSH rule with a narrower deploy access model when the team settles the permanent operations path.
 
-The smoke workflow now runs under GitHub environment `prod` so a production OIDC trust policy can target `repo:EVNSolution/thundercrew-domain:environment:prod`.
+## Frontend hosting note
 
-## Frontend hosting recommendation
+The current frontend has dynamic/server-rendered Next.js routes, server actions, and server-side API calls. Therefore S3-only static hosting is not a direct replacement unless the app is converted to static export.
 
-The current frontend has dynamic/server-rendered Next.js routes, server actions, and server-side API calls. Therefore S3-only static hosting is not a direct replacement for Vercel unless the app is converted to static export.
-
-Recommended AWS paths:
-
-1. **AWS Amplify Hosting compute** for the frontend Next.js app.
-2. **OpenNext/SST-style AWS deployment** if we want infrastructure-as-code ownership and Lambda/CloudFront resources.
-
-Do not remove Vercel production until one AWS path is deployed and verified.
+The current production path is the EC2/EBS host behind Nginx. Amplify Hosting compute or OpenNext/SST-style deployment can be revisited later only if the team decides to replace the existing EC2 lane.
 
 ## Environment variable ownership
 
@@ -69,7 +65,7 @@ Shareable metadata:
 
 - AWS account ID
 - AWS region
-- frontend public URL
+- frontend/backend public URL
 - non-secret deployment IDs
 - environment variable names
 
@@ -80,5 +76,6 @@ Do not commit or print secret values:
 - JWT secrets
 - admin passwords
 - token values
+- SSH private keys
 
-`PROD_AWS_ROLE_ARN` is not a password, but it is deployment authority metadata. Keep it in GitHub organization variables rather than committed files.
+`PROD_AWS_ROLE_ARN` is not a password, but it is deployment authority metadata. Keep it in GitHub organization/environment variables rather than committed files.

--- a/docs/deployment/aws-ec2-ebs-deployment.md
+++ b/docs/deployment/aws-ec2-ebs-deployment.md
@@ -14,7 +14,7 @@
 - Temporary DNS: `sslip.io` hostname bound to the EC2 public IP
 - TLS: Let's Encrypt certificate issued on the EC2 host
 
-Vercel remains active until a permanent AWS domain cutover is decided.
+The AWS EC2/EBS host and temporary `sslip.io` hostname are the current MVP1 production basis. Vercel remains only legacy/backup deployment history until a permanent domain cutover is decided.
 
 ## AWS resources
 
@@ -24,7 +24,7 @@ Vercel remains active until a permanent AWS domain cutover is decided.
 - Instance type: `t3.medium`
 - OS image: Ubuntu 24.04 LTS
 - Root EBS: encrypted gp3, 30 GiB, delete-on-termination
-- Security group: HTTP 80 and HTTPS 443 open to the public; SSH 22 restricted to the operator IP used at provisioning time
+- Security group: HTTP 80 and HTTPS 443 open to the public; SSH 22 is temporarily open to `0.0.0.0/0` by operator decision so GitHub-hosted runners and multiple operators can deploy. Narrow this after the permanent operations path is settled
 
 ## Runtime topology
 
@@ -72,4 +72,5 @@ Runtime checks:
 
 - `/actuator/health` currently returns the application's JSON `500` error path, so deployment readiness used the real auth/API checks instead.
 - Replace the temporary `sslip.io` hostname with the final domain when DNS is decided.
-- Move repeatable provisioning into an IaC or deploy workflow if this EC2 path becomes the long-term deployment lane.
+- Main-merge updates now run through `.github/workflows/aws-ec2-deploy.yml`; keep this as the simple update lane for the existing EC2 host unless the deployment architecture changes.
+- Replace the temporary SSH `0.0.0.0/0` rule with a narrower deploy access model after the multi-operator deployment constraint is resolved.


### PR DESCRIPTION
## Summary
- Normalize deployment notes to AWS EC2/EBS as the current MVP1 production basis.
- Document the temporary `sslip.io` endpoint as the active public URL basis.
- Remove stale wording that implied Vercel was still production or that AWS hosting still needed to be chosen.
- Record the temporary SSH `0.0.0.0/0` access decision in the deployment evidence/readiness notes.

## Trace
- Target issue: EVNSolution/thundercrew-domain#106
- Change-control issue: EVNSolution/clever-change-control#98
- Branch: `cc-98-aws-sslip-deploy-note`
- Concurrent-work decision: allowed-with-non-overlap; open PR list checked before starting and no overlapping open target PR was present.

## Verification
- `npm run check:workspace` pass
- `npm run lint` pass
- `npm run typecheck` pass
- `npm run build` pass
- stale deployment wording grep returned no matches for old Vercel/current-production phrases

## Deployment impact
Docs-only change. It should still be promoted through `main` so the main-merge AWS deploy path is exercised with the latest metadata.
