### PR TITLE
Open a station detail panel on dashboard marker click (#146)

### DIFF
--- a/development/front-admin-web/app/api/dashboard/battery-station/[stationId]/route.ts
+++ b/development/front-admin-web/app/api/dashboard/battery-station/[stationId]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { loadBatteryStationDetail } from "@/lib/services/battery-station-detail-data";
+
+/**
+ * Per-station detail endpoint hit by the marker-click panel. Keeps the
+ * service-ops session cookie server-side, mirroring the dashboard map-state
+ * and bike-snapshot routes.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ stationId: string }> }
+) {
+  const { stationId } = await context.params;
+  const result = await loadBatteryStationDetail(stationId);
+  return NextResponse.json(result, {
+    headers: {
+      "Cache-Control": "no-store"
+    }
+  });
+}

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BikeDetailPanel } from "@/components/dashboard/BikeDetailPanel";
 import { MapShell } from "@/components/dashboard/MapShell";
+import { StationDetailPanel } from "@/components/dashboard/StationDetailPanel";
 import type { DashboardMapStateResult } from "@/lib/services/dashboard-map-state-data";
 
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
@@ -29,6 +30,7 @@ export function DashboardCanvas({
 }: DashboardCanvasProps) {
   const [state, setState] = useState<DashboardMapStateResult>(initial);
   const [selectedBikeId, setSelectedBikeId] = useState<string | null>(null);
+  const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
   const pollIntervalRef = useRef(pollIntervalMs);
 
   useEffect(() => {
@@ -77,19 +79,38 @@ export function DashboardCanvas({
 
   // Resolve the pin against the latest snapshot every render so a polling
   // refresh that drops the selected bike collapses the panel automatically.
-  // Computing `selectedPin` from `selectedBikeId` purely in render avoids
-  // the set-state-in-effect anti-pattern that React 19's lint rule blocks.
-  const selectedPin = useMemo(() => {
+  // Computing `selectedBikePin` / `selectedStationPin` from the ids purely
+  // in render avoids the set-state-in-effect anti-pattern that React 19's
+  // lint rule blocks.
+  const selectedBikePin = useMemo(() => {
     if (!selectedBikeId) return null;
     return state.data.bikePins.find((pin) => pin.bikeId === selectedBikeId) ?? null;
   }, [selectedBikeId, state.data.bikePins]);
 
+  const selectedStationPin = useMemo(() => {
+    if (!selectedStationId) return null;
+    return state.data.stationPins.find((pin) => pin.stationId === selectedStationId) ?? null;
+  }, [selectedStationId, state.data.stationPins]);
+
   const handleBikeSelect = useCallback((bikeId: string) => {
+    // Mutual exclusion — opening the bike panel closes any open station
+    // panel and vice versa, so the operator never has two right-edge panels
+    // overlapping.
+    setSelectedStationId(null);
     setSelectedBikeId(bikeId);
   }, []);
 
-  const handlePanelClose = useCallback(() => {
+  const handleStationSelect = useCallback((stationId: string) => {
     setSelectedBikeId(null);
+    setSelectedStationId(stationId);
+  }, []);
+
+  const handleBikePanelClose = useCallback(() => {
+    setSelectedBikeId(null);
+  }, []);
+
+  const handleStationPanelClose = useCallback(() => {
+    setSelectedStationId(null);
   }, []);
 
   return (
@@ -98,6 +119,7 @@ export function DashboardCanvas({
         bikePins={state.data.bikePins}
         stationPins={state.data.stationPins}
         onBikeSelect={handleBikeSelect}
+        onStationSelect={handleStationSelect}
       />
       {state.notice ? (
         <div className="dashboard-map-notice" role="status" aria-live="polite">
@@ -105,8 +127,11 @@ export function DashboardCanvas({
           <span>{state.notice}</span>
         </div>
       ) : null}
-      {selectedPin ? (
-        <BikeDetailPanel pin={selectedPin} onClose={handlePanelClose} />
+      {selectedBikePin ? (
+        <BikeDetailPanel pin={selectedBikePin} onClose={handleBikePanelClose} />
+      ) : null}
+      {selectedStationPin ? (
+        <StationDetailPanel pin={selectedStationPin} onClose={handleStationPanelClose} />
       ) : null}
     </>
   );

--- a/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { BatteryStationDetailResult } from "@/lib/services/battery-station-detail-data";
+import type { FrontendDashboardStationPin } from "@/lib/services/service-ops-api";
+
+export interface StationDetailPanelProps {
+  pin: FrontendDashboardStationPin;
+  onClose: () => void;
+}
+
+type FetchOutcome =
+  | { phase: "idle" }
+  | { phase: "loaded"; result: BatteryStationDetailResult }
+  | { phase: "error" };
+
+/**
+ * Right-edge floating panel that opens when an operator clicks a station
+ * marker. Renders immediately from the StationPin (label, lat/lng, available
+ * battery count) and enriches with the single-station fetch when it lands.
+ *
+ * The outcome state is keyed on stationId — a click that swaps the panel to
+ * a different station resets the fetch outcome on the next render rather
+ * than via a synchronous setState inside useEffect (the React 19 purity
+ * lint rule blocks the latter).
+ */
+export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
+  const [outcome, setOutcome] = useState<{ stationId: string; data: FetchOutcome }>({
+    stationId: pin.stationId,
+    data: { phase: "idle" }
+  });
+
+  const isFresh = outcome.stationId === pin.stationId;
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/dashboard/battery-station/${encodeURIComponent(pin.stationId)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => (response.ok ? ((await response.json()) as BatteryStationDetailResult) : null))
+      .then((next) => {
+        if (cancelled) return;
+        setOutcome({
+          stationId: pin.stationId,
+          data: next ? { phase: "loaded", result: next } : { phase: "error" }
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setOutcome({ stationId: pin.stationId, data: { phase: "error" } });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pin.stationId]);
+
+  const result = isFresh && outcome.data.phase === "loaded" ? outcome.data.result : null;
+  const loading = !isFresh || outcome.data.phase === "idle";
+  const live = result?.data;
+
+  // Prefer freshly-fetched single state; fall back to map-state pin.
+  const name = live?.name ?? pin.name;
+  const address = live?.address ?? pin.address;
+  const status = live?.stationStatus ?? pin.status;
+  const maxBatteryCapacity = live?.maxBatteryCapacity ?? pin.maxBatteryCapacity;
+  const currentBatteryCount = live?.currentBatteryCount ?? pin.currentBatteryCount;
+  const availableBatteryCount = live?.availableBatteryCount ?? pin.availableBatteryCount;
+  const availableBatteryLabel = live?.availableBatteryLabel ?? pin.availableBatteryLabel;
+  const capacityPercentage = live?.capacityPercentage ?? pin.availableBatteryPercentage;
+  const latitude = live?.latitude ?? pin.latitude;
+  const longitude = live?.longitude ?? pin.longitude;
+  const updatedAt = live?.updatedAt ?? null;
+
+  return (
+    <aside
+      className="bike-detail-panel"
+      role="complementary"
+      aria-label={`충전소 ${name} 상세`}
+    >
+      <header className="bike-detail-panel-header">
+        <div>
+          <span className="bike-detail-panel-eyebrow">충전소 상세</span>
+          <h2>{name}</h2>
+          <p>{address}</p>
+        </div>
+        <button
+          type="button"
+          className="bike-detail-panel-close"
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          ✕
+        </button>
+      </header>
+
+      <dl className="bike-detail-panel-body">
+        <DetailRow label="상태" value={statusLabel(status)} />
+        <DetailRow label="가용 배터리" value={availableBatteryLabel} />
+        <DetailRow label="현재/최대" value={`${currentBatteryCount} / ${maxBatteryCapacity}`} />
+        <DetailRow label="가용 수량" value={`${availableBatteryCount}`} />
+        <DetailRow label="가용율" value={`${capacityPercentage}%`} />
+        <DetailRow label="위치" value={`${latitude.toFixed(5)}, ${longitude.toFixed(5)}`} />
+        {updatedAt ? <DetailRow label="마지막 업데이트" value={formatRelative(updatedAt)} /> : null}
+      </dl>
+
+      {loading ? (
+        <p className="bike-detail-panel-status" role="status">충전소 상세 조회 중…</p>
+      ) : null}
+      {!loading && result?.notice ? (
+        <p className="bike-detail-panel-status" role="status">{result.notice}</p>
+      ) : null}
+    </aside>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bike-detail-panel-row">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "ACTIVE":
+      return "운영 중";
+    case "MAINTENANCE":
+      return "점검 중";
+    case "INACTIVE":
+      return "비활성";
+    case "운영":
+      return "운영 중";
+    case "점검":
+      return "점검 중";
+    case "비활성":
+      return "비활성";
+    default:
+      return status ?? "—";
+  }
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  const ageMs = Date.now() - ts;
+  if (ageMs < 60_000) return `${Math.max(1, Math.round(ageMs / 1000))}초 전`;
+  if (ageMs < 3_600_000) return `${Math.round(ageMs / 60_000)}분 전`;
+  if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}시간 전`;
+  return new Date(ts).toLocaleString("ko-KR");
+}

--- a/development/front-admin-web/lib/services/battery-station-detail-data.ts
+++ b/development/front-admin-web/lib/services/battery-station-detail-data.ts
@@ -1,0 +1,63 @@
+import {
+  type FrontendBatteryStation,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type BatteryStationDetailResult = {
+  stationId: string;
+  data: FrontendBatteryStation | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Loader for the station detail panel. Mirrors the bike-current-state and
+ * bike-snapshot loaders so the panel keeps rendering its StationPin info on
+ * every fallback path (no API base / no session / fetch failed) and surfaces
+ * a small notice instead of blanking.
+ */
+export async function loadBatteryStationDetail(stationId: string): Promise<BatteryStationDetailResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      stationId,
+      data: null,
+      source: "mock",
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 충전소 상세를 표시할 수 없습니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      stationId,
+      data: null,
+      source: "mock",
+      notice: "관리자 세션이 없어 충전소 상세를 표시할 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getBatteryStation(stationId);
+    return { stationId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      stationId,
+      data: null,
+      source: "mock",
+      notice: `충전소 상세 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary

- 충전소 마커 클릭 → 우측 패널 오픈 (BikeDetailPanel 과 동일 패턴).
- 차량 / 충전소 패널 mutual exclusion — 한 번에 하나만 노출.
- 폴링이 충전소를 떨어뜨리면 패널 자동 닫힘 (render-time derive).

## Trace

- Target issue: EVNSolution/thundercrew-domain#146
- Change-control issue: EVNSolution/clever-change-control#127
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #127 (BikeDetailPanel skeleton), #135 (디테일 패널 5섹션).

## Scope

Frontend-only. service-ops 백엔드 변경 없음 — 이미 있는 \`GET /api/v1/battery-stations/{id}\` 활용.

Included:
- \`battery-station-detail-data.ts\` 서버 로더 + mock fallback.
- \`/api/dashboard/battery-station/[stationId]\` Next.js route.
- \`StationDetailPanel\` 컴포넌트 (CSS 는 기존 \`.bike-detail-panel\` 재사용).
- DashboardCanvas mutual exclusion + onStationSelect wiring.

Excluded:
- 배터리 카운트 변경 폼.
- 카운트 이력 표시.
- 충전소-라이더/차량 연결 정보.

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run test:service-ops\` | ✅ 120 / 120 pass |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 후 충전소 마커 클릭 → 우측 패널이 열리며 이름/주소/상태/배터리 라벨/현재·가용 카운트/위치 노출.
- [ ] 차량 패널 열려 있는 상태에서 충전소 마커 클릭 → 차량 패널 닫히고 충전소 패널 열림 (반대도 동일).
- [ ] 충전소 패널의 닫기 버튼이 정상 동작.
- [ ] 폴링이 충전소를 떨어뜨리면 패널 자동 닫힘.
- [ ] 백엔드 미구성 / 세션 없음 시 StationPin 정보로 패널 렌더 + 안내 노출.
- [ ] DevTools Network → 마커 클릭마다 \`/api/dashboard/battery-station/{id}\` 가 1회 호출.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #146 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 모니터링 화면의 마커 → 디테일 패널 끝-단이 양쪽(차량+충전소) 모두 닫힙니다. 다음 추천 후속:

- 라이더 교육 단건 수정/삭제 페이지 (현재 행별 삭제 + 등록만).
- 라이더 등록/수정 폼에 교육 입력 통합 (현재 별도 페이지에서 등록).
- vendor 문서 도착 후 Slice F-2 — 실 vendor 구현체.
