### PR TITLE
Surface auto-issued insurance result on rider-bike contract create (#142)

### DIFF
--- a/development/front-admin-web/app/contracts/[slug]/page.tsx
+++ b/development/front-admin-web/app/contracts/[slug]/page.tsx
@@ -23,9 +23,14 @@ export default async function ContractDetailPage({
   searchParams
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{
+    status?: string;
+    autoInsurance?: string;
+    autoInsuranceId?: string;
+    autoInsuranceSkipReason?: string;
+  }>;
 }) {
-  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const [{ slug }, sp] = await Promise.all([params, searchParams]);
   const detail = await loadContractDetail(slug);
 
   if (!detail) {
@@ -33,7 +38,12 @@ export default async function ContractDetailPage({
   }
 
   const contract = detail.contract;
-  const message = status ? statusMessage[status] : null;
+  const message = sp.status ? statusMessage[sp.status] : null;
+  const autoInsuranceFlash = formatAutoInsuranceFlash(
+    sp.autoInsurance,
+    sp.autoInsuranceId,
+    sp.autoInsuranceSkipReason
+  );
   const memoAction = updateContractMemoAction.bind(null, slug);
   const terminateAction = terminateContractAction.bind(null, slug);
 
@@ -42,6 +52,9 @@ export default async function ContractDetailPage({
       <BackToListLink href="/contracts" />
       <PageHeader title={contract.contractType} description={`${contract.riderName} 계약 상세`} />
       {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      {autoInsuranceFlash ? (
+        <p className="action-feedback" role="status">{autoInsuranceFlash}</p>
+      ) : null}
       {detail.notice ? <p className="notice">{detail.notice}</p> : null}
       <section className="content-grid">
         <div className="card">
@@ -54,6 +67,12 @@ export default async function ContractDetailPage({
             <div className="detail-row"><span>상태</span><Badge>{contract.status}</Badge></div>
             <div className="detail-row"><span>구역</span><strong>{contract.area}</strong></div>
             {contract.memo ? <div className="detail-row"><span>메모</span><strong>{contract.memo}</strong></div> : null}
+            {contract.autoIssuedRiderInsuranceId ? (
+              <div className="detail-row"><span>자동 발급 보험 ID</span><strong>{contract.autoIssuedRiderInsuranceId}</strong></div>
+            ) : null}
+            {contract.autoInsuranceSkipReason ? (
+              <div className="detail-row"><span>자동 보험 미발급 사유</span><strong>{autoInsuranceSkipLabel(contract.autoInsuranceSkipReason)}</strong></div>
+            ) : null}
             {contract.terminatedAt ? <div className="detail-row"><span>종료일시</span><strong>{contract.terminatedAt}</strong></div> : null}
             {contract.terminatedReason ? <div className="detail-row"><span>종료 사유</span><strong>{contract.terminatedReason}</strong></div> : null}
           </div>
@@ -87,4 +106,39 @@ export default async function ContractDetailPage({
       </section>
     </div>
   );
+}
+
+function autoInsuranceSkipLabel(reason: string): string {
+  switch (reason) {
+    case "TEMPLATE_NOT_OPTED_IN":
+      return "계약 양식에서 자동 보험을 선택하지 않음";
+    case "DEFAULT_INSURANCE_ITEM_MISSING":
+      return "계약 양식에 기본 보험 항목이 지정되지 않음";
+    case "DEFAULT_INSURANCE_ITEM_NOT_FOUND":
+      return "기본 보험 항목을 찾을 수 없음";
+    case "DEFAULT_INSURANCE_ITEM_DELETED":
+      return "기본 보험 항목이 삭제됨";
+    case "DEFAULT_INSURANCE_ITEM_DISABLED":
+      return "기본 보험 항목이 비활성 상태";
+    case "RIDER_INSURANCE_ALREADY_LINKED":
+      return "라이더가 동일 보험 항목에 이미 연결되어 있어 추가 발급 안 됨";
+    case "RIDER_INSURANCE_DUPLICATE_ON_INSERT":
+      return "동시 등록과의 중복으로 추가 발급 안 됨";
+    default:
+      return reason;
+  }
+}
+
+function formatAutoInsuranceFlash(
+  outcome: string | undefined,
+  autoInsuranceId: string | undefined,
+  skipReason: string | undefined
+): string | null {
+  if (outcome === "issued" && autoInsuranceId) {
+    return `자동 보험 발급됨 — RiderInsurance ID ${autoInsuranceId}.`;
+  }
+  if (outcome === "skip" && skipReason) {
+    return `자동 보험 발급 SKIP — ${autoInsuranceSkipLabel(skipReason)}.`;
+  }
+  return null;
 }

--- a/development/front-admin-web/app/contracts/actions.ts
+++ b/development/front-admin-web/app/contracts/actions.ts
@@ -29,7 +29,27 @@ export async function createContractAction(formData: FormData): Promise<void> {
   }
 
   revalidatePath("/contracts");
-  redirect(`/contracts/${contract.id}?status=created`);
+  redirect(`/contracts/${contract.id}?${createdRedirectQuery(contract).toString()}`);
+}
+
+/**
+ * Build the redirect query for the post-create flash banner. Surfaces the
+ * Slice D auto-issuance outcome so the operator immediately sees whether
+ * the package's bundled insurance was issued, skipped, or never opted in.
+ */
+function createdRedirectQuery(
+  contract: { autoIssuedRiderInsuranceId?: string | null; autoInsuranceSkipReason?: string | null }
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("status", "created");
+  if (contract.autoIssuedRiderInsuranceId) {
+    params.set("autoInsurance", "issued");
+    params.set("autoInsuranceId", contract.autoIssuedRiderInsuranceId);
+  } else if (contract.autoInsuranceSkipReason) {
+    params.set("autoInsurance", "skip");
+    params.set("autoInsuranceSkipReason", contract.autoInsuranceSkipReason);
+  }
+  return params;
 }
 
 export async function updateContractMemoAction(contractId: string, formData: FormData): Promise<void> {

--- a/development/front-admin-web/lib/services/contract-data-core.ts
+++ b/development/front-admin-web/lib/services/contract-data-core.ts
@@ -39,6 +39,8 @@ export function toFrontendContract(
 
   return {
     area: rider?.area ?? "미지정",
+    autoInsuranceSkipReason: contract.autoInsuranceSkipReason ?? null,
+    autoIssuedRiderInsuranceId: contract.autoIssuedRiderInsuranceId ?? null,
     bikeId: contract.bikeId,
     bikeLabel,
     contractTemplateId: contract.contractTemplateId,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -226,6 +226,15 @@ export type ContractTemplateUpdateInput = {
   defaultInsuranceItemId?: string | null;
 };
 
+export type ServiceOpsAutoInsuranceSkipReason =
+  | "TEMPLATE_NOT_OPTED_IN"
+  | "DEFAULT_INSURANCE_ITEM_MISSING"
+  | "DEFAULT_INSURANCE_ITEM_NOT_FOUND"
+  | "DEFAULT_INSURANCE_ITEM_DELETED"
+  | "DEFAULT_INSURANCE_ITEM_DISABLED"
+  | "RIDER_INSURANCE_ALREADY_LINKED"
+  | "RIDER_INSURANCE_DUPLICATE_ON_INSERT";
+
 export type ServiceOpsRiderBikeContract = {
   id: string;
   idx: number | null;
@@ -237,6 +246,15 @@ export type ServiceOpsRiderBikeContract = {
   terminatedAt: string | null;
   terminatedReason: string | null;
   memo: string | null;
+  /**
+   * Slice D: id of the rider_insurance row that the backend auto-issued from
+   * the contract template's `default_insurance_item_id`. Stays {@code null}
+   * for legacy contracts and for any code path that opted out / skipped the
+   * issuance via {@link autoInsuranceSkipReason}.
+   */
+  autoIssuedRiderInsuranceId?: string | null;
+  /** Slice D: short SKIP token explaining why automatic issuance did not run. */
+  autoInsuranceSkipReason?: ServiceOpsAutoInsuranceSkipReason | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/development/front-admin-web/types/domain.ts
+++ b/development/front-admin-web/types/domain.ts
@@ -90,10 +90,21 @@ export type RiderContract = {
   terminatedAt?: string | null;
   terminatedReason?: string | null;
   memo?: string | null;
+  autoIssuedRiderInsuranceId?: string | null;
+  autoInsuranceSkipReason?: AutoInsuranceSkipReason | null;
   createdAt?: string;
   updatedAt?: string;
   source?: "mock" | "service-ops";
 };
+
+export type AutoInsuranceSkipReason =
+  | "TEMPLATE_NOT_OPTED_IN"
+  | "DEFAULT_INSURANCE_ITEM_MISSING"
+  | "DEFAULT_INSURANCE_ITEM_NOT_FOUND"
+  | "DEFAULT_INSURANCE_ITEM_DELETED"
+  | "DEFAULT_INSURANCE_ITEM_DISABLED"
+  | "RIDER_INSURANCE_ALREADY_LINKED"
+  | "RIDER_INSURANCE_DUPLICATE_ON_INSERT";
 
 
 export type InsuranceItemCategory = "PRIMARY" | "ADDON";


### PR DESCRIPTION
## Summary

- 라이더-차량 계약 등록 후 어드민 화면이 백엔드(Slice D)의 자동 보험 발급 결과(`autoIssuedRiderInsuranceId` / `autoInsuranceSkipReason`)를 즉시 표시.
- 등록 후 redirect 시 query param 으로 결과 전달 → 계약 상세 페이지 상단 flash 배너.
- 계약 상세 페이지의 정보 카드에도 자동 발급 보험 ID / 미발급 사유 row 노출 (등록 후 시점이 지나도 확인 가능).
- 7개 SKIP 토큰별 한글 안내 메시지.

## Trace

- Target issue: EVNSolution/thundercrew-domain#142
- Change-control issue: EVNSolution/clever-change-control#125
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #131 (Slice D — backend auto insurance issuance).

## Scope

Frontend-only.

Included:
- 응답 타입 + 도메인 타입 + 매핑 함수 확장.
- createContractAction redirect query 처리.
- 계약 상세 페이지 flash + info row.
- 7 SKIP 토큰별 한글 매핑.

Excluded:
- 자동 발급된 보험을 별도 화면에서 편집/해지 (이미 라이더-보험 흐름으로 가능).
- 계약 종료 시 자동 보험 해지 (별도 슬라이스).

## SKIP 토큰 매핑

| 토큰 | 한글 메시지 |
|------|-------------|
| TEMPLATE_NOT_OPTED_IN | 계약 양식에서 자동 보험을 선택하지 않음 |
| DEFAULT_INSURANCE_ITEM_MISSING | 계약 양식에 기본 보험 항목이 지정되지 않음 |
| DEFAULT_INSURANCE_ITEM_NOT_FOUND | 기본 보험 항목을 찾을 수 없음 |
| DEFAULT_INSURANCE_ITEM_DELETED | 기본 보험 항목이 삭제됨 |
| DEFAULT_INSURANCE_ITEM_DISABLED | 기본 보험 항목이 비활성 상태 |
| RIDER_INSURANCE_ALREADY_LINKED | 라이더가 동일 보험 항목에 이미 연결되어 있어 추가 발급 안 됨 |
| RIDER_INSURANCE_DUPLICATE_ON_INSERT | 동시 등록과의 중복으로 추가 발급 안 됨 |

## Validation

| 항목 | 결과 |
|------|------|
| `npx tsc --noEmit` | ✅ clean |
| `npm run lint` | ✅ clean |
| `npm run test:service-ops` | ✅ 120 / 120 pass |
| `npm run build` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 + 어드민 로그인 후 SUBSCRIPTION 템플릿 (보험 포함, default_insurance_item_id 채워짐) 으로 계약 등록 → 상세 페이지에 "자동 보험 발급됨 — RiderInsurance ID …" 플래시 + 정보 카드에 ID row 노출.
- [ ] CUSTOM 또는 보험 미포함 템플릿으로 등록 → "자동 보험 발급 SKIP — 계약 양식에서 자동 보험을 선택하지 않음" 플래시 + 정보 카드에 미발급 사유 row 노출.
- [ ] 같은 라이더-아이템 활성 행이 이미 있는 상태에서 동일 템플릿으로 두 번째 계약 등록 → "RIDER_INSURANCE_ALREADY_LINKED" 매핑 메시지 노출.
- [ ] 계약 단건 상세 페이지 새로고침 시에도 자동 발급/미발급 row 가 그대로 보임 (백엔드 상세 응답 기반).
- [ ] 백엔드 미구성 / 세션 없음 → 기존 mock-saved 흐름 그대로.

## Concurrent work gate

- Decision: `allowed-with-non-overlap`.
- Open target issues at PR open: #142 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 ④-3·④-4·④-5 어드민 폼 재설계 묶음이 끝납니다. 백엔드 Slice A·B·C·D 가 어드민 UI 와 모두 끝-단까지 연결됨.

다음 추천 후속:

- ⑤ — Slice F-1 (vendor adapter interface + stub).
- 충전소 디테일 패널 (마커 클릭 → 충전소 상세).
- 라이더 등록/수정 폼에 교육 입력 통합 (현재 별도 페이지에서 등록).
