### PR TITLE
Connect dashboard monitoring to backend map-state with polling (#124)

### DIFF
--- a/development/front-admin-web/app/api/dashboard/map-state/route.ts
+++ b/development/front-admin-web/app/api/dashboard/map-state/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
+
+/**
+ * Polling endpoint for the client `DashboardCanvas`. Server components hand
+ * the initial fetch through props; the client refresher hits this route on a
+ * fixed cadence so the polling cost stays inside the Next.js process and the
+ * NCP-targeted client never sees the service-ops cookie.
+ */
+export async function GET() {
+  const result = await loadDashboardMapState();
+  return NextResponse.json(result, {
+    headers: {
+      "Cache-Control": "no-store"
+    }
+  });
+}

--- a/development/front-admin-web/app/dashboard/page.tsx
+++ b/development/front-admin-web/app/dashboard/page.tsx
@@ -1,9 +1,12 @@
-import { MapShell } from "@/components/dashboard/MapShell";
+import { DashboardCanvas } from "@/components/dashboard/DashboardCanvas";
+import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 
-export default function MonitoringPage() {
+export default async function MonitoringPage() {
+  const initial = await loadDashboardMapState();
+
   return (
     <section className="control-map-page" aria-label="지도 기반 관제">
-      <MapShell />
+      <DashboardCanvas initial={initial} />
     </section>
   );
 }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -252,6 +252,9 @@ button, input, select, textarea { font: inherit; }
 .map-shell-notice strong { font-size: 14px; font-weight: 800; }
 .map-shell-notice span { color: var(--rm-text-secondary); font-size: 13px; line-height: 1.55; }
 .map-shell-notice code { padding: 2px 6px; border-radius: 6px; background: var(--rm-bg-active); font-family: var(--font-sans); font-size: 12px; }
+.dashboard-map-notice { position: fixed; right: 24px; bottom: 24px; max-width: 360px; display: grid; gap: 4px; padding: 12px 16px; border-radius: var(--rm-radius-md); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 20; font-size: 13px; line-height: 1.45; }
+.dashboard-map-notice strong { font-size: 12px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
+.dashboard-map-notice span { color: var(--rm-text-primary); }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { MapShell } from "@/components/dashboard/MapShell";
+import type { DashboardMapStateResult } from "@/lib/services/dashboard-map-state-data";
+
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+
+export interface DashboardCanvasProps {
+  initial: DashboardMapStateResult;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Client-side wrapper that owns the polling loop. The server component does
+ * the first fetch (so the page renders SSR-ready), then this component takes
+ * over and refreshes the map state on a fixed cadence.
+ *
+ * Polling deliberately uses our own `/api/dashboard/map-state` route instead
+ * of calling `service-ops-api` from the browser — that keeps the service-ops
+ * cookie server-side and avoids CORS/credential plumbing.
+ */
+export function DashboardCanvas({
+  initial,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS
+}: DashboardCanvasProps) {
+  const [state, setState] = useState<DashboardMapStateResult>(initial);
+  const pollIntervalRef = useRef(pollIntervalMs);
+
+  useEffect(() => {
+    pollIntervalRef.current = pollIntervalMs;
+  }, [pollIntervalMs]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function fetchOnce() {
+      try {
+        const response = await fetch("/api/dashboard/map-state", {
+          cache: "no-store",
+          credentials: "same-origin"
+        });
+        if (!response.ok) {
+          // Keep the previous snapshot rather than blanking the map.
+          return;
+        }
+        const next = (await response.json()) as DashboardMapStateResult;
+        if (!cancelled) {
+          setState(next);
+        }
+      } catch {
+        // Swallow — leave the previous snapshot visible. The notice on the
+        // map shell is the operator's primary signal that data may be stale.
+      }
+    }
+
+    function schedule() {
+      timer = setTimeout(async () => {
+        await fetchOnce();
+        if (!cancelled) {
+          schedule();
+        }
+      }, pollIntervalRef.current);
+    }
+
+    schedule();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <>
+      <MapShell
+        bikePins={state.data.bikePins}
+        stationPins={state.data.stationPins}
+      />
+      {state.notice ? (
+        <div className="dashboard-map-notice" role="status" aria-live="polite">
+          <strong>지도 데이터 안내</strong>
+          <span>{state.notice}</span>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
-import type { NaverMapInstance, NaverMapOptions } from "@/types/naver-maps";
+import type {
+  FrontendDashboardBikePin,
+  FrontendDashboardStationPin
+} from "@/lib/services/service-ops-api";
+import type {
+  NaverMapInstance,
+  NaverMapOptions,
+  NaverMarkerInstance
+} from "@/types/naver-maps";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
 const NCP_STYLE_ID_LIGHT = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT;
@@ -65,15 +73,32 @@ export interface MapShellProps {
   children?: ReactNode;
   initialCenter?: { lat: number; lng: number };
   initialZoom?: number;
+  bikePins?: FrontendDashboardBikePin[];
+  stationPins?: FrontendDashboardStationPin[];
+  onBikeSelect?: (bikeId: string) => void;
+  onStationSelect?: (stationId: string) => void;
 }
 
 export function MapShell({
   children,
   initialCenter = SEOUL_DEFAULT_CENTER,
   initialZoom = DEFAULT_ZOOM,
+  bikePins = [],
+  stationPins = [],
+  onBikeSelect,
+  onStationSelect,
 }: MapShellProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<NaverMapInstance | null>(null);
+  const bikeMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
+  const stationMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
+  const onBikeSelectRef = useRef(onBikeSelect);
+  const onStationSelectRef = useRef(onStationSelect);
+
+  useEffect(() => {
+    onBikeSelectRef.current = onBikeSelect;
+    onStationSelectRef.current = onStationSelect;
+  }, [onBikeSelect, onStationSelect]);
 
   const theme = useSyncExternalStore(subscribeTheme, readDocumentTheme, () => "light");
 
@@ -216,6 +241,91 @@ export function MapShell({
       mapRef.current = null;
     };
   }, [sdkReady, theme, isLocalhost, initialCenter.lat, initialCenter.lng, initialZoom]);
+
+  // Bike markers — diff against the cache so the same bikeId reuses its
+  // NaverMarker instance. This is the cheap path for polling: setPosition
+  // costs nothing compared to `new naver.maps.Marker(...)` which allocates a
+  // DOM node + event listeners every time.
+  useEffect(() => {
+    if (!sdkReady || isLocalhost) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.Marker) return;
+
+    const cache = bikeMarkerCacheRef.current;
+    const incomingIds = new Set<string>();
+
+    for (const pin of bikePins) {
+      incomingIds.add(pin.bikeId);
+      const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
+      const existing = cache.get(pin.bikeId);
+      if (existing) {
+        existing.setPosition?.(position);
+        continue;
+      }
+      const marker = new naver.maps.Marker({
+        position,
+        map,
+        title: pin.pinLabel ?? pin.plateNumber,
+        clickable: Boolean(onBikeSelectRef.current)
+      });
+      if (onBikeSelectRef.current && naver.maps.Event) {
+        naver.maps.Event.addListener(marker, "click", () => {
+          onBikeSelectRef.current?.(pin.bikeId);
+        });
+      }
+      cache.set(pin.bikeId, marker);
+    }
+
+    // Remove markers whose bike disappeared from the latest snapshot.
+    for (const [bikeId, marker] of cache.entries()) {
+      if (!incomingIds.has(bikeId)) {
+        marker.setMap(null);
+        cache.delete(bikeId);
+      }
+    }
+  }, [sdkReady, isLocalhost, bikePins]);
+
+  // Station markers — same diff strategy. Stations don't move, so the cache
+  // mostly catches set-once + occasional add/remove during ops.
+  useEffect(() => {
+    if (!sdkReady || isLocalhost) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.Marker) return;
+
+    const cache = stationMarkerCacheRef.current;
+    const incomingIds = new Set<string>();
+
+    for (const pin of stationPins) {
+      incomingIds.add(pin.stationId);
+      const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
+      const existing = cache.get(pin.stationId);
+      if (existing) {
+        existing.setPosition?.(position);
+        continue;
+      }
+      const marker = new naver.maps.Marker({
+        position,
+        map,
+        title: pin.pinLabel ?? pin.name,
+        clickable: Boolean(onStationSelectRef.current)
+      });
+      if (onStationSelectRef.current && naver.maps.Event) {
+        naver.maps.Event.addListener(marker, "click", () => {
+          onStationSelectRef.current?.(pin.stationId);
+        });
+      }
+      cache.set(pin.stationId, marker);
+    }
+
+    for (const [stationId, marker] of cache.entries()) {
+      if (!incomingIds.has(stationId)) {
+        marker.setMap(null);
+        cache.delete(stationId);
+      }
+    }
+  }, [sdkReady, isLocalhost, stationPins]);
 
   if (!NCP_CLIENT_ID) {
     return (

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -1,0 +1,82 @@
+import {
+  type FrontendDashboardMapState,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type DashboardMapStateResult = {
+  data: FrontendDashboardMapState;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+const EMPTY_SUMMARY = {
+  totalBikes: 0,
+  bikePinCount: 0,
+  onlineBikeCount: 0,
+  signalLostBikeCount: 0,
+  parkedOfflineBikeCount: 0,
+  lowBatteryBikeCount: 0,
+  activeStationCount: 0,
+  stationPinCount: 0,
+  availableBatteryCount: 0
+} as const;
+
+function emptyMapState(): FrontendDashboardMapState {
+  return {
+    generatedAt: new Date().toISOString(),
+    summary: { ...EMPTY_SUMMARY },
+    bikePins: [],
+    stationPins: []
+  };
+}
+
+/**
+ * Mock fallback when the service-ops API is not configured or the session
+ * cookie is missing. The dashboard renders an empty map (no pins) and a
+ * notice. We do not fabricate fake bikes/stations because the operator could
+ * mistake them for real fleet state — better to show "데이터 없음".
+ */
+export async function loadDashboardMapState(): Promise<DashboardMapStateResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      data: emptyMapState(),
+      source: "mock",
+      notice:
+        "SERVICE_OPS_API_BASE_URL이 없어 빈 지도를 표시합니다. 백엔드 연결 시 실제 차량/충전소 핀이 표시됩니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      data: emptyMapState(),
+      source: "mock",
+      notice:
+        "서비스 API 세션 쿠키가 없어 빈 지도를 표시합니다. 관리자 로그인 후 실제 백엔드 데이터로 전환됩니다."
+    };
+  }
+
+  try {
+    const data = await client.getDashboardMapState();
+    return { data, source: "service-ops" };
+  } catch (error) {
+    return {
+      data: emptyMapState(),
+      source: "mock",
+      notice: `서비스 API 조회 실패로 빈 지도를 표시합니다.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary

- 모니터링 화면 \`/dashboard\` 가 백엔드 \`GET /api/v1/dashboard/map-state\` 응답을 받아 NCP Maps 위에 차량/충전소 핀을 그린다.
- 서버 컴포넌트가 첫 SSR 시 1회 호출, 클라이언트 \`DashboardCanvas\` 가 10초 간격 polling 으로 갱신.
- 마커 캐시(\`Map<id, NaverMarkerInstance>\`)로 polling 시 마커 재생성 없이 setPosition 만 — NCP 빌링 절약.
- 백엔드 미구성 / 세션 없음 / API 실패 시 빈 지도 + 안내 카드 (가짜 데이터 안 만듬).

## Trace

- Target issue: EVNSolution/thundercrew-domain#124
- Change-control issue: EVNSolution/clever-change-control#116
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): EVNSolution/thundercrew-domain#117 (monitoring map shell foundation).

## Scope

Frontend-only. \`service-ops-api\` 변경 없음. 마커 클릭 시 디테일 패널은 후속 슬라이스로 분리 (\`onBikeSelect\` / \`onStationSelect\` 콜백 props 만 미리 노출).

Included:
- \`lib/services/dashboard-map-state-data.ts\` — server-side loader + mock fallback (rider-data 패턴).
- \`app/api/dashboard/map-state/route.ts\` — polling endpoint (\`Cache-Control: no-store\`).
- \`MapShell.tsx\` 마커 렌더링 + 캐시.
- \`DashboardCanvas.tsx\` (신규) — 폴링 client component (setTimeout chain, 슬로우 fetch 가 stack 되지 않도록).
- \`/dashboard\` page — async server component, initial fetch + DashboardCanvas wiring.
- \`.dashboard-map-notice\` CSS — 백엔드 fallback 시 우하단 안내 카드.

Excluded:
- 마커 클릭 → 디테일 패널 (다음 슬라이스).
- 폴링 → SSE/WebSocket 전환 (대수가 늘면 별도 결정).
- vendor telemetry 폴링 워커 (Slice F — 진짜 차량 데이터를 흘러들어오게 하는 백엔드 작업).

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 배포 환경에서 \`/dashboard\` 가 백엔드 \`map-state\` 응답을 받아 마커가 그려지는지 확인. 현재 dev DB 에 \`bike_current_states\` 행이 없으면 핀 0개 + 빈 지도가 보여야 함 (mock 가짜 데이터 안 만듦).
- [ ] DevTools Network 탭에서 \`/api/dashboard/map-state\` 가 10초 간격으로 호출되는지 확인.
- [ ] 마커 캐시 동작 확인 — 같은 \`bikeId\` 가 폴링 사이에 위치만 변하면 마커가 재생성되지 않고 \`setPosition\` 으로 이동하는지 (NCP 마커 DOM 노드 ID 가 동일하게 유지).
- [ ] 백엔드 미구성 (\`SERVICE_OPS_API_BASE_URL\` 없음) → 안내 카드 노출 + 마커 0개.
- [ ] 관리자 미로그인 → 안내 카드 + 마커 0개.
- [ ] localhost (\`NCP_DEV_FORCE\` 미설정) → 기존 NCP localhost 가드가 우선 적용 (지도 자체가 안 뜨고 기존 안내 카드).

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #124 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 mock 데이터 없이도 진짜 백엔드 응답을 화면에 흘릴 수 있는 끝-단을 닫았습니다.
실제 차량 핀이 떠 있는 그림을 보려면:

1. (가장 빠른 길) dev 환경에서 \`bike_current_states\` 에 직접 INSERT (라이더 + 차량 + 디바이스 시드 후) 하거나, \`POST /api/v1/telemetry/device-events\` 로 vendor 가짜 이벤트 1건 보내면 즉시 핀이 나타남.
2. (정식 경로) Slice F (vendor telemetry 폴링 워커) 가 dev/prod 에서 vendor API 와 연결되면 자동.