### PR TITLE
Redesign admin web contract template form for category/return/duration (#138)

### DIFF
--- a/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/edit/page.tsx
@@ -6,6 +6,7 @@ import { ContractTemplateForm } from "@/components/contract-templates/ContractTe
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
 import { loadContractTemplateDetail } from "@/lib/services/contract-template-data";
+import { loadInsuranceOptions } from "@/lib/services/insurance-options-data";
 
 const statusMessage: Record<string, string> = {
   "save-error": "계약 양식 수정에 실패했습니다. 이름 중복, 기간 입력, 시스템 양식 여부, 백엔드 연결 상태를 확인하세요."
@@ -18,7 +19,11 @@ export default async function EditContractTemplatePage({
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ status?: string }>;
 }) {
-  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const [{ slug }, { status }, insuranceOptions] = await Promise.all([
+    params,
+    searchParams,
+    loadInsuranceOptions()
+  ]);
   const detail = await loadContractTemplateDetail(slug);
 
   if (!detail) {
@@ -53,12 +58,20 @@ export default async function EditContractTemplatePage({
         action={updateAction}
         cancelHref={`/contract-templates/${template.slug}`}
         defaultValues={{
+          category: template.category,
+          defaultInsuranceItemId: template.defaultInsuranceItemId ?? null,
           description: template.description,
           durationMinutes: template.durationMinutes,
+          durationUnit: template.durationUnit ?? null,
+          durationValue: template.durationValue ?? null,
           enabled: template.enabled,
+          includesInsurance: template.includesInsurance ?? false,
           name: template.name,
+          returnType: template.returnType ?? null,
           unlimited: template.unlimited
         }}
+        insuranceOptions={insuranceOptions.options}
+        insuranceOptionsNotice={insuranceOptions.notice}
         mode="수정"
         statusMessage={status ? statusMessage[status] : null}
       />

--- a/development/front-admin-web/app/contract-templates/[slug]/page.tsx
+++ b/development/front-admin-web/app/contract-templates/[slug]/page.tsx
@@ -48,7 +48,13 @@ export default async function ContractTemplateDetailPage({
         <div className="card">
           <h2>계약 양식 정보</h2>
           <div className="detail-list">
-            <div className="detail-row"><span>기간</span><strong>{template.durationLabel}</strong></div>
+            <div className="detail-row"><span>카테고리</span><strong>{categoryLabel(template.category)}</strong></div>
+            <div className="detail-row"><span>형태</span><strong>{returnTypeLabel(template.returnType)}</strong></div>
+            <div className="detail-row"><span>기간</span><strong>{structuredDurationLabel(template) ?? template.durationLabel}</strong></div>
+            <div className="detail-row"><span>보험 포함</span><strong>{template.includesInsurance ? "포함" : "미포함"}</strong></div>
+            {template.includesInsurance && template.defaultInsuranceItemId ? (
+              <div className="detail-row"><span>기본 보험 ID</span><strong>{template.defaultInsuranceItemId}</strong></div>
+            ) : null}
             <div className="detail-row"><span>사용 상태</span><Badge tone={template.enabled ? "active" : "muted"}>{template.enabled ? "사용" : "비활성"}</Badge></div>
             <div className="detail-row"><span>보호 상태</span><Badge tone={template.systemTemplate ? "outline" : "muted"}>{template.systemTemplate ? "시스템 보호" : "운영자 관리"}</Badge></div>
             <div className="detail-row"><span>설명</span><strong>{template.description ?? "없음"}</strong></div>
@@ -78,4 +84,41 @@ export default async function ContractTemplateDetailPage({
       </section>
     </div>
   );
+}
+
+function categoryLabel(category: string | undefined): string {
+  switch (category) {
+    case "SUBSCRIPTION":
+      return "구독";
+    case "RENTAL":
+      return "렌탈";
+    case "CUSTOM":
+      return "기타 / 자유";
+    default:
+      return "—";
+  }
+}
+
+function returnTypeLabel(returnType: string | null | undefined): string {
+  switch (returnType) {
+    case "TAKEOVER":
+      return "인수형";
+    case "RETURN":
+      return "반납형";
+    default:
+      return "—";
+  }
+}
+
+function structuredDurationLabel(template: { durationUnit?: string | null; durationValue?: number | null }): string | null {
+  if (!template.durationUnit || !template.durationValue) return null;
+  const unitLabels: Record<string, string> = {
+    DAY: "일",
+    WEEK: "주",
+    MONTH: "개월",
+    QUARTER: "분기",
+    HALF_YEAR: "반기",
+    YEAR: "년"
+  };
+  return `${template.durationValue} ${unitLabels[template.durationUnit] ?? template.durationUnit}`;
 }

--- a/development/front-admin-web/app/contract-templates/new/page.tsx
+++ b/development/front-admin-web/app/contract-templates/new/page.tsx
@@ -2,19 +2,35 @@ import { createContractTemplateAction } from "@/app/contract-templates/actions";
 import { ContractTemplateForm } from "@/components/contract-templates/ContractTemplateForm";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
+import { loadInsuranceOptions } from "@/lib/services/insurance-options-data";
 
 const statusMessage: Record<string, string> = {
-  "save-error": "계약 양식 저장에 실패했습니다. 이름 중복, 기간 입력, 백엔드 연결 상태를 확인하세요."
+  "save-error": "계약 양식 저장에 실패했습니다. 카테고리·기간·보험 조합과 백엔드 연결 상태를 확인하세요."
 };
 
-export default async function NewContractTemplatePage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
-  const { status } = await searchParams;
+export default async function NewContractTemplatePage({
+  searchParams
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ status }, insuranceOptions] = await Promise.all([
+    searchParams,
+    loadInsuranceOptions()
+  ]);
 
   return (
     <div className="page-container">
       <BackToListLink href="/contract-templates" />
-      <PageHeader title="계약 양식 등록" description="계약 양식 ID는 DB가 자동 생성합니다. 운영자는 사람이 읽을 수 있는 이름과 기간만 입력합니다." />
-      <ContractTemplateForm action={createContractTemplateAction} statusMessage={status ? statusMessage[status] : null} />
+      <PageHeader
+        title="계약 양식 등록"
+        description="구독·렌탈·기타 카테고리에 따라 형태/기간/보험 옵션을 입력합니다. 양식 ID는 DB가 자동 생성합니다."
+      />
+      <ContractTemplateForm
+        action={createContractTemplateAction}
+        insuranceOptions={insuranceOptions.options}
+        insuranceOptionsNotice={insuranceOptions.notice}
+        statusMessage={status ? statusMessage[status] : null}
+      />
     </div>
   );
 }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -321,6 +321,8 @@ textarea { padding-top: 10px; min-height: 96px; }
 .muted { margin: 8px 0 0; color: var(--rm-text-secondary); font-size: 13px; }
 .button-link { padding: 4px 0; border: 0; background: transparent; color: var(--rm-text-secondary); font-size: 12px; text-decoration: underline; cursor: pointer; }
 .button-link:hover { color: var(--rm-text-primary); }
+.checkbox-row { display: flex; align-items: center; gap: 8px; padding: 8px 0; cursor: pointer; }
+.checkbox-row input[type="checkbox"] { width: 16px; height: 16px; }
 
 @media (max-width: 1024px) {
   .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/development/front-admin-web/components/contract-templates/ContractTemplateForm.tsx
+++ b/development/front-admin-web/components/contract-templates/ContractTemplateForm.tsx
@@ -1,31 +1,89 @@
+"use client";
+
 import Link from "next/link";
+import { useId, useState, type ChangeEvent } from "react";
 
 import { Field } from "@/components/ui/FormField";
-import type { ContractTemplate } from "@/types/domain";
+import type { ContractTemplate, ContractTemplateCategory } from "@/types/domain";
+
+export type ContractTemplateFormInsuranceOption = {
+  id: string;
+  name: string;
+  category: string;
+};
 
 type ContractTemplateFormProps = {
   action: (formData: FormData) => void | Promise<void>;
   cancelHref?: string;
-  defaultValues?: Partial<Pick<ContractTemplate, "description" | "durationMinutes" | "enabled" | "name" | "unlimited">>;
+  defaultValues?: Partial<
+    Pick<
+      ContractTemplate,
+      | "category"
+      | "defaultInsuranceItemId"
+      | "description"
+      | "durationMinutes"
+      | "durationUnit"
+      | "durationValue"
+      | "enabled"
+      | "includesInsurance"
+      | "name"
+      | "returnType"
+      | "unlimited"
+    >
+  >;
+  insuranceOptions: ContractTemplateFormInsuranceOption[];
+  insuranceOptionsNotice?: string | null;
   mode?: "등록" | "수정";
   statusMessage?: string | null;
 };
+
+const CATEGORY_OPTIONS: { value: ContractTemplateCategory; label: string; hint: string }[] = [
+  { value: "SUBSCRIPTION", label: "구독 (12개월)", hint: "12개월 고정 — 인수형/반납형 + 보험 포함 여부 선택." },
+  { value: "RENTAL", label: "렌탈 (단기)", hint: "일/주/월/분기/반기 단위 + 인수형/반납형." },
+  { value: "CUSTOM", label: "기타 (자유 분 단위)", hint: "기존 무제한 또는 임의 일/시간/분 입력." }
+];
+
+const RENTAL_UNIT_OPTIONS = [
+  { value: "DAY", label: "일" },
+  { value: "WEEK", label: "주" },
+  { value: "MONTH", label: "월" },
+  { value: "QUARTER", label: "분기" },
+  { value: "HALF_YEAR", label: "반기 (6개월)" }
+];
 
 export function ContractTemplateForm({
   action,
   cancelHref = "/contract-templates",
   defaultValues,
+  insuranceOptions,
+  insuranceOptionsNotice,
   mode = "등록",
   statusMessage
 }: ContractTemplateFormProps) {
-  const duration = splitDuration(defaultValues?.durationMinutes ?? null);
-  const durationMode = defaultValues?.unlimited || defaultValues?.durationMinutes === null ? "unlimited" : "limited";
+  const initialCategory = (defaultValues?.category as ContractTemplateCategory | undefined) ?? "SUBSCRIPTION";
+  const [category, setCategory] = useState<ContractTemplateCategory>(initialCategory);
+  const [includesInsurance, setIncludesInsurance] = useState(
+    defaultValues?.includesInsurance ?? false
+  );
+  const insuranceCheckboxId = useId();
+
+  const customDuration = splitDuration(defaultValues?.durationMinutes ?? null);
+  const customDurationMode =
+    defaultValues?.unlimited || defaultValues?.durationMinutes === null ? "unlimited" : "limited";
 
   return (
     <form action={action} className="card" aria-label={`계약 양식 ${mode} 폼`}>
+      <input type="hidden" name="category" value={category} />
       <div className="form-grid">
         <Field label="계약 양식명">
-          <input className="input" defaultValue={defaultValues?.name ?? ""} maxLength={100} name="name" placeholder="예: 표준 12일" required />
+          <input
+            className="input"
+            defaultValue={defaultValues?.name ?? ""}
+            maxLength={100}
+            name="name"
+            placeholder="예: 구독 인수형 12개월 (보험 포함)"
+            required
+          />
         </Field>
         <Field label="사용 상태">
           <select className="select" defaultValue={String(defaultValues?.enabled ?? true)} name="enabled">
@@ -33,26 +91,74 @@ export function ContractTemplateForm({
             <option value="false">비활성</option>
           </select>
         </Field>
-        <Field label="기간 방식" hint="무제한은 종료일 없이 운영자가 별도 종료할 때까지 유지합니다.">
-          <select className="select" defaultValue={durationMode} name="durationMode">
-            <option value="limited">기간 지정</option>
-            <option value="unlimited">무제한</option>
+        <Field
+          label="카테고리"
+          hint={CATEGORY_OPTIONS.find((option) => option.value === category)?.hint}
+        >
+          <select
+            className="select"
+            value={category}
+            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+              setCategory(event.target.value as ContractTemplateCategory)
+            }
+          >
+            {CATEGORY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </select>
-        </Field>
-        <Field label="기간 · 일">
-          <input className="input" defaultValue={duration.days || ""} min={0} name="durationDays" placeholder="예: 12" type="number" />
-        </Field>
-        <Field label="기간 · 시간">
-          <input className="input" defaultValue={duration.hours || ""} min={0} name="durationHours" placeholder="예: 6" type="number" />
-        </Field>
-        <Field label="기간 · 분">
-          <input className="input" defaultValue={duration.minutes || ""} min={0} name="durationMinutesPart" placeholder="예: 30" type="number" />
         </Field>
       </div>
       <br />
-      <Field label="설명"><textarea className="input" defaultValue={defaultValues?.description ?? ""} name="description" placeholder="운영자가 구분할 수 있는 계약 양식 설명" rows={3} /></Field>
+
+      {category === "SUBSCRIPTION" ? (
+        <SubscriptionFields
+          defaultReturnType={defaultValues?.returnType ?? null}
+          defaultIncludesInsurance={includesInsurance}
+          onIncludesInsuranceChange={setIncludesInsurance}
+          insuranceCheckboxId={insuranceCheckboxId}
+          insuranceOptions={insuranceOptions}
+          insuranceOptionsNotice={insuranceOptionsNotice}
+          defaultInsuranceItemId={defaultValues?.defaultInsuranceItemId ?? null}
+          includesInsurance={includesInsurance}
+        />
+      ) : null}
+
+      {category === "RENTAL" ? (
+        <RentalFields
+          defaultReturnType={defaultValues?.returnType ?? null}
+          defaultDurationUnit={defaultValues?.durationUnit ?? "DAY"}
+          defaultDurationValue={defaultValues?.durationValue ?? 1}
+          defaultIncludesInsurance={includesInsurance}
+          onIncludesInsuranceChange={setIncludesInsurance}
+          insuranceCheckboxId={insuranceCheckboxId}
+          insuranceOptions={insuranceOptions}
+          insuranceOptionsNotice={insuranceOptionsNotice}
+          defaultInsuranceItemId={defaultValues?.defaultInsuranceItemId ?? null}
+          includesInsurance={includesInsurance}
+        />
+      ) : null}
+
+      {category === "CUSTOM" ? (
+        <CustomFields
+          customDurationMode={customDurationMode}
+          duration={customDuration}
+        />
+      ) : null}
+
+      <br />
+      <Field label="설명">
+        <textarea
+          className="input"
+          defaultValue={defaultValues?.description ?? ""}
+          name="description"
+          placeholder="운영자가 구분할 수 있는 계약 양식 설명"
+          rows={3}
+        />
+      </Field>
       <p className="notice" style={{ marginTop: 16 }}>
-        계약 양식 ID는 DB가 자동 생성합니다. 운영자는 양식명, 기간, 설명, 사용 상태만 입력합니다. 라이더/차량 연결은 계약 등록 화면에서 선택 UI로 처리합니다.
+        계약 양식 ID는 DB가 자동 생성합니다. 카테고리에 따라 백엔드가 SUBSCRIPTION × DAY 같은 잘못된 조합을 거부합니다.
       </p>
       {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
       <div className="form-actions">
@@ -63,11 +169,224 @@ export function ContractTemplateForm({
   );
 }
 
+function SubscriptionFields({
+  defaultReturnType,
+  defaultIncludesInsurance,
+  onIncludesInsuranceChange,
+  insuranceCheckboxId,
+  insuranceOptions,
+  insuranceOptionsNotice,
+  defaultInsuranceItemId,
+  includesInsurance
+}: {
+  defaultReturnType: string | null;
+  defaultIncludesInsurance: boolean;
+  onIncludesInsuranceChange: (next: boolean) => void;
+  insuranceCheckboxId: string;
+  insuranceOptions: ContractTemplateFormInsuranceOption[];
+  insuranceOptionsNotice: string | null | undefined;
+  defaultInsuranceItemId: string | null;
+  includesInsurance: boolean;
+}) {
+  return (
+    <div className="form-grid">
+      <Field label="형태 (인수형 / 반납형)">
+        <select className="select" defaultValue={defaultReturnType ?? "TAKEOVER"} name="returnType" required>
+          <option value="TAKEOVER">인수형 (TAKEOVER)</option>
+          <option value="RETURN">반납형 (RETURN)</option>
+        </select>
+      </Field>
+      <Field label="기간" hint="구독은 12개월 고정 — 운영자가 변경 불가.">
+        <input className="input" disabled value="12개월" />
+        <input type="hidden" name="durationUnit" value="MONTH" />
+        <input type="hidden" name="durationValue" value="12" />
+      </Field>
+      <InsuranceFields
+        defaultIncludesInsurance={defaultIncludesInsurance}
+        onIncludesInsuranceChange={onIncludesInsuranceChange}
+        insuranceCheckboxId={insuranceCheckboxId}
+        insuranceOptions={insuranceOptions}
+        insuranceOptionsNotice={insuranceOptionsNotice}
+        defaultInsuranceItemId={defaultInsuranceItemId}
+        includesInsurance={includesInsurance}
+      />
+    </div>
+  );
+}
+
+function RentalFields({
+  defaultReturnType,
+  defaultDurationUnit,
+  defaultDurationValue,
+  defaultIncludesInsurance,
+  onIncludesInsuranceChange,
+  insuranceCheckboxId,
+  insuranceOptions,
+  insuranceOptionsNotice,
+  defaultInsuranceItemId,
+  includesInsurance
+}: {
+  defaultReturnType: string | null;
+  defaultDurationUnit: string;
+  defaultDurationValue: number;
+  defaultIncludesInsurance: boolean;
+  onIncludesInsuranceChange: (next: boolean) => void;
+  insuranceCheckboxId: string;
+  insuranceOptions: ContractTemplateFormInsuranceOption[];
+  insuranceOptionsNotice: string | null | undefined;
+  defaultInsuranceItemId: string | null;
+  includesInsurance: boolean;
+}) {
+  return (
+    <div className="form-grid">
+      <Field label="형태 (인수형 / 반납형)">
+        <select className="select" defaultValue={defaultReturnType ?? "RETURN"} name="returnType" required>
+          <option value="TAKEOVER">인수형 (TAKEOVER)</option>
+          <option value="RETURN">반납형 (RETURN)</option>
+        </select>
+      </Field>
+      <Field label="기간 단위">
+        <select className="select" defaultValue={defaultDurationUnit} name="durationUnit" required>
+          {RENTAL_UNIT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+      <Field label="기간 값">
+        <input
+          className="input"
+          defaultValue={defaultDurationValue}
+          min={1}
+          name="durationValue"
+          required
+          type="number"
+        />
+      </Field>
+      <InsuranceFields
+        defaultIncludesInsurance={defaultIncludesInsurance}
+        onIncludesInsuranceChange={onIncludesInsuranceChange}
+        insuranceCheckboxId={insuranceCheckboxId}
+        insuranceOptions={insuranceOptions}
+        insuranceOptionsNotice={insuranceOptionsNotice}
+        defaultInsuranceItemId={defaultInsuranceItemId}
+        includesInsurance={includesInsurance}
+      />
+    </div>
+  );
+}
+
+function CustomFields({
+  customDurationMode,
+  duration
+}: {
+  customDurationMode: "limited" | "unlimited";
+  duration: { days: number; hours: number; minutes: number };
+}) {
+  return (
+    <div className="form-grid">
+      <Field label="기간 방식" hint="무제한은 종료일 없이 운영자가 별도 종료할 때까지 유지합니다.">
+        <select className="select" defaultValue={customDurationMode} name="customDurationMode">
+          <option value="limited">기간 지정</option>
+          <option value="unlimited">무제한</option>
+        </select>
+      </Field>
+      <Field label="기간 · 일">
+        <input
+          className="input"
+          defaultValue={duration.days || ""}
+          min={0}
+          name="customDurationDays"
+          placeholder="예: 12"
+          type="number"
+        />
+      </Field>
+      <Field label="기간 · 시간">
+        <input
+          className="input"
+          defaultValue={duration.hours || ""}
+          min={0}
+          name="customDurationHours"
+          placeholder="예: 6"
+          type="number"
+        />
+      </Field>
+      <Field label="기간 · 분">
+        <input
+          className="input"
+          defaultValue={duration.minutes || ""}
+          min={0}
+          name="customDurationMinutesPart"
+          placeholder="예: 30"
+          type="number"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function InsuranceFields({
+  defaultIncludesInsurance,
+  onIncludesInsuranceChange,
+  insuranceCheckboxId,
+  insuranceOptions,
+  insuranceOptionsNotice,
+  defaultInsuranceItemId,
+  includesInsurance
+}: {
+  defaultIncludesInsurance: boolean;
+  onIncludesInsuranceChange: (next: boolean) => void;
+  insuranceCheckboxId: string;
+  insuranceOptions: ContractTemplateFormInsuranceOption[];
+  insuranceOptionsNotice: string | null | undefined;
+  defaultInsuranceItemId: string | null;
+  includesInsurance: boolean;
+}) {
+  return (
+    <>
+      <Field label="보험 포함">
+        <label className="checkbox-row" htmlFor={insuranceCheckboxId}>
+          <input
+            id={insuranceCheckboxId}
+            type="checkbox"
+            name="includesInsurance"
+            value="true"
+            defaultChecked={defaultIncludesInsurance}
+            onChange={(event) => onIncludesInsuranceChange(event.target.checked)}
+          />
+          <span>구독/렌탈 시 기본 보험 자동 발급</span>
+        </label>
+      </Field>
+      {includesInsurance ? (
+        <Field label="기본 보험 항목" hint={insuranceOptionsNotice ?? undefined}>
+          <select
+            className="select"
+            defaultValue={defaultInsuranceItemId ?? insuranceOptions[0]?.id ?? ""}
+            name="defaultInsuranceItemId"
+            required
+            disabled={insuranceOptions.length === 0}
+          >
+            {insuranceOptions.length === 0 ? (
+              <option value="">사용 가능한 보험 항목 없음</option>
+            ) : (
+              insuranceOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name} {option.category ? `(${option.category})` : ""}
+                </option>
+              ))
+            )}
+          </select>
+        </Field>
+      ) : null}
+    </>
+  );
+}
+
 function splitDuration(durationMinutes: number | null): { days: number; hours: number; minutes: number } {
   if (!durationMinutes) {
     return { days: 0, hours: 0, minutes: 0 };
   }
-
   return {
     days: Math.floor(durationMinutes / 1440),
     hours: Math.floor((durationMinutes % 1440) / 60),

--- a/development/front-admin-web/lib/services/contract-template-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/contract-template-command-payload.test.mjs
@@ -7,13 +7,18 @@ import {
   toContractTemplateUpdatePayload
 } from "./contract-template-command-payload.ts";
 
-test("contract template create payload keeps operator fields only and ignores direct ids", () => {
+// CUSTOM category — keeps the legacy day/hour/minute payload shape that
+// existed before Slice ④-3. The form encodes the legacy fields under the
+// `customDuration*` names so the new SUBSCRIPTION/RENTAL paths can use the
+// shorter `durationUnit` / `durationValue` names without colliding.
+test("CUSTOM category create payload sums day/hour/minute and ignores client-supplied ids", () => {
   const formData = new FormData();
+  formData.set("category", "CUSTOM");
   formData.set("name", "표준 12일 6시간");
-  formData.set("durationMode", "limited");
-  formData.set("durationDays", "12");
-  formData.set("durationHours", "6");
-  formData.set("durationMinutesPart", "30");
+  formData.set("customDurationMode", "limited");
+  formData.set("customDurationDays", "12");
+  formData.set("customDurationHours", "6");
+  formData.set("customDurationMinutesPart", "30");
   formData.set("description", "운영자 생성 양식");
   formData.set("enabled", "true");
   formData.set("id", "99999999-9999-4999-8999-999999999999");
@@ -22,6 +27,7 @@ test("contract template create payload keeps operator fields only and ignores di
   formData.set("systemTemplate", "true");
 
   assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    category: "CUSTOM",
     description: "운영자 생성 양식",
     durationMinutes: 17670,
     enabled: true,
@@ -29,16 +35,18 @@ test("contract template create payload keeps operator fields only and ignores di
   });
 });
 
-test("contract template payload supports unlimited duration", () => {
+test("CUSTOM category supports unlimited duration", () => {
   const formData = new FormData();
+  formData.set("category", "CUSTOM");
   formData.set("name", "무제한 현장 계약");
-  formData.set("durationMode", "unlimited");
-  formData.set("durationDays", "12");
-  formData.set("durationHours", "3");
+  formData.set("customDurationMode", "unlimited");
+  formData.set("customDurationDays", "12");
+  formData.set("customDurationHours", "3");
   formData.set("description", "");
   formData.set("enabled", "false");
 
   assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    category: "CUSTOM",
     description: null,
     durationMinutes: null,
     enabled: false,
@@ -46,17 +54,19 @@ test("contract template payload supports unlimited duration", () => {
   });
 });
 
-test("contract template update preserves blank description as clear command", () => {
+test("CUSTOM category update preserves blank description as clear command", () => {
   const formData = new FormData();
+  formData.set("category", "CUSTOM");
   formData.set("name", "표준 13일");
-  formData.set("durationMode", "limited");
-  formData.set("durationDays", "13");
-  formData.set("durationHours", "0");
-  formData.set("durationMinutesPart", "0");
+  formData.set("customDurationMode", "limited");
+  formData.set("customDurationDays", "13");
+  formData.set("customDurationHours", "0");
+  formData.set("customDurationMinutesPart", "0");
   formData.set("description", "");
   formData.set("enabled", "false");
 
   assert.deepEqual(toContractTemplateUpdatePayload(formData), {
+    category: "CUSTOM",
     description: "",
     durationMinutes: 18720,
     enabled: false,
@@ -64,21 +74,114 @@ test("contract template update preserves blank description as clear command", ()
   });
 });
 
-test("contract template payload rejects blank name, zero duration, and invalid enabled state", () => {
+test("payload rejects blank name, zero CUSTOM duration, and invalid enabled state", () => {
   const formData = new FormData();
+  formData.set("category", "CUSTOM");
   formData.set("name", "");
-  formData.set("durationMode", "limited");
-  formData.set("durationDays", "12");
+  formData.set("customDurationMode", "limited");
+  formData.set("customDurationDays", "12");
 
   assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
 
   formData.set("name", "0분 계약");
-  formData.set("durationDays", "0");
-  formData.set("durationHours", "0");
-  formData.set("durationMinutesPart", "0");
+  formData.set("customDurationDays", "0");
+  formData.set("customDurationHours", "0");
+  formData.set("customDurationMinutesPart", "0");
   assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
 
-  formData.set("durationMinutesPart", "30");
+  formData.set("customDurationMinutesPart", "30");
   formData.set("enabled", "maybe");
   assert.throws(() => toContractTemplateUpdatePayload(formData), ContractTemplateCommandPayloadError);
+});
+
+// SUBSCRIPTION — fixed at MONTH × 12 with required returnType.
+test("SUBSCRIPTION category forces MONTH × 12 and includes the structured fields", () => {
+  const formData = new FormData();
+  formData.set("category", "SUBSCRIPTION");
+  formData.set("name", "구독 인수형 12개월 (보험 포함)");
+  formData.set("returnType", "TAKEOVER");
+  formData.set("includesInsurance", "true");
+  formData.set("defaultInsuranceItemId", "22222222-2222-2222-2222-000000000001");
+  formData.set("description", "");
+  formData.set("enabled", "true");
+
+  assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    category: "SUBSCRIPTION",
+    defaultInsuranceItemId: "22222222-2222-2222-2222-000000000001",
+    description: null,
+    durationMinutes: 12 * 30 * 1440,
+    durationUnit: "MONTH",
+    durationValue: 12,
+    enabled: true,
+    includesInsurance: true,
+    name: "구독 인수형 12개월 (보험 포함)",
+    returnType: "TAKEOVER"
+  });
+});
+
+test("SUBSCRIPTION rejects missing returnType", () => {
+  const formData = new FormData();
+  formData.set("category", "SUBSCRIPTION");
+  formData.set("name", "잘못된 구독");
+  formData.set("description", "");
+  formData.set("enabled", "true");
+
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
+});
+
+test("SUBSCRIPTION with insurance requires defaultInsuranceItemId", () => {
+  const formData = new FormData();
+  formData.set("category", "SUBSCRIPTION");
+  formData.set("name", "구독·보험·아이템 누락");
+  formData.set("returnType", "RETURN");
+  formData.set("includesInsurance", "true");
+
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
+});
+
+// RENTAL — durationUnit must be DAY/WEEK/MONTH/QUARTER/HALF_YEAR.
+test("RENTAL category accepts allowed duration units", () => {
+  const formData = new FormData();
+  formData.set("category", "RENTAL");
+  formData.set("name", "단기 렌탈 일주일");
+  formData.set("returnType", "RETURN");
+  formData.set("durationUnit", "WEEK");
+  formData.set("durationValue", "1");
+  formData.set("description", "");
+  formData.set("enabled", "true");
+
+  assert.deepEqual(toContractTemplateCreatePayload(formData), {
+    category: "RENTAL",
+    defaultInsuranceItemId: null,
+    description: null,
+    durationMinutes: 7 * 1440,
+    durationUnit: "WEEK",
+    durationValue: 1,
+    enabled: true,
+    includesInsurance: false,
+    name: "단기 렌탈 일주일",
+    returnType: "RETURN"
+  });
+});
+
+test("RENTAL rejects YEAR duration unit", () => {
+  const formData = new FormData();
+  formData.set("category", "RENTAL");
+  formData.set("name", "잘못된 렌탈·년단위");
+  formData.set("returnType", "TAKEOVER");
+  formData.set("durationUnit", "YEAR");
+  formData.set("durationValue", "1");
+
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
+});
+
+test("RENTAL rejects zero duration value", () => {
+  const formData = new FormData();
+  formData.set("category", "RENTAL");
+  formData.set("name", "잘못된 렌탈·기간0");
+  formData.set("returnType", "RETURN");
+  formData.set("durationUnit", "DAY");
+  formData.set("durationValue", "0");
+
+  assert.throws(() => toContractTemplateCreatePayload(formData), ContractTemplateCommandPayloadError);
 });

--- a/development/front-admin-web/lib/services/contract-template-command-payload.ts
+++ b/development/front-admin-web/lib/services/contract-template-command-payload.ts
@@ -1,4 +1,10 @@
-import type { ContractTemplateCreateInput, ContractTemplateUpdateInput } from "./service-ops-api";
+import type {
+  ContractTemplateCreateInput,
+  ContractTemplateUpdateInput,
+  ServiceOpsContractCategory,
+  ServiceOpsContractDurationUnit,
+  ServiceOpsContractReturnType
+} from "./service-ops-api";
 
 export class ContractTemplateCommandPayloadError extends Error {
   constructor(message: string) {
@@ -7,44 +13,177 @@ export class ContractTemplateCommandPayloadError extends Error {
   }
 }
 
+const RENTAL_UNITS: ReadonlySet<ServiceOpsContractDurationUnit> = new Set([
+  "DAY",
+  "WEEK",
+  "MONTH",
+  "QUARTER",
+  "HALF_YEAR"
+]);
+
 export function toContractTemplateCreatePayload(formData: FormData): ContractTemplateCreateInput {
+  const base = parseStructuredFields(formData);
   return {
+    name: requiredText(formData.get("name"), "Contract template name is required."),
     description: optionalText(formData.get("description")),
-    durationMinutes: toDurationMinutes(formData),
     enabled: toEnabled(formData.get("enabled"), true),
-    name: requiredText(formData.get("name"), "Contract template name is required.")
+    ...base
   };
 }
 
 export function toContractTemplateUpdatePayload(formData: FormData): ContractTemplateUpdateInput {
+  const base = parseStructuredFields(formData);
   return {
+    name: requiredText(formData.get("name"), "Contract template name is required."),
     description: clearableText(formData.get("description")),
-    durationMinutes: toDurationMinutes(formData),
     enabled: toEnabled(formData.get("enabled"), true),
-    name: requiredText(formData.get("name"), "Contract template name is required.")
+    ...base
   };
 }
 
-function toDurationMinutes(formData: FormData): number | null {
-  const mode = String(formData.get("durationMode") ?? "limited").trim();
+/**
+ * Branch on the `category` hidden field set by the form. Each category has
+ * its own validation:
+ *
+ * - SUBSCRIPTION: returnType required, durationUnit forced to MONTH × 12.
+ * - RENTAL: returnType + durationUnit (∈ DAY/WEEK/MONTH/QUARTER/HALF_YEAR)
+ *           + positive durationValue. includesInsurance optional.
+ * - CUSTOM: legacy day/hour/minute payload, optional `unlimited`. structured
+ *           fields stay null so the backend keeps the legacy behavior.
+ *
+ * The backend does its own validation (ServiceOps Slice A) so failed
+ * combinations come back as 409 INVALID_STATE_TRANSITION; this mapper just
+ * keeps obviously-wrong inputs from reaching the API.
+ */
+function parseStructuredFields(formData: FormData): Partial<ContractTemplateCreateInput> {
+  const categoryRaw = String(formData.get("category") ?? "CUSTOM").trim().toUpperCase();
+  const category = categoryRaw as ServiceOpsContractCategory;
+  if (category !== "SUBSCRIPTION" && category !== "RENTAL" && category !== "CUSTOM") {
+    throw new ContractTemplateCommandPayloadError("Invalid contract template category.");
+  }
+
+  if (category === "SUBSCRIPTION") {
+    return {
+      category: "SUBSCRIPTION",
+      returnType: parseReturnType(formData.get("returnType")),
+      durationUnit: "MONTH",
+      durationValue: 12,
+      includesInsurance: parseIncludesInsurance(formData),
+      defaultInsuranceItemId: parseDefaultInsuranceItemId(formData),
+      durationMinutes: 12 * 30 * 1440
+    };
+  }
+
+  if (category === "RENTAL") {
+    const durationUnit = parseRentalDurationUnit(formData.get("durationUnit"));
+    const durationValue = toPositiveInteger(
+      formData.get("durationValue"),
+      "RENTAL duration value must be a positive integer."
+    );
+    return {
+      category: "RENTAL",
+      returnType: parseReturnType(formData.get("returnType")),
+      durationUnit,
+      durationValue,
+      includesInsurance: parseIncludesInsurance(formData),
+      defaultInsuranceItemId: parseDefaultInsuranceItemId(formData),
+      durationMinutes: estimateRentalDurationMinutes(durationUnit, durationValue)
+    };
+  }
+
+  // CUSTOM
+  return {
+    category: "CUSTOM",
+    durationMinutes: toCustomDurationMinutes(formData)
+  };
+}
+
+function parseReturnType(value: FormDataEntryValue | null): ServiceOpsContractReturnType {
+  const text = String(value ?? "").trim().toUpperCase();
+  if (text === "TAKEOVER" || text === "RETURN") {
+    return text;
+  }
+  throw new ContractTemplateCommandPayloadError("returnType must be TAKEOVER or RETURN.");
+}
+
+function parseRentalDurationUnit(value: FormDataEntryValue | null): ServiceOpsContractDurationUnit {
+  const text = String(value ?? "").trim().toUpperCase() as ServiceOpsContractDurationUnit;
+  if (!RENTAL_UNITS.has(text)) {
+    throw new ContractTemplateCommandPayloadError(
+      "RENTAL duration unit must be DAY/WEEK/MONTH/QUARTER/HALF_YEAR."
+    );
+  }
+  return text;
+}
+
+function parseIncludesInsurance(formData: FormData): boolean {
+  // The HTML <input type="checkbox" value="true"> only submits the field when
+  // checked. Treat absence as `false`.
+  return Boolean(formData.get("includesInsurance"));
+}
+
+function parseDefaultInsuranceItemId(formData: FormData): string | null {
+  if (!parseIncludesInsurance(formData)) {
+    return null;
+  }
+  const text = String(formData.get("defaultInsuranceItemId") ?? "").trim();
+  if (!text) {
+    throw new ContractTemplateCommandPayloadError(
+      "defaultInsuranceItemId is required when includesInsurance is true."
+    );
+  }
+  return text;
+}
+
+function estimateRentalDurationMinutes(
+  unit: ServiceOpsContractDurationUnit,
+  value: number
+): number {
+  const minutesPerUnit: Record<ServiceOpsContractDurationUnit, number> = {
+    DAY: 1440,
+    WEEK: 7 * 1440,
+    MONTH: 30 * 1440,
+    QUARTER: 90 * 1440,
+    HALF_YEAR: 180 * 1440,
+    YEAR: 365 * 1440
+  };
+  return minutesPerUnit[unit] * value;
+}
+
+function toCustomDurationMinutes(formData: FormData): number | null {
+  const mode = String(formData.get("customDurationMode") ?? "limited").trim();
   if (mode === "unlimited") {
     return null;
   }
-
   if (mode !== "limited") {
     throw new ContractTemplateCommandPayloadError("Invalid contract template duration mode.");
   }
 
-  const days = toNonNegativeInteger(formData.get("durationDays"), "Duration days must be a non-negative integer.");
-  const hours = toNonNegativeInteger(formData.get("durationHours"), "Duration hours must be a non-negative integer.");
-  const minutes = toNonNegativeInteger(formData.get("durationMinutesPart"), "Duration minutes must be a non-negative integer.");
-  const total = (days * 1440) + (hours * 60) + minutes;
-
+  const days = toNonNegativeInteger(
+    formData.get("customDurationDays"),
+    "Duration days must be a non-negative integer."
+  );
+  const hours = toNonNegativeInteger(
+    formData.get("customDurationHours"),
+    "Duration hours must be a non-negative integer."
+  );
+  const minutes = toNonNegativeInteger(
+    formData.get("customDurationMinutesPart"),
+    "Duration minutes must be a non-negative integer."
+  );
+  const total = days * 1440 + hours * 60 + minutes;
   if (total <= 0) {
     throw new ContractTemplateCommandPayloadError("Limited contract duration must be greater than zero.");
   }
-
   return total;
+}
+
+function toPositiveInteger(value: FormDataEntryValue | null, message: string): number {
+  const n = toNonNegativeInteger(value, message);
+  if (n <= 0) {
+    throw new ContractTemplateCommandPayloadError(message);
+  }
+  return n;
 }
 
 function toNonNegativeInteger(value: FormDataEntryValue | null, message: string): number {
@@ -52,28 +191,17 @@ function toNonNegativeInteger(value: FormDataEntryValue | null, message: string)
   if (!text) {
     return 0;
   }
-
   if (!/^\d+$/.test(text)) {
     throw new ContractTemplateCommandPayloadError(message);
   }
-
   return Number(text);
 }
 
 function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {
   const text = String(value ?? "").trim().toLowerCase();
-  if (!text) {
-    return fallback;
-  }
-
-  if (["true", "1", "on", "enabled"].includes(text)) {
-    return true;
-  }
-
-  if (["false", "0", "off", "disabled"].includes(text)) {
-    return false;
-  }
-
+  if (!text) return fallback;
+  if (["true", "1", "on", "enabled"].includes(text)) return true;
+  if (["false", "0", "off", "disabled"].includes(text)) return false;
   throw new ContractTemplateCommandPayloadError("Invalid enabled status.");
 }
 
@@ -82,7 +210,6 @@ function requiredText(value: FormDataEntryValue | null, message: string): string
   if (!text) {
     throw new ContractTemplateCommandPayloadError(message);
   }
-
   return text;
 }
 

--- a/development/front-admin-web/lib/services/contract-template-data-core.ts
+++ b/development/front-admin-web/lib/services/contract-template-data-core.ts
@@ -15,14 +15,20 @@ export type ContractTemplateDetailResult = {
 
 export function toFrontendContractTemplate(template: ServiceOpsContractTemplate): ContractTemplate {
   return {
+    category: template.category ?? "CUSTOM",
     createdAt: template.createdAt,
+    defaultInsuranceItemId: template.defaultInsuranceItemId ?? null,
     description: template.description,
     durationLabel: toContractTemplateDurationLabel(template.durationMinutes, template.unlimited),
     durationMinutes: template.durationMinutes,
+    durationUnit: template.durationUnit ?? null,
+    durationValue: template.durationValue ?? null,
     enabled: template.enabled,
     id: template.id,
     idx: template.idx,
+    includesInsurance: template.includesInsurance ?? false,
     name: template.name,
+    returnType: template.returnType ?? null,
     slug: template.id,
     source: "service-ops",
     systemTemplate: template.systemTemplate,

--- a/development/front-admin-web/lib/services/insurance-options-data.ts
+++ b/development/front-admin-web/lib/services/insurance-options-data.ts
@@ -1,0 +1,67 @@
+import {
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+import type { ContractTemplateFormInsuranceOption } from "@/components/contract-templates/ContractTemplateForm";
+
+export type InsuranceOptionsResult = {
+  options: ContractTemplateFormInsuranceOption[];
+  notice?: string;
+};
+
+/**
+ * Loads the active insurance items as a flat option list for the contract
+ * template form's `defaultInsuranceItemId` select. Pages 200 rows on the
+ * assumption that the operator catalog stays small; if the catalog grows
+ * the form should switch to a typeahead.
+ */
+export async function loadInsuranceOptions(): Promise<InsuranceOptionsResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      options: [],
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 보험 항목 목록을 가져올 수 없습니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      options: [],
+      notice: "관리자 세션이 없어 보험 항목 목록을 가져올 수 없습니다."
+    };
+  }
+
+  try {
+    const page = await client.listInsuranceItems({ page: 0, size: 200 });
+    const options = page.items
+      .filter((item) => item.enabled)
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        // \`category\` is optional because the backend only attaches it after
+        // Slice B; older rows fall back to "기타" so the select stays usable.
+        category:
+          (item as { category?: string }).category ??
+          "기타"
+      }));
+    return { options };
+  } catch (error) {
+    return {
+      options: [],
+      notice: `보험 항목 목록 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -171,6 +171,16 @@ export type ServiceOpsBikeOperationStatusHistory = {
   updatedAt: string;
 };
 
+export type ServiceOpsContractCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
+export type ServiceOpsContractReturnType = "TAKEOVER" | "RETURN";
+export type ServiceOpsContractDurationUnit =
+  | "DAY"
+  | "WEEK"
+  | "MONTH"
+  | "QUARTER"
+  | "HALF_YEAR"
+  | "YEAR";
+
 export type ServiceOpsContractTemplate = {
   id: string;
   idx: number | null;
@@ -180,6 +190,12 @@ export type ServiceOpsContractTemplate = {
   description: string | null;
   enabled: boolean;
   systemTemplate: boolean;
+  category?: ServiceOpsContractCategory;
+  returnType?: ServiceOpsContractReturnType | null;
+  durationUnit?: ServiceOpsContractDurationUnit | null;
+  durationValue?: number | null;
+  includesInsurance?: boolean;
+  defaultInsuranceItemId?: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -189,6 +205,12 @@ export type ContractTemplateCreateInput = {
   durationMinutes?: number | null;
   description?: string | null;
   enabled?: boolean | null;
+  category?: ServiceOpsContractCategory;
+  returnType?: ServiceOpsContractReturnType | null;
+  durationUnit?: ServiceOpsContractDurationUnit | null;
+  durationValue?: number | null;
+  includesInsurance?: boolean | null;
+  defaultInsuranceItemId?: string | null;
 };
 
 export type ContractTemplateUpdateInput = {
@@ -196,6 +218,12 @@ export type ContractTemplateUpdateInput = {
   durationMinutes?: number | null;
   description?: string | null;
   enabled?: boolean | null;
+  category?: ServiceOpsContractCategory;
+  returnType?: ServiceOpsContractReturnType | null;
+  durationUnit?: ServiceOpsContractDurationUnit | null;
+  durationValue?: number | null;
+  includesInsurance?: boolean | null;
+  defaultInsuranceItemId?: string | null;
 };
 
 export type ServiceOpsRiderBikeContract = {

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -37,6 +37,16 @@ export type Vehicle = {
 };
 
 
+export type ContractTemplateCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
+export type ContractTemplateReturnType = "TAKEOVER" | "RETURN";
+export type ContractTemplateDurationUnit =
+  | "DAY"
+  | "WEEK"
+  | "MONTH"
+  | "QUARTER"
+  | "HALF_YEAR"
+  | "YEAR";
+
 export type ContractTemplate = {
   slug: string;
   id?: string;
@@ -48,6 +58,12 @@ export type ContractTemplate = {
   description?: string | null;
   enabled: boolean;
   systemTemplate: boolean;
+  category?: ContractTemplateCategory;
+  returnType?: ContractTemplateReturnType | null;
+  durationUnit?: ContractTemplateDurationUnit | null;
+  durationValue?: number | null;
+  includesInsurance?: boolean;
+  defaultInsuranceItemId?: string | null;
   createdAt?: string;
   updatedAt?: string;
   source?: "mock" | "service-ops";


### PR DESCRIPTION
## Summary

- 계약 템플릿 등록/수정 폼이 카테고리(SUBSCRIPTION / RENTAL / CUSTOM) 선택에 따라 동적으로 필드를 렌더링.
- SUBSCRIPTION: 형태(인수형/반납형) + MONTH×12 고정 + 보험 포함 옵션 + 기본 보험 항목 select.
- RENTAL: 형태 + 단위(DAY/WEEK/MONTH/QUARTER/HALF_YEAR) + 양의 정수 값 + 보험 포함 옵션.
- CUSTOM: 기존 일/시간/분 입력 + 무제한 토글 (legacy 호환).
- 클라이언트 mapper 가 백엔드 검증 전에 잘못된 조합(SUBSCRIPTION × DAY, RENTAL × YEAR 등)을 차단.

## Trace

- Target issue: EVNSolution/thundercrew-domain#138
- Change-control issue: EVNSolution/clever-change-control#123
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #119 (Slice A — backend), #121 (Slice B — backend insurance items).

## Scope

Frontend-only.

Included:
- ContractTemplateForm "use client" 변환.
- 카테고리/형태/단위 dynamic UI.
- 보험 아이템 catalog server loader.
- 페이로드 mapper 카테고리별 분기 + 검증.
- 단건 상세 페이지 새 필드 노출.
- contract-template-command-payload.test.mjs 11 케이스로 재작성.

Excluded:
- ADDON 보험 다중 선택 UI.
- 라이더-차량 계약 폼의 자동 보험 발급 결과 표시 (별도 슬라이스).
- 시스템 템플릿 보호 UI 변경.

## Validation

| 항목 | 결과 |
|------|------|
| `npx tsc --noEmit` | ✅ clean |
| `npm run lint` | ✅ clean |
| `npm run test:service-ops` | ✅ 115 / 115 pass |
| `npm run build` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 후 `/contract-templates/new` → 카테고리 SUBSCRIPTION 선택 → 형태/12개월(disabled)/보험 포함 체크박스가 노출되고, 보험 체크 시 select 가 시드 4종 보험으로 채워지는지.
- [ ] RENTAL 카테고리 → 단위 select + 값 입력 노출, YEAR 시도 시 클라이언트에서 차단되거나 백엔드에서 거부.
- [ ] CUSTOM 카테고리 → 기존 일/시간/분 입력 + 무제한 토글이 그대로 동작.
- [ ] 등록 후 `/contract-templates/{id}` 가 카테고리/형태/기간/보험 정보를 정확히 표시.
- [ ] 시스템 템플릿(`무제한 계약`) 수정 시도 시 보호 페이지가 그대로 보임.
- [ ] 백엔드 미구성 / 세션 없음 → 보험 select 가 "사용 가능한 보험 항목 없음" 으로 표시.

## Concurrent work gate

- Decision: `allowed-with-non-overlap`.
- Open target issues at PR open: #138 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- ④-4 — 보험 항목 폼 재설계 (카테고리 / 보장유형 / 기본 기간 입력).
- 라이더-차량 계약 등록 폼이 자동 보험 발급 결과(`autoIssuedRiderInsuranceId` / `autoInsuranceSkipReason`) 를 화면에서 표시.
- Slice F-1 — vendor adapter interface + stub.
