### PR TITLE
Add dashboard bike snapshot aggregate endpoint (#132)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/controller/DashboardBikeSnapshotController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/controller/DashboardBikeSnapshotController.java
@@ -1,0 +1,23 @@
+package com.thundercrew.opsapi.dashboard.controller;
+
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse;
+import com.thundercrew.opsapi.dashboard.service.DashboardBikeSnapshotService;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DashboardBikeSnapshotController {
+
+    private final DashboardBikeSnapshotService snapshotService;
+
+    public DashboardBikeSnapshotController(DashboardBikeSnapshotService snapshotService) {
+        this.snapshotService = snapshotService;
+    }
+
+    @GetMapping("/api/v1/dashboard/bikes/{bikeId}/snapshot")
+    DashboardBikeSnapshotResponse getSnapshot(@PathVariable UUID bikeId) {
+        return snapshotService.getSnapshot(bikeId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardBikeSnapshotResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardBikeSnapshotResponse.java
@@ -1,0 +1,108 @@
+package com.thundercrew.opsapi.dashboard.dto;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Aggregate snapshot returned by {@code GET /api/v1/dashboard/bikes/{bikeId}/snapshot}.
+ *
+ * <p>Joins the bike with its current active rider-bike contract, the rider on that
+ * contract (plus the rider's latest education record summary), the rider's active
+ * insurance links, and the bike's currently installed equipment. Telemetry
+ * {@code current state} is intentionally <em>not</em> bundled here — the dashboard
+ * detail panel keeps fetching that from the existing
+ * {@code GET /api/v1/telemetry/bikes/{id}/current-state} endpoint so polling and
+ * the snapshot stay independently cacheable.</p>
+ */
+public record DashboardBikeSnapshotResponse(
+        UUID bikeId,
+        Instant generatedAt,
+        BikeSummary bike,
+        ActiveContractSummary activeContract,
+        RiderSummary rider,
+        List<RiderInsuranceSummary> insurances,
+        List<BikeEquipmentSummary> equipments
+) {
+    public record BikeSummary(
+            UUID id,
+            Long idx,
+            String plateNumber,
+            String vin,
+            String modelName,
+            BikeOperationStatus operationStatus,
+            String memo,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    public record ActiveContractSummary(
+            UUID id,
+            Long idx,
+            UUID contractTemplateId,
+            String templateName,
+            ContractCategory templateCategory,
+            ContractReturnType templateReturnType,
+            ContractDurationUnit templateDurationUnit,
+            Integer templateDurationValue,
+            boolean templateIncludesInsurance,
+            Instant startAt,
+            Instant endAt,
+            Instant terminatedAt,
+            String terminatedReason,
+            String memo
+    ) {
+    }
+
+    public record RiderSummary(
+            UUID id,
+            Long idx,
+            String name,
+            String phoneNumber,
+            String teamName,
+            String areaName,
+            String appLinkStatus,
+            String memo,
+            boolean educationCompleted,
+            RiderEducationType latestEducationType,
+            Instant latestEducationCompletedAt,
+            Instant latestEducationExpiresAt,
+            boolean educationExpired
+    ) {
+    }
+
+    public record RiderInsuranceSummary(
+            UUID id,
+            UUID insuranceItemId,
+            String itemName,
+            InsuranceCategory category,
+            InsuranceCoverageType coverageType,
+            Instant startsAt,
+            Instant endsAt,
+            UUID riderBikeContractId,
+            String memo
+    ) {
+    }
+
+    public record BikeEquipmentSummary(
+            UUID id,
+            UUID equipmentTypeId,
+            String typeName,
+            String equipmentLabel,
+            String modelName,
+            String serialNumber,
+            Instant installedAt,
+            Instant removedAt,
+            String managementDueDate,
+            String memo
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardBikeSnapshotQueryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardBikeSnapshotQueryRepository.java
@@ -1,0 +1,312 @@
+package com.thundercrew.opsapi.dashboard.repository;
+
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractDurationUnit;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCategory;
+import com.thundercrew.opsapi.insurance.domain.InsuranceCoverageType;
+import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Read-side queries that back {@code GET /api/v1/dashboard/bikes/{bikeId}/snapshot}.
+ * The four queries run inside a single read-only transaction at the service
+ * layer so the operator sees a coherent snapshot, even if a rider link is
+ * being mutated while the panel opens.
+ */
+@Repository
+public class DashboardBikeSnapshotQueryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DashboardBikeSnapshotQueryRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public Optional<BikeRow> findActiveBike(UUID bikeId) {
+        try {
+            BikeRow row = jdbcTemplate.queryForObject("""
+                    select
+                        id, idx, plate_number, vin, model_name, operation_status,
+                        memo, created_at, updated_at
+                    from bikes
+                    where id = ? and deleted_at is null
+                    """, this::mapBikeRow, bikeId);
+            return Optional.ofNullable(row);
+        } catch (EmptyResultDataAccessException exception) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<ActiveContractRow> findActiveContractForBike(UUID bikeId, Instant now) {
+        try {
+            ActiveContractRow row = jdbcTemplate.queryForObject("""
+                    select
+                        c.id, c.idx,
+                        c.rider_id, c.contract_template_id,
+                        c.start_at, c.end_at, c.terminated_at, c.terminated_reason, c.memo,
+                        t.name as template_name,
+                        t.category as template_category,
+                        t.return_type as template_return_type,
+                        t.duration_unit as template_duration_unit,
+                        t.duration_value as template_duration_value,
+                        t.includes_insurance as template_includes_insurance
+                    from rider_bike_contracts c
+                    join contract_templates t
+                      on t.id = c.contract_template_id
+                    where c.bike_id = ?
+                      and c.deleted_at is null
+                      and c.start_at <= ?::timestamptz
+                      and ?::timestamptz < coalesce(c.terminated_at, c.end_at, 'infinity'::timestamptz)
+                    order by c.start_at desc, c.idx desc
+                    limit 1
+                    """, this::mapActiveContractRow, bikeId, now.toString(), now.toString());
+            return Optional.ofNullable(row);
+        } catch (EmptyResultDataAccessException exception) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<RiderRow> findRider(UUID riderId, Instant now) {
+        try {
+            RiderRow row = jdbcTemplate.queryForObject("""
+                    select
+                        r.id, r.idx, r.name, r.phone_number, r.team_name, r.area_name,
+                        r.app_account_linked, r.memo,
+                        latest.education_type        as latest_education_type,
+                        latest.completed_at          as latest_completed_at,
+                        latest.expires_at            as latest_expires_at
+                    from riders r
+                    left join lateral (
+                        select education_type, completed_at, expires_at
+                        from rider_education_records
+                        where rider_id = r.id
+                          and deleted_at is null
+                        order by completed_at desc, idx desc
+                        limit 1
+                    ) latest on true
+                    where r.id = ? and r.deleted_at is null
+                    """, (rs, rowNum) -> mapRiderRow(rs, now), riderId);
+            return Optional.ofNullable(row);
+        } catch (EmptyResultDataAccessException exception) {
+            return Optional.empty();
+        }
+    }
+
+    public List<RiderInsuranceRow> findActiveRiderInsurances(UUID riderId) {
+        return jdbcTemplate.query("""
+                select
+                    ri.id, ri.insurance_item_id, ri.starts_at, ri.ends_at,
+                    ri.rider_bike_contract_id, ri.memo,
+                    item.name           as item_name,
+                    item.category       as item_category,
+                    item.coverage_type  as item_coverage_type
+                from rider_insurances ri
+                join insurance_items item
+                  on item.id = ri.insurance_item_id
+                 and item.deleted_at is null
+                where ri.rider_id = ?
+                  and ri.deleted_at is null
+                  and ri.enabled = true
+                order by ri.idx desc
+                """, this::mapRiderInsuranceRow, riderId);
+    }
+
+    public List<BikeEquipmentRow> findActiveBikeEquipments(UUID bikeId) {
+        return jdbcTemplate.query("""
+                select
+                    eq.id, eq.equipment_type_id, eq.equipment_label, eq.model_name,
+                    eq.serial_number, eq.installed_at, eq.removed_at,
+                    eq.management_due_date, eq.memo,
+                    et.name as type_name
+                from bike_equipments eq
+                join equipment_types et
+                  on et.id = eq.equipment_type_id
+                 and et.deleted_at is null
+                where eq.bike_id = ?
+                  and eq.deleted_at is null
+                  and eq.removed_at is null
+                order by eq.idx desc
+                """, this::mapBikeEquipmentRow, bikeId);
+    }
+
+    private BikeRow mapBikeRow(ResultSet rs, int rowNum) throws SQLException {
+        return new BikeRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                rs.getString("plate_number"),
+                rs.getString("vin"),
+                rs.getString("model_name"),
+                BikeOperationStatus.valueOf(rs.getString("operation_status")),
+                rs.getString("memo"),
+                rs.getTimestamp("created_at").toInstant(),
+                rs.getTimestamp("updated_at").toInstant()
+        );
+    }
+
+    private ActiveContractRow mapActiveContractRow(ResultSet rs, int rowNum) throws SQLException {
+        return new ActiveContractRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                rs.getObject("rider_id", UUID.class),
+                rs.getObject("contract_template_id", UUID.class),
+                rs.getTimestamp("start_at").toInstant(),
+                optionalInstant(rs, "end_at"),
+                optionalInstant(rs, "terminated_at"),
+                rs.getString("terminated_reason"),
+                rs.getString("memo"),
+                rs.getString("template_name"),
+                ContractCategory.valueOf(rs.getString("template_category")),
+                optionalEnum(rs.getString("template_return_type"), ContractReturnType.class),
+                optionalEnum(rs.getString("template_duration_unit"), ContractDurationUnit.class),
+                (Integer) rs.getObject("template_duration_value"),
+                rs.getBoolean("template_includes_insurance")
+        );
+    }
+
+    private RiderRow mapRiderRow(ResultSet rs, Instant now) throws SQLException {
+        Instant latestCompletedAt = optionalInstant(rs, "latest_completed_at");
+        Instant latestExpiresAt = optionalInstant(rs, "latest_expires_at");
+        RiderEducationType latestEducationType = optionalEnum(
+                rs.getString("latest_education_type"), RiderEducationType.class);
+        boolean educationExpired = latestExpiresAt != null && !now.isBefore(latestExpiresAt);
+        return new RiderRow(
+                rs.getObject("id", UUID.class),
+                rs.getLong("idx"),
+                rs.getString("name"),
+                rs.getString("phone_number"),
+                rs.getString("team_name"),
+                rs.getString("area_name"),
+                rs.getBoolean("app_account_linked") ? "LINKED" : "NOT_LINKED",
+                rs.getString("memo"),
+                latestEducationType != null,
+                latestEducationType,
+                latestCompletedAt,
+                latestExpiresAt,
+                educationExpired
+        );
+    }
+
+    private RiderInsuranceRow mapRiderInsuranceRow(ResultSet rs, int rowNum) throws SQLException {
+        return new RiderInsuranceRow(
+                rs.getObject("id", UUID.class),
+                rs.getObject("insurance_item_id", UUID.class),
+                rs.getString("item_name"),
+                InsuranceCategory.valueOf(rs.getString("item_category")),
+                optionalEnum(rs.getString("item_coverage_type"), InsuranceCoverageType.class),
+                optionalInstant(rs, "starts_at"),
+                optionalInstant(rs, "ends_at"),
+                rs.getObject("rider_bike_contract_id", UUID.class),
+                rs.getString("memo")
+        );
+    }
+
+    private BikeEquipmentRow mapBikeEquipmentRow(ResultSet rs, int rowNum) throws SQLException {
+        return new BikeEquipmentRow(
+                rs.getObject("id", UUID.class),
+                rs.getObject("equipment_type_id", UUID.class),
+                rs.getString("type_name"),
+                rs.getString("equipment_label"),
+                rs.getString("model_name"),
+                rs.getString("serial_number"),
+                rs.getTimestamp("installed_at").toInstant(),
+                optionalInstant(rs, "removed_at"),
+                rs.getString("management_due_date"),
+                rs.getString("memo")
+        );
+    }
+
+    private static Instant optionalInstant(ResultSet rs, String column) throws SQLException {
+        java.sql.Timestamp timestamp = rs.getTimestamp(column);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private static <E extends Enum<E>> E optionalEnum(String value, Class<E> type) {
+        return value == null ? null : Enum.valueOf(type, value);
+    }
+
+    public record BikeRow(
+            UUID id,
+            Long idx,
+            String plateNumber,
+            String vin,
+            String modelName,
+            BikeOperationStatus operationStatus,
+            String memo,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    public record ActiveContractRow(
+            UUID id,
+            Long idx,
+            UUID riderId,
+            UUID contractTemplateId,
+            Instant startAt,
+            Instant endAt,
+            Instant terminatedAt,
+            String terminatedReason,
+            String memo,
+            String templateName,
+            ContractCategory templateCategory,
+            ContractReturnType templateReturnType,
+            ContractDurationUnit templateDurationUnit,
+            Integer templateDurationValue,
+            boolean templateIncludesInsurance
+    ) {
+    }
+
+    public record RiderRow(
+            UUID id,
+            Long idx,
+            String name,
+            String phoneNumber,
+            String teamName,
+            String areaName,
+            String appLinkStatus,
+            String memo,
+            boolean educationCompleted,
+            RiderEducationType latestEducationType,
+            Instant latestEducationCompletedAt,
+            Instant latestEducationExpiresAt,
+            boolean educationExpired
+    ) {
+    }
+
+    public record RiderInsuranceRow(
+            UUID id,
+            UUID insuranceItemId,
+            String itemName,
+            InsuranceCategory category,
+            InsuranceCoverageType coverageType,
+            Instant startsAt,
+            Instant endsAt,
+            UUID riderBikeContractId,
+            String memo
+    ) {
+    }
+
+    public record BikeEquipmentRow(
+            UUID id,
+            UUID equipmentTypeId,
+            String typeName,
+            String equipmentLabel,
+            String modelName,
+            String serialNumber,
+            Instant installedAt,
+            Instant removedAt,
+            String managementDueDate,
+            String memo
+    ) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardBikeSnapshotService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardBikeSnapshotService.java
@@ -1,0 +1,140 @@
+package com.thundercrew.opsapi.dashboard.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse.ActiveContractSummary;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse.BikeEquipmentSummary;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse.BikeSummary;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse.RiderInsuranceSummary;
+import com.thundercrew.opsapi.dashboard.dto.DashboardBikeSnapshotResponse.RiderSummary;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository.ActiveContractRow;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository.BikeEquipmentRow;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository.BikeRow;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository.RiderInsuranceRow;
+import com.thundercrew.opsapi.dashboard.repository.DashboardBikeSnapshotQueryRepository.RiderRow;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DashboardBikeSnapshotService {
+
+    private final DashboardBikeSnapshotQueryRepository queryRepository;
+    private final Clock clock;
+
+    public DashboardBikeSnapshotService(DashboardBikeSnapshotQueryRepository queryRepository, Clock clock) {
+        this.queryRepository = queryRepository;
+        this.clock = clock;
+    }
+
+    public DashboardBikeSnapshotResponse getSnapshot(UUID bikeId) {
+        Instant now = Instant.now(clock);
+
+        BikeRow bikeRow = queryRepository.findActiveBike(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+
+        ActiveContractRow contractRow = queryRepository.findActiveContractForBike(bikeId, now).orElse(null);
+        RiderRow riderRow = contractRow == null
+                ? null
+                : queryRepository.findRider(contractRow.riderId(), now).orElse(null);
+        List<RiderInsuranceRow> insuranceRows = riderRow == null
+                ? List.of()
+                : queryRepository.findActiveRiderInsurances(riderRow.id());
+        List<BikeEquipmentRow> equipmentRows = queryRepository.findActiveBikeEquipments(bikeId);
+
+        return new DashboardBikeSnapshotResponse(
+                bikeId,
+                now,
+                toBikeSummary(bikeRow),
+                contractRow == null ? null : toActiveContractSummary(contractRow),
+                riderRow == null ? null : toRiderSummary(riderRow),
+                insuranceRows.stream().map(DashboardBikeSnapshotService::toRiderInsuranceSummary).toList(),
+                equipmentRows.stream().map(DashboardBikeSnapshotService::toBikeEquipmentSummary).toList()
+        );
+    }
+
+    private static BikeSummary toBikeSummary(BikeRow row) {
+        return new BikeSummary(
+                row.id(),
+                row.idx(),
+                row.plateNumber(),
+                row.vin(),
+                row.modelName(),
+                row.operationStatus(),
+                row.memo(),
+                row.createdAt(),
+                row.updatedAt()
+        );
+    }
+
+    private static ActiveContractSummary toActiveContractSummary(ActiveContractRow row) {
+        return new ActiveContractSummary(
+                row.id(),
+                row.idx(),
+                row.contractTemplateId(),
+                row.templateName(),
+                row.templateCategory(),
+                row.templateReturnType(),
+                row.templateDurationUnit(),
+                row.templateDurationValue(),
+                row.templateIncludesInsurance(),
+                row.startAt(),
+                row.endAt(),
+                row.terminatedAt(),
+                row.terminatedReason(),
+                row.memo()
+        );
+    }
+
+    private static RiderSummary toRiderSummary(RiderRow row) {
+        return new RiderSummary(
+                row.id(),
+                row.idx(),
+                row.name(),
+                row.phoneNumber(),
+                row.teamName(),
+                row.areaName(),
+                row.appLinkStatus(),
+                row.memo(),
+                row.educationCompleted(),
+                row.latestEducationType(),
+                row.latestEducationCompletedAt(),
+                row.latestEducationExpiresAt(),
+                row.educationExpired()
+        );
+    }
+
+    private static RiderInsuranceSummary toRiderInsuranceSummary(RiderInsuranceRow row) {
+        return new RiderInsuranceSummary(
+                row.id(),
+                row.insuranceItemId(),
+                row.itemName(),
+                row.category(),
+                row.coverageType(),
+                row.startsAt(),
+                row.endsAt(),
+                row.riderBikeContractId(),
+                row.memo()
+        );
+    }
+
+    private static BikeEquipmentSummary toBikeEquipmentSummary(BikeEquipmentRow row) {
+        return new BikeEquipmentSummary(
+                row.id(),
+                row.equipmentTypeId(),
+                row.typeName(),
+                row.equipmentLabel(),
+                row.modelName(),
+                row.serialNumber(),
+                row.installedAt(),
+                row.removedAt(),
+                row.managementDueDate(),
+                row.memo()
+        );
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardBikeSnapshotApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardBikeSnapshotApiTests.java
@@ -1,0 +1,354 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice ③-1: backend dashboard bike snapshot aggregate endpoint.
+ * Verifies the four-query join + nullable contract / rider sections + active
+ * insurance and equipment lists.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DashboardBikeSnapshotApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbb1234-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID BIKE_ID = UUID.fromString("cccc1234-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID OTHER_BIKE_ID = UUID.fromString("cccc5678-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID CONTRACT_TEMPLATE_ID = UUID.fromString("dddd1234-dddd-4000-8000-000000000001");
+    private static final UUID CONTRACT_ID = UUID.fromString("dddd2222-dddd-4000-8000-000000000001");
+    private static final UUID INSURANCE_ITEM_ID = UUID.fromString("22222222-2222-2222-2222-000000000001");
+    private static final UUID RIDER_INSURANCE_ID = UUID.fromString("ffff1234-ffff-ffff-ffff-ffffffffffff");
+    private static final UUID EQUIPMENT_TYPE_ID = UUID.fromString("eeee1234-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID BIKE_EQUIPMENT_ID = UUID.fromString("eeee5678-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID EDUCATION_RECORD_ID = UUID.fromString("eeed0001-eeed-eeed-eeed-eeeeeeeeeeee");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_education_records");
+        jdbcTemplate.update("delete from rider_insurances");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from bike_equipments");
+        jdbcTemplate.update("delete from equipment_types");
+        jdbcTemplate.update("delete from bike_current_states");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from contract_templates where system_template = false");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void fullSnapshotReturnsAllJoinedSections() throws Exception {
+        Instant now = Instant.now();
+        seedRider(RIDER_ID, "스냅샷 라이더", "010-7000-8000", "강남팀", "강남구");
+        seedBike(BIKE_ID, "SNAP-001", "VIN-SNAP-001", "Thunder M1", "IN_SERVICE");
+        seedSubscriptionTemplate(CONTRACT_TEMPLATE_ID, "Snap Template", true, INSURANCE_ITEM_ID);
+        seedActiveContract(CONTRACT_ID, RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID, now.minus(7, ChronoUnit.DAYS));
+        seedRiderInsurance(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID,
+                now.minus(7, ChronoUnit.DAYS), now.plus(358, ChronoUnit.DAYS), CONTRACT_ID);
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "헬멧");
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, "메인 헬멧",
+                "TC-Helmet-V2", "HELMET-SN-001", now.minus(30, ChronoUnit.DAYS));
+        seedEducationRecord(EDUCATION_RECORD_ID, RIDER_ID, "ONLINE",
+                now.minus(20, ChronoUnit.DAYS), now.plus(345, ChronoUnit.DAYS));
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.bike.plateNumber").value("SNAP-001"))
+                .andExpect(jsonPath("$.bike.modelName").value("Thunder M1"))
+                .andExpect(jsonPath("$.bike.operationStatus").value("IN_SERVICE"))
+                .andExpect(jsonPath("$.activeContract.id").value(CONTRACT_ID.toString()))
+                .andExpect(jsonPath("$.activeContract.contractTemplateId").value(CONTRACT_TEMPLATE_ID.toString()))
+                .andExpect(jsonPath("$.activeContract.templateName").value("Snap Template"))
+                .andExpect(jsonPath("$.activeContract.templateCategory").value("SUBSCRIPTION"))
+                .andExpect(jsonPath("$.activeContract.templateReturnType").value("TAKEOVER"))
+                .andExpect(jsonPath("$.activeContract.templateDurationUnit").value("MONTH"))
+                .andExpect(jsonPath("$.activeContract.templateDurationValue").value(12))
+                .andExpect(jsonPath("$.activeContract.templateIncludesInsurance").value(true))
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.rider.name").value("스냅샷 라이더"))
+                .andExpect(jsonPath("$.rider.phoneNumber").value("010-7000-8000"))
+                .andExpect(jsonPath("$.rider.teamName").value("강남팀"))
+                .andExpect(jsonPath("$.rider.areaName").value("강남구"))
+                .andExpect(jsonPath("$.rider.educationCompleted").value(true))
+                .andExpect(jsonPath("$.rider.latestEducationType").value("ONLINE"))
+                .andExpect(jsonPath("$.rider.educationExpired").value(false))
+                .andExpect(jsonPath("$.insurances.length()").value(1))
+                .andExpect(jsonPath("$.insurances[0].id").value(RIDER_INSURANCE_ID.toString()))
+                .andExpect(jsonPath("$.insurances[0].insuranceItemId").value(INSURANCE_ITEM_ID.toString()))
+                .andExpect(jsonPath("$.insurances[0].itemName").value("유상운송종합보험"))
+                .andExpect(jsonPath("$.insurances[0].category").value("PRIMARY"))
+                .andExpect(jsonPath("$.insurances[0].coverageType").value("GENERAL_PAID_TRANSPORT"))
+                .andExpect(jsonPath("$.insurances[0].riderBikeContractId").value(CONTRACT_ID.toString()))
+                .andExpect(jsonPath("$.equipments.length()").value(1))
+                .andExpect(jsonPath("$.equipments[0].id").value(BIKE_EQUIPMENT_ID.toString()))
+                .andExpect(jsonPath("$.equipments[0].typeName").value("헬멧"))
+                .andExpect(jsonPath("$.equipments[0].equipmentLabel").value("메인 헬멧"))
+                .andExpect(jsonPath("$.equipments[0].serialNumber").value("HELMET-SN-001"));
+    }
+
+    @Test
+    void snapshotWithoutActiveContractHasNullContractAndRiderAndEmptyInsurances() throws Exception {
+        seedBike(BIKE_ID, "SNAP-002", "VIN-SNAP-002", "Thunder M1", "READY");
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "잠금장치");
+        seedBikeEquipment(BIKE_EQUIPMENT_ID, BIKE_ID, EQUIPMENT_TYPE_ID, "후륜 잠금",
+                "TC-Lock-A1", "LOCK-SN-001", Instant.now().minus(10, ChronoUnit.DAYS));
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bike.plateNumber").value("SNAP-002"))
+                .andExpect(jsonPath("$.activeContract").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.rider").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.insurances.length()").value(0))
+                .andExpect(jsonPath("$.equipments.length()").value(1));
+    }
+
+    @Test
+    void snapshotWithoutInsurancesReturnsEmptyList() throws Exception {
+        Instant now = Instant.now();
+        seedRider(RIDER_ID, "보험 없는 라이더", "010-7100-8000", null, null);
+        seedBike(BIKE_ID, "SNAP-003", "VIN-SNAP-003", "Thunder M1", "IN_SERVICE");
+        seedSubscriptionTemplate(CONTRACT_TEMPLATE_ID, "No Insurance Template", false, null);
+        seedActiveContract(CONTRACT_ID, RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID, now.minus(1, ChronoUnit.DAYS));
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeContract.id").value(CONTRACT_ID.toString()))
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.insurances.length()").value(0))
+                .andExpect(jsonPath("$.equipments.length()").value(0));
+    }
+
+    @Test
+    void snapshotIgnoresRemovedEquipmentsAndDisabledInsurances() throws Exception {
+        Instant now = Instant.now();
+        seedRider(RIDER_ID, "필터 라이더", "010-7200-8000", null, null);
+        seedBike(BIKE_ID, "SNAP-004", "VIN-SNAP-004", "Thunder M1", "IN_SERVICE");
+        seedSubscriptionTemplate(CONTRACT_TEMPLATE_ID, "Filter Template", true, INSURANCE_ITEM_ID);
+        seedActiveContract(CONTRACT_ID, RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID, now.minus(2, ChronoUnit.DAYS));
+
+        // Disabled rider_insurance should not appear.
+        seedRiderInsuranceWithEnabled(RIDER_INSURANCE_ID, RIDER_ID, INSURANCE_ITEM_ID,
+                now.minus(2, ChronoUnit.DAYS), null, CONTRACT_ID, false);
+
+        // Removed bike_equipment should not appear.
+        seedEquipmentType(EQUIPMENT_TYPE_ID, "리어캐리어");
+        UUID removedEquipmentId = UUID.fromString("eeee9999-eeee-eeee-eeee-eeeeeeeeeeee");
+        seedRemovedBikeEquipment(removedEquipmentId, BIKE_ID, EQUIPMENT_TYPE_ID, "분리된 캐리어",
+                now.minus(60, ChronoUnit.DAYS), now.minus(10, ChronoUnit.DAYS));
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.insurances.length()").value(0))
+                .andExpect(jsonPath("$.equipments.length()").value(0));
+    }
+
+    @Test
+    void unknownBikeReturnsNotFound() throws Exception {
+        UUID missing = UUID.fromString("ffff9999-9999-9999-9999-999999999999");
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", missing)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void snapshotRequiresAuthentication() throws Exception {
+        seedBike(BIKE_ID, "SNAP-AUTH", "VIN-SNAP-AUTH", "Thunder M1", "READY");
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void educationSummaryReportsExpiredWhenLatestRecordExpired() throws Exception {
+        Instant now = Instant.now();
+        seedRider(RIDER_ID, "만료 라이더", "010-7300-8000", null, null);
+        seedBike(BIKE_ID, "SNAP-EXP", "VIN-SNAP-EXP", "Thunder M1", "IN_SERVICE");
+        seedSubscriptionTemplate(CONTRACT_TEMPLATE_ID, "Expired Education Template", false, null);
+        seedActiveContract(CONTRACT_ID, RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID, now.minus(3, ChronoUnit.DAYS));
+        seedEducationRecord(EDUCATION_RECORD_ID, RIDER_ID, "OFFLINE",
+                now.minus(400, ChronoUnit.DAYS), now.minus(35, ChronoUnit.DAYS));
+
+        mockMvc.perform(get("/api/v1/dashboard/bikes/{bikeId}/snapshot", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rider.educationCompleted").value(true))
+                .andExpect(jsonPath("$.rider.latestEducationType").value("OFFLINE"))
+                .andExpect(jsonPath("$.rider.educationExpired").value(true));
+    }
+
+    private void seedRider(UUID id, String name, String phoneNumber, String teamName, String areaName) {
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked)
+                values (?, ?, ?, ?, ?, false)
+                """, id, name, phoneNumber, teamName, areaName);
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String modelName, String operationStatus) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, ?, ?, ?, ?)
+                """, id, plateNumber, vin, modelName, operationStatus);
+    }
+
+    private void seedSubscriptionTemplate(UUID id, String name, boolean includesInsurance, UUID defaultInsuranceItemId) {
+        jdbcTemplate.update("""
+                insert into contract_templates (
+                    id, name, duration_minutes, description, enabled, system_template,
+                    category, return_type, duration_unit, duration_value,
+                    includes_insurance, default_insurance_item_id
+                ) values (?, ?, ?, 'snapshot fixture template', true, false,
+                          'SUBSCRIPTION', 'TAKEOVER', 'MONTH', 12, ?, ?)
+                """, id, name, 12 * 30 * 1440, includesInsurance, defaultInsuranceItemId);
+    }
+
+    private void seedActiveContract(UUID id, UUID riderId, UUID bikeId, UUID templateId, Instant startAt) {
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at)
+                values (?, ?, ?, ?, ?::timestamptz)
+                """, id, riderId, bikeId, templateId, startAt.toString());
+    }
+
+    private void seedRiderInsurance(
+            UUID id, UUID riderId, UUID insuranceItemId,
+            Instant startsAt, Instant endsAt, UUID riderBikeContractId
+    ) {
+        seedRiderInsuranceWithEnabled(id, riderId, insuranceItemId, startsAt, endsAt, riderBikeContractId, true);
+    }
+
+    private void seedRiderInsuranceWithEnabled(
+            UUID id, UUID riderId, UUID insuranceItemId,
+            Instant startsAt, Instant endsAt, UUID riderBikeContractId, boolean enabled
+    ) {
+        jdbcTemplate.update("""
+                insert into rider_insurances (
+                    id, rider_id, insurance_item_id, enabled, starts_at, ends_at, rider_bike_contract_id, memo
+                ) values (?, ?, ?, ?, ?::timestamptz, ?::timestamptz, ?, 'snapshot fixture insurance')
+                """,
+                id, riderId, insuranceItemId, enabled,
+                startsAt == null ? null : startsAt.toString(),
+                endsAt == null ? null : endsAt.toString(),
+                riderBikeContractId);
+    }
+
+    private void seedEquipmentType(UUID id, String name) {
+        jdbcTemplate.update("""
+                insert into equipment_types (id, name)
+                values (?, ?)
+                on conflict (id) do nothing
+                """, id, name);
+    }
+
+    private void seedBikeEquipment(
+            UUID id, UUID bikeId, UUID equipmentTypeId,
+            String label, String modelName, String serialNumber, Instant installedAt
+    ) {
+        jdbcTemplate.update("""
+                insert into bike_equipments (
+                    id, bike_id, equipment_type_id, equipment_label, model_name, serial_number,
+                    installed_at, management_due_date, memo
+                ) values (?, ?, ?, ?, ?, ?, ?::timestamptz, current_date + interval '1 year',
+                          'snapshot fixture equipment')
+                """, id, bikeId, equipmentTypeId, label, modelName, serialNumber, installedAt.toString());
+    }
+
+    private void seedRemovedBikeEquipment(
+            UUID id, UUID bikeId, UUID equipmentTypeId, String label,
+            Instant installedAt, Instant removedAt
+    ) {
+        jdbcTemplate.update("""
+                insert into bike_equipments (
+                    id, bike_id, equipment_type_id, equipment_label,
+                    installed_at, removed_at, management_due_date, memo
+                ) values (?, ?, ?, ?, ?::timestamptz, ?::timestamptz, current_date,
+                          'snapshot removed equipment')
+                """, id, bikeId, equipmentTypeId, label, installedAt.toString(), removedAt.toString());
+    }
+
+    private void seedEducationRecord(
+            UUID id, UUID riderId, String type, Instant completedAt, Instant expiresAt
+    ) {
+        jdbcTemplate.update("""
+                insert into rider_education_records (
+                    id, rider_id, education_type, completed_at, expires_at
+                ) values (?, ?, ?, ?::timestamptz, ?::timestamptz)
+                """,
+                id, riderId, type,
+                completedAt.toString(),
+                expiresAt == null ? null : expiresAt.toString());
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    @SuppressWarnings("unused")
+    private void unusedReferenceToOtherBike() {
+        UUID ignored = OTHER_BIKE_ID;
+        ignored.toString();
+    }
+}


### PR DESCRIPTION
## Summary

- 신규 \`GET /api/v1/dashboard/bikes/{bikeId}/snapshot\` — 디테일 패널이 한 번의 호출로 차량 + 활성 계약 + 라이더(+교육 요약) + 활성 보험 + 활성 장비 정보를 받음.
- 4 쿼리 (bike / contract+template / rider+latest education / insurances+items / equipments+types) 가 한 \`@Transactional(readOnly=true)\` 안에서 실행 → 일관된 스냅샷.
- Telemetry \`currentState\` 는 의도적으로 분리 (기존 \`/api/v1/telemetry/bikes/{id}/current-state\` 에서 별도 fetch).

## Trace

- Target issue: EVNSolution/thundercrew-domain#132
- Change-control issue: EVNSolution/clever-change-control#120
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #119 / #121 / #123 / #131 (Slice A·B·C·D).

## Scope

Backend-only. 다음 슬라이스 (③-2) 가 프론트 디테일 패널을 이 endpoint 에 연결.

Included:
- \`DashboardBikeSnapshotController\` + \`Service\` + \`QueryRepository\` + \`Response\` DTO.
- 통합 테스트 \`DashboardBikeSnapshotApiTests\` (7 케이스).

Excluded:
- 프론트 디테일 패널 변경 (③-2).
- currentState 통합 (별도 endpoint 사용).
- 차량 운영 상태 이력 / 디바이스 설치 이력 / 충전소 / 라이더 다중 활성 계약.

## 응답 구조

\`\`\`
{
  bikeId, generatedAt,
  bike: { id, idx, plateNumber, vin, modelName, operationStatus, memo, createdAt, updatedAt },
  activeContract: null | { id, idx, contractTemplateId, templateName,
                            templateCategory, templateReturnType,
                            templateDurationUnit, templateDurationValue,
                            templateIncludesInsurance,
                            startAt, endAt, terminatedAt, terminatedReason, memo },
  rider: null | { id, idx, name, phoneNumber, teamName, areaName,
                   appLinkStatus, memo,
                   educationCompleted, latestEducationType,
                   latestEducationCompletedAt, latestEducationExpiresAt,
                   educationExpired },
  insurances: [ { id, insuranceItemId, itemName, category, coverageType,
                  startsAt, endsAt, riderBikeContractId, memo } ],
  equipments: [ { id, equipmentTypeId, typeName, equipmentLabel, modelName,
                  serialNumber, installedAt, removedAt,
                  managementDueDate, memo } ]
}
\`\`\`

## Validation

| 항목 | 결과 |
|------|------|
| \`./gradlew compileJava compileTestJava\` | ✅ BUILD SUCCESSFUL (20s) |
| \`./gradlew test --tests ArchitectureBoundaryTests ScaffoldPackageSkeletonTests\` | ✅ BUILD SUCCESSFUL (25s) |
| Testcontainers 통합 테스트 (전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE에서 \`./gradlew test\` 전체 실행 → \`DashboardBikeSnapshotApiTests\` 7 케이스 통과 + 다른 통합 테스트 회귀 없음.
- [ ] dev DB에 시드 스크립트 실행 후 \`GET /api/v1/dashboard/bikes/{seedBikeId}/snapshot\` 호출 → bike 정보가 정확히 반환되고 (활성 계약/라이더/장비/보험이 시드된 경우 채워짐).
- [ ] 존재하지 않는 bikeId → 404 + \`code: RESOURCE_NOT_FOUND\`.
- [ ] 인증 없이 호출 → 401 + \`code: AUTHENTICATION_FAILED\`.
- [ ] removed/disabled 장비·보험은 응답에서 제외.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #132 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 PR 머지 후 \`Slice ③-2 (프론트 디테일 패널 join 탭)\` 로 이어집니다. 그 슬라이스가 머지되면 운영자가 마커 클릭 한 번으로 차량 + 라이더 + 계약 + 보험 + 장비 + 교육 정보를 모두 화면에서 확인 가능.