### PR TITLE
Rider education records baseline (#122)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderEducationRecordCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderEducationRecordCommandController.java
@@ -1,0 +1,51 @@
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordCreateRequest;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordReadResponse;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordUpdateRequest;
+import com.thundercrew.opsapi.rider.service.RiderEducationRecordCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider-education-records")
+public class RiderEducationRecordCommandController {
+
+    private final RiderEducationRecordCommandService commandService;
+
+    public RiderEducationRecordCommandController(RiderEducationRecordCommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    @PostMapping
+    ResponseEntity<RiderEducationRecordReadResponse> create(
+            @Valid @RequestBody RiderEducationRecordCreateRequest request
+    ) {
+        RiderEducationRecordReadResponse response = commandService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/rider-education-records/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/{id}")
+    RiderEducationRecordReadResponse update(
+            @PathVariable UUID id,
+            @Valid @RequestBody RiderEducationRecordUpdateRequest request
+    ) {
+        return commandService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> delete(@PathVariable UUID id) {
+        commandService.softDelete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderEducationRecordReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderEducationRecordReadController.java
@@ -1,0 +1,44 @@
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordReadResponse;
+import com.thundercrew.opsapi.rider.service.RiderEducationRecordReadService;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class RiderEducationRecordReadController {
+
+    private final RiderEducationRecordReadService readService;
+
+    public RiderEducationRecordReadController(RiderEducationRecordReadService readService) {
+        this.readService = readService;
+    }
+
+    @GetMapping("/rider-education-records")
+    PageResponse<RiderEducationRecordReadResponse> list(
+            @PageableDefault(size = 20, sort = "completedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return readService.list(pageable);
+    }
+
+    @GetMapping("/rider-education-records/{id}")
+    RiderEducationRecordReadResponse get(@PathVariable UUID id) {
+        return readService.get(id);
+    }
+
+    @GetMapping("/riders/{riderId}/education-records")
+    PageResponse<RiderEducationRecordReadResponse> listByRider(
+            @PathVariable UUID riderId,
+            @PageableDefault(size = 20, sort = "completedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return readService.listByRider(riderId, pageable);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/RiderEducationRecord.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/RiderEducationRecord.java
@@ -1,0 +1,155 @@
+package com.thundercrew.opsapi.rider.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 라이더 교육 이력 1건. 한 라이더는 여러 교육 record 를 가질 수 있고, 정부
+ * 점검에 대비해 수료증 번호 + 발급 기관 + 만료일 + 증빙 URL 을 함께 기록한다.
+ * 라이더-도메인 안의 종속 테이블이지만 cross-domain FK 정책에 따라 외래 키는
+ * 두지 않고 {@code rider_id} uuid 만 가진다.
+ */
+@Entity
+@Table(name = "rider_education_records")
+public class RiderEducationRecord extends DisplaySequencedEntity {
+
+    @Column(name = "rider_id", nullable = false)
+    private UUID riderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "education_type", nullable = false, length = 20)
+    private RiderEducationType educationType;
+
+    @Column(name = "course_name", length = 200)
+    private String courseName;
+
+    @Column(name = "completed_at", nullable = false)
+    private Instant completedAt;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "certificate_no", length = 100)
+    private String certificateNo;
+
+    @Column(name = "issuing_authority", length = 100)
+    private String issuingAuthority;
+
+    @Column(name = "evidence_url")
+    private String evidenceUrl;
+
+    @Column(name = "memo")
+    private String memo;
+
+    public static RiderEducationRecord create(
+            UUID riderId,
+            RiderEducationType educationType,
+            String courseName,
+            Instant completedAt,
+            Instant expiresAt,
+            String certificateNo,
+            String issuingAuthority,
+            String evidenceUrl,
+            String memo
+    ) {
+        RiderEducationRecord record = new RiderEducationRecord();
+        record.riderId = riderId;
+        record.educationType = educationType;
+        record.courseName = courseName;
+        record.completedAt = completedAt;
+        record.expiresAt = expiresAt;
+        record.certificateNo = certificateNo;
+        record.issuingAuthority = issuingAuthority;
+        record.evidenceUrl = evidenceUrl;
+        record.memo = memo;
+        return record;
+    }
+
+    public void updateOperatorManagedFields(
+            RiderEducationType educationType,
+            String courseName,
+            boolean completedAtProvided,
+            Instant completedAt,
+            boolean expiresAtProvided,
+            Instant expiresAt,
+            boolean certificateNoProvided,
+            String certificateNo,
+            String issuingAuthority,
+            String evidenceUrl,
+            String memo
+    ) {
+        if (educationType != null) {
+            this.educationType = educationType;
+        }
+        if (courseName != null) {
+            this.courseName = courseName;
+        }
+        if (completedAtProvided && completedAt != null) {
+            this.completedAt = completedAt;
+        }
+        if (expiresAtProvided) {
+            this.expiresAt = expiresAt;
+        }
+        if (certificateNoProvided) {
+            this.certificateNo = certificateNo;
+        }
+        if (issuingAuthority != null) {
+            this.issuingAuthority = issuingAuthority;
+        }
+        if (evidenceUrl != null) {
+            this.evidenceUrl = evidenceUrl;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public void markDeletedNow(UUID actorId, Instant deletedAt) {
+        markDeleted(actorId, deletedAt);
+    }
+
+    public UUID getRiderId() {
+        return riderId;
+    }
+
+    public RiderEducationType getEducationType() {
+        return educationType;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public String getCertificateNo() {
+        return certificateNo;
+    }
+
+    public String getIssuingAuthority() {
+        return issuingAuthority;
+    }
+
+    public String getEvidenceUrl() {
+        return evidenceUrl;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    protected RiderEducationRecord() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/RiderEducationType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/domain/RiderEducationType.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.rider.domain;
+
+/**
+ * 라이더 교육 종류. 정부의 운영자 교육 정책 분류와 정렬되어 있다.
+ */
+public enum RiderEducationType {
+    /** 온라인 교육 (이러닝). */
+    ONLINE,
+    /** 오프라인 교육 (집합/현장). */
+    OFFLINE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordCreateRequest.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RiderEducationRecordCreateRequest(
+        @NotNull UUID riderId,
+        @NotNull RiderEducationType educationType,
+        @Size(max = 200) String courseName,
+        @NotNull Instant completedAt,
+        Instant expiresAt,
+        @Size(max = 100) String certificateNo,
+        @Size(max = 100) String issuingAuthority,
+        String evidenceUrl,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordReadResponse.java
@@ -1,0 +1,40 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderEducationRecordReadResponse(
+        UUID id,
+        Long idx,
+        UUID riderId,
+        RiderEducationType educationType,
+        String courseName,
+        Instant completedAt,
+        Instant expiresAt,
+        String certificateNo,
+        String issuingAuthority,
+        String evidenceUrl,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static RiderEducationRecordReadResponse from(RiderEducationRecord record) {
+        return new RiderEducationRecordReadResponse(
+                record.getId(),
+                record.getIdx(),
+                record.getRiderId(),
+                record.getEducationType(),
+                record.getCourseName(),
+                record.getCompletedAt(),
+                record.getExpiresAt(),
+                record.getCertificateNo(),
+                record.getIssuingAuthority(),
+                record.getEvidenceUrl(),
+                record.getMemo(),
+                record.getCreatedAt(),
+                record.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderEducationRecordUpdateRequest.java
@@ -1,0 +1,111 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RiderEducationRecordUpdateRequest {
+
+    private RiderEducationType educationType;
+
+    @Size(max = 200)
+    private String courseName;
+
+    private Instant completedAt;
+    private boolean completedAtProvided;
+
+    private Instant expiresAt;
+    private boolean expiresAtProvided;
+
+    @Size(max = 100)
+    private String certificateNo;
+    private boolean certificateNoProvided;
+
+    @Size(max = 100)
+    private String issuingAuthority;
+
+    private String evidenceUrl;
+
+    private String memo;
+
+    public RiderEducationType educationType() {
+        return educationType;
+    }
+
+    public void setEducationType(RiderEducationType educationType) {
+        this.educationType = educationType;
+    }
+
+    public String courseName() {
+        return courseName;
+    }
+
+    public void setCourseName(String courseName) {
+        this.courseName = courseName;
+    }
+
+    public Instant completedAt() {
+        return completedAt;
+    }
+
+    public boolean completedAtProvided() {
+        return completedAtProvided;
+    }
+
+    public void setCompletedAt(Instant completedAt) {
+        this.completedAt = completedAt;
+        this.completedAtProvided = true;
+    }
+
+    public Instant expiresAt() {
+        return expiresAt;
+    }
+
+    public boolean expiresAtProvided() {
+        return expiresAtProvided;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+        this.expiresAtProvided = true;
+    }
+
+    public String certificateNo() {
+        return certificateNo;
+    }
+
+    public boolean certificateNoProvided() {
+        return certificateNoProvided;
+    }
+
+    public void setCertificateNo(String certificateNo) {
+        this.certificateNo = certificateNo;
+        this.certificateNoProvided = true;
+    }
+
+    public String issuingAuthority() {
+        return issuingAuthority;
+    }
+
+    public void setIssuingAuthority(String issuingAuthority) {
+        this.issuingAuthority = issuingAuthority;
+    }
+
+    public String evidenceUrl() {
+        return evidenceUrl;
+    }
+
+    public void setEvidenceUrl(String evidenceUrl) {
+        this.evidenceUrl = evidenceUrl;
+    }
+
+    public String memo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
@@ -1,6 +1,8 @@
 package com.thundercrew.opsapi.rider.dto;
 
 import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -16,9 +18,18 @@ public record RiderReadResponse(
         Instant appLinkedAt,
         String appLinkStatus,
         String memo,
+        boolean educationCompleted,
+        RiderEducationType latestEducationType,
+        Instant latestEducationCompletedAt,
+        boolean educationExpired,
         Instant createdAt,
         Instant updatedAt
 ) {
+    /**
+     * Page 응답에서 사용하는 N+1 free 형태. 교육 요약은 모두 비어 있고,
+     * 단건 상세 조회({@link #from(Rider, RiderEducationRecord, Instant)}) 에서
+     * 채워진다.
+     */
     public static RiderReadResponse from(Rider rider) {
         return new RiderReadResponse(
                 rider.getId(),
@@ -32,6 +43,44 @@ public record RiderReadResponse(
                 rider.getAppLinkedAt(),
                 rider.isAppAccountLinked() ? "LINKED" : "NOT_LINKED",
                 rider.getMemo(),
+                false,
+                null,
+                null,
+                false,
+                rider.getCreatedAt(),
+                rider.getUpdatedAt()
+        );
+    }
+
+    /**
+     * 단건 상세 조회용. 가장 최근 교육 record + 현재 시점을 받아 만료 여부를
+     * 계산한다. {@code latest} 가 {@code null} 이면 educationCompleted=false 로
+     * 비어 있는 상태가 된다.
+     */
+    public static RiderReadResponse from(Rider rider, RiderEducationRecord latest, Instant now) {
+        boolean completed = latest != null;
+        Instant completedAt = completed ? latest.getCompletedAt() : null;
+        RiderEducationType type = completed ? latest.getEducationType() : null;
+        boolean expired = completed
+                && latest.getExpiresAt() != null
+                && now != null
+                && !now.isBefore(latest.getExpiresAt());
+        return new RiderReadResponse(
+                rider.getId(),
+                rider.getIdx(),
+                rider.getName(),
+                rider.getPhoneNumber(),
+                rider.getTeamName(),
+                rider.getAreaName(),
+                rider.isAppAccountLinked(),
+                rider.getAppAccountId(),
+                rider.getAppLinkedAt(),
+                rider.isAppAccountLinked() ? "LINKED" : "NOT_LINKED",
+                rider.getMemo(),
+                completed,
+                type,
+                completedAt,
+                expired,
                 rider.getCreatedAt(),
                 rider.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderEducationRecordRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderEducationRecordRepository.java
@@ -1,0 +1,26 @@
+package com.thundercrew.opsapi.rider.repository;
+
+import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface RiderEducationRecordRepository extends Repository<RiderEducationRecord, UUID> {
+
+    RiderEducationRecord save(RiderEducationRecord record);
+
+    Optional<RiderEducationRecord> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<RiderEducationRecord> findByDeletedAtIsNull(Pageable pageable);
+
+    Page<RiderEducationRecord> findByRiderIdAndDeletedAtIsNullOrderByCompletedAtDesc(UUID riderId, Pageable pageable);
+
+    List<RiderEducationRecord> findByRiderIdAndDeletedAtIsNullOrderByCompletedAtDesc(UUID riderId);
+
+    boolean existsByCertificateNoAndDeletedAtIsNull(String certificateNo);
+
+    boolean existsByCertificateNoAndIdNotAndDeletedAtIsNull(String certificateNo, UUID id);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderEducationRecordCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderEducationRecordCommandService.java
@@ -1,0 +1,155 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ReferenceDeletedException;
+import com.thundercrew.opsapi.common.api.ReferenceNotFoundException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordCreateRequest;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordReadResponse;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordUpdateRequest;
+import com.thundercrew.opsapi.rider.repository.RiderEducationRecordRepository;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class RiderEducationRecordCommandService {
+
+    private final RiderEducationRecordRepository educationRecordRepository;
+    private final RiderRepository riderRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public RiderEducationRecordCommandService(
+            RiderEducationRecordRepository educationRecordRepository,
+            RiderRepository riderRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.educationRecordRepository = educationRecordRepository;
+        this.riderRepository = riderRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public RiderEducationRecordReadResponse create(RiderEducationRecordCreateRequest request) {
+        assertActiveRiderReference(request.riderId());
+        assertExpiryIsAfterCompletion(request.completedAt(), request.expiresAt());
+        assertCertificateNoIsAvailable(request.certificateNo(), null);
+
+        RiderEducationRecord record = RiderEducationRecord.create(
+                request.riderId(),
+                request.educationType(),
+                request.courseName(),
+                request.completedAt(),
+                request.expiresAt(),
+                StringUtils.hasText(request.certificateNo()) ? request.certificateNo() : null,
+                request.issuingAuthority(),
+                request.evidenceUrl(),
+                request.memo()
+        );
+        try {
+            RiderEducationRecord saved = educationRecordRepository.save(record);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return RiderEducationRecordReadResponse.from(saved);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("RiderEducationRecord", "certificateNo");
+        }
+    }
+
+    @Transactional
+    public RiderEducationRecordReadResponse update(UUID id, RiderEducationRecordUpdateRequest request) {
+        RiderEducationRecord record = educationRecordRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderEducationRecord", id));
+
+        Instant effectiveCompletedAt = request.completedAtProvided()
+                ? request.completedAt()
+                : record.getCompletedAt();
+        Instant effectiveExpiresAt = request.expiresAtProvided()
+                ? request.expiresAt()
+                : record.getExpiresAt();
+        assertExpiryIsAfterCompletion(effectiveCompletedAt, effectiveExpiresAt);
+
+        if (request.certificateNoProvided()) {
+            String newCertificateNo = StringUtils.hasText(request.certificateNo())
+                    ? request.certificateNo()
+                    : null;
+            assertCertificateNoIsAvailable(newCertificateNo, id);
+        }
+
+        try {
+            record.updateOperatorManagedFields(
+                    request.educationType(),
+                    request.courseName(),
+                    request.completedAtProvided(),
+                    request.completedAt(),
+                    request.expiresAtProvided(),
+                    request.expiresAt(),
+                    request.certificateNoProvided(),
+                    request.certificateNo(),
+                    request.issuingAuthority(),
+                    request.evidenceUrl(),
+                    request.memo()
+            );
+            entityManager.flush();
+            return RiderEducationRecordReadResponse.from(record);
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateActiveResourceException("RiderEducationRecord", "certificateNo");
+        }
+    }
+
+    @Transactional
+    public void softDelete(UUID id) {
+        RiderEducationRecord record = educationRecordRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderEducationRecord", id));
+        record.markDeletedNow(null, clock.instant());
+    }
+
+    private void assertActiveRiderReference(UUID riderId) {
+        if (riderRepository.findByIdAndDeletedAtIsNull(riderId).isPresent()) {
+            return;
+        }
+        if (riderRepository.existsById(riderId)) {
+            throw new ReferenceDeletedException("Rider", riderId);
+        }
+        throw new ReferenceNotFoundException("Rider", riderId);
+    }
+
+    private void assertExpiryIsAfterCompletion(Instant completedAt, Instant expiresAt) {
+        if (completedAt != null && expiresAt != null && !expiresAt.isAfter(completedAt)) {
+            throw new InvalidStateTransitionException("expiresAt must be after completedAt.");
+        }
+    }
+
+    private void assertCertificateNoIsAvailable(String certificateNo, UUID excludeId) {
+        if (!StringUtils.hasText(certificateNo)) {
+            return;
+        }
+        boolean duplicate = excludeId == null
+                ? educationRecordRepository.existsByCertificateNoAndDeletedAtIsNull(certificateNo)
+                : educationRecordRepository.existsByCertificateNoAndIdNotAndDeletedAtIsNull(certificateNo, excludeId);
+        if (duplicate) {
+            throw new DuplicateActiveResourceException("RiderEducationRecord", "certificateNo");
+        }
+    }
+
+    /**
+     * Future-extension hook used by the read service when it wants to derive
+     * the latest education type for a rider — kept here so the command
+     * service stays the single source of truth for {@link RiderEducationType}.
+     */
+    public RiderEducationType domainTypeOf(RiderEducationRecord record) {
+        return record == null ? null : record.getEducationType();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderEducationRecordReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderEducationRecordReadService.java
@@ -1,0 +1,42 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.rider.dto.RiderEducationRecordReadResponse;
+import com.thundercrew.opsapi.rider.repository.RiderEducationRecordRepository;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class RiderEducationRecordReadService {
+
+    private final RiderEducationRecordRepository educationRecordRepository;
+
+    public RiderEducationRecordReadService(RiderEducationRecordRepository educationRecordRepository) {
+        this.educationRecordRepository = educationRecordRepository;
+    }
+
+    public PageResponse<RiderEducationRecordReadResponse> list(Pageable pageable) {
+        return PageResponse.of(
+                educationRecordRepository.findByDeletedAtIsNull(pageable)
+                        .map(RiderEducationRecordReadResponse::from)
+        );
+    }
+
+    public PageResponse<RiderEducationRecordReadResponse> listByRider(UUID riderId, Pageable pageable) {
+        return PageResponse.of(
+                educationRecordRepository
+                        .findByRiderIdAndDeletedAtIsNullOrderByCompletedAtDesc(riderId, pageable)
+                        .map(RiderEducationRecordReadResponse::from)
+        );
+    }
+
+    public RiderEducationRecordReadResponse get(UUID id) {
+        return educationRecordRepository.findByIdAndDeletedAtIsNull(id)
+                .map(RiderEducationRecordReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("RiderEducationRecord", id));
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderReadService.java
@@ -2,8 +2,13 @@ package com.thundercrew.opsapi.rider.service;
 
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
 import com.thundercrew.opsapi.rider.dto.RiderReadResponse;
+import com.thundercrew.opsapi.rider.repository.RiderEducationRecordRepository;
 import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,9 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class RiderReadService {
 
     private final RiderRepository riderRepository;
+    private final RiderEducationRecordRepository educationRecordRepository;
+    private final Clock clock;
 
-    public RiderReadService(RiderRepository riderRepository) {
+    public RiderReadService(
+            RiderRepository riderRepository,
+            RiderEducationRecordRepository educationRecordRepository,
+            Clock clock
+    ) {
         this.riderRepository = riderRepository;
+        this.educationRecordRepository = educationRecordRepository;
+        this.clock = clock;
     }
 
     public PageResponse<RiderReadResponse> list(Pageable pageable) {
@@ -24,8 +37,15 @@ public class RiderReadService {
     }
 
     public RiderReadResponse get(UUID id) {
-        return riderRepository.findByIdAndDeletedAtIsNull(id)
-                .map(RiderReadResponse::from)
+        Rider rider = riderRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
+        RiderEducationRecord latest = findLatestEducation(id);
+        return RiderReadResponse.from(rider, latest, clock.instant());
+    }
+
+    private RiderEducationRecord findLatestEducation(UUID riderId) {
+        List<RiderEducationRecord> records = educationRecordRepository
+                .findByRiderIdAndDeletedAtIsNullOrderByCompletedAtDesc(riderId);
+        return records.isEmpty() ? null : records.get(0);
     }
 }

--- a/development/service-ops-api/src/main/resources/db/migration/V9__init_rider_education_records.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V9__init_rider_education_records.sql
@@ -1,0 +1,42 @@
+-- Track rider safety/operations training history as a dedicated table so that
+-- a rider can have many education records over time, expiry can be tracked,
+-- and government inspection can pull certificate evidence per rider. The
+-- existing riders table is left untouched; the read API will compute summary
+-- columns (educationCompleted, latestEducationType, latestEducationCompletedAt,
+-- educationExpired) on the fly.
+
+create table rider_education_records (
+    id uuid primary key,
+    idx bigserial not null unique,
+    rider_id uuid not null,
+    education_type varchar(20) not null,
+    course_name varchar(200),
+    completed_at timestamptz not null,
+    expires_at timestamptz,
+    certificate_no varchar(100),
+    issuing_authority varchar(100),
+    evidence_url text,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_rider_education_records_education_type
+        check (education_type in ('ONLINE', 'OFFLINE')),
+    constraint ck_rider_education_records_expires_after_completed
+        check (expires_at is null or expires_at > completed_at)
+);
+
+create index ix_rider_education_records_rider_completed
+    on rider_education_records(rider_id, completed_at desc)
+    where deleted_at is null;
+
+create unique index ux_rider_education_records_certificate_active
+    on rider_education_records(certificate_no)
+    where certificate_no is not null and deleted_at is null;
+
+create index ix_rider_education_records_expires_active
+    on rider_education_records(expires_at)
+    where expires_at is not null and deleted_at is null;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -93,6 +93,7 @@ class ArchitectureBoundaryTests {
                 if (!hasWriteRouteMapping
                         || isAllowedAuthCommand(method)
                         || isRiderCommand(method)
+                        || isRiderEducationRecordCommand(method)
                         || isBikeCommand(method)
                         || isContractTemplateCommand(method)
                         || isRiderBikeContractCommand(method)
@@ -128,6 +129,7 @@ class ArchitectureBoundaryTests {
 
                 if (!isAllowedAuthCommand(method)
                         && !isRiderCommand(method)
+                        && !isRiderEducationRecordCommand(method)
                         && !isBikeCommand(method)
                         && !isContractTemplateCommand(method)
                         && !isRiderBikeContractCommand(method)
@@ -162,6 +164,14 @@ class ArchitectureBoundaryTests {
                 || method.getName().equals("update")
                 || method.getName().equals("linkAppAccount")
                 || method.getName().equals("unlinkAppAccount")
+                || method.getName().equals("delete"));
+    }
+
+    private static boolean isRiderEducationRecordCommand(JavaMethod method) {
+        return method.getOwner().getName().equals(
+                "com.thundercrew.opsapi.rider.controller.RiderEducationRecordCommandController")
+                && (method.getName().equals("create")
+                || method.getName().equals("update")
                 || method.getName().equals("delete"));
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderEducationRecordApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderEducationRecordApiTests.java
@@ -1,0 +1,304 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice C: rider education records baseline. Verifies the new
+ * {@code rider_education_records} table + command/read endpoints + the four
+ * derived columns layered onto {@code GET /riders/{id}}.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderEducationRecordApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("ccccdddd-eeee-ffff-aaaa-000000000001");
+    private static final UUID OTHER_RIDER_ID = UUID.fromString("ccccdddd-eeee-ffff-aaaa-000000000002");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_education_records");
+        jdbcTemplate.update("delete from rider_insurances");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '테스트 라이더 1', '010-3000-1001', false)
+                """, RIDER_ID);
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, '테스트 라이더 2', '010-3000-1002', false)
+                """, OTHER_RIDER_ID);
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void createEducationRecordSucceedsWithFullPayload() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/rider-education-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "educationType":"ONLINE",
+                                  "courseName":"전기이륜차 안전 운행 교육 2026",
+                                  "completedAt":"2026-04-01T00:00:00Z",
+                                  "expiresAt":"2027-04-01T00:00:00Z",
+                                  "certificateNo":"CRT-001",
+                                  "issuingAuthority":"교통안전공단",
+                                  "evidenceUrl":"https://evidence.example.com/CRT-001.pdf"
+                                }
+                                """.formatted(RIDER_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.riderId").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.educationType").value("ONLINE"))
+                .andExpect(jsonPath("$.courseName").value("전기이륜차 안전 운행 교육 2026"))
+                .andExpect(jsonPath("$.certificateNo").value("CRT-001"))
+                .andExpect(jsonPath("$.issuingAuthority").value("교통안전공단"))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void createEducationRecordRejectsExpiryBeforeCompletion() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-education-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "educationType":"OFFLINE",
+                                  "completedAt":"2026-04-01T00:00:00Z",
+                                  "expiresAt":"2026-03-01T00:00:00Z"
+                                }
+                                """.formatted(RIDER_ID)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void createEducationRecordRejectsDuplicateActiveCertificateNo() throws Exception {
+        seedRecord(UUID.randomUUID(), RIDER_ID, "ONLINE", "2026-03-01T00:00:00Z", null, "CRT-DUP");
+
+        mockMvc.perform(post("/api/v1/rider-education-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "educationType":"OFFLINE",
+                                  "completedAt":"2026-04-01T00:00:00Z",
+                                  "certificateNo":"CRT-DUP"
+                                }
+                                """.formatted(RIDER_ID)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void createEducationRecordRejectsMissingRider() throws Exception {
+        UUID missing = UUID.fromString("99999999-9999-9999-9999-999999999999");
+        mockMvc.perform(post("/api/v1/rider-education-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "educationType":"ONLINE",
+                                  "completedAt":"2026-04-01T00:00:00Z"
+                                }
+                                """.formatted(missing)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listByRiderReturnsRecordsInDescOrder() throws Exception {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        seedRecord(first, RIDER_ID, "ONLINE", "2026-01-15T00:00:00Z", null, null);
+        seedRecord(second, RIDER_ID, "OFFLINE", "2026-04-01T00:00:00Z", null, null);
+        seedRecord(UUID.randomUUID(), OTHER_RIDER_ID, "ONLINE", "2026-04-01T00:00:00Z", null, null);
+
+        mockMvc.perform(get("/api/v1/riders/{riderId}/education-records", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].id").value(second.toString()))
+                .andExpect(jsonPath("$.items[1].id").value(first.toString()));
+    }
+
+    @Test
+    void softDeleteHidesFromActiveList() throws Exception {
+        UUID recordId = UUID.randomUUID();
+        seedRecord(recordId, RIDER_ID, "ONLINE", "2026-04-01T00:00:00Z", null, "CRT-DEL");
+
+        mockMvc.perform(delete("/api/v1/rider-education-records/{id}", recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/rider-education-records/{id}", recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound());
+
+        // 같은 certificate_no 로 새 record 발급 가능 (active unique 만 enforced).
+        mockMvc.perform(post("/api/v1/rider-education-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "riderId":"%s",
+                                  "educationType":"OFFLINE",
+                                  "completedAt":"2026-05-01T00:00:00Z",
+                                  "certificateNo":"CRT-DEL"
+                                }
+                                """.formatted(RIDER_ID)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void updateEducationRecordChangesProvidedFields() throws Exception {
+        UUID recordId = UUID.randomUUID();
+        seedRecord(recordId, RIDER_ID, "ONLINE", "2026-04-01T00:00:00Z", null, null);
+
+        mockMvc.perform(patch("/api/v1/rider-education-records/{id}", recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "educationType":"OFFLINE",
+                                  "courseName":"보강 교육",
+                                  "expiresAt":"2027-04-01T00:00:00Z",
+                                  "certificateNo":"CRT-200"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.educationType").value("OFFLINE"))
+                .andExpect(jsonPath("$.courseName").value("보강 교육"))
+                .andExpect(jsonPath("$.expiresAt").value("2027-04-01T00:00:00Z"))
+                .andExpect(jsonPath("$.certificateNo").value("CRT-200"));
+    }
+
+    @Test
+    void riderReadResponseExposesEducationSummary() throws Exception {
+        Instant now = Instant.now();
+        Instant completedAt = now.minus(30, ChronoUnit.DAYS);
+        Instant expiresAt = now.plus(335, ChronoUnit.DAYS);
+        seedRecord(UUID.randomUUID(), RIDER_ID, "ONLINE", completedAt.toString(), expiresAt.toString(), null);
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.educationCompleted").value(true))
+                .andExpect(jsonPath("$.latestEducationType").value("ONLINE"))
+                .andExpect(jsonPath("$.educationExpired").value(false));
+    }
+
+    @Test
+    void riderReadResponseShowsExpiredWhenLatestRecordExpired() throws Exception {
+        Instant now = Instant.now();
+        Instant completedAt = now.minus(400, ChronoUnit.DAYS);
+        Instant expiresAt = now.minus(35, ChronoUnit.DAYS);
+        seedRecord(UUID.randomUUID(), RIDER_ID, "OFFLINE", completedAt.toString(), expiresAt.toString(), null);
+
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.educationCompleted").value(true))
+                .andExpect(jsonPath("$.latestEducationType").value("OFFLINE"))
+                .andExpect(jsonPath("$.educationExpired").value(true));
+    }
+
+    @Test
+    void riderWithoutRecordsReportsNotCompleted() throws Exception {
+        mockMvc.perform(get("/api/v1/riders/{id}", RIDER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.educationCompleted").value(false))
+                .andExpect(jsonPath("$.latestEducationType").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.educationExpired").value(false));
+    }
+
+    private void seedRecord(
+            UUID id,
+            UUID riderId,
+            String type,
+            String completedAtIso,
+            String expiresAtIso,
+            String certificateNo
+    ) {
+        String expires = expiresAtIso == null ? null : expiresAtIso;
+        jdbcTemplate.update("""
+                insert into rider_education_records (
+                    id, rider_id, education_type, completed_at, expires_at, certificate_no
+                ) values (?, ?, ?, ?::timestamptz, ?::timestamptz, ?)
+                """, id, riderId, type, completedAtIso, expires, certificateNo);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAccessToken(result);
+    }
+
+    private String extractAccessToken(MvcResult result) throws Exception {
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
## Summary

- 신규 테이블 `rider_education_records` (라이더 교육 이력) + 도메인/서비스/컨트롤러/DTO 풀 셋.
- `POST/PATCH/DELETE /api/v1/rider-education-records`, `GET .../`, `GET .../{id}`, `GET /api/v1/riders/{riderId}/education-records`.
- `GET /api/v1/riders/{id}` 응답에 4개 derived 컬럼 추가 (`educationCompleted` / `latestEducationType` / `latestEducationCompletedAt` / `educationExpired`).
- 정부 점검 대비 — 수료증 번호/발급 기관/만료일/증빙 URL 추적 가능.

## Trace

- Target issue: EVNSolution/thundercrew-domain#122
- Change-control issue: EVNSolution/clever-change-control#115
- Root project-start: EVNSolution/clever-change-control#45
- Independent of Slice A (#118) and Slice B (#120).

## Scope

Backend-only. 라이더 도메인에 신규 종속 테이블 + 신규 API. Slice A·B 와 충돌 없음 (다른 도메인).

Included:
- Flyway V9 + 새 테이블/인덱스/check constraint.
- \`RiderEducationRecord\` 엔티티 + \`RiderEducationType\` enum.
- Command service (생성/수정/소프트 삭제 + 라이더 reference + expiry/certificate 검증).
- Read service + 컨트롤러 2개 (Command, Read).
- Create/Update/Read DTO.
- \`RiderReadResponse\` 에 4개 derived 컬럼 추가 — page list 는 N+1 회피용 cheap variant 사용, single get 만 join.
- ArchUnit issue_70 화이트리스트에 새 command controller 추가.
- 통합 테스트 \`RiderEducationRecordApiTests\` (10 케이스).

Excluded:
- 어드민 폼 (Slice E).
- 정부 보고서 PDF, 만료 임박 알림, 자동 만료 처리 잡.

## Validation

| 항목 | 결과 |
|------|------|
| \`./gradlew compileJava compileTestJava\` | ✅ BUILD SUCCESSFUL (17s) |
| \`./gradlew test --tests ArchitectureBoundaryTests ScaffoldPackageSkeletonTests\` | ✅ BUILD SUCCESSFUL (26s) — ArchUnit issue_70 룰에 새 컨트롤러 등록 후 통과 |
| Testcontainers 통합 테스트 (\`./gradlew test\` 전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE에서 \`./gradlew test\` 전체 (Testcontainers PostgreSQL 포함) 실행 → \`RiderEducationRecordApiTests\` 10 케이스 통과 + 기존 \`RiderCommandApiContractTests\` / \`ReadOnlyApiContractTests\` 회귀 없음.
- [ ] V9 마이그레이션이 dev DB 에 반영되는지 (\`select count(*) from information_schema.tables where table_name=rider_education_records\` = 1).
- [ ] 라이더 단건 조회 \`GET /api/v1/riders/{id}\` 가 4개 derived 컬럼을 노출하는지.
- [ ] 라이더 페이지 조회 \`GET /api/v1/riders\` 응답은 N+1 회피로 \`educationCompleted=false\` 그대로 노출 (성능 검증).
- [ ] 어드민 폼이 새 \`POST /api/v1/rider-education-records\` 를 호출해 라이더 등록과 별개로 교육 이력 등록 가능한지 (Slice E 에서 어드민 UI 추가).

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues: #116 / #118 / #120 / #122 (file-disjoint).
- Open target PRs: #117 / #119 / #121 (file-disjoint).
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

세 백엔드 슬라이스 (A·B·C) 모두 dev base 에서 분기 + 파일 충돌 0 — 머지 순서 무관. 후속으로:

- **Slice D**: 구독 패키지 + 자동 보험 발급 로직 (A·B 머지 후).
- **Slice E**: 어드민 웹 폼 재설계 (A·B·C 모두 머지 후).