### PR TITLE
Add rider education records section and create page on the admin web (#136)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -316,6 +316,11 @@ textarea { padding-top: 10px; min-height: 96px; }
 .empty-state { padding: 48px 24px; text-align: center; background: var(--color-bg-soft); border-radius: 12px; box-shadow: 0 0 0 1px var(--color-border); }
 .empty-state-icon { width: 48px; height: 48px; margin: 0 auto 16px; border-radius: 16px; background: var(--mint-12); display: grid; place-items: center; font-weight: 900; }
 .notice { padding: 16px; border-radius: 12px; background: var(--mint-08); box-shadow: 0 0 0 1px var(--mint-20); color: var(--color-text-secondary); line-height: 1.6; }
+.card-header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.card-header h2 { margin: 0; }
+.muted { margin: 8px 0 0; color: var(--rm-text-secondary); font-size: 13px; }
+.button-link { padding: 4px 0; border: 0; background: transparent; color: var(--rm-text-secondary); font-size: 12px; text-decoration: underline; cursor: pointer; }
+.button-link:hover { color: var(--rm-text-primary); }
 
 @media (max-width: 1024px) {
   .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/development/front-admin-web/app/riders/[slug]/education-records/actions.ts
+++ b/development/front-admin-web/app/riders/[slug]/education-records/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  type RiderEducationRecordCreateInput,
+  type ServiceOpsRiderEducationType,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export async function createRiderEducationRecordAction(
+  riderId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let payload: RiderEducationRecordCreateInput;
+  try {
+    payload = toEducationPayload(riderId, formData);
+  } catch {
+    redirect(`/riders/${riderId}/education-records/new?status=validation-error`);
+  }
+
+  try {
+    await client.createRiderEducationRecord(payload);
+  } catch {
+    redirect(`/riders/${riderId}/education-records/new?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderId}`);
+  redirect(`/riders/${riderId}?status=education-created`);
+}
+
+export async function deleteRiderEducationRecordAction(
+  riderId: string,
+  recordId: string
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderId}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteRiderEducationRecord(recordId);
+  } catch {
+    redirect(`/riders/${riderId}?status=education-delete-error`);
+  }
+
+  revalidatePath(`/riders/${riderId}`);
+  redirect(`/riders/${riderId}?status=education-deleted`);
+}
+
+function toEducationPayload(riderId: string, formData: FormData): RiderEducationRecordCreateInput {
+  const educationType = String(formData.get("educationType") ?? "").trim() as ServiceOpsRiderEducationType;
+  if (educationType !== "ONLINE" && educationType !== "OFFLINE") {
+    throw new Error("educationType must be ONLINE or OFFLINE");
+  }
+  const completedAtIso = toIsoTimestamp(formData.get("completedAt"));
+  if (!completedAtIso) {
+    throw new Error("completedAt is required");
+  }
+  return {
+    riderId,
+    educationType,
+    courseName: optionalText(formData.get("courseName")),
+    completedAt: completedAtIso,
+    expiresAt: toIsoTimestamp(formData.get("expiresAt")) ?? null,
+    certificateNo: optionalText(formData.get("certificateNo")),
+    issuingAuthority: optionalText(formData.get("issuingAuthority")),
+    evidenceUrl: optionalText(formData.get("evidenceUrl")),
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function toIsoTimestamp(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  // The HTML <input type="date"> sends `YYYY-MM-DD`; backend expects an
+  // ISO instant. Promote the form value to the start of the day in UTC so
+  // operator-entered "completion date" matches the inspector's expectation
+  // of a local-day boundary without dragging in client-tz subtleties.
+  const [year, month, day] = text.split("-").map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  return date.toISOString();
+}

--- a/development/front-admin-web/app/riders/[slug]/education-records/new/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/education-records/new/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from "next/navigation";
+
+import { createRiderEducationRecordAction } from "@/app/riders/[slug]/education-records/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderEducationRecordForm } from "@/components/riders/RiderEducationRecordForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "교육 이력 저장에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요.",
+  "validation-error": "필수값(교육 종류, 완료일)이 누락되었거나 잘못 입력되었습니다."
+};
+
+export default async function NewRiderEducationRecordPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const message = status ? statusMessage[status] : null;
+  const action = createRiderEducationRecordAction.bind(
+    null,
+    detail.rider.id ?? detail.rider.slug
+  );
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="교육 이력 등록"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 안전 운행 / 정부 지정 교육 이력을 추가합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderEducationRecordForm action={action} backHref={`/riders/${detail.rider.slug}`} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -1,15 +1,23 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import {
+  deleteRiderEducationRecordAction
+} from "@/app/riders/[slug]/education-records/actions";
 import { deleteRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadRiderEducationRecords } from "@/lib/services/rider-education-data";
+import type { ServiceOpsRiderEducationRecord } from "@/lib/services/service-ops-api";
 
 const statusMessage: Record<string, string> = {
   created: "라이더가 등록되었습니다.",
   "delete-error": "라이더 비활성 삭제에 실패했습니다. 활성 계약/보험 연결이나 백엔드 연결 상태를 확인하세요.",
+  "education-created": "교육 이력이 등록되었습니다.",
+  "education-deleted": "교육 이력이 삭제되었습니다.",
+  "education-delete-error": "교육 이력 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
   "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 없이 mock 상세로 돌아왔습니다.",
   updated: "라이더 정보가 수정되었습니다."
@@ -32,6 +40,8 @@ export default async function RiderDetailPage({
   const { contracts, insurance, notice, rider } = detail;
   const message = status ? statusMessage[status] : null;
   const deleteAction = deleteRiderAction.bind(null, rider.slug);
+  const riderId = rider.id ?? rider.slug;
+  const educationResult = await loadRiderEducationRecords(riderId);
 
   return (
     <div className="page-container">
@@ -71,6 +81,95 @@ export default async function RiderDetailPage({
           </form>
         </aside>
       </section>
+      <RiderEducationSection
+        riderId={riderId}
+        riderSlug={rider.slug}
+        records={educationResult.records}
+        notice={educationResult.notice}
+        nowMs={educationResult.nowMs}
+      />
     </div>
   );
+}
+
+function RiderEducationSection({
+  riderId,
+  riderSlug,
+  records,
+  notice,
+  nowMs
+}: {
+  riderId: string;
+  riderSlug: string;
+  records: ServiceOpsRiderEducationRecord[];
+  notice: string | undefined;
+  nowMs: number;
+}) {
+  return (
+    <section className="card" aria-label="라이더 교육 이력">
+      <header className="card-header">
+        <h2>교육 이력</h2>
+        <Link className="button-primary" href={`/riders/${riderSlug}/education-records/new`}>
+          교육 이력 등록
+        </Link>
+      </header>
+      {notice ? <p className="notice">{notice}</p> : null}
+      {records.length === 0 ? (
+        <p className="muted">등록된 교육 이력 없음</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>종류</th>
+              <th>과정명</th>
+              <th>완료일</th>
+              <th>만료일</th>
+              <th>수료증</th>
+              <th>발급 기관</th>
+              <th>상태</th>
+              <th>작업</th>
+            </tr>
+          </thead>
+          <tbody>
+            {records.map((record) => {
+              const expired = isRecordExpired(record, nowMs);
+              const deleteAction = deleteRiderEducationRecordAction.bind(null, riderId, record.id);
+              return (
+                <tr key={record.id}>
+                  <td>{record.educationType === "ONLINE" ? "온라인" : "오프라인"}</td>
+                  <td>{record.courseName ?? "—"}</td>
+                  <td>{formatDate(record.completedAt)}</td>
+                  <td>{record.expiresAt ? formatDate(record.expiresAt) : "—"}</td>
+                  <td>{record.certificateNo ?? "—"}</td>
+                  <td>{record.issuingAuthority ?? "—"}</td>
+                  <td>
+                    <Badge tone={expired ? "muted" : "active"}>
+                      {expired ? "만료" : "유효"}
+                    </Badge>
+                  </td>
+                  <td>
+                    <form action={deleteAction}>
+                      <button className="button-link" type="submit">삭제</button>
+                    </form>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+function isRecordExpired(record: ServiceOpsRiderEducationRecord, now: number): boolean {
+  if (!record.expiresAt) return false;
+  const ts = Date.parse(record.expiresAt);
+  return Number.isFinite(ts) && ts <= now;
+}
+
+function formatDate(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  return new Date(ts).toLocaleDateString("ko-KR");
 }

--- a/development/front-admin-web/components/riders/RiderEducationRecordForm.tsx
+++ b/development/front-admin-web/components/riders/RiderEducationRecordForm.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+
+type RiderEducationRecordFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  backHref: string;
+};
+
+export function RiderEducationRecordForm({ action, backHref }: RiderEducationRecordFormProps) {
+  return (
+    <form action={action} className="card" aria-label="라이더 교육 이력 등록 폼">
+      <div className="form-grid">
+        <Field label="교육 종류">
+          <select className="select" defaultValue="ONLINE" name="educationType" required>
+            <option value="ONLINE">온라인 교육</option>
+            <option value="OFFLINE">오프라인 교육</option>
+          </select>
+        </Field>
+        <Field label="과정명">
+          <input
+            className="input"
+            maxLength={200}
+            name="courseName"
+            placeholder="예: 전기이륜차 안전 운행 교육 2026"
+          />
+        </Field>
+        <Field label="완료일">
+          <input className="input" name="completedAt" required type="date" />
+        </Field>
+        <Field label="만료일 (선택)">
+          <input className="input" name="expiresAt" type="date" />
+        </Field>
+        <Field label="수료증 번호 (선택)">
+          <input
+            className="input"
+            maxLength={100}
+            name="certificateNo"
+            placeholder="예: CRT-2026-00001"
+          />
+        </Field>
+        <Field label="발급 기관 (선택)">
+          <input
+            className="input"
+            maxLength={100}
+            name="issuingAuthority"
+            placeholder="예: 교통안전공단"
+          />
+        </Field>
+      </div>
+      <br />
+      <Field label="증빙 URL (선택)">
+        <input
+          className="input"
+          name="evidenceUrl"
+          placeholder="예: https://evidence.example.com/CRT-2026-00001.pdf"
+          type="url"
+        />
+      </Field>
+      <br />
+      <Field label="메모 (선택)">
+        <textarea
+          className="input"
+          name="memo"
+          placeholder="운영자가 볼 내부 메모"
+          rows={4}
+        />
+      </Field>
+      <div className="form-actions">
+        <Link className="button-secondary" href={backHref}>취소</Link>
+        <button className="button-primary" type="submit">교육 이력 등록</button>
+      </div>
+    </form>
+  );
+}

--- a/development/front-admin-web/lib/services/rider-education-data.ts
+++ b/development/front-admin-web/lib/services/rider-education-data.ts
@@ -1,0 +1,74 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsRiderEducationRecord,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderEducationRecordsResult = {
+  riderId: string;
+  records: ServiceOpsRiderEducationRecord[];
+  source: "service-ops" | "mock";
+  notice?: string;
+  /**
+   * Snapshot of `Date.now()` taken on the server during the load. The detail
+   * page uses this to decide which records are expired without calling
+   * `Date.now()` itself during render — the React 19 purity lint rule blocks
+   * impure clock reads from server component bodies.
+   */
+  nowMs: number;
+};
+
+/**
+ * Loader for the rider's education record history. The rider detail page
+ * embeds this list in the {@code 교육 이력} section. We page through up to
+ * 50 rows because the operator typically only cares about recent training
+ * entries; older records are still in the backend but not surfaced in the
+ * detail page.
+ */
+export async function loadRiderEducationRecords(riderId: string): Promise<RiderEducationRecordsResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      riderId,
+      records: [],
+      source: "mock",
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 교육 이력을 표시할 수 없습니다.",
+      nowMs: Date.now()
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      riderId,
+      records: [],
+      source: "mock",
+      notice: "관리자 세션이 없어 교육 이력을 표시할 수 없습니다.",
+      nowMs: Date.now()
+    };
+  }
+
+  try {
+    const page = await client.listRiderEducationRecordsByRider(riderId, { page: 0, size: 50 });
+    return { riderId, records: page.items, source: "service-ops", nowMs: Date.now() };
+  } catch (error) {
+    return {
+      riderId,
+      records: [],
+      source: "mock",
+      notice: `교육 이력 조회 실패.${formatServiceOpsError(error)}`,
+      nowMs: Date.now()
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -77,6 +77,36 @@ export type RiderCreateInput = {
 
 export type RiderUpdateInput = Partial<RiderCreateInput>;
 
+export type ServiceOpsRiderEducationType = "ONLINE" | "OFFLINE";
+
+export type ServiceOpsRiderEducationRecord = {
+  id: string;
+  idx: number | null;
+  riderId: string;
+  educationType: ServiceOpsRiderEducationType;
+  courseName: string | null;
+  completedAt: string;
+  expiresAt: string | null;
+  certificateNo: string | null;
+  issuingAuthority: string | null;
+  evidenceUrl: string | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RiderEducationRecordCreateInput = {
+  riderId: string;
+  educationType: ServiceOpsRiderEducationType;
+  courseName?: string | null;
+  completedAt: string;
+  expiresAt?: string | null;
+  certificateNo?: string | null;
+  issuingAuthority?: string | null;
+  evidenceUrl?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE" | "REPAIRING" | "INSPECTION_REQUIRED";
 
 export type ServiceOpsBike = {
@@ -711,6 +741,14 @@ export type ServiceOpsApiClient = {
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
   updateRider: (id: string, request: RiderUpdateInput) => Promise<FrontendRider>;
   deleteRider: (id: string) => Promise<void>;
+  listRiderEducationRecordsByRider: (
+    riderId: string,
+    params?: { page?: number; size?: number; sort?: string }
+  ) => Promise<ServiceOpsPage<ServiceOpsRiderEducationRecord>>;
+  createRiderEducationRecord: (
+    request: RiderEducationRecordCreateInput
+  ) => Promise<ServiceOpsRiderEducationRecord>;
+  deleteRiderEducationRecord: (id: string) => Promise<void>;
 };
 
 type ServiceOpsApiOptions = {
@@ -1090,6 +1128,20 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       ),
     deleteRider: async (id) => {
       await request<void>(`/riders/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
+    listRiderEducationRecordsByRider: (riderId, { page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsRiderEducationRecord>>(
+        `/riders/${encodeURIComponent(riderId)}/education-records`,
+        { method: "GET" },
+        { page, size, sort }
+      ),
+    createRiderEducationRecord: (createRequest) =>
+      request<ServiceOpsRiderEducationRecord>("/rider-education-records", {
+        body: JSON.stringify(createRequest),
+        method: "POST"
+      }),
+    deleteRiderEducationRecord: async (id) => {
+      await request<void>(`/rider-education-records/${encodeURIComponent(id)}`, { method: "DELETE" });
     }
   };
 }


### PR DESCRIPTION
## Summary

- 라이더 상세 페이지(\`/riders/{slug}\`)에 \`교육 이력\` 카드 추가 — 활성 교육 record 테이블 + 만료 뱃지 + 행별 삭제 + \`교육 이력 등록\` 버튼.
- 새 페이지 \`/riders/{slug}/education-records/new\` — 교육 종류 / 과정명 / 완료일 / 만료일 / 수료증 번호 / 발급 기관 / 증빙 URL / 메모 폼.
- service-ops 클라이언트 + server action + server-side loader 추가 (백엔드 Slice C 와 처음으로 어드민 UI 가 직접 연결됨).

## Trace

- Target issue: EVNSolution/thundercrew-domain#136
- Change-control issue: EVNSolution/clever-change-control#122
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #123 (Slice C — backend rider education records).

## Scope

Frontend-only.

Included:
- \`service-ops-api.ts\` — RiderEducationRecord 타입 + 3 메소드.
- \`rider-education-data.ts\` 서버 로더 + nowMs 스냅샷.
- \`/riders/[slug]/education-records/actions.ts\` — create + delete server actions.
- \`/riders/[slug]/education-records/new/page.tsx\` — 등록 페이지.
- \`RiderEducationRecordForm\` 컴포넌트.
- 라이더 상세 페이지 카드 추가.
- \`.card-header\` / \`.muted\` / \`.button-link\` CSS (palette 일관 유지).

Excluded:
- 단건 상세 / 수정 페이지 (후속 슬라이스).
- 라이더 등록/수정 폼 자체에 교육 입력 통합.
- 라이더 목록 페이지의 교육 상태 컬럼.
- 정부 보고서 PDF 생성.

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean (React 19 purity rule 통과) |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 백엔드 + 시드 + 어드민 로그인 후 \`/riders/{slug}\` → \`교육 이력\` 카드가 렌더링되고 빈 상태(\`등록된 교육 이력 없음\`) 노출.
- [ ] \`교육 이력 등록\` 버튼 클릭 → 등록 폼 페이지 이동 → 입력 후 제출 → 라이더 상세로 돌아오고 새 행 노출.
- [ ] 만료된 record 는 \`만료\` 뱃지, 만료 안 된 record 는 \`유효\` 뱃지.
- [ ] 행별 삭제 버튼 → 삭제 후 새로고침 시 사라짐 (백엔드 soft-delete).
- [ ] 백엔드 미구성 / 세션 없음 → 카드에 안내 문구 + 빈 상태 (등록 버튼은 redirect 로 mock-saved 처리).
- [ ] DevTools Network → 라이더 상세 페이지 진입 시 \`/riders/{id}/education-records\` 1회 호출.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #136 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- **④-2 — 단건 상세/수정 페이지** (운영자가 만료일/수료증 번호 정정 가능).
- **④-3 — 계약 템플릿 폼 재설계** — 카테고리/형태/단위/보험 옵션 입력 UI.
- **④-4 — 보험 항목 폼 재설계** — 카테고리/유형/기본 기간 입력 UI.
- **Slice F-1 — vendor adapter interface + stub**.