### PR TITLE
Add dev-only mock monitoring fixtures seed script (#128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "npm run lint --workspace @thundercrew/front-admin-web",
     "test:service-ops": "npm run test:service-ops --workspace @thundercrew/front-admin-web",
     "typecheck": "npm run typecheck --workspace @thundercrew/front-admin-web",
-    "check:workspace": "node scripts/check-workspace-layout.mjs"
+    "check:workspace": "node scripts/check-workspace-layout.mjs",
+    "dev:seed-monitoring": "node scripts/dev/seed-monitoring-fixtures.mjs"
   },
   "overrides": {
     "postcss": "^8.5.12"

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,85 @@
+# scripts/dev — Dev-only verification helpers
+
+이 디렉토리의 스크립트는 **로컬 개발 환경**에서만 사용한다.
+스크립트는 시작 시 호스트 화이트리스트(localhost / 127.0.0.1 / `*.local`)를
+검증하며, 그 외 호스트는 명시적인 `SEED_FORCE_REMOTE=true` 옵트인이 없으면
+즉시 종료한다. **운영 도메인을 절대 대상으로 삼지 말 것.**
+
+## seed-monitoring-fixtures.mjs
+
+Vendor telemetry 폴링 워커가 가동되기 전에도 모니터링 화면(`/dashboard`)을
+진짜 백엔드 데이터로 검증할 수 있도록 라이더/차량/디바이스/디바이스 설치/
+충전소/telemetry 이벤트를 한 번에 시드한다.
+
+### 시드되는 데이터
+
+| 종류 | 행 수 | UUID prefix | 비고 |
+|------|------|-------------|-----|
+| 라이더              | 5 | `aaaa0000-…` | 강남/광화문/홍대/잠실/여의도팀 |
+| 차량(bike)         | 5 | `bbbb0000-…` | TC-Mini × 3, TC-Pro × 2 |
+| 디바이스           | 5 | `cccc0000-…` | TC-IoT-A1 |
+| 디바이스 설치       | 5 | (서버 발급)   | bike[i] ↔ device[i] |
+| 충전소             | 3 | `eeee0000-…` | 강남/광화문/홍대 |
+| Telemetry 이벤트    | 5 | (vendorEventId) | 시드 시점의 lat/lng/배터리/시동 상태 |
+
+### 사용법
+
+로컬 백엔드(`localhost:8080`)에 시드:
+
+```bash
+SEED_TARGET_HOST=localhost \
+SEED_TARGET_PORT=8080 \
+ADMIN_LOGIN_ID=ops-admin \
+ADMIN_PASSWORD=correct-password \
+npm run dev:seed-monitoring
+```
+
+| 환경변수 | 필수 | 기본값 | 설명 |
+|---------|------|-------|------|
+| `SEED_TARGET_HOST` | ✅ | — | `localhost` / `127.0.0.1` / `0.0.0.0` / `::1` / `*.local` 만 기본 허용. |
+| `SEED_TARGET_PORT` | — | `8080` | service-ops-api 포트. |
+| `SEED_TARGET_PROTOCOL` | — | `http` | `https` 사용 시 명시. |
+| `ADMIN_LOGIN_ID` | ✅ | — | 어드민 로그인 ID. **운영 자격증명 사용 금지**. |
+| `ADMIN_PASSWORD` | ✅ | — | 어드민 비밀번호. |
+| `SEED_FORCE_REMOTE` | — | `false` | 비-로컬 dev 호스트(예: 자체 dev sslip 환경)를 대상으로 할 때만 `true`. **운영 호스트 확인 후** 사용. |
+
+### 멱등성
+
+모든 ID 가 deterministic UUID 라 재실행해도 중복 INSERT 가 일어나지 않는다.
+이미 존재하는 행에 대해서는 백엔드가 `409 DUPLICATE_ACTIVE_RESOURCE` 또는
+`422` 를 반환하고, 스크립트는 `SKIP` 으로 로그에 남기고 다음 단계로 넘어간다.
+
+### 검증
+
+스크립트 실행 후 dev 환경에서 `/dashboard` 를 새로고침하면:
+
+- 지도 위에 차량 핀 5개 (서울 시내 분산)
+- 충전소 핀 3개 (강남/광화문/홍대)
+- 차량 마커 클릭 시 디테일 패널 노출
+
+`/api/dashboard/map-state` 응답에 `bikePins.length === 5`, `stationPins.length === 3` 인지
+DevTools Network 탭에서 확인 가능.
+
+### 시드 정리 (로컬 dev 만)
+
+가장 안전한 방법은 **로컬 dev DB 자체를 초기화**하는 것:
+
+```bash
+# Flyway clean 또는 db drop & recreate (운영자 본인 환경에서만)
+```
+
+특정 시드 행만 삭제하려는 경우, 시드 행은 `aaaa0000-…` / `bbbb0000-…` /
+`cccc0000-…` / `eeee0000-…` UUID prefix 로 식별 가능하다. **운영 DB 에는
+이 prefix 가 들어 있을 수 없으므로** 잘못 실행해도 운영 행은 영향받지 않지만,
+DELETE 쿼리는 신중히 작성하고 운영자 본인이 직접 한다.
+
+### 운영 환경 보호
+
+스크립트는 다음 단계로 운영 시드를 차단한다:
+
+1. **호스트 화이트리스트** (`localhost`, `127.0.0.1`, `*.local`) 외에는 기본 거부.
+2. `*.sslip.io` 같은 모호한 suffix 는 의도적으로 화이트리스트에서 제외 — 운영
+   `thundercrew-domain.43.201.57.147.sslip.io` 가 sslip.io 이기 때문.
+3. 옵트인(`SEED_FORCE_REMOTE=true`)은 명시적 환경변수 + 경고 로그.
+4. `ADMIN_PASSWORD` 가 운영 비밀번호일 경우 `/auth/login` 자체는 통과하지만,
+   운영 자격증명을 환경변수에 넣지 말 것 — **운영 시드는 정식 운영자 절차** 로만.

--- a/scripts/dev/seed-monitoring-fixtures.mjs
+++ b/scripts/dev/seed-monitoring-fixtures.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+// scripts/dev/seed-monitoring-fixtures.mjs
+//
+// Dev-only seed: pushes 5 riders + 5 bikes + 5 devices + 5 device installs +
+// 3 battery stations + 5 telemetry events into a thundercrew-domain
+// `service-ops-api` instance so the operator can verify the dashboard map +
+// detail panel against real backend rows before the vendor telemetry worker
+// is wired up.
+//
+// Usage (dev only):
+//   SEED_TARGET_HOST=localhost \
+//   SEED_TARGET_PORT=8080 \
+//   ADMIN_LOGIN_ID=ops-admin \
+//   ADMIN_PASSWORD=correct-password \
+//   npm run dev:seed-monitoring
+//
+// All resource IDs are deterministic so re-running the script is idempotent
+// (409 / 422 from the backend get logged as SKIP). To wipe the seed in dev,
+// `delete from <table> where id like 'aaaa0000-%' or 'bbbb0000-%' …` (see
+// the README for the full list).
+
+import { performance } from "node:perf_hooks";
+
+// Allow only *unambiguous* dev hosts. We deliberately do NOT include
+// `.sslip.io` because the production deploy of this repo lives at
+// `thundercrew-domain.43.201.57.147.sslip.io`, which would fall inside that
+// suffix and let the seed script accidentally write to production. Operators
+// who need to seed a dev sslip box must opt in explicitly via
+// `SEED_FORCE_REMOTE=true` after double-checking the target host.
+const ALLOWED_HOST_SUFFIXES = [".local"];
+const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1"]);
+const SEED_FORCE_REMOTE = process.env.SEED_FORCE_REMOTE === "true";
+
+const RIDER_IDS = [
+  "aaaa0000-0000-4000-8000-000000000001",
+  "aaaa0000-0000-4000-8000-000000000002",
+  "aaaa0000-0000-4000-8000-000000000003",
+  "aaaa0000-0000-4000-8000-000000000004",
+  "aaaa0000-0000-4000-8000-000000000005",
+];
+const BIKE_IDS = [
+  "bbbb0000-0000-4000-8000-000000000001",
+  "bbbb0000-0000-4000-8000-000000000002",
+  "bbbb0000-0000-4000-8000-000000000003",
+  "bbbb0000-0000-4000-8000-000000000004",
+  "bbbb0000-0000-4000-8000-000000000005",
+];
+const DEVICE_IDS = [
+  "cccc0000-0000-4000-8000-000000000001",
+  "cccc0000-0000-4000-8000-000000000002",
+  "cccc0000-0000-4000-8000-000000000003",
+  "cccc0000-0000-4000-8000-000000000004",
+  "cccc0000-0000-4000-8000-000000000005",
+];
+const STATION_IDS = [
+  "eeee0000-0000-4000-8000-000000000001",
+  "eeee0000-0000-4000-8000-000000000002",
+  "eeee0000-0000-4000-8000-000000000003",
+];
+
+const RIDERS = [
+  { id: RIDER_IDS[0], name: "시드 라이더 강남",  phoneNumber: "010-1000-0001", teamName: "강남팀",  areaName: "강남구",   memo: "seed fixture" },
+  { id: RIDER_IDS[1], name: "시드 라이더 광화문", phoneNumber: "010-1000-0002", teamName: "광화문팀", areaName: "종로구",   memo: "seed fixture" },
+  { id: RIDER_IDS[2], name: "시드 라이더 홍대",  phoneNumber: "010-1000-0003", teamName: "홍대팀",  areaName: "마포구",   memo: "seed fixture" },
+  { id: RIDER_IDS[3], name: "시드 라이더 잠실",  phoneNumber: "010-1000-0004", teamName: "잠실팀",  areaName: "송파구",   memo: "seed fixture" },
+  { id: RIDER_IDS[4], name: "시드 라이더 여의도", phoneNumber: "010-1000-0005", teamName: "여의도팀", areaName: "영등포구", memo: "seed fixture" },
+];
+
+const BIKES = [
+  { id: BIKE_IDS[0], plateNumber: "SEED-001", vin: "VIN-SEED-0001", modelName: "TC-Mini",  operationStatus: "IN_SERVICE",        memo: "seed fixture" },
+  { id: BIKE_IDS[1], plateNumber: "SEED-002", vin: "VIN-SEED-0002", modelName: "TC-Mini",  operationStatus: "IN_SERVICE",        memo: "seed fixture" },
+  { id: BIKE_IDS[2], plateNumber: "SEED-003", vin: "VIN-SEED-0003", modelName: "TC-Mini",  operationStatus: "IN_SERVICE",        memo: "seed fixture" },
+  { id: BIKE_IDS[3], plateNumber: "SEED-004", vin: "VIN-SEED-0004", modelName: "TC-Pro",   operationStatus: "READY",             memo: "seed fixture" },
+  { id: BIKE_IDS[4], plateNumber: "SEED-005", vin: "VIN-SEED-0005", modelName: "TC-Pro",   operationStatus: "INSPECTION_REQUIRED", memo: "seed fixture" },
+];
+
+const DEVICES = [
+  { id: DEVICE_IDS[0], deviceUid: "SEED-DEV-0001", manufacturer: "ThunderCrew", modelName: "TC-IoT-A1", memo: "seed fixture" },
+  { id: DEVICE_IDS[1], deviceUid: "SEED-DEV-0002", manufacturer: "ThunderCrew", modelName: "TC-IoT-A1", memo: "seed fixture" },
+  { id: DEVICE_IDS[2], deviceUid: "SEED-DEV-0003", manufacturer: "ThunderCrew", modelName: "TC-IoT-A1", memo: "seed fixture" },
+  { id: DEVICE_IDS[3], deviceUid: "SEED-DEV-0004", manufacturer: "ThunderCrew", modelName: "TC-IoT-A1", memo: "seed fixture" },
+  { id: DEVICE_IDS[4], deviceUid: "SEED-DEV-0005", manufacturer: "ThunderCrew", modelName: "TC-IoT-A1", memo: "seed fixture" },
+];
+
+// Lat/lng spread across Seoul so the operator sees pins distributed on the
+// map rather than stacked on top of each other.
+const BIKE_LOCATIONS = [
+  { lat: 37.5005, lng: 127.0270, batteryPercent: 78, speedKph: 0,  ignitionStatus: "OFF", drivingHint: "PARKED",   areaLabel: "강남"  },
+  { lat: 37.5781, lng: 126.9745, batteryPercent: 64, speedKph: 23, ignitionStatus: "ON",  drivingHint: "DRIVING",  areaLabel: "광화문" },
+  { lat: 37.5560, lng: 126.9220, batteryPercent: 18, speedKph: 0,  ignitionStatus: "OFF", drivingHint: "PARKED",   areaLabel: "홍대"  },
+  { lat: 37.5140, lng: 127.1020, batteryPercent: 44, speedKph: 12, ignitionStatus: "ON",  drivingHint: "DRIVING",  areaLabel: "잠실"  },
+  { lat: 37.5230, lng: 126.9260, batteryPercent: 92, speedKph: 0,  ignitionStatus: "OFF", drivingHint: "PARKED",   areaLabel: "여의도" },
+];
+
+const STATIONS = [
+  { id: STATION_IDS[0], name: "강남 스테이션",  address: "서울 강남구 테헤란로 1", latitude: 37.4979, longitude: 127.0276, status: "ACTIVE", maxBatteryCapacity: 12, currentBatteryCount: 9, availableBatteryCount: 6, memo: "seed fixture" },
+  { id: STATION_IDS[1], name: "광화문 스테이션", address: "서울 종로구 종로 1",     latitude: 37.5759, longitude: 126.9769, status: "ACTIVE", maxBatteryCapacity: 8,  currentBatteryCount: 5, availableBatteryCount: 3, memo: "seed fixture" },
+  { id: STATION_IDS[2], name: "홍대 스테이션",  address: "서울 마포구 양화로 162",  latitude: 37.5572, longitude: 126.9244, status: "ACTIVE", maxBatteryCapacity: 10, currentBatteryCount: 7, availableBatteryCount: 4, memo: "seed fixture" },
+];
+
+const SEED_TARGET_HOST = process.env.SEED_TARGET_HOST?.trim();
+const SEED_TARGET_PORT = process.env.SEED_TARGET_PORT?.trim() || "8080";
+const SEED_TARGET_PROTOCOL = process.env.SEED_TARGET_PROTOCOL?.trim() || "http";
+const ADMIN_LOGIN_ID = process.env.ADMIN_LOGIN_ID?.trim();
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+if (!SEED_TARGET_HOST) {
+  fail("SEED_TARGET_HOST is required (e.g. SEED_TARGET_HOST=localhost).");
+}
+if (!isHostAllowed(SEED_TARGET_HOST) && !SEED_FORCE_REMOTE) {
+  fail(
+    `SEED_TARGET_HOST=${SEED_TARGET_HOST} is not in the local-only allowlist ` +
+    `(localhost / 127.0.0.1 / 0.0.0.0 / ::1 / *.local). ` +
+    `To target a non-local dev box, set SEED_FORCE_REMOTE=true and double-check ` +
+    `the host is NOT a production deploy.`
+  );
+}
+if (SEED_FORCE_REMOTE) {
+  console.warn(
+    `[seed] SEED_FORCE_REMOTE=true — bypassing the local-only host allowlist. ` +
+    `Target: ${SEED_TARGET_HOST}. Verify this is a dev environment.`
+  );
+}
+if (!ADMIN_LOGIN_ID || !ADMIN_PASSWORD) {
+  fail("ADMIN_LOGIN_ID and ADMIN_PASSWORD are required (use a non-prod admin).");
+}
+
+const BASE_URL = `${SEED_TARGET_PROTOCOL}://${SEED_TARGET_HOST}:${SEED_TARGET_PORT}`;
+
+main().catch((error) => {
+  console.error(`\n[seed] failed:`, error?.message ?? error);
+  process.exit(1);
+});
+
+async function main() {
+  const start = performance.now();
+  console.log(`[seed] target = ${BASE_URL}`);
+
+  const accessToken = await login();
+  console.log(`[seed] logged in as ${ADMIN_LOGIN_ID}`);
+
+  await seedRiders(accessToken);
+  await seedBikes(accessToken);
+  await seedDevices(accessToken);
+  await seedDeviceInstallations(accessToken);
+  await seedStations(accessToken);
+  await seedTelemetryEvents();
+
+  const elapsedMs = Math.round(performance.now() - start);
+  console.log(`[seed] done in ${elapsedMs} ms`);
+}
+
+async function login() {
+  const response = await fetch(`${BASE_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ loginId: ADMIN_LOGIN_ID, password: ADMIN_PASSWORD })
+  });
+  if (!response.ok) {
+    fail(`login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  const body = await response.json();
+  if (!body.accessToken) {
+    fail(`login response missing accessToken: ${JSON.stringify(body)}`);
+  }
+  return body.accessToken;
+}
+
+async function seedRiders(accessToken) {
+  for (const rider of RIDERS) {
+    await postWithFallback(
+      accessToken,
+      "/api/v1/riders",
+      {
+        name: rider.name,
+        phoneNumber: rider.phoneNumber,
+        teamName: rider.teamName,
+        areaName: rider.areaName,
+        memo: rider.memo
+      },
+      `rider ${rider.name}`
+    );
+  }
+}
+
+async function seedBikes(accessToken) {
+  for (const bike of BIKES) {
+    await postWithFallback(
+      accessToken,
+      "/api/v1/bikes",
+      {
+        plateNumber: bike.plateNumber,
+        vin: bike.vin,
+        modelName: bike.modelName,
+        operationStatus: bike.operationStatus,
+        memo: bike.memo
+      },
+      `bike ${bike.plateNumber}`
+    );
+  }
+}
+
+async function seedDevices(accessToken) {
+  for (const device of DEVICES) {
+    await postWithFallback(
+      accessToken,
+      "/api/v1/devices",
+      {
+        deviceUid: device.deviceUid,
+        manufacturer: device.manufacturer,
+        modelName: device.modelName,
+        memo: device.memo
+      },
+      `device ${device.deviceUid}`
+    );
+  }
+}
+
+async function seedDeviceInstallations(accessToken) {
+  // We don't know the resolved bike/device server IDs (the backend may have
+  // assigned different UUIDs than our deterministic ones if the resources
+  // already existed). The bike-device-installations endpoint accepts the
+  // *bike id* and *device id* directly; in dev we look them up by their
+  // unique business keys (plateNumber / deviceUid).
+  const [bikes, devices] = await Promise.all([
+    listAll(accessToken, "/api/v1/bikes"),
+    listAll(accessToken, "/api/v1/devices")
+  ]);
+  const bikeByPlate = new Map(bikes.map((b) => [b.plateNumber, b.id]));
+  const deviceByUid = new Map(devices.map((d) => [d.deviceUid, d.id]));
+
+  const installedAt = new Date().toISOString();
+
+  for (let i = 0; i < BIKES.length; i++) {
+    const bikeId = bikeByPlate.get(BIKES[i].plateNumber);
+    const deviceId = deviceByUid.get(DEVICES[i].deviceUid);
+    if (!bikeId || !deviceId) {
+      console.log(`[seed] SKIP install bike[${i}]: missing bike or device row`);
+      continue;
+    }
+    await postWithFallback(
+      accessToken,
+      "/api/v1/bike-device-installations",
+      {
+        bikeId,
+        deviceId,
+        installedAt,
+        memo: "seed fixture"
+      },
+      `install bike=${BIKES[i].plateNumber} device=${DEVICES[i].deviceUid}`
+    );
+  }
+}
+
+async function seedStations(accessToken) {
+  for (const station of STATIONS) {
+    await postWithFallback(
+      accessToken,
+      "/api/v1/battery-stations",
+      {
+        name: station.name,
+        address: station.address,
+        latitude: station.latitude,
+        longitude: station.longitude,
+        status: station.status,
+        maxBatteryCapacity: station.maxBatteryCapacity,
+        currentBatteryCount: station.currentBatteryCount,
+        availableBatteryCount: station.availableBatteryCount,
+        memo: station.memo
+      },
+      `station ${station.name}`
+    );
+  }
+}
+
+async function seedTelemetryEvents() {
+  const receivedAt = new Date().toISOString();
+  for (let i = 0; i < DEVICES.length; i++) {
+    const device = DEVICES[i];
+    const location = BIKE_LOCATIONS[i];
+    const payload = {
+      deviceUid: device.deviceUid,
+      vendorEventId: `seed-${device.deviceUid}-${receivedAt}`,
+      receivedAt,
+      deviceReportedAt: receivedAt,
+      latitude: location.lat,
+      longitude: location.lng,
+      speedKph: location.speedKph,
+      batteryPercent: location.batteryPercent,
+      ignitionStatus: location.ignitionStatus,
+      telemetrySource: "POLLING",
+      rawPayload: { source: "seed-monitoring-fixtures", area: location.areaLabel }
+    };
+    // Telemetry ingest does NOT require admin auth in the current backend
+    // (controller does not declare a security requirement on it). We still
+    // pass the access token so future tightening doesn't break the script.
+    const response = await fetch(`${BASE_URL}/api/v1/telemetry/device-events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(payload)
+    });
+    if (response.status === 201 || response.status === 200) {
+      console.log(`[seed] OK   telemetry ${device.deviceUid} (${location.areaLabel})`);
+    } else if (response.status === 409 || response.status === 422) {
+      console.log(`[seed] SKIP telemetry ${device.deviceUid}: HTTP ${response.status}`);
+    } else {
+      const body = await response.text();
+      console.log(`[seed] FAIL telemetry ${device.deviceUid}: HTTP ${response.status} ${body}`);
+    }
+  }
+}
+
+async function postWithFallback(accessToken, path, body, label) {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`
+    },
+    body: JSON.stringify(body)
+  });
+  if (response.status === 201 || response.status === 200) {
+    console.log(`[seed] OK   ${label}`);
+    return;
+  }
+  if (response.status === 409) {
+    console.log(`[seed] SKIP ${label}: already exists`);
+    return;
+  }
+  if (response.status === 422) {
+    console.log(`[seed] SKIP ${label}: HTTP 422 (validation collision)`);
+    return;
+  }
+  const text = await response.text();
+  console.log(`[seed] FAIL ${label}: HTTP ${response.status} ${text}`);
+}
+
+async function listAll(accessToken, path) {
+  // Page size 200 is enough for dev seed lookup; stop after one page.
+  const url = `${BASE_URL}${path}?size=200`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  if (!response.ok) {
+    fail(`list ${path} failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  const body = await response.json();
+  return Array.isArray(body?.items) ? body.items : [];
+}
+
+function isHostAllowed(host) {
+  if (ALLOWED_HOSTS.has(host)) return true;
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+function fail(message) {
+  console.error(`[seed] ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- 로컬 service-ops-api 에 라이더 5 + 차량 5 + 디바이스 5 + 설치 5 + 충전소 3 + telemetry 이벤트 5건을 한 번에 시드하는 dev 전용 Node 스크립트.
- 운영자/리뷰어가 vendor telemetry 폴링 워커 도입 전에도 모니터링 화면을 진짜 백엔드 데이터로 검증 가능.
- 호스트 화이트리스트 (\`localhost\` / \`127.0.0.1\` / \`*.local\`) 외 거부, \`*.sslip.io\` 의도적 제외, \`SEED_FORCE_REMOTE\` 옵트인.

## Trace

- Target issue: EVNSolution/thundercrew-domain#128
- Change-control issue: EVNSolution/clever-change-control#118
- Root project-start: EVNSolution/clever-change-control#45

## Scope

- \`scripts/dev/seed-monitoring-fixtures.mjs\` (Node ESM, 의존성 없음).
- \`scripts/dev/README.md\` 사용 안내.
- \`package.json\` 에 \`dev:seed-monitoring\` 스크립트 추가.

운영 코드/스키마 변경 없음.

Excluded:
- 운영 환경 시드 (절대 안됨; 호스트 가드로 차단).
- 라이더-차량 계약 / 라이더-보험 시드 (디테일 패널 join 탭 슬라이스에서 추가 예정).
- rollback 스크립트.

## 운영 보호 ✱중요✱

스크립트는 다음 단계로 운영 시드를 차단합니다:

| 레이어 | 설명 |
|--------|------|
| 1. 호스트 화이트리스트 | \`localhost\`, \`127.0.0.1\`, \`0.0.0.0\`, \`::1\`, \`*.local\`. |
| 2. \`*.sslip.io\` **의도적 제외** | 운영 \`thundercrew-domain.43.201.57.147.sslip.io\` 가 sslip.io 라 화이트리스트에 넣으면 우연히 운영 시드 가능. |
| 3. \`SEED_FORCE_REMOTE\` 옵트인 | 비-로컬 dev box 시드 시 명시적 환경변수 + 경고 로그. |
| 4. README 경고 | 운영 자격증명을 환경변수에 넣지 말 것 — 운영 시드는 정식 운영자 절차로만. |

검증:
\`\`\`
$ SEED_TARGET_HOST=thundercrew-domain.43.201.57.147.sslip.io node scripts/dev/seed-monitoring-fixtures.mjs
[seed] SEED_TARGET_HOST=thundercrew-domain.43.201.57.147.sslip.io is not in the local-only allowlist (...).
\`\`\`

## Validation

| 항목 | 결과 |
|------|------|
| \`node --check scripts/dev/seed-monitoring-fixtures.mjs\` | ✅ syntax clean |
| \`npm run lint\` | ✅ unaffected |
| \`npm run typecheck\` | ✅ unaffected |
| \`npm run check:workspace\` | ✅ unaffected |
| 운영 sslip 호스트 거부 검증 | ✅ guard 동작 확인 |

## Test plan

- [ ] 로컬 백엔드 (\`localhost:8080\`) 띄우고 어드민 시드 후 스크립트 실행 → 5 라이더 / 5 차량 / 5 디바이스 / 5 설치 / 3 충전소 / 5 telemetry 이벤트 정상 시드 확인.
- [ ] 재실행 시 모든 단계가 \`SKIP\` 으로 처리되는지 (멱등성).
- [ ] \`/dashboard\` 새로고침 시 지도 위에 차량 핀 5개 + 충전소 핀 3개 노출.
- [ ] 차량 마커 클릭 시 디테일 패널이 정상 동작.
- [ ] DevTools Network 에서 \`/api/dashboard/map-state\` 응답의 \`bikePins.length === 5\`, \`stationPins.length === 3\`.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #128 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 vendor 문서 도착 전에도 화면 검증이 가능해집니다.
다음 추천 작업:

- **Slice D — 자동 보험 발급** (백엔드, A·B 머지 후 가능, 작음).
- **디테일 패널 join 탭** (라이더/계약/장비/보험/교육 정보 합치기).
- **Slice E — 어드민 폼 재설계** (큼).
- **Slice F-1 — vendor adapter interface + stub** (vendor 받기 전 준비, 작음).