### PR TITLE
Add vendor telemetry adapter interface, stub, and disabled scheduler (#144)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/StubVendorTelemetryFeed.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/StubVendorTelemetryFeed.java
@@ -1,0 +1,55 @@
+package com.thundercrew.opsapi.vendor;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link VendorTelemetryFeed}. Always returns an empty result so the
+ * polling skeleton can ship before real vendor documentation is available;
+ * runtime sees the scheduler call this stub, log "0 events", and move on.
+ *
+ * <p>Activated when the application uses the default
+ * {@code thundercrew.vendor-telemetry.feed-implementation=stub} property
+ * and no other {@link VendorTelemetryFeed} bean is registered. A real
+ * vendor implementation will register itself with a different qualifying
+ * property so this stub is bypassed in production.</p>
+ */
+@Component
+@ConditionalOnMissingBean(VendorTelemetryFeed.class)
+@ConditionalOnProperty(
+        prefix = "thundercrew.vendor-telemetry",
+        name = "feed-implementation",
+        havingValue = "stub",
+        matchIfMissing = true)
+public class StubVendorTelemetryFeed implements VendorTelemetryFeed {
+
+    private final AtomicLong invocationCount = new AtomicLong();
+
+    @Override
+    public VendorTelemetryFetchResult pullRecent(Instant since) {
+        invocationCount.incrementAndGet();
+        // Stub does not advance the cursor — operators should see "no
+        // progress yet" until the real feed is wired in. Returning {@code
+        // since} unchanged keeps the scheduler's cursor handling code
+        // exercised in tests.
+        return VendorTelemetryFetchResult.empty(since);
+    }
+
+    /** Inspect how many times the stub has been called — useful in tests. */
+    public long invocationCount() {
+        return invocationCount.get();
+    }
+
+    /**
+     * Marker so the application context can confirm the stub is actually
+     * picked up by Spring instead of silently falling back to a real
+     * implementation when both are present.
+     */
+    @Configuration
+    static class StubVendorTelemetryFeedConfiguration {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorPackage.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorPackage.java
@@ -1,0 +1,12 @@
+/**
+ * Vendor telemetry adapter layer. Holds the {@link
+ * com.thundercrew.opsapi.vendor.VendorTelemetryFeed} interface that vendor
+ * integrations implement, the default {@link
+ * com.thundercrew.opsapi.vendor.StubVendorTelemetryFeed} (returns no events
+ * — used until real vendor docs land), the {@link
+ * com.thundercrew.opsapi.vendor.VendorTelemetryAdapter} that pipes feed
+ * results into the existing telemetry ingest service, and the disabled-
+ * by-default {@link
+ * com.thundercrew.opsapi.vendor.VendorTelemetryPollingScheduler}.
+ */
+package com.thundercrew.opsapi.vendor;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryAdapter.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryAdapter.java
@@ -1,0 +1,72 @@
+package com.thundercrew.opsapi.vendor;
+
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestRequest;
+import com.thundercrew.opsapi.telemetry.service.TelemetryIngestionService;
+import com.thundercrew.opsapi.vendor.VendorTelemetryFeed.VendorTelemetryFetchResult;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Pipes vendor-fetched events into our existing
+ * {@link TelemetryIngestionService}. Sits between the polling scheduler and
+ * the ingest service so the scheduler stays trivial and any retry / dead-
+ * letter logic can be added here later without touching the feed contract.
+ */
+@Component
+public class VendorTelemetryAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VendorTelemetryAdapter.class);
+
+    private final VendorTelemetryFeed feed;
+    private final TelemetryIngestionService ingestionService;
+
+    public VendorTelemetryAdapter(VendorTelemetryFeed feed, TelemetryIngestionService ingestionService) {
+        this.feed = feed;
+        this.ingestionService = ingestionService;
+    }
+
+    /**
+     * Pull one batch from the vendor feed and forward each event to the
+     * ingest service. Returns the cursor to persist for the next pull and a
+     * count of how many events succeeded vs. failed in this batch.
+     */
+    public VendorTelemetryPullSummary pullOnce(Instant since) {
+        VendorTelemetryFetchResult result = feed.pullRecent(since);
+        if (result.events().isEmpty()) {
+            LOGGER.debug("Vendor telemetry pull: 0 events (cursor={})", result.nextCursor());
+            return new VendorTelemetryPullSummary(0, 0, result.nextCursor());
+        }
+
+        AtomicInteger ok = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+        for (TelemetryIngestRequest event : result.events()) {
+            try {
+                ingestionService.ingest(event);
+                ok.incrementAndGet();
+            } catch (RuntimeException exception) {
+                failed.incrementAndGet();
+                // Single bad vendor event must not stop the rest of the
+                // batch. The vendor feed implementation is the right place
+                // to handle dead-letter buffering for retried events; we
+                // just log and continue here.
+                LOGGER.warn(
+                        "Vendor telemetry ingest failed for deviceUid={} vendorEventId={}: {}",
+                        event.deviceUid(),
+                        event.vendorEventId(),
+                        exception.toString());
+            }
+        }
+        LOGGER.info(
+                "Vendor telemetry pull: ok={} failed={} cursor={}",
+                ok.get(),
+                failed.get(),
+                result.nextCursor());
+        return new VendorTelemetryPullSummary(ok.get(), failed.get(), result.nextCursor());
+    }
+
+    public record VendorTelemetryPullSummary(int succeeded, int failed, Instant nextCursor) {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryFeed.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryFeed.java
@@ -1,0 +1,49 @@
+package com.thundercrew.opsapi.vendor;
+
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestRequest;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Pulls a recent batch of telemetry events from a third-party vendor and
+ * normalises each event into our internal {@link TelemetryIngestRequest}
+ * shape. A vendor-specific implementation lives outside this package; the
+ * default in-tree implementation is {@link StubVendorTelemetryFeed} and
+ * returns an empty result so the polling skeleton can ship before the real
+ * vendor docs arrive.
+ *
+ * <p>The feed is the only piece that is allowed to know about vendor URLs,
+ * authentication, payload field names, and rate-limit handling — once a
+ * vendor implementation is wired in, everything downstream
+ * ({@link VendorTelemetryAdapter}, {@link VendorTelemetryPollingScheduler})
+ * can stay unchanged.</p>
+ */
+public interface VendorTelemetryFeed {
+
+    /**
+     * Pull telemetry events that the vendor has emitted since {@code since}.
+     *
+     * @param since the cursor returned by the previous successful call, or
+     *              {@code null} on the very first poll.
+     * @return events normalised to {@link TelemetryIngestRequest} plus a
+     *         next-cursor that the scheduler must persist before the next
+     *         call.
+     */
+    VendorTelemetryFetchResult pullRecent(Instant since);
+
+    /**
+     * Result of a single {@link #pullRecent(Instant)} call.
+     *
+     * @param events     normalised events ready for {@code TelemetryIngestionService.ingest}.
+     * @param nextCursor opaque cursor (typically the latest event's
+     *                   {@code receivedAt}); the scheduler hands it back on
+     *                   the next call. {@code null} means "no progress made
+     *                   — replay from the same cursor next time".
+     */
+    record VendorTelemetryFetchResult(List<TelemetryIngestRequest> events, Instant nextCursor) {
+
+        public static VendorTelemetryFetchResult empty(Instant nextCursor) {
+            return new VendorTelemetryFetchResult(List.of(), nextCursor);
+        }
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryPollingScheduler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/vendor/VendorTelemetryPollingScheduler.java
@@ -1,0 +1,89 @@
+package com.thundercrew.opsapi.vendor;
+
+import com.thundercrew.opsapi.vendor.VendorTelemetryAdapter.VendorTelemetryPullSummary;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Disabled-by-default polling scheduler that drives
+ * {@link VendorTelemetryAdapter}. Activated by setting
+ * {@code thundercrew.vendor-telemetry.enabled=true} in the runtime
+ * environment; tests and dev runs leave it off so the adapter and its
+ * scheduler bean tree do not interfere with the normal admin/dashboard
+ * workflows.
+ *
+ * <p>The cursor is held in-memory only. A real vendor implementation will
+ * want to persist it (e.g. via {@code device_api_sync_runs}) so a restart
+ * does not replay the same window — that is intentionally out of scope for
+ * the F-1 skeleton.</p>
+ */
+@Component
+@ConditionalOnProperty(
+        prefix = "thundercrew.vendor-telemetry",
+        name = "enabled",
+        havingValue = "true")
+public class VendorTelemetryPollingScheduler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VendorTelemetryPollingScheduler.class);
+
+    private final VendorTelemetryAdapter adapter;
+    private final AtomicReference<Instant> cursor = new AtomicReference<>();
+
+    public VendorTelemetryPollingScheduler(VendorTelemetryAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Scheduled(
+            fixedDelayString = "${thundercrew.vendor-telemetry.poll-interval-ms:60000}",
+            initialDelayString = "${thundercrew.vendor-telemetry.initial-delay-ms:30000}"
+    )
+    public void poll() {
+        Instant since = cursor.get();
+        try {
+            VendorTelemetryPullSummary summary = adapter.pullOnce(since);
+            if (summary.nextCursor() != null) {
+                cursor.set(summary.nextCursor());
+            }
+        } catch (RuntimeException exception) {
+            LOGGER.error("Vendor telemetry polling cycle failed: {}", exception.toString());
+        }
+    }
+
+    /** Visible for testing. */
+    Instant currentCursor() {
+        return cursor.get();
+    }
+
+    /**
+     * Required to enable {@code @Scheduled} only when the polling bean is
+     * activated. Keeping the {@link EnableScheduling} annotation on a
+     * conditional inner config means the rest of the codebase does not
+     * accidentally start a Spring scheduler thread pool when vendor polling
+     * is off.
+     */
+    @Configuration
+    @ConditionalOnProperty(
+            prefix = "thundercrew.vendor-telemetry",
+            name = "enabled",
+            havingValue = "true")
+    @EnableScheduling
+    static class VendorTelemetrySchedulingConfiguration {
+
+        @Bean
+        VendorTelemetrySchedulingMarker vendorTelemetrySchedulingMarker() {
+            return new VendorTelemetrySchedulingMarker();
+        }
+    }
+
+    /** Marker bean so tests can assert that scheduling was activated. */
+    public static final class VendorTelemetrySchedulingMarker {
+    }
+}

--- a/development/service-ops-api/src/main/resources/application.properties
+++ b/development/service-ops-api/src/main/resources/application.properties
@@ -11,3 +11,11 @@ thundercrew.auth.jwt.secret=${THUNDERCREW_AUTH_JWT_SECRET:}
 thundercrew.auth.jwt.issuer=${THUNDERCREW_AUTH_JWT_ISSUER:thundercrew-domain}
 thundercrew.auth.jwt.access-token-ttl=${THUNDERCREW_AUTH_JWT_ACCESS_TOKEN_TTL:PT30M}
 thundercrew.auth.refresh-token-ttl=${THUNDERCREW_AUTH_REFRESH_TOKEN_TTL:P14D}
+# Vendor telemetry adapter (Slice F-1 skeleton). Disabled by default —
+# operators flip the enabled flag once a real vendor implementation is
+# wired in. The stub feed satisfies the adapter contract so dev and tests
+# can exercise the scheduling code without producing fake telemetry rows.
+thundercrew.vendor-telemetry.enabled=${THUNDERCREW_VENDOR_TELEMETRY_ENABLED:false}
+thundercrew.vendor-telemetry.feed-implementation=${THUNDERCREW_VENDOR_TELEMETRY_FEED:stub}
+thundercrew.vendor-telemetry.poll-interval-ms=${THUNDERCREW_VENDOR_TELEMETRY_POLL_MS:60000}
+thundercrew.vendor-telemetry.initial-delay-ms=${THUNDERCREW_VENDOR_TELEMETRY_INITIAL_DELAY_MS:30000}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -39,7 +39,8 @@ class ArchitectureBoundaryTests {
                     "..devicesync..",
                     "..telemetry..",
                     "..station..",
-                    "..dashboard..");
+                    "..dashboard..",
+                    "..vendor..");
 
     @ArchTest
     static final ArchRule issue_70_auth_commands_are_the_only_auth_write_route_exceptions = methods()

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
@@ -1,0 +1,124 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import com.thundercrew.opsapi.telemetry.domain.TelemetrySource;
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestRequest;
+import com.thundercrew.opsapi.telemetry.dto.TelemetryIngestResponse;
+import com.thundercrew.opsapi.telemetry.service.TelemetryIngestionService;
+import com.thundercrew.opsapi.vendor.StubVendorTelemetryFeed;
+import com.thundercrew.opsapi.vendor.VendorTelemetryAdapter;
+import com.thundercrew.opsapi.vendor.VendorTelemetryAdapter.VendorTelemetryPullSummary;
+import com.thundercrew.opsapi.vendor.VendorTelemetryFeed;
+import com.thundercrew.opsapi.vendor.VendorTelemetryFeed.VendorTelemetryFetchResult;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class VendorTelemetryAdapterTests {
+
+    @Test
+    void stubFeedReturnsEmptyAndAdapterDoesNotInvokeIngest() {
+        StubVendorTelemetryFeed feed = new StubVendorTelemetryFeed();
+        TelemetryIngestionService ingestionService = mock(TelemetryIngestionService.class);
+        VendorTelemetryAdapter adapter = new VendorTelemetryAdapter(feed, ingestionService);
+
+        VendorTelemetryPullSummary summary = adapter.pullOnce(null);
+
+        assertThat(summary.succeeded()).isZero();
+        assertThat(summary.failed()).isZero();
+        assertThat(summary.nextCursor()).isNull();
+        assertThat(feed.invocationCount()).isEqualTo(1);
+        verify(ingestionService, times(0)).ingest(any(TelemetryIngestRequest.class));
+    }
+
+    @Test
+    void adapterForwardsAllVendorEventsToIngestionService() {
+        Instant now = Instant.parse("2030-01-01T00:00:00Z");
+        TelemetryIngestRequest first = sampleEvent("VENDOR-A1", now);
+        TelemetryIngestRequest second = sampleEvent("VENDOR-A2", now.plusSeconds(1));
+        VendorTelemetryFeed feed = since -> new VendorTelemetryFetchResult(List.of(first, second), now.plusSeconds(1));
+        TelemetryIngestionService ingestionService = mock(TelemetryIngestionService.class);
+        when(ingestionService.ingest(any(TelemetryIngestRequest.class)))
+                .thenReturn(stubIngestResponse());
+
+        VendorTelemetryPullSummary summary = new VendorTelemetryAdapter(feed, ingestionService).pullOnce(null);
+
+        assertThat(summary.succeeded()).isEqualTo(2);
+        assertThat(summary.failed()).isZero();
+        assertThat(summary.nextCursor()).isEqualTo(now.plusSeconds(1));
+        verify(ingestionService).ingest(first);
+        verify(ingestionService).ingest(second);
+    }
+
+    @Test
+    void adapterContinuesBatchWhenSingleEventThrows() {
+        Instant now = Instant.parse("2030-02-01T00:00:00Z");
+        TelemetryIngestRequest good = sampleEvent("VENDOR-OK", now);
+        TelemetryIngestRequest bad = sampleEvent("VENDOR-BAD", now.plusSeconds(1));
+        VendorTelemetryFeed feed = since -> new VendorTelemetryFetchResult(List.of(good, bad), now.plusSeconds(1));
+        TelemetryIngestionService ingestionService = mock(TelemetryIngestionService.class);
+        when(ingestionService.ingest(good)).thenReturn(stubIngestResponse());
+        doThrow(new RuntimeException("simulated ingest failure"))
+                .when(ingestionService).ingest(bad);
+
+        VendorTelemetryPullSummary summary = new VendorTelemetryAdapter(feed, ingestionService).pullOnce(null);
+
+        assertThat(summary.succeeded()).isEqualTo(1);
+        assertThat(summary.failed()).isEqualTo(1);
+        assertThat(summary.nextCursor()).isEqualTo(now.plusSeconds(1));
+        verify(ingestionService).ingest(good);
+        verify(ingestionService).ingest(bad);
+    }
+
+    @Test
+    void stubFeedKeepsCursorUnchangedAcrossInvocations() {
+        StubVendorTelemetryFeed feed = new StubVendorTelemetryFeed();
+        Instant cursor = Instant.parse("2030-03-01T00:00:00Z");
+        VendorTelemetryFetchResult first = feed.pullRecent(cursor);
+        VendorTelemetryFetchResult second = feed.pullRecent(first.nextCursor());
+
+        assertThat(first.events()).isEmpty();
+        assertThat(second.events()).isEmpty();
+        assertThat(first.nextCursor()).isEqualTo(cursor);
+        assertThat(second.nextCursor()).isEqualTo(cursor);
+        assertThat(feed.invocationCount()).isEqualTo(2);
+    }
+
+    private static TelemetryIngestRequest sampleEvent(String deviceUid, Instant receivedAt) {
+        return new TelemetryIngestRequest(
+                deviceUid,
+                "vendor-event-" + deviceUid,
+                receivedAt,
+                receivedAt,
+                new BigDecimal("37.5005000"),
+                new BigDecimal("127.0270000"),
+                new BigDecimal("12.5"),
+                new BigDecimal("75"),
+                TelemetryIgnitionStatus.ON,
+                TelemetrySource.POLLING,
+                null);
+    }
+
+    private static TelemetryIngestResponse stubIngestResponse() {
+        return new TelemetryIngestResponse(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "VENDOR-STUB",
+                UUID.randomUUID(),
+                Instant.now(),
+                false,
+                true,
+                true,
+                "ACCEPTED");
+    }
+}


### PR DESCRIPTION
## Summary

- Vendor telemetry 통합을 위한 인터페이스(`VendorTelemetryFeed`) + stub(`StubVendorTelemetryFeed`) + adapter(`VendorTelemetryAdapter`) + 스케줄러(`VendorTelemetryPollingScheduler`) 의 백엔드 골격 추가.
- vendor 문서 도착 후 (Slice F-2) 실제 구현체만 끼워 넣으면 ingest 라인까지 동작.
- 기본 비활성 (`thundercrew.vendor-telemetry.enabled=false`). 활성 시 stub 이 1분 주기로 빈 결과 반환.

## Trace

- Target issue: EVNSolution/thundercrew-domain#144
- Change-control issue: EVNSolution/clever-change-control#126
- Root project-start: EVNSolution/clever-change-control#45
- Builds on: 텔레메트리 ingest 도메인 (`POST /api/v1/telemetry/device-events`).

## Scope

Backend-only.

Included:
- 신규 `vendor` 패키지: 인터페이스 + stub + adapter + scheduler.
- application.properties 4개 신규 설정 (env 변수 override 지원).
- ArchUnit `common_must_not_depend_on_bounded_contexts` 에 `..vendor..` 패키지 추가.
- 단위 테스트 4 케이스 (`VendorTelemetryAdapterTests`).

Excluded:
- 실제 vendor REST/MQTT 호출 코드 (Slice F-2 — vendor 문서 도착 시).
- vendor 인증 (API key / OAuth / mTLS) 설정.
- vendor specific payload 변환.
- cursor persistence (현재 in-memory, 후속 슬라이스에서 device_api_sync_runs 와 연동).

## 설계 한 줄 요약

```
[vendor IoT API]  ←──  VendorTelemetryFeed (real)        ←  Slice F-2
                  ←──  StubVendorTelemetryFeed (default) ←  이번 PR
                            │
                            ▼
                  [VendorTelemetryAdapter]  → TelemetryIngestionService.ingest
                            ▲
                            │ 1분 주기
                  [VendorTelemetryPollingScheduler]  ← @ConditionalOnProperty
                                                       (enabled=true 일 때만)
```

## 설정 항목

| Property | Env 변수 | 기본값 | 설명 |
|----------|---------|-------|------|
| `thundercrew.vendor-telemetry.enabled` | `THUNDERCREW_VENDOR_TELEMETRY_ENABLED` | `false` | 스케줄러 활성화 여부. |
| `thundercrew.vendor-telemetry.feed-implementation` | `THUNDERCREW_VENDOR_TELEMETRY_FEED` | `stub` | 어떤 feed 구현체를 사용할지. 실 구현체 추가 시 `real` 등으로 변경. |
| `thundercrew.vendor-telemetry.poll-interval-ms` | `THUNDERCREW_VENDOR_TELEMETRY_POLL_MS` | `60000` | fixed delay (ms). |
| `thundercrew.vendor-telemetry.initial-delay-ms` | `THUNDERCREW_VENDOR_TELEMETRY_INITIAL_DELAY_MS` | `30000` | 부팅 후 첫 polling 까지 지연. |

## Validation

| 항목 | 결과 |
|------|------|
| `./gradlew compileJava compileTestJava` | ✅ BUILD SUCCESSFUL (24s) |
| `./gradlew test --tests ArchitectureBoundaryTests --tests ScaffoldPackageSkeletonTests --tests VendorTelemetryAdapterTests` | ✅ BUILD SUCCESSFUL (38s) |
| Testcontainers 통합 테스트 (전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE 에서 `./gradlew test` 전체 실행 → `VendorTelemetryAdapterTests` 4 케이스 통과 + 기존 통합 테스트 회귀 없음.
- [ ] 기본 부팅 (env 미설정) 시 vendor scheduler 가 활성화되지 않는지 (Spring scheduler thread pool 안 뜸).
- [ ] `THUNDERCREW_VENDOR_TELEMETRY_ENABLED=true` 환경변수로 부팅 시 1분 주기 polling 로그 확인 (`Vendor telemetry pull: 0 events`).
- [ ] dev DB 에 영향이 없는지 (stub 이 빈 결과 → ingest 호출 없음).

## Concurrent work gate

- Decision: `allowed-with-non-overlap`.
- Open target issues at PR open: #144 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스 머지 후 vendor 문서 도착 시 추가할 작업 (Slice F-2):

1. `VendorTelemetryFeed` 의 실제 구현체 (HTTP / MQTT / webhook 수신 + payload 정규화).
2. `feed-implementation=real` 같은 식별자로 활성화.
3. cursor persistence (`device_api_sync_runs` 와 연동하여 재시작 시 replay 방지).
4. vendor 인증 정보 (API key / OAuth / HMAC) 의 secret 관리.
5. dead-letter / retry 정책 (현재 adapter 가 단순 로깅만).
