### PR TITLE
Auto-issue insurance for subscription contract templates (#130)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
@@ -15,10 +15,31 @@ public record RiderBikeContractReadResponse(
         Instant terminatedAt,
         String terminatedReason,
         String memo,
+        UUID autoIssuedRiderInsuranceId,
+        String autoInsuranceSkipReason,
         Instant createdAt,
         Instant updatedAt
 ) {
     public static RiderBikeContractReadResponse from(RiderBikeContract contract) {
+        return from(contract, null, null);
+    }
+
+    /**
+     * Used by {@code create} when the service has just attempted automatic
+     * insurance issuance off the matching contract template:
+     * <ul>
+     *   <li>{@code autoIssuedRiderInsuranceId} carries the new RiderInsurance id when it succeeded.</li>
+     *   <li>{@code autoInsuranceSkipReason} carries a short SKIP token when the
+     *       service intentionally did not issue (already linked, item disabled,
+     *       etc.). Both fields stay {@code null} when the template did not opt
+     *       in to automatic issuance.</li>
+     * </ul>
+     */
+    public static RiderBikeContractReadResponse from(
+            RiderBikeContract contract,
+            UUID autoIssuedRiderInsuranceId,
+            String autoInsuranceSkipReason
+    ) {
         return new RiderBikeContractReadResponse(
                 contract.getId(),
                 contract.getIdx(),
@@ -30,6 +51,8 @@ public record RiderBikeContractReadResponse(
                 contract.getTerminatedAt(),
                 contract.getTerminatedReason(),
                 contract.getMemo(),
+                autoIssuedRiderInsuranceId,
+                autoInsuranceSkipReason,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/RiderBikeContractCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/RiderBikeContractCommandService.java
@@ -13,11 +13,16 @@ import com.thundercrew.opsapi.contract.dto.RiderBikeContractTerminateRequest;
 import com.thundercrew.opsapi.contract.dto.RiderBikeContractUpdateRequest;
 import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
 import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.insurance.domain.InsuranceItem;
+import com.thundercrew.opsapi.insurance.domain.RiderInsurance;
+import com.thundercrew.opsapi.insurance.repository.InsuranceItemRepository;
+import com.thundercrew.opsapi.insurance.repository.RiderInsuranceRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,17 +31,31 @@ public class RiderBikeContractCommandService {
 
     private static final Instant OPEN_ENDED_OVERLAP_BOUND = Instant.parse("9999-12-31T23:59:59Z");
 
+    static final String AUTO_INSURANCE_SKIP_TEMPLATE_NOT_OPTED_IN = "TEMPLATE_NOT_OPTED_IN";
+    static final String AUTO_INSURANCE_SKIP_DEFAULT_ITEM_MISSING = "DEFAULT_INSURANCE_ITEM_MISSING";
+    static final String AUTO_INSURANCE_SKIP_DEFAULT_ITEM_NOT_FOUND = "DEFAULT_INSURANCE_ITEM_NOT_FOUND";
+    static final String AUTO_INSURANCE_SKIP_DEFAULT_ITEM_DELETED = "DEFAULT_INSURANCE_ITEM_DELETED";
+    static final String AUTO_INSURANCE_SKIP_DEFAULT_ITEM_DISABLED = "DEFAULT_INSURANCE_ITEM_DISABLED";
+    static final String AUTO_INSURANCE_SKIP_ALREADY_LINKED = "RIDER_INSURANCE_ALREADY_LINKED";
+    static final String AUTO_INSURANCE_SKIP_DUPLICATE_ON_INSERT = "RIDER_INSURANCE_DUPLICATE_ON_INSERT";
+
     private final RiderBikeContractRepository riderBikeContractRepository;
     private final ContractTemplateRepository contractTemplateRepository;
+    private final InsuranceItemRepository insuranceItemRepository;
+    private final RiderInsuranceRepository riderInsuranceRepository;
     private final EntityManager entityManager;
 
     public RiderBikeContractCommandService(
             RiderBikeContractRepository riderBikeContractRepository,
             ContractTemplateRepository contractTemplateRepository,
+            InsuranceItemRepository insuranceItemRepository,
+            RiderInsuranceRepository riderInsuranceRepository,
             EntityManager entityManager
     ) {
         this.riderBikeContractRepository = riderBikeContractRepository;
         this.contractTemplateRepository = contractTemplateRepository;
+        this.insuranceItemRepository = insuranceItemRepository;
+        this.riderInsuranceRepository = riderInsuranceRepository;
         this.entityManager = entityManager;
     }
 
@@ -60,7 +79,9 @@ public class RiderBikeContractCommandService {
         RiderBikeContract saved = riderBikeContractRepository.save(contract);
         entityManager.flush();
         entityManager.refresh(saved);
-        return RiderBikeContractReadResponse.from(saved);
+
+        AutoInsuranceOutcome outcome = tryAutoIssueInsurance(saved, template);
+        return RiderBikeContractReadResponse.from(saved, outcome.riderInsuranceId(), outcome.skipReason());
     }
 
     @Transactional
@@ -78,6 +99,60 @@ public class RiderBikeContractCommandService {
         contract.terminate(request.terminatedAt(), request.terminatedReason());
         entityManager.flush();
         return RiderBikeContractReadResponse.from(contract);
+    }
+
+    /**
+     * Resolve the contract template's automatic-insurance pointer and, when
+     * everything lines up, create a matching {@link RiderInsurance} row in the
+     * same transaction. Each early return carries a short SKIP token so the
+     * response can explain *why* the package didn't auto-issue without the
+     * service throwing — failing the contract for an insurance-side problem
+     * would surprise the operator.
+     */
+    private AutoInsuranceOutcome tryAutoIssueInsurance(RiderBikeContract contract, ContractTemplate template) {
+        if (!template.isIncludesInsurance()) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_TEMPLATE_NOT_OPTED_IN);
+        }
+        UUID defaultInsuranceItemId = template.getDefaultInsuranceItemId();
+        if (defaultInsuranceItemId == null) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_DEFAULT_ITEM_MISSING);
+        }
+        InsuranceItem item = insuranceItemRepository.findById(defaultInsuranceItemId).orElse(null);
+        if (item == null) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_DEFAULT_ITEM_NOT_FOUND);
+        }
+        if (item.isDeleted()) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_DEFAULT_ITEM_DELETED);
+        }
+        if (!item.isEnabled()) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_DEFAULT_ITEM_DISABLED);
+        }
+        if (riderInsuranceRepository.existsByRiderIdAndInsuranceItemIdAndDeletedAtIsNull(
+                contract.getRiderId(), defaultInsuranceItemId)) {
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_ALREADY_LINKED);
+        }
+
+        RiderInsurance auto = RiderInsurance.create(
+                contract.getRiderId(),
+                defaultInsuranceItemId,
+                "Auto-issued from contract template " + template.getName(),
+                Boolean.TRUE,
+                contract.getStartAt(),
+                contract.getEndAt(),
+                contract.getId()
+        );
+        try {
+            RiderInsurance saved = riderInsuranceRepository.save(auto);
+            entityManager.flush();
+            entityManager.refresh(saved);
+            return AutoInsuranceOutcome.issued(saved.getId());
+        } catch (DataIntegrityViolationException exception) {
+            // A concurrent caller (or a race between the existsBy… check and
+            // the actual insert) raced us to the unique index. Translate to
+            // SKIP so the contract still succeeds; the rider already has an
+            // active link to the same item, which is the desired end state.
+            return AutoInsuranceOutcome.skip(AUTO_INSURANCE_SKIP_DUPLICATE_ON_INSERT);
+        }
     }
 
     private RiderBikeContract findActiveContract(UUID id) {
@@ -160,6 +235,16 @@ public class RiderBikeContractCommandService {
         }
         if (riderBikeContractRepository.existsOverlappingBikePeriod(bikeId, startAt, effectiveEndAt)) {
             throw new PeriodOverlapException("Bike already has an overlapping rider contract.");
+        }
+    }
+
+    private record AutoInsuranceOutcome(UUID riderInsuranceId, String skipReason) {
+        static AutoInsuranceOutcome issued(UUID riderInsuranceId) {
+            return new AutoInsuranceOutcome(riderInsuranceId, null);
+        }
+
+        static AutoInsuranceOutcome skip(String reason) {
+            return new AutoInsuranceOutcome(null, reason);
         }
     }
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderBikeContractAutoInsuranceTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderBikeContractAutoInsuranceTests.java
@@ -1,0 +1,293 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice D: rider-bike contract creation auto-issues a rider insurance row
+ * when the contract template opts in (\`includes_insurance=true\` +
+ * \`default_insurance_item_id\`). Each early-return path in the service is
+ * mirrored as a SKIP token in the response.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderBikeContractAutoInsuranceTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbb1111-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID BIKE_ID = UUID.fromString("cccc1111-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID INSURANCE_ITEM_ID = UUID.fromString("eeee1111-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID DISABLED_INSURANCE_ITEM_ID = UUID.fromString("eeee2222-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID DELETED_INSURANCE_ITEM_ID = UUID.fromString("eeee3333-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID PHANTOM_INSURANCE_ITEM_ID = UUID.fromString("eeee9999-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final Instant CONTRACT_START = Instant.parse("2030-01-01T00:00:00Z");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_insurances");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from contract_templates where system_template = false");
+        jdbcTemplate.update("""
+                delete from insurance_items
+                where id not in (
+                    '22222222-2222-2222-2222-000000000001',
+                    '22222222-2222-2222-2222-000000000002',
+                    '22222222-2222-2222-2222-000000000003',
+                    '22222222-2222-2222-2222-000000000004'
+                )
+                """);
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        seedRider(RIDER_ID, "자동 보험 라이더", "010-9000-1000");
+        seedBike(BIKE_ID, "AUTO-INS-001", "VIN-AUTO-INS-001");
+        seedInsuranceItem(INSURANCE_ITEM_ID, "자동 발급 보험", true, false);
+        seedInsuranceItem(DISABLED_INSURANCE_ITEM_ID, "비활성 보험", false, false);
+        seedInsuranceItem(DELETED_INSURANCE_ITEM_ID, "삭제된 보험", true, true);
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void subscriptionTemplateAutoIssuesInsuranceWhenIncludesInsuranceWithItem() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Auto-Issue", true, INSURANCE_ITEM_ID);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoIssuedRiderInsuranceId").isString())
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value(org.hamcrest.Matchers.nullValue()))
+                .andReturn();
+
+        UUID autoIssuedId = UUID.fromString(extractTextField(result, "autoIssuedRiderInsuranceId"));
+        Map<String, Object> riderInsurance = jdbcTemplate.queryForMap("""
+                select rider_id, insurance_item_id, rider_bike_contract_id,
+                       starts_at, ends_at, enabled
+                from rider_insurances
+                where id = ?
+                """, autoIssuedId);
+        assertThat(riderInsurance.get("rider_id")).isEqualTo(RIDER_ID);
+        assertThat(riderInsurance.get("insurance_item_id")).isEqualTo(INSURANCE_ITEM_ID);
+        assertThat(riderInsurance.get("rider_bike_contract_id"))
+                .isEqualTo(UUID.fromString(extractTextField(result, "id")));
+        assertThat(riderInsurance.get("enabled")).isEqualTo(true);
+    }
+
+    @Test
+    void templateThatDoesNotOptInSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs No-Insurance", false, null);
+
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoIssuedRiderInsuranceId").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("TEMPLATE_NOT_OPTED_IN"));
+    }
+
+    @Test
+    void templateOptedInWithoutDefaultItemSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Missing Item", true, null);
+
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("DEFAULT_INSURANCE_ITEM_MISSING"));
+    }
+
+    @Test
+    void templatePointingAtMissingInsuranceItemSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Phantom Item", true, PHANTOM_INSURANCE_ITEM_ID);
+
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("DEFAULT_INSURANCE_ITEM_NOT_FOUND"));
+    }
+
+    @Test
+    void templatePointingAtDisabledItemSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Disabled Item", true, DISABLED_INSURANCE_ITEM_ID);
+
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("DEFAULT_INSURANCE_ITEM_DISABLED"));
+    }
+
+    @Test
+    void templatePointingAtDeletedItemSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Deleted Item", true, DELETED_INSURANCE_ITEM_ID);
+
+        mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("DEFAULT_INSURANCE_ITEM_DELETED"));
+    }
+
+    @Test
+    void riderAlreadyLinkedToSameItemSkipsAutoIssuance() throws Exception {
+        UUID templateId = seedSubscriptionTemplate("Subs Already Linked", true, INSURANCE_ITEM_ID);
+        UUID existingLinkId = UUID.fromString("ffff1111-ffff-ffff-ffff-ffffffffffff");
+        jdbcTemplate.update("""
+                insert into rider_insurances (id, rider_id, insurance_item_id, enabled)
+                values (?, ?, ?, true)
+                """, existingLinkId, RIDER_ID, INSURANCE_ITEM_ID);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/rider-bike-contracts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(contractBody(RIDER_ID, BIKE_ID, templateId, CONTRACT_START)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.autoIssuedRiderInsuranceId").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.autoInsuranceSkipReason").value("RIDER_INSURANCE_ALREADY_LINKED"))
+                .andReturn();
+
+        // Existing rider insurance row is the only active row; no second row
+        // got inserted.
+        Integer count = jdbcTemplate.queryForObject("""
+                select count(*) from rider_insurances
+                where rider_id = ? and insurance_item_id = ? and deleted_at is null
+                """, Integer.class, RIDER_ID, INSURANCE_ITEM_ID);
+        assertThat(count).isEqualTo(1);
+        // And the contract was still created.
+        UUID contractId = UUID.fromString(extractTextField(result, "id"));
+        Integer contractCount = jdbcTemplate.queryForObject(
+                "select count(*) from rider_bike_contracts where id = ?",
+                Integer.class, contractId);
+        assertThat(contractCount).isEqualTo(1);
+    }
+
+    private UUID seedSubscriptionTemplate(String name, boolean includesInsurance, UUID defaultInsuranceItemId) {
+        UUID templateId = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into contract_templates (
+                    id, name, duration_minutes, description, enabled, system_template,
+                    category, return_type, duration_unit, duration_value,
+                    includes_insurance, default_insurance_item_id
+                ) values (?, ?, ?, '계약 자동 보험 fixture', true, false,
+                          'SUBSCRIPTION', 'TAKEOVER', 'MONTH', 12, ?, ?)
+                """,
+                templateId,
+                name,
+                12 * 30 * 1440,
+                includesInsurance,
+                defaultInsuranceItemId);
+        return templateId;
+    }
+
+    private void seedRider(UUID id, String name, String phoneNumber) {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, app_account_linked)
+                values (?, ?, ?, false)
+                """, id, name, phoneNumber);
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, operation_status)
+                values (?, ?, ?, 'READY')
+                """, id, plateNumber, vin);
+    }
+
+    private void seedInsuranceItem(UUID id, String name, boolean enabled, boolean deleted) {
+        jdbcTemplate.update("""
+                insert into insurance_items (id, name, description, enabled, deleted_at)
+                values (?, ?, '자동 발급 fixture', ?, %s)
+                """.formatted(deleted ? "now()" : "null"), id, name, enabled);
+    }
+
+    private String contractBody(UUID riderId, UUID bikeId, UUID contractTemplateId, Instant startAt) {
+        return """
+                {
+                  "riderId":"%s",
+                  "bikeId":"%s",
+                  "contractTemplateId":"%s",
+                  "startAt":"%s"
+                }
+                """.formatted(riderId, bikeId, contractTemplateId, startAt);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractTextField(MvcResult result, String fieldName) throws Exception {
+        Pattern pattern = Pattern.compile("\"" + fieldName + "\"\\s*:\\s*\"([^\"]+)\"");
+        Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find())
+                .as("expected field %s in response: %s", fieldName, result.getResponse().getContentAsString())
+                .isTrue();
+        return matcher.group(1);
+    }
+
+    @SuppressWarnings("unused")
+    private static List<String> noop() {
+        return List.of();
+    }
+}


### PR DESCRIPTION
## Summary

- 구독 계약 템플릿이 \`includes_insurance=true\` + \`default_insurance_item_id\` 를 가지면, 라이더-차량 계약 생성 시 같은 트랜잭션 안에서 라이더-보험 행을 자동 발급.
- 응답 본문에 \`autoIssuedRiderInsuranceId\` (성공) / \`autoInsuranceSkipReason\` (SKIP 토큰) 노출.
- 보험 측 문제 (없는 default item, disabled, 이미 active 링크 등) 가 contract 생성을 절대 실패시키지 않도록 6개 SKIP 분기 명시적 처리.

## Trace

- Target issue: EVNSolution/thundercrew-domain#130
- Change-control issue: EVNSolution/clever-change-control#119
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): Slice A (#119) + Slice B (#121).

## Scope

Backend-only.

Included:
- \`RiderBikeContractCommandService.create\` 자동 발급 로직 + 6개 SKIP 토큰.
- \`RiderBikeContractReadResponse\` 에 두 새 필드.
- \`RiderBikeContractAutoInsuranceTests\` (7 케이스: happy + 6 SKIP).

Excluded:
- 계약 종료 시 보험 자동 해지.
- 보험 갱신.
- 어드민 UI (Slice E).

## SKIP 토큰 매트릭스

| 토큰 | 조건 |
|------|------|
| \`TEMPLATE_NOT_OPTED_IN\` | template.includesInsurance = false |
| \`DEFAULT_INSURANCE_ITEM_MISSING\` | includesInsurance=true 이지만 default_insurance_item_id IS NULL |
| \`DEFAULT_INSURANCE_ITEM_NOT_FOUND\` | default_insurance_item_id 가 가리키는 row 없음 |
| \`DEFAULT_INSURANCE_ITEM_DELETED\` | InsuranceItem.deleted_at IS NOT NULL |
| \`DEFAULT_INSURANCE_ITEM_DISABLED\` | InsuranceItem.enabled = false |
| \`RIDER_INSURANCE_ALREADY_LINKED\` | (rider, item) active 행 이미 존재 |
| \`RIDER_INSURANCE_DUPLICATE_ON_INSERT\` | DB unique race (concurrent contract create) |

## Validation

| 항목 | 결과 |
|------|------|
| \`./gradlew compileJava compileTestJava\` | ✅ BUILD SUCCESSFUL (24s) |
| \`./gradlew test --tests ArchitectureBoundaryTests ScaffoldPackageSkeletonTests\` | ✅ BUILD SUCCESSFUL (26s) |
| Testcontainers 통합 테스트 (전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE에서 \`./gradlew test\` 전체 실행 → \`RiderBikeContractAutoInsuranceTests\` 7 케이스 통과 + 기존 \`RiderBikeContractCommandApiContractTests\` 회귀 없음.
- [ ] dev 환경에서 SUBSCRIPTION 시드 템플릿 (V7 의 \`구독 인수형 12개월 (보험 포함)\`) 의 \`default_insurance_item_id\` 를 V8 시드 보험 (\`22222222-…-000000000001\`) 으로 UPDATE 후 contract 생성 → 자동 발급 확인.
- [ ] template 의 \`includes_insurance=false\` → SKIP \`TEMPLATE_NOT_OPTED_IN\`.
- [ ] InsuranceItem 을 disable 후 contract 생성 → SKIP \`DEFAULT_INSURANCE_ITEM_DISABLED\`, contract 는 정상 생성.
- [ ] 같은 라이더-아이템으로 두 번째 contract 생성 → 두 번째는 \`RIDER_INSURANCE_ALREADY_LINKED\`.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #128 (file-disjoint, scripts) / #130 (이 PR 타깃).
- Open target PRs at PR open: #129 (scripts only).
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 백엔드의 contract+insurance 도메인 마무리. 다음 추천:

- **디테일 패널 join 탭** — 마커 클릭 시 라이더/계약/장비/보험/교육 정보 합쳐 보여주기.
- **Slice E — 어드민 폼 재설계** — 운영자가 새 카테고리/형태/단위/교육 입력 UI 사용.
- **Slice F-1 — vendor adapter interface + stub** — vendor 문서 도착 전 미리 깔아두기.