### PR TITLE
Redesign admin web insurance item form for category/coverage/period (#140)

### DIFF
--- a/development/front-admin-web/app/insurance/items/[slug]/edit/page.tsx
+++ b/development/front-admin-web/app/insurance/items/[slug]/edit/page.tsx
@@ -35,7 +35,15 @@ export default async function EditInsuranceItemPage({
       <InsuranceItemForm
         action={updateAction}
         cancelHref={`/insurance/items/${item.slug}`}
-        defaultValues={{ description: item.description, enabled: item.enabled, name: item.name }}
+        defaultValues={{
+          category: item.category,
+          coverageType: item.coverageType ?? null,
+          defaultDurationUnit: item.defaultDurationUnit ?? null,
+          defaultDurationValue: item.defaultDurationValue ?? null,
+          description: item.description,
+          enabled: item.enabled,
+          name: item.name
+        }}
         mode="수정"
         statusMessage={status ? statusMessage[status] : null}
       />

--- a/development/front-admin-web/app/insurance/items/[slug]/page.tsx
+++ b/development/front-admin-web/app/insurance/items/[slug]/page.tsx
@@ -43,6 +43,9 @@ export default async function InsuranceItemDetailPage({
         <div className="card">
           <h2>보험 항목 정보</h2>
           <div className="detail-list">
+            <div className="detail-row"><span>카테고리</span><strong>{categoryLabel(item.category)}</strong></div>
+            <div className="detail-row"><span>보장유형</span><strong>{coverageLabel(item.coverageType)}</strong></div>
+            <div className="detail-row"><span>기본 기간</span><strong>{durationLabel(item.defaultDurationUnit, item.defaultDurationValue)}</strong></div>
             <div className="detail-row"><span>사용 상태</span><Badge tone={item.enabled ? "active" : "muted"}>{item.enabled ? "사용" : "비활성"}</Badge></div>
             <div className="detail-row"><span>설명</span><strong>{item.description ?? "없음"}</strong></div>
             {item.createdAt ? <div className="detail-row"><span>생성일시</span><strong>{item.createdAt}</strong></div> : null}
@@ -66,4 +69,46 @@ export default async function InsuranceItemDetailPage({
       </section>
     </div>
   );
+}
+
+function categoryLabel(category: string | undefined): string {
+  switch (category) {
+    case "PRIMARY":
+      return "메인 (12개월)";
+    case "ADDON":
+      return "부가 (시간제/원데이)";
+    default:
+      return "—";
+  }
+}
+
+function coverageLabel(coverageType: string | null | undefined): string {
+  switch (coverageType) {
+    case "GENERAL_PAID_TRANSPORT":
+      return "유상운송종합보험";
+    case "LIABILITY_PAID_TRANSPORT":
+      return "유상운송책임보험";
+    case "HOURLY":
+      return "시간제 보험";
+    case "ONE_DAY":
+      return "원데이 보험";
+    case "OTHER":
+      return "기타";
+    default:
+      return "—";
+  }
+}
+
+function durationLabel(unit: string | null | undefined, value: number | null | undefined): string {
+  if (!unit || value == null) return "—";
+  const unitMap: Record<string, string> = {
+    HOUR: "시간",
+    DAY: "일",
+    WEEK: "주",
+    MONTH: "개월",
+    QUARTER: "분기",
+    HALF_YEAR: "반기",
+    YEAR: "년"
+  };
+  return `${value} ${unitMap[unit] ?? unit}`;
 }

--- a/development/front-admin-web/components/insurance-items/InsuranceItemForm.tsx
+++ b/development/front-admin-web/components/insurance-items/InsuranceItemForm.tsx
@@ -6,17 +6,71 @@ import type { InsuranceItem } from "@/types/domain";
 type InsuranceItemFormProps = {
   action: (formData: FormData) => void | Promise<void>;
   cancelHref?: string;
-  defaultValues?: Partial<Pick<InsuranceItem, "description" | "enabled" | "name">>;
+  defaultValues?: Partial<
+    Pick<
+      InsuranceItem,
+      | "category"
+      | "coverageType"
+      | "defaultDurationUnit"
+      | "defaultDurationValue"
+      | "description"
+      | "enabled"
+      | "name"
+    >
+  >;
   mode?: "등록" | "수정";
   statusMessage?: string | null;
 };
 
-export function InsuranceItemForm({ action, cancelHref = "/insurance/items", defaultValues, mode = "등록", statusMessage }: InsuranceItemFormProps) {
+const CATEGORY_OPTIONS: { value: "PRIMARY" | "ADDON"; label: string; hint: string }[] = [
+  { value: "PRIMARY", label: "메인 (12개월)", hint: "유상운송 종합/책임 — 12개월 단위 메인 보험." },
+  { value: "ADDON", label: "부가 (시간제/원데이)", hint: "시간 단위 또는 하루 단위 부가 보험." }
+];
+
+const COVERAGE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "지정 안 함" },
+  { value: "GENERAL_PAID_TRANSPORT", label: "유상운송종합보험" },
+  { value: "LIABILITY_PAID_TRANSPORT", label: "유상운송책임보험" },
+  { value: "HOURLY", label: "시간제 보험" },
+  { value: "ONE_DAY", label: "원데이 보험" },
+  { value: "OTHER", label: "기타" }
+];
+
+const DURATION_UNIT_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "지정 안 함" },
+  { value: "HOUR", label: "시간" },
+  { value: "DAY", label: "일" },
+  { value: "WEEK", label: "주" },
+  { value: "MONTH", label: "개월" },
+  { value: "QUARTER", label: "분기" },
+  { value: "HALF_YEAR", label: "반기" },
+  { value: "YEAR", label: "년" }
+];
+
+export function InsuranceItemForm({
+  action,
+  cancelHref = "/insurance/items",
+  defaultValues,
+  mode = "등록",
+  statusMessage
+}: InsuranceItemFormProps) {
+  const category = defaultValues?.category ?? "PRIMARY";
+  const coverageType = defaultValues?.coverageType ?? "";
+  const durationUnit = defaultValues?.defaultDurationUnit ?? "";
+  const durationValue = defaultValues?.defaultDurationValue ?? "";
+
   return (
     <form action={action} className="card" aria-label={`보험 항목 ${mode} 폼`}>
       <div className="form-grid">
         <Field label="보험 항목명">
-          <input className="input" defaultValue={defaultValues?.name ?? ""} maxLength={100} name="name" placeholder="예: 라이더 기본 보험" required />
+          <input
+            className="input"
+            defaultValue={defaultValues?.name ?? ""}
+            maxLength={100}
+            name="name"
+            placeholder="예: 유상운송종합보험"
+            required
+          />
         </Field>
         <Field label="사용 상태">
           <select className="select" defaultValue={String(defaultValues?.enabled ?? true)} name="enabled">
@@ -24,10 +78,57 @@ export function InsuranceItemForm({ action, cancelHref = "/insurance/items", def
             <option value="false">비활성</option>
           </select>
         </Field>
+        <Field label="카테고리" hint={CATEGORY_OPTIONS.find((option) => option.value === category)?.hint}>
+          <select className="select" defaultValue={category} name="category">
+            {CATEGORY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="보장유형">
+          <select className="select" defaultValue={coverageType ?? ""} name="coverageType">
+            {COVERAGE_OPTIONS.map((option) => (
+              <option key={option.value || "empty"} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="기본 기간 단위" hint="단위와 값은 함께 입력합니다.">
+          <select className="select" defaultValue={durationUnit ?? ""} name="defaultDurationUnit">
+            {DURATION_UNIT_OPTIONS.map((option) => (
+              <option key={option.value || "empty"} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="기본 기간 값">
+          <input
+            className="input"
+            defaultValue={durationValue === null || durationValue === undefined ? "" : durationValue}
+            min={1}
+            name="defaultDurationValue"
+            placeholder="예: 12"
+            type="number"
+          />
+        </Field>
       </div>
       <br />
-      <Field label="설명"><textarea className="input" defaultValue={defaultValues?.description ?? ""} name="description" placeholder="운영자가 구분할 수 있는 보험 항목 설명" rows={3} /></Field>
-      <p className="notice" style={{ marginTop: 16 }}>보험 항목 ID는 DB가 자동 생성합니다. 라이더와의 연결은 보험 등록 화면에서 이름 기준 선택 UI로 처리합니다.</p>
+      <Field label="설명">
+        <textarea
+          className="input"
+          defaultValue={defaultValues?.description ?? ""}
+          name="description"
+          placeholder="운영자가 구분할 수 있는 보험 항목 설명"
+          rows={3}
+        />
+      </Field>
+      <p className="notice" style={{ marginTop: 16 }}>
+        보험 항목 ID는 DB가 자동 생성합니다. 카테고리(메인/부가)와 보장유형은 라이더-보험 폼에서 선택지로 노출됩니다.
+      </p>
       {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
       <div className="form-actions">
         <Link className="button-secondary" href={cancelHref}>취소</Link>

--- a/development/front-admin-web/lib/services/insurance-item-command-payload.test.mjs
+++ b/development/front-admin-web/lib/services/insurance-item-command-payload.test.mjs
@@ -63,3 +63,87 @@ test("insurance item payloads reject blank name and invalid enabled value", () =
   formData.set("enabled", "maybe");
   assert.throws(() => toInsuranceItemUpdatePayload(formData), InsuranceItemCommandPayloadError);
 });
+
+// New Slice ④-4 fields — category, coverageType, defaultDurationUnit/Value.
+
+test("insurance item payload includes category/coverage/duration when provided together", () => {
+  const formData = new FormData();
+  formData.set("name", "유상운송종합보험");
+  formData.set("description", "메인 보험");
+  formData.set("enabled", "true");
+  formData.set("category", "PRIMARY");
+  formData.set("coverageType", "GENERAL_PAID_TRANSPORT");
+  formData.set("defaultDurationUnit", "MONTH");
+  formData.set("defaultDurationValue", "12");
+
+  assert.deepEqual(toInsuranceItemCreatePayload(formData), {
+    name: "유상운송종합보험",
+    description: "메인 보험",
+    enabled: true,
+    category: "PRIMARY",
+    coverageType: "GENERAL_PAID_TRANSPORT",
+    defaultDurationUnit: "MONTH",
+    defaultDurationValue: 12
+  });
+});
+
+test("insurance item payload omits classification fields when none supplied", () => {
+  const formData = new FormData();
+  formData.set("name", "라이더 기본 보험");
+  formData.set("description", "");
+  formData.set("enabled", "true");
+  // No category / coverageType / duration fields → partial stays empty so the
+  // legacy create payload shape is preserved.
+
+  assert.deepEqual(toInsuranceItemCreatePayload(formData), {
+    name: "라이더 기본 보험",
+    description: null,
+    enabled: true
+  });
+});
+
+test("insurance item payload rejects half-supplied default duration", () => {
+  const formData = new FormData();
+  formData.set("name", "잘못된 기본 기간");
+  formData.set("enabled", "true");
+  formData.set("category", "ADDON");
+  formData.set("coverageType", "HOURLY");
+  formData.set("defaultDurationUnit", "HOUR");
+  // defaultDurationValue intentionally missing → should throw.
+
+  assert.throws(() => toInsuranceItemCreatePayload(formData), InsuranceItemCommandPayloadError);
+});
+
+test("insurance item payload rejects unknown category, coverage type, or duration unit", () => {
+  const cases = [
+    { field: "category", value: "BOGUS" },
+    { field: "coverageType", value: "BOGUS_TYPE" },
+    { field: "defaultDurationUnit", value: "DECADE" }
+  ];
+
+  for (const { field, value } of cases) {
+    const formData = new FormData();
+    formData.set("name", "유효한 이름");
+    formData.set("enabled", "true");
+    formData.set(field, value);
+    if (field === "defaultDurationUnit") {
+      formData.set("defaultDurationValue", "1");
+    }
+    assert.throws(
+      () => toInsuranceItemCreatePayload(formData),
+      InsuranceItemCommandPayloadError,
+      `${field}=${value} should be rejected`
+    );
+  }
+});
+
+test("insurance item payload rejects zero or non-positive default duration value", () => {
+  const formData = new FormData();
+  formData.set("name", "유효한 이름");
+  formData.set("enabled", "true");
+  formData.set("category", "ADDON");
+  formData.set("defaultDurationUnit", "DAY");
+  formData.set("defaultDurationValue", "0");
+
+  assert.throws(() => toInsuranceItemCreatePayload(formData), InsuranceItemCommandPayloadError);
+});

--- a/development/front-admin-web/lib/services/insurance-item-command-payload.ts
+++ b/development/front-admin-web/lib/services/insurance-item-command-payload.ts
@@ -1,4 +1,10 @@
-import type { InsuranceItemCreateInput, InsuranceItemUpdateInput } from "./service-ops-api";
+import type {
+  InsuranceItemCreateInput,
+  InsuranceItemUpdateInput,
+  ServiceOpsInsuranceCategory,
+  ServiceOpsInsuranceCoverageType,
+  ServiceOpsInsuranceDurationUnit
+} from "./service-ops-api";
 
 export class InsuranceItemCommandPayloadError extends Error {
   constructor(message: string) {
@@ -7,20 +13,97 @@ export class InsuranceItemCommandPayloadError extends Error {
   }
 }
 
+const COVERAGE_VALUES: ReadonlySet<ServiceOpsInsuranceCoverageType> = new Set([
+  "GENERAL_PAID_TRANSPORT",
+  "LIABILITY_PAID_TRANSPORT",
+  "HOURLY",
+  "ONE_DAY",
+  "OTHER"
+]);
+
+const DURATION_UNIT_VALUES: ReadonlySet<ServiceOpsInsuranceDurationUnit> = new Set([
+  "HOUR",
+  "DAY",
+  "WEEK",
+  "MONTH",
+  "QUARTER",
+  "HALF_YEAR",
+  "YEAR"
+]);
+
 export function toInsuranceItemCreatePayload(formData: FormData): InsuranceItemCreateInput {
   return {
+    name: requiredText(formData.get("name"), "Insurance item name is required."),
     description: optionalText(formData.get("description")),
     enabled: toEnabled(formData.get("enabled"), true),
-    name: requiredText(formData.get("name"), "Insurance item name is required.")
+    ...parseClassificationFields(formData)
   };
 }
 
 export function toInsuranceItemUpdatePayload(formData: FormData): InsuranceItemUpdateInput {
   return {
+    name: requiredText(formData.get("name"), "Insurance item name is required."),
     description: clearableText(formData.get("description")),
     enabled: toEnabled(formData.get("enabled"), true),
-    name: requiredText(formData.get("name"), "Insurance item name is required.")
+    ...parseClassificationFields(formData)
   };
+}
+
+/**
+ * Parse the new Slice B fields. Each field is optional individually, but
+ * `defaultDurationUnit` and `defaultDurationValue` must come together — the
+ * backend service-layer rule (\\`InsuranceItemCommandService\\`) enforces the
+ * same invariant. Returning a partial object lets the legacy create payload
+ * (name + description + enabled only) keep flowing untouched.
+ */
+function parseClassificationFields(formData: FormData): Partial<InsuranceItemCreateInput> {
+  const partial: Partial<InsuranceItemCreateInput> = {};
+
+  const categoryRaw = String(formData.get("category") ?? "").trim().toUpperCase();
+  if (categoryRaw) {
+    if (categoryRaw !== "PRIMARY" && categoryRaw !== "ADDON") {
+      throw new InsuranceItemCommandPayloadError("Invalid insurance category.");
+    }
+    partial.category = categoryRaw as ServiceOpsInsuranceCategory;
+  }
+
+  const coverageRaw = String(formData.get("coverageType") ?? "").trim().toUpperCase();
+  if (coverageRaw) {
+    if (!COVERAGE_VALUES.has(coverageRaw as ServiceOpsInsuranceCoverageType)) {
+      throw new InsuranceItemCommandPayloadError("Invalid insurance coverage type.");
+    }
+    partial.coverageType = coverageRaw as ServiceOpsInsuranceCoverageType;
+  }
+
+  const durationUnitRaw = String(formData.get("defaultDurationUnit") ?? "").trim().toUpperCase();
+  const durationValueRaw = String(formData.get("defaultDurationValue") ?? "").trim();
+  const hasUnit = durationUnitRaw.length > 0;
+  const hasValue = durationValueRaw.length > 0;
+
+  if (hasUnit !== hasValue) {
+    throw new InsuranceItemCommandPayloadError(
+      "defaultDurationUnit and defaultDurationValue must be supplied together."
+    );
+  }
+
+  if (hasUnit) {
+    if (!DURATION_UNIT_VALUES.has(durationUnitRaw as ServiceOpsInsuranceDurationUnit)) {
+      throw new InsuranceItemCommandPayloadError("Invalid insurance duration unit.");
+    }
+    if (!/^\d+$/.test(durationValueRaw)) {
+      throw new InsuranceItemCommandPayloadError(
+        "defaultDurationValue must be a non-negative integer."
+      );
+    }
+    const value = Number(durationValueRaw);
+    if (value <= 0) {
+      throw new InsuranceItemCommandPayloadError("defaultDurationValue must be greater than zero.");
+    }
+    partial.defaultDurationUnit = durationUnitRaw as ServiceOpsInsuranceDurationUnit;
+    partial.defaultDurationValue = value;
+  }
+
+  return partial;
 }
 
 function toEnabled(value: FormDataEntryValue | null, fallback: boolean): boolean {

--- a/development/front-admin-web/lib/services/insurance-item-data-core.ts
+++ b/development/front-admin-web/lib/services/insurance-item-data-core.ts
@@ -15,7 +15,11 @@ export type InsuranceItemDetailResult = {
 
 export function toFrontendInsuranceItem(item: ServiceOpsInsuranceItem): InsuranceItem {
   return {
+    category: item.category ?? "PRIMARY",
+    coverageType: item.coverageType ?? null,
     createdAt: item.createdAt,
+    defaultDurationUnit: item.defaultDurationUnit ?? null,
+    defaultDurationValue: item.defaultDurationValue ?? null,
     description: item.description,
     enabled: item.enabled,
     id: item.id,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -258,12 +258,32 @@ export type RiderBikeContractTerminateInput = {
   terminatedReason?: string | null;
 };
 
+export type ServiceOpsInsuranceCategory = "PRIMARY" | "ADDON";
+export type ServiceOpsInsuranceCoverageType =
+  | "GENERAL_PAID_TRANSPORT"
+  | "LIABILITY_PAID_TRANSPORT"
+  | "HOURLY"
+  | "ONE_DAY"
+  | "OTHER";
+export type ServiceOpsInsuranceDurationUnit =
+  | "HOUR"
+  | "DAY"
+  | "WEEK"
+  | "MONTH"
+  | "QUARTER"
+  | "HALF_YEAR"
+  | "YEAR";
+
 export type ServiceOpsInsuranceItem = {
   id: string;
   idx: number | null;
   name: string;
   description: string | null;
   enabled: boolean;
+  category?: ServiceOpsInsuranceCategory;
+  coverageType?: ServiceOpsInsuranceCoverageType | null;
+  defaultDurationUnit?: ServiceOpsInsuranceDurationUnit | null;
+  defaultDurationValue?: number | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -272,12 +292,20 @@ export type InsuranceItemCreateInput = {
   name: string;
   description?: string | null;
   enabled?: boolean | null;
+  category?: ServiceOpsInsuranceCategory;
+  coverageType?: ServiceOpsInsuranceCoverageType | null;
+  defaultDurationUnit?: ServiceOpsInsuranceDurationUnit | null;
+  defaultDurationValue?: number | null;
 };
 
 export type InsuranceItemUpdateInput = {
   name?: string | null;
   description?: string | null;
   enabled?: boolean | null;
+  category?: ServiceOpsInsuranceCategory;
+  coverageType?: ServiceOpsInsuranceCoverageType | null;
+  defaultDurationUnit?: ServiceOpsInsuranceDurationUnit | null;
+  defaultDurationValue?: number | null;
 };
 
 export type ServiceOpsRiderInsurance = {

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -96,6 +96,22 @@ export type RiderContract = {
 };
 
 
+export type InsuranceItemCategory = "PRIMARY" | "ADDON";
+export type InsuranceItemCoverageType =
+  | "GENERAL_PAID_TRANSPORT"
+  | "LIABILITY_PAID_TRANSPORT"
+  | "HOURLY"
+  | "ONE_DAY"
+  | "OTHER";
+export type InsuranceItemDurationUnit =
+  | "HOUR"
+  | "DAY"
+  | "WEEK"
+  | "MONTH"
+  | "QUARTER"
+  | "HALF_YEAR"
+  | "YEAR";
+
 export type InsuranceItem = {
   slug: string;
   id?: string;
@@ -103,6 +119,10 @@ export type InsuranceItem = {
   name: string;
   description?: string | null;
   enabled: boolean;
+  category?: InsuranceItemCategory;
+  coverageType?: InsuranceItemCoverageType | null;
+  defaultDurationUnit?: InsuranceItemDurationUnit | null;
+  defaultDurationValue?: number | null;
   createdAt?: string;
   updatedAt?: string;
   source?: "mock" | "service-ops";


### PR DESCRIPTION
## Summary

- 보험 항목 등록/수정 폼이 카테고리(PRIMARY / ADDON), 보장유형(유상운송종합 / 책임 / 시간제 / 원데이 / 기타), 기본 기간 단위·값 입력에 맞춰 재설계.
- 단위와 값은 함께 입력해야 하고 (한쪽만 있으면 거부), 카테고리 / 보장유형은 명시적 enum 값만 허용 (백엔드 검증 전에 클라이언트 단에서 차단).
- 단건 상세 페이지가 카테고리 / 보장유형 / 기본 기간 row 노출.
- 기존 legacy 페이로드 (name/description/enabled 만) 도 그대로 동작.

## Trace

- Target issue: EVNSolution/thundercrew-domain#140
- Change-control issue: EVNSolution/clever-change-control#124
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #121 (Slice B — backend insurance category/coverage/period).

## Scope

Frontend-only.

Included:
- ServiceOpsInsuranceItem / 입력 타입 + frontend domain 타입 확장.
- InsuranceItemForm 재설계.
- payload mapper 카테고리/보장유형/기본 기간 처리.
- 단건 상세 새 row.
- insurance-item-command-payload.test.mjs 5 신규 케이스.

Excluded:
- 라이더-보험 폼 자체 변경 (별도 슬라이스).
- ADDON 다중 발급 정책 변경.

## Validation

| 항목 | 결과 |
|------|------|
| `npx tsc --noEmit` | ✅ clean |
| `npm run lint` | ✅ clean |
| `npm run test:service-ops` | ✅ 120 / 120 pass |
| `npm run build` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 후 `/insurance/items/new` → 카테고리·보장유형·기본 기간 입력 후 등록 → 상세 페이지가 모든 새 필드를 정확히 표시.
- [ ] 단위만 입력하고 값 비우면 클라이언트 mapper 가 거부 → save-error 페이지로 리다이렉트.
- [ ] 카테고리 select 에 PRIMARY / ADDON 두 옵션이 노출되고, 보장유형 select 에 5종 + "지정 안 함" 옵션 노출.
- [ ] 기존 보험 항목 (시드 4종 포함) 수정 페이지가 카테고리/보장유형/기본 기간이 미리 채워진 상태로 열림.
- [ ] 백엔드 미구성 시 form 자체는 동작 (mock-saved 흐름).

## Concurrent work gate

- Decision: `allowed-with-non-overlap`.
- Open target issues at PR open: #140 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- ④-5 — 라이더-차량 계약 등록 폼이 자동 보험 발급 결과(`autoIssuedRiderInsuranceId` / `autoInsuranceSkipReason`) 화면 표시.
- 보너스 — 충전소 디테일 패널 (마커 클릭 → 충전소 상세).
- Slice F-1 — vendor adapter interface + stub.
