### PR TITLE
Open a bike detail panel on dashboard marker click (#126)

### DIFF
--- a/development/front-admin-web/app/api/dashboard/bike-current-state/[bikeId]/route.ts
+++ b/development/front-admin-web/app/api/dashboard/bike-current-state/[bikeId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { loadBikeCurrentState } from "@/lib/services/bike-current-state-data";
+
+/**
+ * Per-bike telemetry endpoint hit by the marker-click detail panel. Keeps
+ * the service-ops cookie server-side, mirroring the dashboard map-state
+ * route. Path param matches the backend's URL shape so operators can grep
+ * `bikeId` consistently across server and client logs.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ bikeId: string }> }
+) {
+  const { bikeId } = await context.params;
+  const result = await loadBikeCurrentState(bikeId);
+  return NextResponse.json(result, {
+    headers: {
+      "Cache-Control": "no-store"
+    }
+  });
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -255,6 +255,18 @@ button, input, select, textarea { font: inherit; }
 .dashboard-map-notice { position: fixed; right: 24px; bottom: 24px; max-width: 360px; display: grid; gap: 4px; padding: 12px 16px; border-radius: var(--rm-radius-md); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 20; font-size: 13px; line-height: 1.45; }
 .dashboard-map-notice strong { font-size: 12px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
 .dashboard-map-notice span { color: var(--rm-text-primary); }
+.bike-detail-panel { position: fixed; right: 24px; top: 50%; transform: translateY(-50%); width: 360px; max-height: calc(100vh - 96px); display: grid; gap: 16px; padding: 20px 22px; border-radius: var(--rm-radius-lg); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 30; overflow: auto; }
+.bike-detail-panel-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.bike-detail-panel-eyebrow { font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--rm-text-secondary); }
+.bike-detail-panel-header h2 { margin: 4px 0 2px; font-size: 18px; font-weight: 800; letter-spacing: -.02em; }
+.bike-detail-panel-header p { margin: 0; font-size: 13px; color: var(--rm-text-secondary); }
+.bike-detail-panel-close { width: 28px; height: 28px; padding: 0; border: 0; border-radius: 8px; background: var(--rm-bg-active); color: var(--rm-text-primary); font-size: 14px; cursor: pointer; }
+.bike-detail-panel-close:hover { background: var(--rm-line-active); }
+.bike-detail-panel-body { display: grid; gap: 6px; margin: 0; padding: 12px 0 0; border-top: 1px solid var(--rm-line-subtle); }
+.bike-detail-panel-row { display: grid; grid-template-columns: 96px 1fr; gap: 10px; align-items: baseline; padding: 4px 0; }
+.bike-detail-panel-row dt { margin: 0; font-size: 12px; font-weight: 600; color: var(--rm-text-secondary); }
+.bike-detail-panel-row dd { margin: 0; font-size: 13px; color: var(--rm-text-primary); font-variant-numeric: tabular-nums; }
+.bike-detail-panel-status { margin: 0; font-size: 12px; color: var(--rm-text-secondary); }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { BikeCurrentStateResult } from "@/lib/services/bike-current-state-data";
+import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+
+export interface BikeDetailPanelProps {
+  pin: FrontendDashboardBikePin;
+  onClose: () => void;
+}
+
+type FetchOutcome =
+  | { phase: "idle" }
+  | { phase: "loaded"; result: BikeCurrentStateResult }
+  | { phase: "error" };
+
+/**
+ * Right-edge floating panel that opens when an operator clicks a bike marker.
+ * The pin from the polling map-state already carries label/plate/active rider
+ * info, so the panel renders immediately. The single-bike telemetry endpoint
+ * is fetched in parallel and fills the connection / driving / battery /
+ * lastReceivedAt rows when it returns.
+ */
+export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
+  // Keyed on bikeId so a click that swaps the panel to a different bike
+  // resets the fetch outcome on the next render rather than via a synchronous
+  // setState inside useEffect (the lint rule that bans the latter).
+  const [outcome, setOutcome] = useState<{ bikeId: string; data: FetchOutcome }>({
+    bikeId: pin.bikeId,
+    data: { phase: "idle" }
+  });
+
+  const isFresh = outcome.bikeId === pin.bikeId;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/dashboard/bike-current-state/${encodeURIComponent(pin.bikeId)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          return null;
+        }
+        return (await response.json()) as BikeCurrentStateResult;
+      })
+      .then((next) => {
+        if (cancelled) return;
+        setOutcome({
+          bikeId: pin.bikeId,
+          data: next ? { phase: "loaded", result: next } : { phase: "error" }
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setOutcome({ bikeId: pin.bikeId, data: { phase: "error" } });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pin.bikeId]);
+
+  const result =
+    isFresh && outcome.data.phase === "loaded" ? outcome.data.result : null;
+  const loading = !isFresh || outcome.data.phase === "idle";
+  const live = result?.data;
+
+  // Prefer the freshly-fetched single state; fall back to map-state pin which
+  // is at most one polling cycle (10s) stale.
+  const lastReceivedAt = live?.lastReceivedAt ?? pin.lastReceivedAt;
+  const connectionStatus = live?.connectionStatus ?? pin.connectionStatus;
+  const drivingStatus = live?.drivingStatus ?? pin.drivingStatus;
+  const batteryStatus = live?.batteryStatus ?? pin.batteryStatus;
+  const batteryPercent = live?.batteryPercent ?? pin.batteryPercent;
+  const speedKph = live?.speedKph ?? pin.speedKph;
+  const ignitionStatus = live?.ignitionStatus ?? pin.ignitionStatus;
+  const latitude = live?.latitude ?? pin.latitude;
+  const longitude = live?.longitude ?? pin.longitude;
+
+  return (
+    <aside
+      className="bike-detail-panel"
+      role="complementary"
+      aria-label={`차량 ${pin.plateNumber} 상세`}
+    >
+      <header className="bike-detail-panel-header">
+        <div>
+          <span className="bike-detail-panel-eyebrow">차량 상세</span>
+          <h2>{pin.plateNumber}</h2>
+          <p>{pin.modelName ?? "모델 미지정"}</p>
+        </div>
+        <button
+          type="button"
+          className="bike-detail-panel-close"
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          ✕
+        </button>
+      </header>
+
+      <dl className="bike-detail-panel-body">
+        <DetailRow label="활성 라이더" value={pin.activeRiderLabel ?? "미배정"} />
+        <DetailRow label="연결 상태" value={connectionStatus} />
+        <DetailRow label="주행 상태" value={drivingStatus} />
+        <DetailRow label="시동" value={ignitionStatus} />
+        <DetailRow
+          label="속도"
+          value={speedKph != null ? `${speedKph.toFixed(1)} km/h` : "—"}
+        />
+        <DetailRow
+          label="배터리"
+          value={
+            batteryPercent != null
+              ? `${batteryPercent.toFixed(0)}% · ${batteryStatus}`
+              : batteryStatus
+          }
+        />
+        <DetailRow
+          label="위치"
+          value={`${latitude.toFixed(5)}, ${longitude.toFixed(5)}`}
+        />
+        <DetailRow label="마지막 수신" value={formatRelative(lastReceivedAt)} />
+        <DetailRow label="텔레메트리 출처" value={live?.telemetrySource ?? pin.telemetrySource} />
+      </dl>
+
+      {loading ? (
+        <p className="bike-detail-panel-status" role="status">단일 차량 텔레메트리 조회 중…</p>
+      ) : null}
+      {!loading && result?.notice ? (
+        <p className="bike-detail-panel-status" role="status">{result.notice}</p>
+      ) : null}
+    </aside>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bike-detail-panel-row">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  const ageMs = Date.now() - ts;
+  if (ageMs < 60_000) return `${Math.max(1, Math.round(ageMs / 1000))}초 전`;
+  if (ageMs < 3_600_000) return `${Math.round(ageMs / 60_000)}분 전`;
+  if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}시간 전`;
+  return new Date(ts).toLocaleString("ko-KR");
+}

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { BikeDetailPanel } from "@/components/dashboard/BikeDetailPanel";
 import { MapShell } from "@/components/dashboard/MapShell";
 import type { DashboardMapStateResult } from "@/lib/services/dashboard-map-state-data";
 
@@ -13,9 +14,10 @@ export interface DashboardCanvasProps {
 }
 
 /**
- * Client-side wrapper that owns the polling loop. The server component does
- * the first fetch (so the page renders SSR-ready), then this component takes
- * over and refreshes the map state on a fixed cadence.
+ * Client-side wrapper that owns the polling loop and the marker-click
+ * detail panel state. The server component does the first fetch (so the
+ * page renders SSR-ready), then this component takes over and refreshes
+ * the map state on a fixed cadence.
  *
  * Polling deliberately uses our own `/api/dashboard/map-state` route instead
  * of calling `service-ops-api` from the browser — that keeps the service-ops
@@ -26,6 +28,7 @@ export function DashboardCanvas({
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS
 }: DashboardCanvasProps) {
   const [state, setState] = useState<DashboardMapStateResult>(initial);
+  const [selectedBikeId, setSelectedBikeId] = useState<string | null>(null);
   const pollIntervalRef = useRef(pollIntervalMs);
 
   useEffect(() => {
@@ -72,17 +75,38 @@ export function DashboardCanvas({
     };
   }, []);
 
+  // Resolve the pin against the latest snapshot every render so a polling
+  // refresh that drops the selected bike collapses the panel automatically.
+  // Computing `selectedPin` from `selectedBikeId` purely in render avoids
+  // the set-state-in-effect anti-pattern that React 19's lint rule blocks.
+  const selectedPin = useMemo(() => {
+    if (!selectedBikeId) return null;
+    return state.data.bikePins.find((pin) => pin.bikeId === selectedBikeId) ?? null;
+  }, [selectedBikeId, state.data.bikePins]);
+
+  const handleBikeSelect = useCallback((bikeId: string) => {
+    setSelectedBikeId(bikeId);
+  }, []);
+
+  const handlePanelClose = useCallback(() => {
+    setSelectedBikeId(null);
+  }, []);
+
   return (
     <>
       <MapShell
         bikePins={state.data.bikePins}
         stationPins={state.data.stationPins}
+        onBikeSelect={handleBikeSelect}
       />
       {state.notice ? (
         <div className="dashboard-map-notice" role="status" aria-live="polite">
           <strong>지도 데이터 안내</strong>
           <span>{state.notice}</span>
         </div>
+      ) : null}
+      {selectedPin ? (
+        <BikeDetailPanel pin={selectedPin} onClose={handlePanelClose} />
       ) : null}
     </>
   );

--- a/development/front-admin-web/lib/services/bike-current-state-data.ts
+++ b/development/front-admin-web/lib/services/bike-current-state-data.ts
@@ -1,0 +1,64 @@
+import {
+  type FrontendBikeCurrentState,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type BikeCurrentStateResult = {
+  bikeId: string;
+  data: FrontendBikeCurrentState | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Single-bike telemetry loader. Returns {@code data: null} on every fallback
+ * path (no API base, no session, fetch failed, 404) so the detail panel can
+ * still render the BikePin info it already has and show a small notice.
+ */
+export async function loadBikeCurrentState(bikeId: string): Promise<BikeCurrentStateResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice:
+        "SERVICE_OPS_API_BASE_URL이 없어 단일 차량 텔레메트리를 표시할 수 없습니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice:
+        "관리자 세션이 없어 단일 차량 텔레메트리를 표시할 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getBikeCurrentState(bikeId);
+    return { bikeId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice: `단일 차량 텔레메트리 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -536,11 +536,39 @@ export type FrontendDashboardMapState = {
   stationPins: FrontendDashboardStationPin[];
 };
 
+export type ServiceOpsBikeCurrentState = {
+  bikeId: string;
+  deviceId: string | null;
+  telemetryLogId: string | null;
+  lastReceivedAt: string;
+  latitude: number | string;
+  longitude: number | string;
+  speedKph: number | string | null;
+  batteryPercent: number | string | null;
+  ignitionStatus: string;
+  telemetrySource: string;
+  drivingStatus: string;
+  connectionStatus: string;
+  batteryStatus: string;
+  updatedAt: string;
+};
+
+export type FrontendBikeCurrentState = Omit<
+  ServiceOpsBikeCurrentState,
+  "latitude" | "longitude" | "speedKph" | "batteryPercent"
+> & {
+  latitude: number;
+  longitude: number;
+  speedKph: number | null;
+  batteryPercent: number | null;
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
   getDashboardMapState: () => Promise<FrontendDashboardMapState>;
+  getBikeCurrentState: (bikeId: string) => Promise<FrontendBikeCurrentState>;
   getIntegrityReferenceChecks: () => Promise<ServiceOpsIntegrityScan>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
@@ -721,6 +749,13 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     },
     getDashboardMapState: async () =>
       toFrontendDashboardMapState(await request<ServiceOpsDashboardMapState>("/dashboard/map-state", { method: "GET" })),
+    getBikeCurrentState: async (bikeId) =>
+      toFrontendBikeCurrentState(
+        await request<ServiceOpsBikeCurrentState>(
+          `/telemetry/bikes/${encodeURIComponent(bikeId)}/current-state`,
+          { method: "GET" }
+        )
+      ),
     getIntegrityReferenceChecks: () =>
       request<ServiceOpsIntegrityScan>("/integrity/reference-checks", { method: "GET" }),
     listVehicles: async ({ page = 0, size = 20, sort } = {}) => {
@@ -970,6 +1005,16 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     deleteRider: async (id) => {
       await request<void>(`/riders/${encodeURIComponent(id)}`, { method: "DELETE" });
     }
+  };
+}
+
+export function toFrontendBikeCurrentState(state: ServiceOpsBikeCurrentState): FrontendBikeCurrentState {
+  return {
+    ...state,
+    latitude: toNumber(state.latitude),
+    longitude: toNumber(state.longitude),
+    speedKph: toNullableNumber(state.speedKph),
+    batteryPercent: toNullableNumber(state.batteryPercent)
   };
 }
 


### PR DESCRIPTION
## Summary

- 차량 마커 클릭 시 우측 디테일 패널 오픈 — 라이더 라벨, 플레이트, 모델, 연결 상태, 주행 상태, 시동, 속도, 배터리, 위치, 마지막 수신, 텔레메트리 출처 표시.
- 패널은 BikePin 정보로 즉시 렌더 → 단일 차량 \`GET /api/v1/telemetry/bikes/{id}/current-state\` fetch 결과로 enrich.
- 폴링이 선택된 차량을 떨어뜨리면 패널 자동 닫힘 (render-time derive).

## Trace

- Target issue: EVNSolution/thundercrew-domain#126
- Change-control issue: EVNSolution/clever-change-control#117
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): EVNSolution/thundercrew-domain#125 (dashboard map-state polling).

## Scope

Frontend-only.

Included:
- \`getBikeCurrentState(bikeId)\` API client + 타입 + 변환 함수.
- \`bike-current-state-data.ts\` server-side loader + mock fallback.
- \`/api/dashboard/bike-current-state/[bikeId]\` polling-pattern route.
- \`BikeDetailPanel\` 컴포넌트.
- DashboardCanvas selectedBikeId 상태 + onBikeSelect wiring.
- \`.bike-detail-panel\` 디자인 토큰 사용 CSS.

Excluded:
- 계약/보험/장비/교육 join 탭 (후속).
- 원격 제어 UI.
- 충전소 디테일 패널 (별도 슬라이스).

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean (React 19 \`set-state-in-effect\` 룰 통과) |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 배포 환경에서 차량 마커 클릭 → 우측 패널 오픈 확인.
- [ ] 다른 마커 클릭 → 패널이 새 차량으로 갱신, fetch 다시 발생.
- [ ] 닫기 버튼 클릭 → 패널 사라짐.
- [ ] 선택 차량이 폴링 사이에서 사라지면 패널 자동 닫힘.
- [ ] 백엔드 미구성/세션 없음 시 패널은 BikePin 정보만 보이고 안내 문구 노출.
- [ ] DevTools Network 에서 마커 클릭 시 \`/api/dashboard/bike-current-state/{id}\` 가 1회만 호출되는지 (재선택 시에만 추가 호출).

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #126 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 모니터링 화면이 "지도 + 마커 + 디테일 패널" 의 기본 끝-단을 닫았습니다. 다음 합리적 후속:

- 패널 안에서 라이더/계약/장비/보험/교육 정보 join (별도 PR).
- 충전소 디테일 패널 (\`onStationSelect\` 는 이미 prop 으로 노출됨).
- Slice D — 자동 보험 발급 (백엔드).
- Slice E — 어드민 폼 재설계.
- Slice F — vendor telemetry 폴링 (vendor 문서 도착 시).