### PR TITLE
Wire detail panel sections to bike snapshot endpoint (#134)

### DIFF
--- a/development/front-admin-web/app/api/dashboard/bike-snapshot/[bikeId]/route.ts
+++ b/development/front-admin-web/app/api/dashboard/bike-snapshot/[bikeId]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { loadBikeSnapshot } from "@/lib/services/dashboard-bike-snapshot-data";
+
+/**
+ * Per-bike join snapshot endpoint hit by the marker-click detail panel.
+ * Like the other dashboard routes, it keeps the service-ops cookie
+ * server-side and forwards the loader result with a no-store cache header.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ bikeId: string }> }
+) {
+  const { bikeId } = await context.params;
+  const result = await loadBikeSnapshot(bikeId);
+  return NextResponse.json(result, {
+    headers: {
+      "Cache-Control": "no-store"
+    }
+  });
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -267,6 +267,14 @@ button, input, select, textarea { font: inherit; }
 .bike-detail-panel-row dt { margin: 0; font-size: 12px; font-weight: 600; color: var(--rm-text-secondary); }
 .bike-detail-panel-row dd { margin: 0; font-size: 13px; color: var(--rm-text-primary); font-variant-numeric: tabular-nums; }
 .bike-detail-panel-status { margin: 0; font-size: 12px; color: var(--rm-text-secondary); }
+.bike-detail-panel-empty { margin: 0; font-size: 12px; color: var(--rm-text-muted); font-style: italic; }
+.bike-detail-panel-section { display: grid; gap: 8px; padding: 12px 0 0; border-top: 1px solid var(--rm-line-subtle); }
+.bike-detail-panel-section:first-of-type { padding-top: 0; border-top: 0; }
+.bike-detail-panel-section-title { margin: 0; font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--rm-text-secondary); }
+.bike-detail-panel-list { display: grid; gap: 10px; }
+.bike-detail-panel-list-item { display: grid; gap: 2px; padding: 8px 10px; border-radius: 10px; background: var(--rm-bg-section); }
+.bike-detail-panel-list-title { font-size: 13px; font-weight: 700; color: var(--rm-text-primary); }
+.bike-detail-panel-list-meta { font-size: 12px; color: var(--rm-text-secondary); }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import type { BikeCurrentStateResult } from "@/lib/services/bike-current-state-data";
+import type { BikeSnapshotResult } from "@/lib/services/dashboard-bike-snapshot-data";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 
 export interface BikeDetailPanelProps {
@@ -10,66 +11,92 @@ export interface BikeDetailPanelProps {
   onClose: () => void;
 }
 
-type FetchOutcome =
+type FetchOutcome<T> =
   | { phase: "idle" }
-  | { phase: "loaded"; result: BikeCurrentStateResult }
+  | { phase: "loaded"; result: T }
   | { phase: "error" };
 
 /**
  * Right-edge floating panel that opens when an operator clicks a bike marker.
  * The pin from the polling map-state already carries label/plate/active rider
- * info, so the panel renders immediately. The single-bike telemetry endpoint
- * is fetched in parallel and fills the connection / driving / battery /
- * lastReceivedAt rows when it returns.
+ * info, so the panel renders immediately. Two parallel fetches enrich it:
+ *
+ * 1. Single-bike telemetry (`/api/dashboard/bike-current-state/{id}`) fills
+ *    the connection / driving / battery / lastReceivedAt rows.
+ * 2. Bike snapshot (`/api/dashboard/bike-snapshot/{id}`) fills the rider /
+ *    contract / insurance / equipment sections with one backend call (the
+ *    backend already joined those four tables in a single read tx).
  */
 export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
-  // Keyed on bikeId so a click that swaps the panel to a different bike
-  // resets the fetch outcome on the next render rather than via a synchronous
-  // setState inside useEffect (the lint rule that bans the latter).
-  const [outcome, setOutcome] = useState<{ bikeId: string; data: FetchOutcome }>({
-    bikeId: pin.bikeId,
-    data: { phase: "idle" }
-  });
+  const [telemetry, setTelemetry] = useState<{
+    bikeId: string;
+    data: FetchOutcome<BikeCurrentStateResult>;
+  }>({ bikeId: pin.bikeId, data: { phase: "idle" } });
+  const [snapshot, setSnapshot] = useState<{
+    bikeId: string;
+    data: FetchOutcome<BikeSnapshotResult>;
+  }>({ bikeId: pin.bikeId, data: { phase: "idle" } });
 
-  const isFresh = outcome.bikeId === pin.bikeId;
+  const isTelemetryFresh = telemetry.bikeId === pin.bikeId;
+  const isSnapshotFresh = snapshot.bikeId === pin.bikeId;
 
   useEffect(() => {
     let cancelled = false;
-
     fetch(`/api/dashboard/bike-current-state/${encodeURIComponent(pin.bikeId)}`, {
       cache: "no-store",
       credentials: "same-origin"
     })
-      .then(async (response) => {
-        if (!response.ok) {
-          return null;
-        }
-        return (await response.json()) as BikeCurrentStateResult;
-      })
+      .then(async (response) => (response.ok ? ((await response.json()) as BikeCurrentStateResult) : null))
       .then((next) => {
         if (cancelled) return;
-        setOutcome({
+        setTelemetry({
           bikeId: pin.bikeId,
           data: next ? { phase: "loaded", result: next } : { phase: "error" }
         });
       })
       .catch(() => {
         if (cancelled) return;
-        setOutcome({ bikeId: pin.bikeId, data: { phase: "error" } });
+        setTelemetry({ bikeId: pin.bikeId, data: { phase: "error" } });
       });
-
     return () => {
       cancelled = true;
     };
   }, [pin.bikeId]);
 
-  const result =
-    isFresh && outcome.data.phase === "loaded" ? outcome.data.result : null;
-  const loading = !isFresh || outcome.data.phase === "idle";
-  const live = result?.data;
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/dashboard/bike-snapshot/${encodeURIComponent(pin.bikeId)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => (response.ok ? ((await response.json()) as BikeSnapshotResult) : null))
+      .then((next) => {
+        if (cancelled) return;
+        setSnapshot({
+          bikeId: pin.bikeId,
+          data: next ? { phase: "loaded", result: next } : { phase: "error" }
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSnapshot({ bikeId: pin.bikeId, data: { phase: "error" } });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pin.bikeId]);
 
-  // Prefer the freshly-fetched single state; fall back to map-state pin which
-  // is at most one polling cycle (10s) stale.
+  const telemetryResult =
+    isTelemetryFresh && telemetry.data.phase === "loaded" ? telemetry.data.result : null;
+  const telemetryLoading = !isTelemetryFresh || telemetry.data.phase === "idle";
+  const live = telemetryResult?.data;
+
+  const snapshotResult =
+    isSnapshotFresh && snapshot.data.phase === "loaded" ? snapshot.data.result : null;
+  const snapshotLoading = !isSnapshotFresh || snapshot.data.phase === "idle";
+  const snap = snapshotResult?.data;
+
+  // Telemetry derived values (snapshot does not bundle telemetry — see PR #133).
   const lastReceivedAt = live?.lastReceivedAt ?? pin.lastReceivedAt;
   const connectionStatus = live?.connectionStatus ?? pin.connectionStatus;
   const drivingStatus = live?.drivingStatus ?? pin.drivingStatus;
@@ -79,6 +106,7 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
   const ignitionStatus = live?.ignitionStatus ?? pin.ignitionStatus;
   const latitude = live?.latitude ?? pin.latitude;
   const longitude = live?.longitude ?? pin.longitude;
+  const telemetrySource = live?.telemetrySource ?? pin.telemetrySource;
 
   return (
     <aside
@@ -102,8 +130,7 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
         </button>
       </header>
 
-      <dl className="bike-detail-panel-body">
-        <DetailRow label="활성 라이더" value={pin.activeRiderLabel ?? "미배정"} />
+      <Section title="텔레메트리">
         <DetailRow label="연결 상태" value={connectionStatus} />
         <DetailRow label="주행 상태" value={drivingStatus} />
         <DetailRow label="시동" value={ignitionStatus} />
@@ -124,16 +151,72 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
           value={`${latitude.toFixed(5)}, ${longitude.toFixed(5)}`}
         />
         <DetailRow label="마지막 수신" value={formatRelative(lastReceivedAt)} />
-        <DetailRow label="텔레메트리 출처" value={live?.telemetrySource ?? pin.telemetrySource} />
-      </dl>
+        <DetailRow label="텔레메트리 출처" value={telemetrySource} />
+        {telemetryLoading ? (
+          <p className="bike-detail-panel-status">텔레메트리 조회 중…</p>
+        ) : null}
+        {!telemetryLoading && telemetryResult?.notice ? (
+          <p className="bike-detail-panel-status">{telemetryResult.notice}</p>
+        ) : null}
+      </Section>
 
-      {loading ? (
-        <p className="bike-detail-panel-status" role="status">단일 차량 텔레메트리 조회 중…</p>
-      ) : null}
-      {!loading && result?.notice ? (
-        <p className="bike-detail-panel-status" role="status">{result.notice}</p>
-      ) : null}
+      <Section title="라이더">
+        {snap?.rider ? (
+          <RiderSection rider={snap.rider} />
+        ) : (
+          <EmptySectionMessage
+            loading={snapshotLoading}
+            notice={snapshotResult?.notice}
+            empty="활성 계약 라이더 없음"
+          />
+        )}
+      </Section>
+
+      <Section title="활성 계약">
+        {snap?.activeContract ? (
+          <ContractSection contract={snap.activeContract} />
+        ) : (
+          <EmptySectionMessage
+            loading={snapshotLoading}
+            notice={snapshotResult?.notice}
+            empty="활성 계약 없음"
+          />
+        )}
+      </Section>
+
+      <Section title="보험">
+        {snap?.insurances && snap.insurances.length > 0 ? (
+          <InsuranceList insurances={snap.insurances} />
+        ) : (
+          <EmptySectionMessage
+            loading={snapshotLoading}
+            notice={snapshotResult?.notice}
+            empty="활성 보험 없음"
+          />
+        )}
+      </Section>
+
+      <Section title="장비">
+        {snap?.equipments && snap.equipments.length > 0 ? (
+          <EquipmentList equipments={snap.equipments} />
+        ) : (
+          <EmptySectionMessage
+            loading={snapshotLoading}
+            notice={snapshotResult?.notice}
+            empty="설치된 장비 없음"
+          />
+        )}
+      </Section>
     </aside>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="bike-detail-panel-section">
+      <h3 className="bike-detail-panel-section-title">{title}</h3>
+      <dl className="bike-detail-panel-body">{children}</dl>
+    </section>
   );
 }
 
@@ -144,6 +227,155 @@ function DetailRow({ label, value }: { label: string; value: string }) {
       <dd>{value}</dd>
     </div>
   );
+}
+
+function EmptySectionMessage({
+  loading,
+  notice,
+  empty
+}: {
+  loading: boolean;
+  notice: string | undefined;
+  empty: string;
+}) {
+  if (loading) {
+    return <p className="bike-detail-panel-status">조회 중…</p>;
+  }
+  if (notice) {
+    return <p className="bike-detail-panel-status">{notice}</p>;
+  }
+  return <p className="bike-detail-panel-empty">{empty}</p>;
+}
+
+function RiderSection({ rider }: { rider: NonNullable<NonNullable<BikeSnapshotResult["data"]>["rider"]> }) {
+  const educationLabel = rider.educationCompleted
+    ? rider.educationExpired
+      ? "만료"
+      : "완료"
+    : "미완료";
+  const educationDetail = rider.latestEducationCompletedAt
+    ? `${rider.latestEducationType ?? "—"} · ${formatDate(rider.latestEducationCompletedAt)}${
+        rider.latestEducationExpiresAt
+          ? ` (만료 ${formatDate(rider.latestEducationExpiresAt)})`
+          : ""
+      }`
+    : "이력 없음";
+  return (
+    <>
+      <DetailRow label="이름" value={rider.name} />
+      <DetailRow label="연락처" value={rider.phoneNumber} />
+      <DetailRow label="소속" value={rider.teamName ?? "—"} />
+      <DetailRow label="구역" value={rider.areaName ?? "—"} />
+      <DetailRow label="앱 계정" value={rider.appLinkStatus} />
+      <DetailRow label="교육 상태" value={educationLabel} />
+      <DetailRow label="최근 교육" value={educationDetail} />
+    </>
+  );
+}
+
+function ContractSection({
+  contract
+}: {
+  contract: NonNullable<NonNullable<BikeSnapshotResult["data"]>["activeContract"]>;
+}) {
+  const durationLabel = formatContractDuration(
+    contract.templateDurationUnit,
+    contract.templateDurationValue
+  );
+  const periodLabel = `${formatDate(contract.startAt)} ~ ${
+    contract.endAt ? formatDate(contract.endAt) : "무기한"
+  }`;
+  return (
+    <>
+      <DetailRow label="템플릿" value={contract.templateName} />
+      <DetailRow label="카테고리" value={contract.templateCategory} />
+      <DetailRow
+        label="형태"
+        value={contract.templateReturnType ?? "—"}
+      />
+      <DetailRow label="기간" value={durationLabel} />
+      <DetailRow label="시작/종료" value={periodLabel} />
+      <DetailRow
+        label="보험 포함"
+        value={contract.templateIncludesInsurance ? "예" : "아니오"}
+      />
+      {contract.terminatedAt ? (
+        <DetailRow label="종료" value={`${formatDate(contract.terminatedAt)} · ${contract.terminatedReason ?? "—"}`} />
+      ) : null}
+    </>
+  );
+}
+
+function InsuranceList({
+  insurances
+}: {
+  insurances: NonNullable<BikeSnapshotResult["data"]>["insurances"];
+}) {
+  return (
+    <div className="bike-detail-panel-list">
+      {insurances.map((row) => {
+        const period = row.startsAt
+          ? `${formatDate(row.startsAt)} ~ ${row.endsAt ? formatDate(row.endsAt) : "기한 없음"}`
+          : "기간 미지정";
+        return (
+          <div key={row.id} className="bike-detail-panel-list-item">
+            <div className="bike-detail-panel-list-title">{row.itemName}</div>
+            <div className="bike-detail-panel-list-meta">
+              {row.category}
+              {row.coverageType ? ` · ${row.coverageType}` : ""}
+            </div>
+            <div className="bike-detail-panel-list-meta">{period}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EquipmentList({
+  equipments
+}: {
+  equipments: NonNullable<BikeSnapshotResult["data"]>["equipments"];
+}) {
+  return (
+    <div className="bike-detail-panel-list">
+      {equipments.map((row) => (
+        <div key={row.id} className="bike-detail-panel-list-item">
+          <div className="bike-detail-panel-list-title">
+            {row.equipmentLabel ?? row.typeName}
+          </div>
+          <div className="bike-detail-panel-list-meta">
+            {row.typeName}
+            {row.modelName ? ` · ${row.modelName}` : ""}
+            {row.serialNumber ? ` · ${row.serialNumber}` : ""}
+          </div>
+          <div className="bike-detail-panel-list-meta">
+            설치 {formatDate(row.installedAt)}
+            {row.managementDueDate ? ` · 점검 만료 ${row.managementDueDate}` : ""}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatContractDuration(unit: string | null, value: number | null): string {
+  if (!unit || value == null) return "—";
+  const unitLabel: Record<string, string> = {
+    DAY: "일",
+    WEEK: "주",
+    MONTH: "개월",
+    QUARTER: "분기",
+    HALF_YEAR: "반기",
+    YEAR: "년"
+  };
+  return `${value} ${unitLabel[unit] ?? unit}`;
+}
+
+function formatDate(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  return new Date(ts).toLocaleDateString("ko-KR");
 }
 
 function formatRelative(iso: string): string {

--- a/development/front-admin-web/lib/services/dashboard-bike-snapshot-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-bike-snapshot-data.ts
@@ -1,0 +1,65 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsBikeSnapshot,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type BikeSnapshotResult = {
+  bikeId: string;
+  data: ServiceOpsBikeSnapshot | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Loader for the per-bike join snapshot. Mirrors the dashboard map-state
+ * loader pattern: returns {@code data: null} on every fallback (no API base,
+ * no session, fetch failed, 404) so the detail panel can keep rendering the
+ * BikePin info it already has and surface a small notice.
+ */
+export async function loadBikeSnapshot(bikeId: string): Promise<BikeSnapshotResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice:
+        "SERVICE_OPS_API_BASE_URL이 없어 차량 상세 데이터를 표시할 수 없습니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice:
+        "관리자 세션이 없어 차량 상세 데이터를 표시할 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getBikeSnapshot(bikeId);
+    return { bikeId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      bikeId,
+      data: null,
+      source: "mock",
+      notice: `차량 상세 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -563,12 +563,93 @@ export type FrontendBikeCurrentState = Omit<
   batteryPercent: number | null;
 };
 
+export type ServiceOpsBikeSnapshotBike = {
+  id: string;
+  idx: number | null;
+  plateNumber: string;
+  vin: string;
+  modelName: string | null;
+  operationStatus: ServiceOpsBikeOperationStatus;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ServiceOpsBikeSnapshotActiveContract = {
+  id: string;
+  idx: number | null;
+  contractTemplateId: string;
+  templateName: string;
+  templateCategory: string;
+  templateReturnType: string | null;
+  templateDurationUnit: string | null;
+  templateDurationValue: number | null;
+  templateIncludesInsurance: boolean;
+  startAt: string;
+  endAt: string | null;
+  terminatedAt: string | null;
+  terminatedReason: string | null;
+  memo: string | null;
+};
+
+export type ServiceOpsBikeSnapshotRider = {
+  id: string;
+  idx: number | null;
+  name: string;
+  phoneNumber: string;
+  teamName: string | null;
+  areaName: string | null;
+  appLinkStatus: string;
+  memo: string | null;
+  educationCompleted: boolean;
+  latestEducationType: string | null;
+  latestEducationCompletedAt: string | null;
+  latestEducationExpiresAt: string | null;
+  educationExpired: boolean;
+};
+
+export type ServiceOpsBikeSnapshotRiderInsurance = {
+  id: string;
+  insuranceItemId: string;
+  itemName: string;
+  category: string;
+  coverageType: string | null;
+  startsAt: string | null;
+  endsAt: string | null;
+  riderBikeContractId: string | null;
+  memo: string | null;
+};
+
+export type ServiceOpsBikeSnapshotEquipment = {
+  id: string;
+  equipmentTypeId: string;
+  typeName: string;
+  equipmentLabel: string | null;
+  modelName: string | null;
+  serialNumber: string | null;
+  installedAt: string;
+  removedAt: string | null;
+  managementDueDate: string | null;
+  memo: string | null;
+};
+
+export type ServiceOpsBikeSnapshot = {
+  bikeId: string;
+  generatedAt: string;
+  bike: ServiceOpsBikeSnapshotBike;
+  activeContract: ServiceOpsBikeSnapshotActiveContract | null;
+  rider: ServiceOpsBikeSnapshotRider | null;
+  insurances: ServiceOpsBikeSnapshotRiderInsurance[];
+  equipments: ServiceOpsBikeSnapshotEquipment[];
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
   getDashboardMapState: () => Promise<FrontendDashboardMapState>;
   getBikeCurrentState: (bikeId: string) => Promise<FrontendBikeCurrentState>;
+  getBikeSnapshot: (bikeId: string) => Promise<ServiceOpsBikeSnapshot>;
   getIntegrityReferenceChecks: () => Promise<ServiceOpsIntegrityScan>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
@@ -755,6 +836,11 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
           `/telemetry/bikes/${encodeURIComponent(bikeId)}/current-state`,
           { method: "GET" }
         )
+      ),
+    getBikeSnapshot: async (bikeId) =>
+      request<ServiceOpsBikeSnapshot>(
+        `/dashboard/bikes/${encodeURIComponent(bikeId)}/snapshot`,
+        { method: "GET" }
       ),
     getIntegrityReferenceChecks: () =>
       request<ServiceOpsIntegrityScan>("/integrity/reference-checks", { method: "GET" }),


### PR DESCRIPTION
## Summary

- 마커 클릭 디테일 패널이 5섹션으로 확장 — \`텔레메트리\` (기존) + \`라이더\` + \`활성 계약\` + \`보험\` + \`장비\`.
- 백엔드 \`GET /api/v1/dashboard/bikes/{bikeId}/snapshot\` (PR #133) 와 기존 \`GET /api/v1/telemetry/bikes/{id}/current-state\` 를 병렬 fetch.
- 마커 swap 시 두 fetch 가 outcome-state-keyed-on-bikeId 패턴으로 재진입 (React 19 \`set-state-in-effect\` 룰 통과).

## Trace

- Target issue: EVNSolution/thundercrew-domain#134
- Change-control issue: EVNSolution/clever-change-control#121
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #133 (snapshot endpoint), #127 (panel skeleton).

## Scope

Frontend-only.

Included:
- \`getBikeSnapshot\` 클라이언트 메소드 + 타입.
- \`dashboard-bike-snapshot-data.ts\` server loader + mock fallback.
- \`/api/dashboard/bike-snapshot/[bikeId]\` Next.js route.
- BikeDetailPanel 5섹션 + Empty/Loading/Fallback 메시지.
- \`.bike-detail-panel-*\` CSS 추가 (기존 \`--rm-*\` palette 만 사용).

Excluded:
- 충전소 디테일 패널.
- 디바이스 설치 이력 / 차량 운영 상태 이력 (백엔드 snapshot 에 포함 안됨).
- 패널 안의 화면 navigation (\`/riders/{id}\` 같은 링크).
- 라이더 다중 활성 계약.

## 화면 구성

\`\`\`
┌────────────────────────────────────┐
│ 차량 상세                 [✕]      │
│ 서울A-1234                         │
│ Thunder M1                         │
├────────────────────────────────────┤
│ ▤ 텔레메트리                       │
│ 연결 상태  ONLINE                  │
│ 주행 상태  DRIVING                 │
│ ...                                │
├────────────────────────────────────┤
│ ▤ 라이더                           │
│ 이름       김지도                  │
│ 연락처     010-1111-2222           │
│ 교육 상태  완료                    │
│ ...                                │
├────────────────────────────────────┤
│ ▤ 활성 계약                        │
│ 템플릿     구독 인수형 12개월      │
│ 카테고리   SUBSCRIPTION            │
│ ...                                │
├────────────────────────────────────┤
│ ▤ 보험                             │
│ ┌─유상운송종합보험──────────────┐ │
│ │ PRIMARY · GENERAL_PAID...     │ │
│ │ 2026-05-01 ~ 2027-04-30       │ │
│ └────────────────────────────────┘ │
├────────────────────────────────────┤
│ ▤ 장비                             │
│ ┌─메인 헬멧───────────────────────┐ │
│ │ 헬멧 · TC-Helmet-V2 · SN-001  │ │
│ │ 설치 2026-04-01 · 점검 만료...│ │
│ └────────────────────────────────┘ │
└────────────────────────────────────┘
\`\`\`

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 백엔드 + \`npm run dev:seed-monitoring\` 시드 후 마커 클릭 → 5섹션 모두 데이터로 채워지는지 확인.
- [ ] 시드 안 된 차량 마커 클릭 → 라이더/계약/보험 섹션은 \`활성 계약 없음\` 등 안내, 텔레메트리는 BikePin 정보로 채워짐.
- [ ] 다른 마커 클릭으로 swap → 두 fetch 모두 재실행 되고 이전 차량 데이터 잔류 없음.
- [ ] 백엔드 미구성 시 텔레메트리/스냅샷 모두 \`데이터 없음\` 안내 + BikePin 정보만 표시.
- [ ] DevTools Network → 마커 클릭마다 \`/api/dashboard/bike-current-state/{id}\` 와 \`/api/dashboard/bike-snapshot/{id}\` 가 각각 1회 호출.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #134 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 디테일 패널 join 탭이 끝-단까지 닫혔습니다. 운영자가 마커 클릭 한 번으로 차량 + 라이더 + 계약 + 보험 + 장비 + 교육 정보를 모두 화면에서 확인 가능. 다음 추천 작업:

- **Slice E — 어드민 폼 재설계** — 운영자가 새 카테고리/형태/단위/교육 입력 UI 사용 (큼).
- **Slice F-1 — vendor adapter interface + stub** — vendor 받기 전 미리 인터페이스 깔아두기 (작음).
- **충전소 디테일 패널** — 충전소 마커 클릭 시 같은 패턴.