### PR TITLE
Add rider education record edit page on the admin web (#148)

### DIFF
--- a/development/front-admin-web/app/riders/[slug]/education-records/[recordId]/edit/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/education-records/[recordId]/edit/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+
+import { updateRiderEducationRecordAction } from "@/app/riders/[slug]/education-records/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderEducationRecordForm } from "@/components/riders/RiderEducationRecordForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadRiderEducationRecord } from "@/lib/services/rider-education-record-detail-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "교육 이력 수정에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요.",
+  "validation-error": "필수값(교육 종류, 완료일)이 누락되었거나 잘못 입력되었습니다."
+};
+
+export default async function EditRiderEducationRecordPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string; recordId: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug, recordId }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const recordResult = await loadRiderEducationRecord(recordId);
+  if (!recordResult.data) {
+    return (
+      <div className="page-container">
+        <BackToListLink href={`/riders/${detail.rider.slug}`} />
+        <PageHeader
+          title="교육 이력 수정"
+          description={`${detail.rider.name} (${detail.rider.phone}) 의 교육 이력을 불러오지 못했습니다.`}
+        />
+        {recordResult.notice ? <p className="notice">{recordResult.notice}</p> : null}
+      </div>
+    );
+  }
+
+  const record = recordResult.data;
+  const message = status ? statusMessage[status] : null;
+  const action = updateRiderEducationRecordAction.bind(
+    null,
+    detail.rider.id ?? detail.rider.slug,
+    record.id
+  );
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="교육 이력 수정"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 교육 이력을 정정합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderEducationRecordForm
+        action={action}
+        backHref={`/riders/${detail.rider.slug}`}
+        defaultValues={{
+          educationType: record.educationType,
+          courseName: record.courseName,
+          completedAt: record.completedAt,
+          expiresAt: record.expiresAt,
+          certificateNo: record.certificateNo,
+          issuingAuthority: record.issuingAuthority,
+          evidenceUrl: record.evidenceUrl,
+          memo: record.memo
+        }}
+        mode="수정"
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/education-records/actions.ts
+++ b/development/front-admin-web/app/riders/[slug]/education-records/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 
 import {
   type RiderEducationRecordCreateInput,
+  type RiderEducationRecordUpdateInput,
   type ServiceOpsRiderEducationType,
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
@@ -38,6 +39,37 @@ export async function createRiderEducationRecordAction(
 
   revalidatePath(`/riders/${riderId}`);
   redirect(`/riders/${riderId}?status=education-created`);
+}
+
+export async function updateRiderEducationRecordAction(
+  riderId: string,
+  recordId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderId}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let payload: RiderEducationRecordUpdateInput;
+  try {
+    payload = toEducationUpdatePayload(formData);
+  } catch {
+    redirect(`/riders/${riderId}/education-records/${recordId}/edit?status=validation-error`);
+  }
+
+  try {
+    await client.updateRiderEducationRecord(recordId, payload);
+  } catch {
+    redirect(`/riders/${riderId}/education-records/${recordId}/edit?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderId}`);
+  redirect(`/riders/${riderId}?status=education-updated`);
 }
 
 export async function deleteRiderEducationRecordAction(
@@ -74,6 +106,27 @@ function toEducationPayload(riderId: string, formData: FormData): RiderEducation
   }
   return {
     riderId,
+    educationType,
+    courseName: optionalText(formData.get("courseName")),
+    completedAt: completedAtIso,
+    expiresAt: toIsoTimestamp(formData.get("expiresAt")) ?? null,
+    certificateNo: optionalText(formData.get("certificateNo")),
+    issuingAuthority: optionalText(formData.get("issuingAuthority")),
+    evidenceUrl: optionalText(formData.get("evidenceUrl")),
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+function toEducationUpdatePayload(formData: FormData): RiderEducationRecordUpdateInput {
+  const educationType = String(formData.get("educationType") ?? "").trim() as ServiceOpsRiderEducationType;
+  if (educationType !== "ONLINE" && educationType !== "OFFLINE") {
+    throw new Error("educationType must be ONLINE or OFFLINE");
+  }
+  const completedAtIso = toIsoTimestamp(formData.get("completedAt"));
+  if (!completedAtIso) {
+    throw new Error("completedAt is required");
+  }
+  return {
     educationType,
     courseName: optionalText(formData.get("courseName")),
     completedAt: completedAtIso,

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -18,6 +18,7 @@ const statusMessage: Record<string, string> = {
   "education-created": "교육 이력이 등록되었습니다.",
   "education-deleted": "교육 이력이 삭제되었습니다.",
   "education-delete-error": "교육 이력 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  "education-updated": "교육 이력이 수정되었습니다.",
   "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 없이 mock 상세로 돌아왔습니다.",
   updated: "라이더 정보가 수정되었습니다."
@@ -148,7 +149,14 @@ function RiderEducationSection({
                     </Badge>
                   </td>
                   <td>
-                    <form action={deleteAction}>
+                    <Link
+                      className="button-link"
+                      href={`/riders/${riderSlug}/education-records/${record.id}/edit`}
+                    >
+                      수정
+                    </Link>
+                    <span aria-hidden="true"> · </span>
+                    <form action={deleteAction} style={{ display: "inline" }}>
                       <button className="button-link" type="submit">삭제</button>
                     </form>
                   </td>

--- a/development/front-admin-web/components/riders/RiderEducationRecordForm.tsx
+++ b/development/front-admin-web/components/riders/RiderEducationRecordForm.tsx
@@ -5,14 +5,38 @@ import { Field } from "@/components/ui/FormField";
 type RiderEducationRecordFormProps = {
   action: (formData: FormData) => void | Promise<void>;
   backHref: string;
+  defaultValues?: {
+    educationType?: "ONLINE" | "OFFLINE";
+    courseName?: string | null;
+    completedAt?: string | null;
+    expiresAt?: string | null;
+    certificateNo?: string | null;
+    issuingAuthority?: string | null;
+    evidenceUrl?: string | null;
+    memo?: string | null;
+  };
+  mode?: "등록" | "수정";
 };
 
-export function RiderEducationRecordForm({ action, backHref }: RiderEducationRecordFormProps) {
+export function RiderEducationRecordForm({
+  action,
+  backHref,
+  defaultValues,
+  mode = "등록"
+}: RiderEducationRecordFormProps) {
+  const completedAtDate = toDateInputValue(defaultValues?.completedAt ?? null);
+  const expiresAtDate = toDateInputValue(defaultValues?.expiresAt ?? null);
+
   return (
-    <form action={action} className="card" aria-label="라이더 교육 이력 등록 폼">
+    <form action={action} className="card" aria-label={`라이더 교육 이력 ${mode} 폼`}>
       <div className="form-grid">
         <Field label="교육 종류">
-          <select className="select" defaultValue="ONLINE" name="educationType" required>
+          <select
+            className="select"
+            defaultValue={defaultValues?.educationType ?? "ONLINE"}
+            name="educationType"
+            required
+          >
             <option value="ONLINE">온라인 교육</option>
             <option value="OFFLINE">오프라인 교육</option>
           </select>
@@ -20,20 +44,33 @@ export function RiderEducationRecordForm({ action, backHref }: RiderEducationRec
         <Field label="과정명">
           <input
             className="input"
+            defaultValue={defaultValues?.courseName ?? ""}
             maxLength={200}
             name="courseName"
             placeholder="예: 전기이륜차 안전 운행 교육 2026"
           />
         </Field>
         <Field label="완료일">
-          <input className="input" name="completedAt" required type="date" />
+          <input
+            className="input"
+            defaultValue={completedAtDate}
+            name="completedAt"
+            required
+            type="date"
+          />
         </Field>
         <Field label="만료일 (선택)">
-          <input className="input" name="expiresAt" type="date" />
+          <input
+            className="input"
+            defaultValue={expiresAtDate}
+            name="expiresAt"
+            type="date"
+          />
         </Field>
         <Field label="수료증 번호 (선택)">
           <input
             className="input"
+            defaultValue={defaultValues?.certificateNo ?? ""}
             maxLength={100}
             name="certificateNo"
             placeholder="예: CRT-2026-00001"
@@ -42,6 +79,7 @@ export function RiderEducationRecordForm({ action, backHref }: RiderEducationRec
         <Field label="발급 기관 (선택)">
           <input
             className="input"
+            defaultValue={defaultValues?.issuingAuthority ?? ""}
             maxLength={100}
             name="issuingAuthority"
             placeholder="예: 교통안전공단"
@@ -52,6 +90,7 @@ export function RiderEducationRecordForm({ action, backHref }: RiderEducationRec
       <Field label="증빙 URL (선택)">
         <input
           className="input"
+          defaultValue={defaultValues?.evidenceUrl ?? ""}
           name="evidenceUrl"
           placeholder="예: https://evidence.example.com/CRT-2026-00001.pdf"
           type="url"
@@ -61,6 +100,7 @@ export function RiderEducationRecordForm({ action, backHref }: RiderEducationRec
       <Field label="메모 (선택)">
         <textarea
           className="input"
+          defaultValue={defaultValues?.memo ?? ""}
           name="memo"
           placeholder="운영자가 볼 내부 메모"
           rows={4}
@@ -68,8 +108,22 @@ export function RiderEducationRecordForm({ action, backHref }: RiderEducationRec
       </Field>
       <div className="form-actions">
         <Link className="button-secondary" href={backHref}>취소</Link>
-        <button className="button-primary" type="submit">교육 이력 등록</button>
+        <button className="button-primary" type="submit">교육 이력 {mode}</button>
       </div>
     </form>
   );
+}
+
+function toDateInputValue(iso: string | null): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  // Use UTC parts so the same calendar day round-trips through the
+  // backend even when the operator is in a non-UTC timezone — the
+  // create action already coerces the form value to a UTC start-of-day
+  // ISO instant.
+  const year = date.getUTCFullYear().toString().padStart(4, "0");
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = date.getUTCDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }

--- a/development/front-admin-web/lib/services/rider-education-record-detail-data.ts
+++ b/development/front-admin-web/lib/services/rider-education-record-detail-data.ts
@@ -1,0 +1,65 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsRiderEducationRecord,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderEducationRecordDetailResult = {
+  recordId: string;
+  data: ServiceOpsRiderEducationRecord | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Single-record loader for the rider education record edit page. Returns
+ * {@code data: null} on every fallback path (no API base, no session,
+ * fetch failed, 404) so the page can render a "조회 실패" notice instead
+ * of crashing.
+ */
+export async function loadRiderEducationRecord(
+  recordId: string
+): Promise<RiderEducationRecordDetailResult> {
+  if (!serviceOpsApiConfigured()) {
+    return {
+      recordId,
+      data: null,
+      source: "mock",
+      notice: "SERVICE_OPS_API_BASE_URL이 없어 교육 이력을 불러올 수 없습니다."
+    };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      recordId,
+      data: null,
+      source: "mock",
+      notice: "관리자 세션이 없어 교육 이력을 불러올 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getRiderEducationRecord(recordId);
+    return { recordId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      recordId,
+      data: null,
+      source: "mock",
+      notice: `교육 이력 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -107,6 +107,17 @@ export type RiderEducationRecordCreateInput = {
   memo?: string | null;
 };
 
+export type RiderEducationRecordUpdateInput = {
+  educationType?: ServiceOpsRiderEducationType;
+  courseName?: string | null;
+  completedAt?: string;
+  expiresAt?: string | null;
+  certificateNo?: string | null;
+  issuingAuthority?: string | null;
+  evidenceUrl?: string | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE" | "REPAIRING" | "INSPECTION_REQUIRED";
 
 export type ServiceOpsBike = {
@@ -819,8 +830,13 @@ export type ServiceOpsApiClient = {
     riderId: string,
     params?: { page?: number; size?: number; sort?: string }
   ) => Promise<ServiceOpsPage<ServiceOpsRiderEducationRecord>>;
+  getRiderEducationRecord: (id: string) => Promise<ServiceOpsRiderEducationRecord>;
   createRiderEducationRecord: (
     request: RiderEducationRecordCreateInput
+  ) => Promise<ServiceOpsRiderEducationRecord>;
+  updateRiderEducationRecord: (
+    id: string,
+    request: RiderEducationRecordUpdateInput
   ) => Promise<ServiceOpsRiderEducationRecord>;
   deleteRiderEducationRecord: (id: string) => Promise<void>;
 };
@@ -1209,11 +1225,24 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         { method: "GET" },
         { page, size, sort }
       ),
+    getRiderEducationRecord: (id) =>
+      request<ServiceOpsRiderEducationRecord>(
+        `/rider-education-records/${encodeURIComponent(id)}`,
+        { method: "GET" }
+      ),
     createRiderEducationRecord: (createRequest) =>
       request<ServiceOpsRiderEducationRecord>("/rider-education-records", {
         body: JSON.stringify(createRequest),
         method: "POST"
       }),
+    updateRiderEducationRecord: (id, updateRequest) =>
+      request<ServiceOpsRiderEducationRecord>(
+        `/rider-education-records/${encodeURIComponent(id)}`,
+        {
+          body: JSON.stringify(updateRequest),
+          method: "PATCH"
+        }
+      ),
     deleteRiderEducationRecord: async (id) => {
       await request<void>(`/rider-education-records/${encodeURIComponent(id)}`, { method: "DELETE" });
     }


### PR DESCRIPTION
## Summary

- 라이더 교육 이력 단건 수정 페이지 추가 (`/riders/{slug}/education-records/{recordId}/edit`).
- 라이더 상세 페이지의 교육 이력 표 행에 "수정 · 삭제" 컨트롤.
- 등록 폼 컴포넌트 재사용 + defaultValues 로 기존 값 미리 채움.

## Trace

- Target issue: EVNSolution/thundercrew-domain#148
- Change-control issue: EVNSolution/clever-change-control#128
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #137 (Slice ④-1 — 라이더 교육 어드민 등록 + 삭제).

## Scope

Frontend-only.

Included:
- service-ops 클라이언트 \`getRiderEducationRecord\` / \`updateRiderEducationRecord\` 메소드.
- 단건 record server-side loader.
- 새 페이지 \`/riders/[slug]/education-records/[recordId]/edit\`.
- \`updateRiderEducationRecordAction\` server action.
- RiderEducationRecordForm 에 \`defaultValues\` / \`mode\` props 추가.
- 라이더 상세 페이지 행별 "수정" 링크 + status flash.

Excluded:
- 단건 상세 전용 페이지 (수정 폼만으로 충분).
- 검색/필터링.
- 라이더 등록/수정 폼 자체에 교육 입력 통합.

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run test:service-ops\` | ✅ 120 / 120 pass |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 + 어드민 로그인 후 라이더 상세 → 교육 이력 표 행에 "수정" 링크 확인.
- [ ] 수정 페이지가 모든 필드를 기존 값으로 채워서 열리는지 (특히 만료일이 정확한 calendar date).
- [ ] 만료일 정정 후 제출 → 라이더 상세로 돌아오고 표에 새 값이 노출, 만료/유효 뱃지 도 갱신.
- [ ] 백엔드에서 record 가 없으면 (404) 페이지가 "조회 실패" notice 만 보여주고 폼은 노출 안 함.
- [ ] 백엔드 미구성 / 세션 없음 → mock-saved 흐름.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #148 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- 라이더 등록/수정 폼에 교육 입력 통합 (등록 직후 첫 교육 이력까지 한번에 입력).
- 충전소 디테일 패널 안의 배터리 카운트 변경 폼.
- vendor 문서 도착 시 Slice F-2 — 실 vendor 구현체.
