### PR TITLE
Contract template category, return type, and duration unit baseline (#118)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractCategory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractCategory.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.contract.domain;
+
+/**
+ * Business classification for a {@link ContractTemplate}. The legacy
+ * {@code 무제한 계약} system template stays under {@link #CUSTOM} so that
+ * pre-existing rows survive the migration without losing their semantics.
+ */
+public enum ContractCategory {
+    /** 12개월 구독 (월 단위 12개월 고정). */
+    SUBSCRIPTION,
+    /** 일/주/월/분기/반기 단위 단기 렌탈. */
+    RENTAL,
+    /** 기존 운영자 정의 / 시스템 템플릿. */
+    CUSTOM
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractDurationUnit.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractDurationUnit.java
@@ -1,0 +1,35 @@
+package com.thundercrew.opsapi.contract.domain;
+
+/**
+ * 계약 기간 단위. {@link ContractTemplate#getDurationValue()} 와 함께 쓰인다.
+ *
+ * <p>{@link #toMinutes(int)} 는 {@code duration_minutes} 호환 컬럼을 채우기 위한
+ * derived 값. 분기는 90일, 반기는 180일, 년은 365일 기준 단순 환산이며 운영
+ * 캘린더 기반의 정확한 만료 시점은 {@code RiderBikeContract.endAt} 단계에서
+ * 계산한다 (계약 시점에 따른 윤년/월별 일수 보정).</p>
+ */
+public enum ContractDurationUnit {
+    DAY(1440),
+    WEEK(7 * 1440),
+    MONTH(30 * 1440),
+    QUARTER(90 * 1440),
+    HALF_YEAR(180 * 1440),
+    YEAR(365 * 1440);
+
+    private final int minutesPerUnit;
+
+    ContractDurationUnit(int minutesPerUnit) {
+        this.minutesPerUnit = minutesPerUnit;
+    }
+
+    /**
+     * 호환용 {@code duration_minutes} 값을 산출한다. value 가 {@code <= 0} 이면
+     * {@code null} 을 반환해 호환 컬럼이 비어 있도록 둔다.
+     */
+    public Integer toMinutes(int value) {
+        if (value <= 0) {
+            return null;
+        }
+        return Math.toIntExact((long) minutesPerUnit * value);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractReturnType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractReturnType.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.contract.domain;
+
+/**
+ * 계약 종료 시 차량 처분 방식.
+ * <ul>
+ *   <li>{@link #TAKEOVER} — 인수형. 라이더가 차량을 인수.</li>
+ *   <li>{@link #RETURN} — 반납형. 라이더가 차량을 반납.</li>
+ * </ul>
+ * SUBSCRIPTION/RENTAL 카테고리에서는 필수, CUSTOM 에서는 선택.
+ */
+public enum ContractReturnType {
+    TAKEOVER,
+    RETURN
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/domain/ContractTemplate.java
@@ -3,6 +3,8 @@ package com.thundercrew.opsapi.contract.domain;
 import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -24,7 +26,32 @@ public class ContractTemplate extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean systemTemplate;
 
-    public static ContractTemplate create(
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ContractCategory category = ContractCategory.CUSTOM;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "return_type", length = 20)
+    private ContractReturnType returnType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "duration_unit", length = 20)
+    private ContractDurationUnit durationUnit;
+
+    @Column(name = "duration_value")
+    private Integer durationValue;
+
+    @Column(name = "includes_insurance", nullable = false)
+    private boolean includesInsurance = false;
+
+    @Column(name = "default_insurance_item_id")
+    private UUID defaultInsuranceItemId;
+
+    /**
+     * Legacy create — keeps existing callers (frontend that still sends only
+     * {@code durationMinutes}) working as a CUSTOM template.
+     */
+    public static ContractTemplate createLegacy(
             String name,
             Integer durationMinutes,
             String description,
@@ -36,27 +63,94 @@ public class ContractTemplate extends DisplaySequencedEntity {
         template.description = description;
         template.enabled = enabled == null || enabled;
         template.systemTemplate = false;
+        template.category = ContractCategory.CUSTOM;
         return template;
     }
 
-    public void updateAdminManagedFields(
+    /**
+     * Structured create — caller picks an explicit category/returnType/duration
+     * combination. {@code durationMinutes} is derived from
+     * {@code (durationUnit, durationValue)} so the legacy column stays in sync.
+     */
+    public static ContractTemplate createStructured(
             String name,
-            boolean durationMinutesProvided,
-            Integer durationMinutes,
             String description,
-            Boolean enabled
+            Boolean enabled,
+            ContractCategory category,
+            ContractReturnType returnType,
+            ContractDurationUnit durationUnit,
+            Integer durationValue,
+            boolean includesInsurance,
+            UUID defaultInsuranceItemId
     ) {
+        ContractTemplate template = new ContractTemplate();
+        template.name = name;
+        template.description = description;
+        template.enabled = enabled == null || enabled;
+        template.systemTemplate = false;
+        template.category = category == null ? ContractCategory.CUSTOM : category;
+        template.returnType = returnType;
+        template.durationUnit = durationUnit;
+        template.durationValue = durationValue;
+        template.includesInsurance = includesInsurance;
+        template.defaultInsuranceItemId = defaultInsuranceItemId;
+        template.durationMinutes = computeDurationMinutes(durationUnit, durationValue);
+        return template;
+    }
+
+    public void updateBasicFields(String name, String description, Boolean enabled) {
         if (name != null) {
             this.name = name;
-        }
-        if (durationMinutesProvided) {
-            this.durationMinutes = durationMinutes;
         }
         if (description != null) {
             this.description = description;
         }
         if (enabled != null) {
             this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Direct update of the legacy {@code durationMinutes} column. Service must
+     * only call this when the structured fields are not supplied so we don't
+     * silently overwrite the {@code (durationUnit, durationValue)} pair.
+     */
+    public void applyLegacyDurationMinutes(boolean provided, Integer durationMinutes) {
+        if (!provided) {
+            return;
+        }
+        this.durationMinutes = durationMinutes;
+        this.durationUnit = null;
+        this.durationValue = null;
+    }
+
+    public void updateClassification(
+            ContractCategory category,
+            boolean returnTypeProvided,
+            ContractReturnType returnType,
+            boolean durationProvided,
+            ContractDurationUnit durationUnit,
+            Integer durationValue,
+            Boolean includesInsurance,
+            boolean defaultInsuranceItemIdProvided,
+            UUID defaultInsuranceItemId
+    ) {
+        if (category != null) {
+            this.category = category;
+        }
+        if (returnTypeProvided) {
+            this.returnType = returnType;
+        }
+        if (durationProvided) {
+            this.durationUnit = durationUnit;
+            this.durationValue = durationValue;
+            this.durationMinutes = computeDurationMinutes(durationUnit, durationValue);
+        }
+        if (includesInsurance != null) {
+            this.includesInsurance = includesInsurance;
+        }
+        if (defaultInsuranceItemIdProvided) {
+            this.defaultInsuranceItemId = defaultInsuranceItemId;
         }
     }
 
@@ -83,6 +177,37 @@ public class ContractTemplate extends DisplaySequencedEntity {
 
     public boolean isSystemTemplate() {
         return systemTemplate;
+    }
+
+    public ContractCategory getCategory() {
+        return category;
+    }
+
+    public ContractReturnType getReturnType() {
+        return returnType;
+    }
+
+    public ContractDurationUnit getDurationUnit() {
+        return durationUnit;
+    }
+
+    public Integer getDurationValue() {
+        return durationValue;
+    }
+
+    public boolean isIncludesInsurance() {
+        return includesInsurance;
+    }
+
+    public UUID getDefaultInsuranceItemId() {
+        return defaultInsuranceItemId;
+    }
+
+    private static Integer computeDurationMinutes(ContractDurationUnit unit, Integer value) {
+        if (unit == null || value == null || value <= 0) {
+            return null;
+        }
+        return unit.toMinutes(value);
     }
 
     protected ContractTemplate() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateCreateRequest.java
@@ -1,15 +1,33 @@
 package com.thundercrew.opsapi.contract.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
+/**
+ * Backward-compatible: legacy callers can still send only {@code name +
+ * durationMinutes + description + enabled} (the request lands as a CUSTOM
+ * template). New callers should send {@code category + returnType +
+ * durationUnit + durationValue + includesInsurance} so the template carries
+ * structured business meaning. When both shapes arrive the new fields win and
+ * {@code durationMinutes} is ignored at the service layer.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ContractTemplateCreateRequest(
         @NotBlank @Size(max = 100) String name,
         @Positive Integer durationMinutes,
         String description,
-        Boolean enabled
+        Boolean enabled,
+        ContractCategory category,
+        ContractReturnType returnType,
+        ContractDurationUnit durationUnit,
+        @Positive Integer durationValue,
+        Boolean includesInsurance,
+        UUID defaultInsuranceItemId
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateReadResponse.java
@@ -1,5 +1,8 @@
 package com.thundercrew.opsapi.contract.dto;
 
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import com.thundercrew.opsapi.contract.domain.ContractTemplate;
 import java.time.Instant;
 import java.util.UUID;
@@ -13,6 +16,12 @@ public record ContractTemplateReadResponse(
         String description,
         boolean enabled,
         boolean systemTemplate,
+        ContractCategory category,
+        ContractReturnType returnType,
+        ContractDurationUnit durationUnit,
+        Integer durationValue,
+        boolean includesInsurance,
+        UUID defaultInsuranceItemId,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -26,6 +35,12 @@ public record ContractTemplateReadResponse(
                 template.getDescription(),
                 template.isEnabled(),
                 template.isSystemTemplate(),
+                template.getCategory(),
+                template.getReturnType(),
+                template.getDurationUnit(),
+                template.getDurationValue(),
+                template.isIncludesInsurance(),
+                template.getDefaultInsuranceItemId(),
                 template.getCreatedAt(),
                 template.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/ContractTemplateUpdateRequest.java
@@ -1,9 +1,13 @@
 package com.thundercrew.opsapi.contract.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContractTemplateUpdateRequest {
@@ -14,12 +18,28 @@ public class ContractTemplateUpdateRequest {
 
     @Positive
     private Integer durationMinutes;
-
     private boolean durationMinutesProvided;
 
     private String description;
 
     private Boolean enabled;
+
+    private ContractCategory category;
+
+    private ContractReturnType returnType;
+    private boolean returnTypeProvided;
+
+    private ContractDurationUnit durationUnit;
+    private boolean durationUnitProvided;
+
+    @Positive
+    private Integer durationValue;
+    private boolean durationValueProvided;
+
+    private Boolean includesInsurance;
+
+    private UUID defaultInsuranceItemId;
+    private boolean defaultInsuranceItemIdProvided;
 
     public String name() {
         return name;
@@ -56,5 +76,77 @@ public class ContractTemplateUpdateRequest {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public ContractCategory category() {
+        return category;
+    }
+
+    public void setCategory(ContractCategory category) {
+        this.category = category;
+    }
+
+    public ContractReturnType returnType() {
+        return returnType;
+    }
+
+    public boolean returnTypeProvided() {
+        return returnTypeProvided;
+    }
+
+    public void setReturnType(ContractReturnType returnType) {
+        this.returnType = returnType;
+        this.returnTypeProvided = true;
+    }
+
+    public ContractDurationUnit durationUnit() {
+        return durationUnit;
+    }
+
+    public boolean durationUnitProvided() {
+        return durationUnitProvided;
+    }
+
+    public void setDurationUnit(ContractDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
+        this.durationUnitProvided = true;
+    }
+
+    public Integer durationValue() {
+        return durationValue;
+    }
+
+    public boolean durationValueProvided() {
+        return durationValueProvided;
+    }
+
+    public void setDurationValue(Integer durationValue) {
+        this.durationValue = durationValue;
+        this.durationValueProvided = true;
+    }
+
+    public boolean structuredDurationProvided() {
+        return durationUnitProvided || durationValueProvided;
+    }
+
+    public Boolean includesInsurance() {
+        return includesInsurance;
+    }
+
+    public void setIncludesInsurance(Boolean includesInsurance) {
+        this.includesInsurance = includesInsurance;
+    }
+
+    public UUID defaultInsuranceItemId() {
+        return defaultInsuranceItemId;
+    }
+
+    public boolean defaultInsuranceItemIdProvided() {
+        return defaultInsuranceItemIdProvided;
+    }
+
+    public void setDefaultInsuranceItemId(UUID defaultInsuranceItemId) {
+        this.defaultInsuranceItemId = defaultInsuranceItemId;
+        this.defaultInsuranceItemIdProvided = true;
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractTemplateCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractTemplateCommandService.java
@@ -3,6 +3,9 @@ package com.thundercrew.opsapi.contract.service;
 import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
 import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import com.thundercrew.opsapi.contract.domain.ContractTemplate;
 import com.thundercrew.opsapi.contract.dto.ContractTemplateCreateRequest;
 import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
@@ -10,6 +13,8 @@ import com.thundercrew.opsapi.contract.dto.ContractTemplateUpdateRequest;
 import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Clock;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -18,6 +23,14 @@ import org.springframework.util.StringUtils;
 
 @Service
 public class ContractTemplateCommandService {
+
+    private static final Set<ContractDurationUnit> RENTAL_ALLOWED_UNITS = EnumSet.of(
+            ContractDurationUnit.DAY,
+            ContractDurationUnit.WEEK,
+            ContractDurationUnit.MONTH,
+            ContractDurationUnit.QUARTER,
+            ContractDurationUnit.HALF_YEAR
+    );
 
     private final ContractTemplateRepository contractTemplateRepository;
     private final EntityManager entityManager;
@@ -36,12 +49,48 @@ public class ContractTemplateCommandService {
     @Transactional
     public ContractTemplateReadResponse create(ContractTemplateCreateRequest request) {
         assertNameIsNotDuplicated(request.name());
-        ContractTemplate template = ContractTemplate.create(
-                request.name(),
-                request.durationMinutes(),
-                request.description(),
-                request.enabled()
-        );
+
+        boolean structured = request.category() != null
+                || request.returnType() != null
+                || request.durationUnit() != null
+                || request.durationValue() != null
+                || request.includesInsurance() != null
+                || request.defaultInsuranceItemId() != null;
+
+        ContractTemplate template;
+        if (structured) {
+            ContractCategory category = request.category() == null
+                    ? ContractCategory.CUSTOM
+                    : request.category();
+            boolean includesInsurance = Boolean.TRUE.equals(request.includesInsurance());
+            assertClassificationIsConsistent(
+                    category,
+                    request.returnType(),
+                    request.durationUnit(),
+                    request.durationValue(),
+                    includesInsurance,
+                    request.defaultInsuranceItemId()
+            );
+            template = ContractTemplate.createStructured(
+                    request.name(),
+                    request.description(),
+                    request.enabled(),
+                    category,
+                    request.returnType(),
+                    request.durationUnit(),
+                    request.durationValue(),
+                    includesInsurance,
+                    request.defaultInsuranceItemId()
+            );
+        } else {
+            template = ContractTemplate.createLegacy(
+                    request.name(),
+                    request.durationMinutes(),
+                    request.description(),
+                    request.enabled()
+            );
+        }
+
         try {
             ContractTemplate saved = contractTemplateRepository.save(template);
             entityManager.flush();
@@ -61,14 +110,63 @@ public class ContractTemplateCommandService {
                 && contractTemplateRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
             throw new DuplicateActiveResourceException("ContractTemplate", "name");
         }
+
+        boolean structuredTouched = request.category() != null
+                || request.returnTypeProvided()
+                || request.structuredDurationProvided()
+                || request.includesInsurance() != null
+                || request.defaultInsuranceItemIdProvided();
+
         try {
-            template.updateAdminManagedFields(
-                    request.name(),
-                    request.durationMinutesProvided(),
-                    request.durationMinutes(),
-                    request.description(),
-                    request.enabled()
-            );
+            template.updateBasicFields(request.name(), request.description(), request.enabled());
+
+            if (structuredTouched) {
+                ContractCategory effectiveCategory = request.category() != null
+                        ? request.category()
+                        : template.getCategory();
+                ContractReturnType effectiveReturnType = request.returnTypeProvided()
+                        ? request.returnType()
+                        : template.getReturnType();
+                ContractDurationUnit effectiveUnit;
+                Integer effectiveValue;
+                boolean durationStructuredProvided = request.structuredDurationProvided();
+                if (durationStructuredProvided) {
+                    effectiveUnit = request.durationUnit();
+                    effectiveValue = request.durationValue();
+                } else {
+                    effectiveUnit = template.getDurationUnit();
+                    effectiveValue = template.getDurationValue();
+                }
+                boolean effectiveIncludesInsurance = request.includesInsurance() != null
+                        ? request.includesInsurance()
+                        : template.isIncludesInsurance();
+                UUID effectiveDefaultInsuranceItemId = request.defaultInsuranceItemIdProvided()
+                        ? request.defaultInsuranceItemId()
+                        : template.getDefaultInsuranceItemId();
+
+                assertClassificationIsConsistent(
+                        effectiveCategory,
+                        effectiveReturnType,
+                        effectiveUnit,
+                        effectiveValue,
+                        effectiveIncludesInsurance,
+                        effectiveDefaultInsuranceItemId
+                );
+                template.updateClassification(
+                        request.category(),
+                        request.returnTypeProvided(),
+                        request.returnType(),
+                        durationStructuredProvided,
+                        request.durationUnit(),
+                        request.durationValue(),
+                        request.includesInsurance(),
+                        request.defaultInsuranceItemIdProvided(),
+                        request.defaultInsuranceItemId()
+                );
+            } else if (request.durationMinutesProvided()) {
+                template.applyLegacyDurationMinutes(true, request.durationMinutes());
+            }
+
             entityManager.flush();
             return ContractTemplateReadResponse.from(template);
         } catch (DataIntegrityViolationException exception) {
@@ -93,6 +191,53 @@ public class ContractTemplateCommandService {
     private void assertTemplateIsMutable(ContractTemplate template) {
         if (template.isSystemTemplate()) {
             throw new InvalidStateTransitionException("System contract template cannot be modified or deleted.");
+        }
+    }
+
+    /**
+     * Enforce the per-category combination rules:
+     * <ul>
+     *   <li>SUBSCRIPTION: returnType required, fixed at MONTH × 12.</li>
+     *   <li>RENTAL: returnType required, durationUnit ∈ {DAY, WEEK, MONTH, QUARTER, HALF_YEAR}, durationValue required.</li>
+     *   <li>CUSTOM: free-form (every classification field is optional).</li>
+     *   <li>includesInsurance=true requires a defaultInsuranceItemId so the package
+     *       can resolve a real insurance item (Slice B will introduce that resolver).</li>
+     * </ul>
+     */
+    private void assertClassificationIsConsistent(
+            ContractCategory category,
+            ContractReturnType returnType,
+            ContractDurationUnit durationUnit,
+            Integer durationValue,
+            boolean includesInsurance,
+            UUID defaultInsuranceItemId
+    ) {
+        if (category == ContractCategory.SUBSCRIPTION) {
+            if (returnType == null) {
+                throw new InvalidStateTransitionException(
+                        "SUBSCRIPTION 카테고리는 returnType (TAKEOVER/RETURN) 이 필요합니다.");
+            }
+            if (durationUnit != ContractDurationUnit.MONTH || durationValue == null || durationValue != 12) {
+                throw new InvalidStateTransitionException(
+                        "SUBSCRIPTION 카테고리는 durationUnit=MONTH, durationValue=12 만 허용됩니다.");
+            }
+        } else if (category == ContractCategory.RENTAL) {
+            if (returnType == null) {
+                throw new InvalidStateTransitionException(
+                        "RENTAL 카테고리는 returnType (TAKEOVER/RETURN) 이 필요합니다.");
+            }
+            if (durationUnit == null || !RENTAL_ALLOWED_UNITS.contains(durationUnit)) {
+                throw new InvalidStateTransitionException(
+                        "RENTAL 카테고리는 durationUnit 이 DAY/WEEK/MONTH/QUARTER/HALF_YEAR 중 하나여야 합니다.");
+            }
+            if (durationValue == null || durationValue <= 0) {
+                throw new InvalidStateTransitionException(
+                        "RENTAL 카테고리는 양의 durationValue 가 필요합니다.");
+            }
+        }
+        if (includesInsurance && defaultInsuranceItemId == null) {
+            throw new InvalidStateTransitionException(
+                    "includesInsurance=true 인 템플릿은 defaultInsuranceItemId 가 필요합니다.");
         }
     }
 }

--- a/development/service-ops-api/src/main/resources/db/migration/V7__add_contract_template_category_and_form.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V7__add_contract_template_category_and_form.sql
@@ -1,0 +1,81 @@
+-- Add business classification columns to contract_templates so the operator can
+-- describe the template as 구독(SUBSCRIPTION) / 렌탈(RENTAL) / CUSTOM, choose
+-- 인수형(TAKEOVER) vs 반납형(RETURN), pick a duration unit/value, and flag
+-- whether the package includes a default insurance item.
+--
+-- The legacy duration_minutes column is preserved for read-side compatibility;
+-- the new (duration_unit, duration_value) pair is the source of truth going
+-- forward and must be present whenever the category is SUBSCRIPTION or RENTAL.
+--
+-- default_insurance_item_id is a no-FK uuid pointer per the cross-domain policy
+-- (see integrity reference scan endpoint). The follow-up Slice B issue will add
+-- the matching insurance category/period model.
+
+alter table contract_templates
+    add column category varchar(20) not null default 'CUSTOM',
+    add column return_type varchar(20),
+    add column duration_unit varchar(20),
+    add column duration_value integer,
+    add column includes_insurance boolean not null default false,
+    add column default_insurance_item_id uuid;
+
+alter table contract_templates
+    add constraint ck_contract_templates_category
+        check (category in ('SUBSCRIPTION', 'RENTAL', 'CUSTOM')),
+    add constraint ck_contract_templates_return_type
+        check (return_type is null or return_type in ('TAKEOVER', 'RETURN')),
+    add constraint ck_contract_templates_duration_unit
+        check (duration_unit is null
+               or duration_unit in ('DAY', 'WEEK', 'MONTH', 'QUARTER', 'HALF_YEAR', 'YEAR')),
+    add constraint ck_contract_templates_duration_value
+        check (duration_value is null or duration_value > 0),
+    add constraint ck_contract_templates_subscription_return_type_required
+        check (category <> 'SUBSCRIPTION' or return_type is not null),
+    add constraint ck_contract_templates_subscription_duration_fixed
+        check (category <> 'SUBSCRIPTION'
+               or (duration_unit = 'MONTH' and duration_value = 12)),
+    add constraint ck_contract_templates_rental_return_type_required
+        check (category <> 'RENTAL' or return_type is not null),
+    add constraint ck_contract_templates_rental_duration_unit
+        check (category <> 'RENTAL'
+               or duration_unit in ('DAY', 'WEEK', 'MONTH', 'QUARTER', 'HALF_YEAR')),
+    add constraint ck_contract_templates_rental_duration_value
+        check (category <> 'RENTAL' or duration_value is not null);
+-- includes_insurance=true 가 default_insurance_item_id 를 요구하는 규칙은
+-- service-layer 검증으로 둔다. Slice B(insurance category/period)가 머지되기
+-- 전까지는 seed/운영 데이터가 NULL 상태일 수 있고, 향후 컬럼이 nullable로
+-- 유지되어야 하기 때문.
+
+create index ix_contract_templates_category_active
+    on contract_templates(category)
+    where deleted_at is null;
+
+-- The pre-existing 무제한 계약 system template stays as CUSTOM with NULL form
+-- fields. The default value on `category` already covers it; this update pins
+-- the audit timestamp to make the migration self-describing in history.
+update contract_templates
+set category = 'CUSTOM',
+    updated_at = now()
+where deleted_at is null
+  and system_template = true;
+
+-- Default package seed. UUIDs are deterministic so re-running the migration in
+-- another environment lands the same primary keys (eases trace + diffing).
+-- includes_insurance=true rows leave `default_insurance_item_id` NULL until
+-- Slice B introduces the matching insurance items; the partial unique index on
+-- name keeps duplicate seeds out, and `on conflict do nothing` makes the
+-- insert idempotent if the rows already exist.
+insert into contract_templates (
+    id, name, duration_minutes, description, enabled, system_template,
+    category, return_type, duration_unit, duration_value, includes_insurance,
+    default_insurance_item_id, created_at, updated_at
+) values
+    ('11111111-1111-1111-1111-000000000001', '구독 인수형 12개월 (보험 포함)',          525600, '12개월 구독 / 인수형 / 보험 포함', true, false, 'SUBSCRIPTION', 'TAKEOVER', 'MONTH', 12, true,  null, now(), now()),
+    ('11111111-1111-1111-1111-000000000002', '구독 인수형 12개월 (보험 미포함)',        525600, '12개월 구독 / 인수형 / 보험 미포함', true, false, 'SUBSCRIPTION', 'TAKEOVER', 'MONTH', 12, false, null, now(), now()),
+    ('11111111-1111-1111-1111-000000000003', '구독 반납형 12개월 (보험 포함)',          525600, '12개월 구독 / 반납형 / 보험 포함', true, false, 'SUBSCRIPTION', 'RETURN',   'MONTH', 12, true,  null, now(), now()),
+    ('11111111-1111-1111-1111-000000000004', '구독 반납형 12개월 (보험 미포함)',        525600, '12개월 구독 / 반납형 / 보험 미포함', true, false, 'SUBSCRIPTION', 'RETURN',   'MONTH', 12, false, null, now(), now()),
+    ('11111111-1111-1111-1111-000000000005', '렌탈 인수형 (일 단위)',                   1440,  '단기 렌탈 / 인수형 / 일 단위', true, false, 'RENTAL', 'TAKEOVER', 'DAY',   1, false, null, now(), now()),
+    ('11111111-1111-1111-1111-000000000006', '렌탈 반납형 (일 단위)',                   1440,  '단기 렌탈 / 반납형 / 일 단위', true, false, 'RENTAL', 'RETURN',   'DAY',   1, false, null, now(), now()),
+    ('11111111-1111-1111-1111-000000000007', '렌탈 인수형 (월 단위)',                   43200, '중기 렌탈 / 인수형 / 월 단위', true, false, 'RENTAL', 'TAKEOVER', 'MONTH', 1, false, null, now(), now()),
+    ('11111111-1111-1111-1111-000000000008', '렌탈 반납형 (월 단위)',                   43200, '중기 렌탈 / 반납형 / 월 단위', true, false, 'RENTAL', 'RETURN',   'MONTH', 1, false, null, now(), now())
+on conflict do nothing;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractTemplateClassificationApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractTemplateClassificationApiTests.java
@@ -1,0 +1,359 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice A: contract template category, return type, duration unit, and the
+ * package-with-insurance flag. Validates the new business rules layered on
+ * top of the existing legacy API surface (which is still verified by
+ * {@code ContractTemplateCommandApiContractTests}).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ContractTemplateClassificationApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID DEFAULT_INSURANCE_ITEM_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-aaaaaaaaaaaa");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        // V7 seed rows live with system_template = false; preserve them for
+        // tests that assert on seed presence and reset only operator-created
+        // rows by using a non-overlapping name predicate.
+        jdbcTemplate.update("""
+                delete from contract_templates
+                where system_template = false
+                  and id not in (
+                      '11111111-1111-1111-1111-000000000001',
+                      '11111111-1111-1111-1111-000000000002',
+                      '11111111-1111-1111-1111-000000000003',
+                      '11111111-1111-1111-1111-000000000004',
+                      '11111111-1111-1111-1111-000000000005',
+                      '11111111-1111-1111-1111-000000000006',
+                      '11111111-1111-1111-1111-000000000007',
+                      '11111111-1111-1111-1111-000000000008'
+                  )
+                """);
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void subscriptionTemplateAcceptsMonth12WithReturnTypeAndInsurance() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"테스트 12개월 구독·인수형·보험포함",
+                                  "category":"SUBSCRIPTION",
+                                  "returnType":"TAKEOVER",
+                                  "durationUnit":"MONTH",
+                                  "durationValue":12,
+                                  "includesInsurance":true,
+                                  "defaultInsuranceItemId":"%s"
+                                }
+                                """.formatted(DEFAULT_INSURANCE_ITEM_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.category").value("SUBSCRIPTION"))
+                .andExpect(jsonPath("$.returnType").value("TAKEOVER"))
+                .andExpect(jsonPath("$.durationUnit").value("MONTH"))
+                .andExpect(jsonPath("$.durationValue").value(12))
+                .andExpect(jsonPath("$.includesInsurance").value(true))
+                .andExpect(jsonPath("$.defaultInsuranceItemId").value(DEFAULT_INSURANCE_ITEM_ID.toString()))
+                .andExpect(jsonPath("$.durationMinutes").value(12 * 30 * 1440))
+                .andReturn();
+        assertThat(result.getResponse().getStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void subscriptionTemplateRejectsNonMonth12Combinations() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 구독·일단위",
+                                  "category":"SUBSCRIPTION",
+                                  "returnType":"TAKEOVER",
+                                  "durationUnit":"DAY",
+                                  "durationValue":30
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 구독·6개월",
+                                  "category":"SUBSCRIPTION",
+                                  "returnType":"RETURN",
+                                  "durationUnit":"MONTH",
+                                  "durationValue":6
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void subscriptionTemplateRejectsMissingReturnType() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 구독·반환유형 누락",
+                                  "category":"SUBSCRIPTION",
+                                  "durationUnit":"MONTH",
+                                  "durationValue":12
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void rentalTemplateAcceptsAllowedUnitsAndRejectsYear() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"테스트 일단위 렌탈",
+                                  "category":"RENTAL",
+                                  "returnType":"RETURN",
+                                  "durationUnit":"DAY",
+                                  "durationValue":7
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.category").value("RENTAL"))
+                .andExpect(jsonPath("$.durationUnit").value("DAY"))
+                .andExpect(jsonPath("$.durationValue").value(7))
+                .andExpect(jsonPath("$.includesInsurance").value(false));
+
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 렌탈·년단위",
+                                  "category":"RENTAL",
+                                  "returnType":"TAKEOVER",
+                                  "durationUnit":"YEAR",
+                                  "durationValue":1
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 렌탈·기간없음",
+                                  "category":"RENTAL",
+                                  "returnType":"RETURN",
+                                  "durationUnit":"WEEK"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void includesInsuranceRequiresDefaultInsuranceItemId() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 구독·보험포함·보험없음",
+                                  "category":"SUBSCRIPTION",
+                                  "returnType":"TAKEOVER",
+                                  "durationUnit":"MONTH",
+                                  "durationValue":12,
+                                  "includesInsurance":true
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void migrationSeedRowsArePresent() throws Exception {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+                select id, name, category, return_type, duration_unit, duration_value, includes_insurance
+                from contract_templates
+                where deleted_at is null and system_template = false
+                  and id like '11111111-1111-1111-1111-%'
+                order by id asc
+                """);
+
+        assertThat(rows).hasSize(8);
+        assertThat(rows.get(0).get("category")).isEqualTo("SUBSCRIPTION");
+        assertThat(rows.get(0).get("return_type")).isEqualTo("TAKEOVER");
+        assertThat(rows.get(0).get("duration_unit")).isEqualTo("MONTH");
+        assertThat(rows.get(0).get("duration_value")).isEqualTo(12);
+        assertThat(rows.get(0).get("includes_insurance")).isEqualTo(true);
+
+        assertThat(rows.get(4).get("category")).isEqualTo("RENTAL");
+        assertThat(rows.get(4).get("duration_unit")).isEqualTo("DAY");
+        assertThat(rows.get(4).get("includes_insurance")).isEqualTo(false);
+    }
+
+    @Test
+    void legacyDurationMinutesPayloadStillCreatesCustomTemplate() throws Exception {
+        mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"테스트 레거시 17280분","durationMinutes":17280}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.category").value("CUSTOM"))
+                .andExpect(jsonPath("$.returnType").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.durationUnit").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.durationValue").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.durationMinutes").value(17280))
+                .andExpect(jsonPath("$.includesInsurance").value(false));
+    }
+
+    @Test
+    void updateChangesCategoryAndStructuredDuration() throws Exception {
+        // Create RENTAL first.
+        MvcResult created = mockMvc.perform(post("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"테스트 일단위 렌탈 (수정 대상)",
+                                  "category":"RENTAL",
+                                  "returnType":"RETURN",
+                                  "durationUnit":"DAY",
+                                  "durationValue":3
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String id = extractId(created);
+
+        // Promote to SUBSCRIPTION with valid MONTH/12.
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category":"SUBSCRIPTION",
+                                  "returnType":"TAKEOVER",
+                                  "durationUnit":"MONTH",
+                                  "durationValue":12
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("SUBSCRIPTION"))
+                .andExpect(jsonPath("$.returnType").value("TAKEOVER"))
+                .andExpect(jsonPath("$.durationUnit").value("MONTH"))
+                .andExpect(jsonPath("$.durationValue").value(12));
+
+        // Try inconsistent SUBSCRIPTION change — must reject.
+        mockMvc.perform(patch("/api/v1/contract-templates/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"durationUnit":"DAY","durationValue":30}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void readResponseExposesNewClassificationFields() throws Exception {
+        mockMvc.perform(get("/api/v1/contract-templates")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[?(@.id=='11111111-1111-1111-1111-000000000001')].category").value(
+                        org.hamcrest.Matchers.contains("SUBSCRIPTION")))
+                .andExpect(jsonPath("$.items[?(@.id=='11111111-1111-1111-1111-000000000005')].durationUnit").value(
+                        org.hamcrest.Matchers.contains("DAY")));
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
## Summary

- `contract_templates` 에 비즈니스 분류 컬럼 추가 (`category` / `return_type` / `duration_unit` / `duration_value` / `includes_insurance` / `default_insurance_item_id`).
- 기본 패키지 시드 8개: 구독·인수형/반납형 × with/without 보험 (4) + 렌탈·인수형/반납형 × 일/월 단위 (4).
- `POST/PATCH /api/v1/contract-templates` 가 카테고리별 허용 조합을 검증 (SUBSCRIPTION = MONTH×12, RENTAL = DAY/WEEK/MONTH/QUARTER/HALF_YEAR), legacy `durationMinutes` 페이로드는 그대로 호환.

## Trace

- Target issue: EVNSolution/thundercrew-domain#118
- Change-control issue: EVNSolution/clever-change-control#113
- Root project-start: EVNSolution/clever-change-control#45

## Scope

Backend-only baseline. 라이더 ↔ 차량 계약 자체(`rider_bike_contracts`)는 변경하지 않고 템플릿 분류만 도입합니다. Slice B(insurance category/period) 와 Slice C(rider education records) 가 별도 issue/branch 로 이어집니다.

Included:
- Flyway V7 마이그레이션:
  - 6개 신규 컬럼 + check constraint (SUBSCRIPTION × DAY/30 같은 잘못된 조합 차단).
  - 시드 8개. 기존 \`무제한 계약\` 시스템 템플릿은 \`category=CUSTOM\` 으로 보존.
- Java enum 3종 (\`ContractCategory\`, \`ContractReturnType\`, \`ContractDurationUnit\`).
- \`ContractTemplate\` 엔티티 확장 + \`createLegacy\` / \`createStructured\` 진입점 분리.
- \`ContractTemplateCreateRequest\` / \`UpdateRequest\` / \`ReadResponse\` 새 필드 추가.
- \`ContractTemplateCommandService\` 검증 로직 (\`assertClassificationIsConsistent\`) 추가.
- 신규 \`ContractTemplateClassificationApiTests\` (8개 케이스).

Excluded:
- 보험 도메인 변경 (Slice B).
- 라이더 교육 (Slice C).
- 프론트 어드민 폼 (Slice E).
- 자동 보험 발급 로직 (\`default_insurance_item_id\` 컬럼만 둠).

## Validation

| 항목 | 결과 |
|------|------|
| \`./gradlew compileJava compileTestJava\` | ✅ BUILD SUCCESSFUL (1m 42s) |
| \`./gradlew test --tests ArchitectureBoundaryTests ScaffoldPackageSkeletonTests\` | ✅ BUILD SUCCESSFUL (27s) |
| Testcontainers 통합 테스트 (\`./gradlew test\` 전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경에서 한 번 돌려서 verify 필요. |

## Test plan

- [ ] IDE에서 \`./gradlew test\` 전체 (Testcontainers PostgreSQL 포함) 실행 → 통합 테스트 8개 (\`ContractTemplateClassificationApiTests\`) 통과 + 기존 \`ContractTemplateCommandApiContractTests\` / \`ReadOnlyApiContractTests\` / \`RiderBikeContractCommandApiContractTests\` 회귀 없음 확인.
- [ ] 새로 추가된 V7 시드 8행이 dev DB에 반영되는지 (\`select count(*) from contract_templates where deleted_at is null and id like 11111111-1111-1111-1111-%\` = 8).
- [ ] 기존 시스템 템플릿 (\`무제한 계약\`) 이 \`category=CUSTOM\` 으로 살아 있는지.
- [ ] PATCH 로 SUBSCRIPTION × DAY/30 같은 잘못된 조합이 \`409 INVALID_STATE_TRANSITION\` 으로 거부되는지.
- [ ] 기존 admin web 어드민 폼이 새 컬럼 없이 \`durationMinutes\` 만 보내는 페이로드도 그대로 동작하는지 (legacy 호환).

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #116 (frontend monitoring baseline, file-disjoint), #118 (이 PR의 타깃).
- Open target PRs at PR open: #117 (frontend monitoring baseline, file-disjoint).
- Open clever-change-control issues: #100, #24, #23 (delivery server / msa-platform — 무관).

## Note

브랜치는 dev 에서 분기 (PR #117 의 \`cc-112-monitoring-mapshell-foundation\` 와 파일 충돌 0). PR #117 머지 순서와 무관하게 머지 가능합니다.