### PR TITLE
Insurance category, coverage type, and period baseline (#120)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceCategory.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceCategory.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.insurance.domain;
+
+/**
+ * 보험 분류.
+ * <ul>
+ *   <li>{@link #PRIMARY} — 메인 보험 (유상운송종합/책임 등 12개월 단위).</li>
+ *   <li>{@link #ADDON} — 부가 보험 (시간제/원데이 등 짧은 기간, 다중 발급 가능).</li>
+ * </ul>
+ */
+public enum InsuranceCategory {
+    PRIMARY,
+    ADDON
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceCoverageType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceCoverageType.java
@@ -1,0 +1,18 @@
+package com.thundercrew.opsapi.insurance.domain;
+
+/**
+ * 보장 유형. 운영자가 보험을 분류·검색하는 기준이며, 정부/감독 보고서에서도
+ * 이 enum 값을 그대로 보여줄 수 있도록 명시적 enum 으로 둔다.
+ */
+public enum InsuranceCoverageType {
+    /** 유상운송종합보험 — 메인 12개월. */
+    GENERAL_PAID_TRANSPORT,
+    /** 유상운송책임보험 — 메인 12개월. */
+    LIABILITY_PAID_TRANSPORT,
+    /** 시간제보험 — 시간 단위 부가. */
+    HOURLY,
+    /** 원데이보험 — 하루 단위 부가. */
+    ONE_DAY,
+    /** 분류되지 않은 기타. */
+    OTHER
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceDurationUnit.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceDurationUnit.java
@@ -1,0 +1,15 @@
+package com.thundercrew.opsapi.insurance.domain;
+
+/**
+ * 보험 기본 기간 단위. 시간제 보험을 표현하기 위해 {@link #HOUR} 부터 시작한다는
+ * 점이 {@code ContractDurationUnit} 과 다르다 (계약은 일 단위가 최소).
+ */
+public enum InsuranceDurationUnit {
+    HOUR,
+    DAY,
+    WEEK,
+    MONTH,
+    QUARTER,
+    HALF_YEAR,
+    YEAR
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/InsuranceItem.java
@@ -3,6 +3,8 @@ package com.thundercrew.opsapi.insurance.domain;
 import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -19,22 +21,51 @@ public class InsuranceItem extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InsuranceCategory category = InsuranceCategory.PRIMARY;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coverage_type", length = 40)
+    private InsuranceCoverageType coverageType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "default_duration_unit", length = 20)
+    private InsuranceDurationUnit defaultDurationUnit;
+
+    @Column(name = "default_duration_value")
+    private Integer defaultDurationValue;
+
     public static InsuranceItem create(
             String name,
             String description,
-            Boolean enabled
+            Boolean enabled,
+            InsuranceCategory category,
+            InsuranceCoverageType coverageType,
+            InsuranceDurationUnit defaultDurationUnit,
+            Integer defaultDurationValue
     ) {
         InsuranceItem item = new InsuranceItem();
         item.name = name;
         item.description = description;
         item.enabled = enabled == null || enabled;
+        item.category = category == null ? InsuranceCategory.PRIMARY : category;
+        item.coverageType = coverageType;
+        item.defaultDurationUnit = defaultDurationUnit;
+        item.defaultDurationValue = defaultDurationValue;
         return item;
     }
 
     public void updateOperatorManagedFields(
             String name,
             String description,
-            Boolean enabled
+            Boolean enabled,
+            InsuranceCategory category,
+            boolean coverageTypeProvided,
+            InsuranceCoverageType coverageType,
+            boolean defaultDurationProvided,
+            InsuranceDurationUnit defaultDurationUnit,
+            Integer defaultDurationValue
     ) {
         if (name != null) {
             this.name = name;
@@ -44,6 +75,16 @@ public class InsuranceItem extends DisplaySequencedEntity {
         }
         if (enabled != null) {
             this.enabled = enabled;
+        }
+        if (category != null) {
+            this.category = category;
+        }
+        if (coverageTypeProvided) {
+            this.coverageType = coverageType;
+        }
+        if (defaultDurationProvided) {
+            this.defaultDurationUnit = defaultDurationUnit;
+            this.defaultDurationValue = defaultDurationValue;
         }
     }
 
@@ -62,6 +103,22 @@ public class InsuranceItem extends DisplaySequencedEntity {
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public InsuranceCategory getCategory() {
+        return category;
+    }
+
+    public InsuranceCoverageType getCoverageType() {
+        return coverageType;
+    }
+
+    public InsuranceDurationUnit getDefaultDurationUnit() {
+        return defaultDurationUnit;
+    }
+
+    public Integer getDefaultDurationValue() {
+        return defaultDurationValue;
     }
 
     protected InsuranceItem() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/domain/RiderInsurance.java
@@ -22,29 +22,56 @@ public class RiderInsurance extends DisplaySequencedEntity {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    @Column(name = "starts_at")
+    private Instant startsAt;
+
+    @Column(name = "ends_at")
+    private Instant endsAt;
+
+    @Column(name = "rider_bike_contract_id")
+    private UUID riderBikeContractId;
+
     public static RiderInsurance create(
             UUID riderId,
             UUID insuranceItemId,
             String memo,
-            Boolean enabled
+            Boolean enabled,
+            Instant startsAt,
+            Instant endsAt,
+            UUID riderBikeContractId
     ) {
         RiderInsurance riderInsurance = new RiderInsurance();
         riderInsurance.riderId = riderId;
         riderInsurance.insuranceItemId = insuranceItemId;
         riderInsurance.memo = memo;
         riderInsurance.enabled = enabled == null || enabled;
+        riderInsurance.startsAt = startsAt;
+        riderInsurance.endsAt = endsAt;
+        riderInsurance.riderBikeContractId = riderBikeContractId;
         return riderInsurance;
     }
 
     public void updateOperatorManagedFields(
             String memo,
-            Boolean enabled
+            Boolean enabled,
+            boolean periodProvided,
+            Instant startsAt,
+            Instant endsAt,
+            boolean riderBikeContractIdProvided,
+            UUID riderBikeContractId
     ) {
         if (memo != null) {
             this.memo = memo;
         }
         if (enabled != null) {
             this.enabled = enabled;
+        }
+        if (periodProvided) {
+            this.startsAt = startsAt;
+            this.endsAt = endsAt;
+        }
+        if (riderBikeContractIdProvided) {
+            this.riderBikeContractId = riderBikeContractId;
         }
     }
 
@@ -53,11 +80,11 @@ public class RiderInsurance extends DisplaySequencedEntity {
         markDeleted(actorId, deletedAt);
     }
 
-    public java.util.UUID getRiderId() {
+    public UUID getRiderId() {
         return riderId;
     }
 
-    public java.util.UUID getInsuranceItemId() {
+    public UUID getInsuranceItemId() {
         return insuranceItemId;
     }
 
@@ -67,6 +94,18 @@ public class RiderInsurance extends DisplaySequencedEntity {
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public Instant getStartsAt() {
+        return startsAt;
+    }
+
+    public Instant getEndsAt() {
+        return endsAt;
+    }
+
+    public UUID getRiderBikeContractId() {
+        return riderBikeContractId;
     }
 
     protected RiderInsurance() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemCreateRequest.java
@@ -1,13 +1,27 @@
 package com.thundercrew.opsapi.insurance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceDurationUnit;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+/**
+ * Backward-compatible: legacy callers send only {@code name + description +
+ * enabled} and the row defaults to {@code category=PRIMARY} with NULL coverage
+ * type and NULL default duration. Structured callers add classification and
+ * default-period fields.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record InsuranceItemCreateRequest(
         @NotBlank @Size(max = 100) String name,
         String description,
-        Boolean enabled
+        Boolean enabled,
+        InsuranceCategory category,
+        InsuranceCoverageType coverageType,
+        InsuranceDurationUnit defaultDurationUnit,
+        @Positive Integer defaultDurationValue
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemReadResponse.java
@@ -1,5 +1,8 @@
 package com.thundercrew.opsapi.insurance.dto;
 
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceDurationUnit;
 import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
 import java.time.Instant;
 import java.util.UUID;
@@ -10,6 +13,10 @@ public record InsuranceItemReadResponse(
         String name,
         String description,
         boolean enabled,
+        InsuranceCategory category,
+        InsuranceCoverageType coverageType,
+        InsuranceDurationUnit defaultDurationUnit,
+        Integer defaultDurationValue,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -20,6 +27,10 @@ public record InsuranceItemReadResponse(
                 item.getName(),
                 item.getDescription(),
                 item.isEnabled(),
+                item.getCategory(),
+                item.getCoverageType(),
+                item.getDefaultDurationUnit(),
+                item.getDefaultDurationValue(),
                 item.getCreatedAt(),
                 item.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/InsuranceItemUpdateRequest.java
@@ -1,7 +1,11 @@
 package com.thundercrew.opsapi.insurance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceDurationUnit;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,6 +18,18 @@ public class InsuranceItemUpdateRequest {
     private String description;
 
     private Boolean enabled;
+
+    private InsuranceCategory category;
+
+    private InsuranceCoverageType coverageType;
+    private boolean coverageTypeProvided;
+
+    private InsuranceDurationUnit defaultDurationUnit;
+    private boolean defaultDurationUnitProvided;
+
+    @Positive
+    private Integer defaultDurationValue;
+    private boolean defaultDurationValueProvided;
 
     public String name() {
         return name;
@@ -37,5 +53,48 @@ public class InsuranceItemUpdateRequest {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public InsuranceCategory category() {
+        return category;
+    }
+
+    public void setCategory(InsuranceCategory category) {
+        this.category = category;
+    }
+
+    public InsuranceCoverageType coverageType() {
+        return coverageType;
+    }
+
+    public boolean coverageTypeProvided() {
+        return coverageTypeProvided;
+    }
+
+    public void setCoverageType(InsuranceCoverageType coverageType) {
+        this.coverageType = coverageType;
+        this.coverageTypeProvided = true;
+    }
+
+    public InsuranceDurationUnit defaultDurationUnit() {
+        return defaultDurationUnit;
+    }
+
+    public void setDefaultDurationUnit(InsuranceDurationUnit defaultDurationUnit) {
+        this.defaultDurationUnit = defaultDurationUnit;
+        this.defaultDurationUnitProvided = true;
+    }
+
+    public Integer defaultDurationValue() {
+        return defaultDurationValue;
+    }
+
+    public void setDefaultDurationValue(Integer defaultDurationValue) {
+        this.defaultDurationValue = defaultDurationValue;
+        this.defaultDurationValueProvided = true;
+    }
+
+    public boolean defaultDurationProvided() {
+        return defaultDurationUnitProvided || defaultDurationValueProvided;
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceCreateRequest.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.insurance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -9,6 +10,9 @@ public record RiderInsuranceCreateRequest(
         @NotNull UUID riderId,
         @NotNull UUID insuranceItemId,
         String memo,
-        Boolean enabled
+        Boolean enabled,
+        Instant startsAt,
+        Instant endsAt,
+        UUID riderBikeContractId
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceReadResponse.java
@@ -11,6 +11,9 @@ public record RiderInsuranceReadResponse(
         UUID insuranceItemId,
         String memo,
         boolean enabled,
+        Instant startsAt,
+        Instant endsAt,
+        UUID riderBikeContractId,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -22,6 +25,9 @@ public record RiderInsuranceReadResponse(
                 riderInsurance.getInsuranceItemId(),
                 riderInsurance.getMemo(),
                 riderInsurance.isEnabled(),
+                riderInsurance.getStartsAt(),
+                riderInsurance.getEndsAt(),
+                riderInsurance.getRiderBikeContractId(),
                 riderInsurance.getCreatedAt(),
                 riderInsurance.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/dto/RiderInsuranceUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.thundercrew.opsapi.insurance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Instant;
+import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RiderInsuranceUpdateRequest {
@@ -8,6 +10,15 @@ public class RiderInsuranceUpdateRequest {
     private String memo;
 
     private Boolean enabled;
+
+    private Instant startsAt;
+    private boolean startsAtProvided;
+
+    private Instant endsAt;
+    private boolean endsAtProvided;
+
+    private UUID riderBikeContractId;
+    private boolean riderBikeContractIdProvided;
 
     public String memo() {
         return memo;
@@ -23,5 +34,40 @@ public class RiderInsuranceUpdateRequest {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public Instant startsAt() {
+        return startsAt;
+    }
+
+    public void setStartsAt(Instant startsAt) {
+        this.startsAt = startsAt;
+        this.startsAtProvided = true;
+    }
+
+    public Instant endsAt() {
+        return endsAt;
+    }
+
+    public void setEndsAt(Instant endsAt) {
+        this.endsAt = endsAt;
+        this.endsAtProvided = true;
+    }
+
+    public boolean periodProvided() {
+        return startsAtProvided || endsAtProvided;
+    }
+
+    public UUID riderBikeContractId() {
+        return riderBikeContractId;
+    }
+
+    public boolean riderBikeContractIdProvided() {
+        return riderBikeContractIdProvided;
+    }
+
+    public void setRiderBikeContractId(UUID riderBikeContractId) {
+        this.riderBikeContractId = riderBikeContractId;
+        this.riderBikeContractIdProvided = true;
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceItemCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/InsuranceItemCommandService.java
@@ -3,6 +3,9 @@ package com.thundercrew.opsapi.insurance.service;
 import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
 import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceDurationUnit;
 import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
 import com.thundercrew.opsapi.insurance.dto.InsuranceItemCreateRequest;
 import com.thundercrew.opsapi.insurance.dto.InsuranceItemReadResponse;
@@ -40,10 +43,18 @@ public class InsuranceItemCommandService {
     @Transactional
     public InsuranceItemReadResponse create(InsuranceItemCreateRequest request) {
         assertNameIsNotDuplicated(request.name());
+        assertDefaultPeriodIsConsistent(
+                request.defaultDurationUnit(),
+                request.defaultDurationValue()
+        );
         InsuranceItem item = InsuranceItem.create(
                 request.name(),
                 request.description(),
-                request.enabled()
+                request.enabled(),
+                request.category(),
+                request.coverageType(),
+                request.defaultDurationUnit(),
+                request.defaultDurationValue()
         );
         try {
             InsuranceItem saved = insuranceItemRepository.save(item);
@@ -63,11 +74,23 @@ public class InsuranceItemCommandService {
                 && insuranceItemRepository.existsByNameAndIdNotAndDeletedAtIsNull(request.name(), id)) {
             throw new DuplicateActiveResourceException("InsuranceItem", "name");
         }
+        if (request.defaultDurationProvided()) {
+            assertDefaultPeriodIsConsistent(
+                    request.defaultDurationUnit(),
+                    request.defaultDurationValue()
+            );
+        }
         try {
             item.updateOperatorManagedFields(
                     request.name(),
                     request.description(),
-                    request.enabled()
+                    request.enabled(),
+                    request.category(),
+                    request.coverageTypeProvided(),
+                    request.coverageType(),
+                    request.defaultDurationProvided(),
+                    request.defaultDurationUnit(),
+                    request.defaultDurationValue()
             );
             entityManager.flush();
             return InsuranceItemReadResponse.from(item);
@@ -91,6 +114,19 @@ public class InsuranceItemCommandService {
     private void assertNameIsNotDuplicated(String name) {
         if (insuranceItemRepository.existsByNameAndDeletedAtIsNull(name)) {
             throw new DuplicateActiveResourceException("InsuranceItem", "name");
+        }
+    }
+
+    /**
+     * 단위와 값은 함께 들어와야 한다. 한쪽만 있으면 잘못된 상태.
+     */
+    private void assertDefaultPeriodIsConsistent(
+            InsuranceDurationUnit unit,
+            Integer value
+    ) {
+        if ((unit == null) != (value == null)) {
+            throw new InvalidStateTransitionException(
+                    "defaultDurationUnit 과 defaultDurationValue 는 함께 제공되어야 합니다.");
         }
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/RiderInsuranceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/insurance/service/RiderInsuranceCommandService.java
@@ -15,6 +15,7 @@ import com.thundercrew.opsapi.insurance.repository.RiderInsuranceRepository;
 import com.thundercrew.opsapi.rider.repository.RiderRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -47,13 +48,23 @@ public class RiderInsuranceCommandService {
     public RiderInsuranceReadResponse create(RiderInsuranceCreateRequest request) {
         assertActiveRiderReference(request.riderId());
         findEnabledInsuranceItemReference(request.insuranceItemId());
+        assertPeriodIsConsistent(request.startsAt(), request.endsAt());
+
+        // 이번 슬라이스에서는 PRIMARY/ADDON 모두 동일한 (rider, item) 활성
+        // unique 정책을 유지한다 — DB partial unique index 가 그대로이기
+        // 때문. 부가 보험 다중 발급 (starts_at 별 unique) 은 후속 슬라이스에서
+        // partial unique index 자체를 (rider_id, insurance_item_id,
+        // COALESCE(starts_at,'epoch')) 형태로 바꾼 뒤에 풀어준다.
         assertRiderInsurancePairIsNotDuplicated(request.riderId(), request.insuranceItemId());
 
         RiderInsurance riderInsurance = RiderInsurance.create(
                 request.riderId(),
                 request.insuranceItemId(),
                 request.memo(),
-                request.enabled()
+                request.enabled(),
+                request.startsAt(),
+                request.endsAt(),
+                request.riderBikeContractId()
         );
         try {
             RiderInsurance saved = riderInsuranceRepository.save(riderInsurance);
@@ -73,7 +84,19 @@ public class RiderInsuranceCommandService {
             assertActiveRiderReference(riderInsurance.getRiderId());
             findEnabledInsuranceItemReference(riderInsurance.getInsuranceItemId());
         }
-        riderInsurance.updateOperatorManagedFields(request.memo(), request.enabled());
+        Instant effectiveStartsAt = request.periodProvided() ? request.startsAt() : riderInsurance.getStartsAt();
+        Instant effectiveEndsAt = request.periodProvided() ? request.endsAt() : riderInsurance.getEndsAt();
+        assertPeriodIsConsistent(effectiveStartsAt, effectiveEndsAt);
+
+        riderInsurance.updateOperatorManagedFields(
+                request.memo(),
+                request.enabled(),
+                request.periodProvided(),
+                request.startsAt(),
+                request.endsAt(),
+                request.riderBikeContractIdProvided(),
+                request.riderBikeContractId()
+        );
         entityManager.flush();
         return RiderInsuranceReadResponse.from(riderInsurance);
     }
@@ -110,6 +133,12 @@ public class RiderInsuranceCommandService {
     private void assertRiderInsurancePairIsNotDuplicated(UUID riderId, UUID insuranceItemId) {
         if (riderInsuranceRepository.existsByRiderIdAndInsuranceItemIdAndDeletedAtIsNull(riderId, insuranceItemId)) {
             throw new DuplicateActiveResourceException("RiderInsurance", "riderId/insuranceItemId");
+        }
+    }
+
+    private void assertPeriodIsConsistent(Instant startsAt, Instant endsAt) {
+        if (startsAt != null && endsAt != null && !endsAt.isAfter(startsAt)) {
+            throw new InvalidStateTransitionException("endsAt must be after startsAt.");
         }
     }
 }

--- a/development/service-ops-api/src/main/resources/db/migration/V8__add_insurance_category_and_period.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V8__add_insurance_category_and_period.sql
@@ -1,0 +1,65 @@
+-- Add classification and period columns to the insurance domain so the
+-- operator can describe an item as PRIMARY (메인 12개월 단위 보험) or ADDON
+-- (시간제 / 원데이 등 부가 보험), pick a coverage type aligned with the
+-- 유상운송 product line, and stamp a rider-insurance link with its own
+-- starts_at / ends_at lifecycle plus a no-FK pointer to the rider-bike
+-- contract that triggered the insurance.
+--
+-- The unique policy on rider_insurances stays intact in this slice; multi-
+-- issue policy for ADDON insurance is enforced at the service layer because
+-- the rules depend on coverage_type and overlap windows, which a partial
+-- unique index cannot express cleanly.
+
+alter table insurance_items
+    add column category varchar(20) not null default 'PRIMARY',
+    add column coverage_type varchar(40),
+    add column default_duration_unit varchar(20),
+    add column default_duration_value integer;
+
+alter table insurance_items
+    add constraint ck_insurance_items_category
+        check (category in ('PRIMARY', 'ADDON')),
+    add constraint ck_insurance_items_coverage_type
+        check (coverage_type is null or coverage_type in
+            ('GENERAL_PAID_TRANSPORT', 'LIABILITY_PAID_TRANSPORT',
+             'HOURLY', 'ONE_DAY', 'OTHER')),
+    add constraint ck_insurance_items_default_duration_unit
+        check (default_duration_unit is null or default_duration_unit in
+            ('HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'HALF_YEAR', 'YEAR')),
+    add constraint ck_insurance_items_default_duration_value
+        check (default_duration_value is null or default_duration_value > 0);
+
+create index ix_insurance_items_category_active
+    on insurance_items(category)
+    where deleted_at is null;
+
+alter table rider_insurances
+    add column starts_at timestamptz,
+    add column ends_at timestamptz,
+    add column rider_bike_contract_id uuid;
+
+alter table rider_insurances
+    add constraint ck_rider_insurances_period
+        check (starts_at is null or ends_at is null or ends_at > starts_at);
+
+create index ix_rider_insurances_period_active
+    on rider_insurances(rider_id, starts_at, ends_at)
+    where deleted_at is null;
+
+create index ix_rider_insurances_contract_active
+    on rider_insurances(rider_bike_contract_id)
+    where rider_bike_contract_id is not null and deleted_at is null;
+
+-- 기본 보험 4종 시드. ID 가 deterministic 이라 Slice A 의
+-- contract_templates.default_insurance_item_id 가 향후 이 ID 를 가리킬 수
+-- 있도록 한다 (현재 그 컬럼은 Slice A 에서 NULL 로 둔 상태).
+insert into insurance_items (
+    id, name, description, enabled,
+    category, coverage_type, default_duration_unit, default_duration_value,
+    created_at, updated_at
+) values
+    ('22222222-2222-2222-2222-000000000001', '유상운송종합보험', '12개월 메인 보험. 라이더 운영 표준 보험.',         true, 'PRIMARY', 'GENERAL_PAID_TRANSPORT', 'MONTH', 12, now(), now()),
+    ('22222222-2222-2222-2222-000000000002', '유상운송책임보험', '12개월 메인 책임 보험.',                              true, 'PRIMARY', 'LIABILITY_PAID_TRANSPORT', 'MONTH', 12, now(), now()),
+    ('22222222-2222-2222-2222-000000000003', '시간제보험',       '시간 단위 부가 보험.',                                 true, 'ADDON',   'HOURLY',                   'HOUR',   1, now(), now()),
+    ('22222222-2222-2222-2222-000000000004', '원데이보험',       '하루 단위 부가 보험.',                                 true, 'ADDON',   'ONE_DAY',                  'DAY',    1, now(), now())
+on conflict do nothing;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/InsuranceClassificationApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/InsuranceClassificationApiTests.java
@@ -1,0 +1,279 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice B: insurance category/coverage/period baseline. Validates the new
+ * classification model + V8 seed presence + period lifecycle on rider-insurance
+ * links. Existing {@code InsuranceItemCommandApiContractTests} keeps verifying
+ * the legacy-create surface.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InsuranceClassificationApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_insurances");
+        // Preserve V8 seed (`22222222-…`) so seed-presence tests keep working.
+        jdbcTemplate.update("""
+                delete from insurance_items
+                where id not in (
+                    '22222222-2222-2222-2222-000000000001',
+                    '22222222-2222-2222-2222-000000000002',
+                    '22222222-2222-2222-2222-000000000003',
+                    '22222222-2222-2222-2222-000000000004'
+                )
+                """);
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void migrationSeedRowsArePresent() throws Exception {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+                select id, name, category, coverage_type, default_duration_unit, default_duration_value
+                from insurance_items
+                where deleted_at is null
+                  and id like '22222222-2222-2222-2222-%'
+                order by id asc
+                """);
+
+        assertThat(rows).hasSize(4);
+        assertThat(rows.get(0).get("name")).isEqualTo("유상운송종합보험");
+        assertThat(rows.get(0).get("category")).isEqualTo("PRIMARY");
+        assertThat(rows.get(0).get("coverage_type")).isEqualTo("GENERAL_PAID_TRANSPORT");
+        assertThat(rows.get(0).get("default_duration_unit")).isEqualTo("MONTH");
+        assertThat(rows.get(0).get("default_duration_value")).isEqualTo(12);
+
+        assertThat(rows.get(2).get("name")).isEqualTo("시간제보험");
+        assertThat(rows.get(2).get("category")).isEqualTo("ADDON");
+        assertThat(rows.get(2).get("coverage_type")).isEqualTo("HOURLY");
+        assertThat(rows.get(2).get("default_duration_unit")).isEqualTo("HOUR");
+    }
+
+    @Test
+    void createInsuranceItemAcceptsClassificationFields() throws Exception {
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"테스트 새 메인 보험",
+                                  "description":"테스트",
+                                  "enabled":true,
+                                  "category":"PRIMARY",
+                                  "coverageType":"LIABILITY_PAID_TRANSPORT",
+                                  "defaultDurationUnit":"MONTH",
+                                  "defaultDurationValue":12
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.category").value("PRIMARY"))
+                .andExpect(jsonPath("$.coverageType").value("LIABILITY_PAID_TRANSPORT"))
+                .andExpect(jsonPath("$.defaultDurationUnit").value("MONTH"))
+                .andExpect(jsonPath("$.defaultDurationValue").value(12));
+    }
+
+    @Test
+    void legacyCreatePayloadStillWorksAndDefaultsToPrimary() throws Exception {
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"테스트 레거시 보험","description":"기간/카테고리 미지정"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.category").value("PRIMARY"))
+                .andExpect(jsonPath("$.coverageType").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.defaultDurationUnit").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.defaultDurationValue").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    void createInsuranceItemRejectsHalfDurationField() throws Exception {
+        mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"잘못된 기간 입력",
+                                  "category":"ADDON",
+                                  "defaultDurationUnit":"DAY"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void updateChangesClassificationFields() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"테스트 수정 대상 보험"}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String id = extractId(created);
+
+        mockMvc.perform(patch("/api/v1/insurance-items/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category":"ADDON",
+                                  "coverageType":"ONE_DAY",
+                                  "defaultDurationUnit":"DAY",
+                                  "defaultDurationValue":1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("ADDON"))
+                .andExpect(jsonPath("$.coverageType").value("ONE_DAY"))
+                .andExpect(jsonPath("$.defaultDurationUnit").value("DAY"))
+                .andExpect(jsonPath("$.defaultDurationValue").value(1));
+    }
+
+    @Test
+    void riderInsuranceLinkAcceptsPeriodAndContractPointer() throws Exception {
+        UUID riderId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        UUID insuranceItemId = UUID.fromString("22222222-2222-2222-2222-000000000001");
+        UUID contractId = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '테스트 라이더', '010-3000-4000', false)
+                """, riderId);
+
+        mockMvc.perform(post("/api/v1/rider-insurances")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "insuranceItemId":"%s",
+                                  "memo":"보험 발급",
+                                  "startsAt":"2026-05-01T00:00:00Z",
+                                  "endsAt":"2027-05-01T00:00:00Z",
+                                  "riderBikeContractId":"%s"
+                                }
+                                """.formatted(riderId, insuranceItemId, contractId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.startsAt").value("2026-05-01T00:00:00Z"))
+                .andExpect(jsonPath("$.endsAt").value("2027-05-01T00:00:00Z"))
+                .andExpect(jsonPath("$.riderBikeContractId").value(contractId.toString()));
+    }
+
+    @Test
+    void riderInsuranceLinkRejectsEndBeforeStart() throws Exception {
+        UUID riderId = UUID.fromString("44444444-4444-4444-4444-444444444445");
+        UUID insuranceItemId = UUID.fromString("22222222-2222-2222-2222-000000000003");
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '테스트 라이더 2', '010-3000-4001', false)
+                """, riderId);
+
+        mockMvc.perform(post("/api/v1/rider-insurances")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "insuranceItemId":"%s",
+                                  "startsAt":"2026-05-01T00:00:00Z",
+                                  "endsAt":"2026-04-01T00:00:00Z"
+                                }
+                                """.formatted(riderId, insuranceItemId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void readResponseExposesNewClassificationFields() throws Exception {
+        mockMvc.perform(get("/api/v1/insurance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(
+                        "$.items[?(@.id=='22222222-2222-2222-2222-000000000001')].category")
+                        .value(org.hamcrest.Matchers.contains("PRIMARY")))
+                .andExpect(jsonPath(
+                        "$.items[?(@.id=='22222222-2222-2222-2222-000000000003')].defaultDurationUnit")
+                        .value(org.hamcrest.Matchers.contains("HOUR")));
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
## Summary

- `insurance_items` 에 분류(PRIMARY/ADDON), 보장유형(유상운송종합/책임/시간제/원데이/기타), 기본 기간(unit + value) 컬럼 추가.
- `rider_insurances` 에 `starts_at` / `ends_at` / `rider_bike_contract_id` 추가 — 보험 라이프사이클 + 계약 연결 표현 가능.
- 4개 기본 보험 시드 (유상운송종합/책임 12개월 + 시간제 + 원데이). UUID 가 deterministic 이라 Slice A 의 \`default_insurance_item_id\` 가 향후 가리킬 수 있음.
- Service 검증: half-supplied default duration 거부, `endsAt > startsAt` 강제, 기존 unique 정책 유지.

## Trace

- Target issue: EVNSolution/thundercrew-domain#120
- Change-control issue: EVNSolution/clever-change-control#114
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (no hard dep): Slice A — EVNSolution/thundercrew-domain#118 (`default_insurance_item_id` pointer)

## Scope

Backend-only. Slice A 와 같은 패턴이며 보험 도메인만 건드림. 기존 unique 정책은 유지하고 ADDON 다중 발급(시작시점별 unique)은 후속 슬라이스로 분리.

Included:
- Flyway V8 + 시드 4개.
- \`InsuranceCategory\` / \`InsuranceCoverageType\` / \`InsuranceDurationUnit\` enum.
- \`InsuranceItem\` / \`RiderInsurance\` 엔티티 + Create/Update/Read DTO + Service.
- 통합 테스트 \`InsuranceClassificationApiTests\` (8 케이스).

Excluded:
- 자동 보험 발급 로직 (Slice D).
- ADDON 다중 발급 partial-unique 정책 변경 (후속).
- 라이더 교육 (Slice C — 별도 PR).
- 프론트 어드민 폼 (Slice E).

## Validation

| 항목 | 결과 |
|------|------|
| \`./gradlew compileJava compileTestJava\` | ✅ BUILD SUCCESSFUL (19s) |
| \`./gradlew test --tests ArchitectureBoundaryTests ScaffoldPackageSkeletonTests\` | ✅ BUILD SUCCESSFUL (24s) |
| Testcontainers 통합 테스트 (\`./gradlew test\` 전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE에서 \`./gradlew test\` 전체 (Testcontainers PostgreSQL 포함) 실행 → \`InsuranceClassificationApiTests\` 8개 통과 + 기존 \`InsuranceItemCommandApiContractTests\` / \`RiderInsuranceCommandApiContractTests\` / \`ReadOnlyApiContractTests\` 회귀 없음.
- [ ] V8 시드 4행이 dev DB 에 반영되는지 (\`select count(*) from insurance_items where id like 22222222-2222-2222-2222-%\` = 4).
- [ ] 기존 보험 행은 \`category=PRIMARY\` 디폴트로 보존되는지.
- [ ] 라이더-보험 링크 생성 시 \`endsAt < startsAt\` 가 \`409 INVALID_STATE_TRANSITION\` 으로 거부되는지.
- [ ] 어드민 웹 어드민 폼이 새 컬럼 없이 \`name\` / \`description\` / \`enabled\` 만 보내는 페이로드도 그대로 동작하는지 (legacy 호환).

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues: #116 / #118 (file-disjoint) / #120 (이 PR 타깃).
- Open target PRs: #117 / #119 (file-disjoint).
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

Slice A (PR #119) 와 파일 충돌 0 — 다른 도메인. dev 머지 순서 무관. 향후 Slice D 에서 contract template + insurance item 자동 발급 로직을 도입할 때 두 슬라이스가 모두 머지된 상태가 전제.