### PR TITLE
Add inline battery count edit on the station detail panel (#150)

### DIFF
--- a/development/front-admin-web/app/api/dashboard/battery-station/[stationId]/battery-counts/route.ts
+++ b/development/front-admin-web/app/api/dashboard/battery-station/[stationId]/battery-counts/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+
+import {
+  type BatteryStationCountUpdateInput,
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type StationBatteryCountUpdateResult = {
+  ok: boolean;
+  station: import("@/lib/services/service-ops-api").FrontendBatteryStation | null;
+  notice?: string;
+};
+
+/**
+ * Inline battery-count edit endpoint hit by the station detail panel.
+ * Keeps the service-ops session cookie server-side and returns the freshly
+ * updated station so the panel can reflect new counts without waiting for
+ * the next dashboard polling cycle.
+ *
+ * Validation rules ({@code availableBatteryCount <= currentBatteryCount <=
+ * maxBatteryCapacity}, all non-negative) live on the backend; this route
+ * surfaces backend errors as a friendly notice.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ stationId: string }> }
+) {
+  const { stationId } = await context.params;
+
+  if (!serviceOpsApiConfigured()) {
+    return NextResponse.json(
+      {
+        ok: false,
+        station: null,
+        notice: "SERVICE_OPS_API_BASE_URL이 없어 카운트를 갱신할 수 없습니다."
+      },
+      {
+        headers: { "Cache-Control": "no-store" }
+      }
+    );
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    return NextResponse.json(
+      {
+        ok: false,
+        station: null,
+        notice: "관리자 세션이 없어 카운트를 갱신할 수 없습니다. 다시 로그인해 주세요."
+      },
+      {
+        headers: { "Cache-Control": "no-store" }
+      }
+    );
+  }
+
+  let body: Partial<BatteryStationCountUpdateInput>;
+  try {
+    body = (await request.json()) as Partial<BatteryStationCountUpdateInput>;
+  } catch {
+    return NextResponse.json(
+      { ok: false, station: null, notice: "요청 본문을 해석할 수 없습니다." },
+      { status: 400, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  const payload = sanitizePayload(body);
+  if (!payload.ok) {
+    return NextResponse.json(
+      { ok: false, station: null, notice: payload.notice },
+      { status: 400, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  try {
+    const station = await client.updateBatteryStationCounts(stationId, payload.value);
+    return NextResponse.json(
+      { ok: true, station },
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        station: null,
+        notice: `카운트 갱신 실패.${formatServiceOpsError(error)}`
+      },
+      { status: 502, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+}
+
+function sanitizePayload(
+  body: Partial<BatteryStationCountUpdateInput>
+):
+  | { ok: true; value: BatteryStationCountUpdateInput }
+  | { ok: false; notice: string } {
+  const max = toNonNegativeInt(body.maxBatteryCapacity, "최대 보관 수량");
+  if (!max.ok) return { ok: false, notice: max.notice };
+  const current = toNonNegativeInt(body.currentBatteryCount, "현재 보관 수량");
+  if (!current.ok) return { ok: false, notice: current.notice };
+  const available = toNonNegativeInt(body.availableBatteryCount, "가용 수량");
+  if (!available.ok) return { ok: false, notice: available.notice };
+
+  if (current.value > max.value) {
+    return { ok: false, notice: "현재 보관 수량은 최대 보관 수량을 넘을 수 없습니다." };
+  }
+  if (available.value > current.value) {
+    return { ok: false, notice: "가용 수량은 현재 보관 수량을 넘을 수 없습니다." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      maxBatteryCapacity: max.value,
+      currentBatteryCount: current.value,
+      availableBatteryCount: available.value,
+      reason: body.reason ? String(body.reason).trim() || null : null,
+      memo: body.memo ? String(body.memo).trim() || null : null
+    }
+  };
+}
+
+function toNonNegativeInt(
+  raw: unknown,
+  label: string
+): { ok: true; value: number } | { ok: false; notice: string } {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    return { ok: false, notice: `${label}은 0 이상의 정수여야 합니다.` };
+  }
+  return { ok: true, value: n };
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -275,6 +275,14 @@ button, input, select, textarea { font: inherit; }
 .bike-detail-panel-list-item { display: grid; gap: 2px; padding: 8px 10px; border-radius: 10px; background: var(--rm-bg-section); }
 .bike-detail-panel-list-title { font-size: 13px; font-weight: 700; color: var(--rm-text-primary); }
 .bike-detail-panel-list-meta { font-size: 12px; color: var(--rm-text-secondary); }
+.station-count-edit { display: grid; gap: 10px; padding: 12px 0 0; border-top: 1px solid var(--rm-line-subtle); }
+.station-count-edit-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.station-count-edit-field { display: grid; gap: 4px; font-size: 12px; color: var(--rm-text-secondary); }
+.station-count-edit-field input { font-size: 13px; padding: 6px 8px; }
+.station-count-edit-field-wide { display: grid; gap: 4px; font-size: 12px; color: var(--rm-text-secondary); }
+.station-count-edit-field-wide input { font-size: 13px; padding: 6px 8px; }
+.station-count-edit-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.station-count-edit-actions button { padding: 6px 14px; font-size: 13px; }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
 import type { BatteryStationDetailResult } from "@/lib/services/battery-station-detail-data";
-import type { FrontendDashboardStationPin } from "@/lib/services/service-ops-api";
+import type { FrontendBatteryStation, FrontendDashboardStationPin } from "@/lib/services/service-ops-api";
+
+type CountUpdateOutcome =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "success"; station: FrontendBatteryStation }
+  | { phase: "error"; notice: string };
 
 export interface StationDetailPanelProps {
   pin: FrontendDashboardStationPin;
@@ -30,8 +36,14 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
     stationId: pin.stationId,
     data: { phase: "idle" }
   });
+  const [countUpdate, setCountUpdate] = useState<{ stationId: string; outcome: CountUpdateOutcome }>({
+    stationId: pin.stationId,
+    outcome: { phase: "idle" }
+  });
 
   const isFresh = outcome.stationId === pin.stationId;
+  const countUpdateFresh = countUpdate.stationId === pin.stationId;
+  const countUpdateOutcome: CountUpdateOutcome = countUpdateFresh ? countUpdate.outcome : { phase: "idle" };
 
   useEffect(() => {
     let cancelled = false;
@@ -58,9 +70,12 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
 
   const result = isFresh && outcome.data.phase === "loaded" ? outcome.data.result : null;
   const loading = !isFresh || outcome.data.phase === "idle";
-  const live = result?.data;
+  // Prefer the freshly-updated station from the inline count edit if it
+  // succeeded; otherwise fall back to the single fetch result; finally to
+  // the map-state pin.
+  const updated = countUpdateOutcome.phase === "success" ? countUpdateOutcome.station : null;
+  const live = updated ?? result?.data ?? null;
 
-  // Prefer freshly-fetched single state; fall back to map-state pin.
   const name = live?.name ?? pin.name;
   const address = live?.address ?? pin.address;
   const status = live?.stationStatus ?? pin.status;
@@ -72,6 +87,49 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
   const latitude = live?.latitude ?? pin.latitude;
   const longitude = live?.longitude ?? pin.longitude;
   const updatedAt = live?.updatedAt ?? null;
+
+  async function handleCountUpdateSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const stationId = pin.stationId;
+    setCountUpdate({ stationId, outcome: { phase: "submitting" } });
+    try {
+      const response = await fetch(
+        `/api/dashboard/battery-station/${encodeURIComponent(stationId)}/battery-counts`,
+        {
+          body: JSON.stringify({
+            maxBatteryCapacity: numberOrNull(formData.get("maxBatteryCapacity")),
+            currentBatteryCount: numberOrNull(formData.get("currentBatteryCount")),
+            availableBatteryCount: numberOrNull(formData.get("availableBatteryCount")),
+            reason: stringOrNull(formData.get("reason"))
+          }),
+          cache: "no-store",
+          credentials: "same-origin",
+          headers: { "Content-Type": "application/json" },
+          method: "POST"
+        }
+      );
+      const body = (await response.json()) as {
+        ok: boolean;
+        station: FrontendBatteryStation | null;
+        notice?: string;
+      };
+      if (body.ok && body.station) {
+        setCountUpdate({ stationId, outcome: { phase: "success", station: body.station } });
+      } else {
+        setCountUpdate({
+          stationId,
+          outcome: { phase: "error", notice: body.notice ?? "카운트 갱신 실패." }
+        });
+      }
+    } catch {
+      setCountUpdate({
+        stationId,
+        outcome: { phase: "error", notice: "네트워크 오류로 카운트 갱신에 실패했습니다." }
+      });
+    }
+  }
 
   return (
     <aside
@@ -111,8 +169,89 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
       {!loading && result?.notice ? (
         <p className="bike-detail-panel-status" role="status">{result.notice}</p>
       ) : null}
+
+      <form className="station-count-edit" onSubmit={handleCountUpdateSubmit}>
+        <h3 className="bike-detail-panel-section-title">배터리 카운트 변경</h3>
+        <div className="station-count-edit-grid">
+          <label className="station-count-edit-field">
+            <span>최대</span>
+            <input
+              className="input"
+              defaultValue={maxBatteryCapacity}
+              key={`max-${pin.stationId}-${live?.updatedAt ?? "init"}`}
+              min={0}
+              name="maxBatteryCapacity"
+              required
+              type="number"
+            />
+          </label>
+          <label className="station-count-edit-field">
+            <span>현재</span>
+            <input
+              className="input"
+              defaultValue={currentBatteryCount}
+              key={`current-${pin.stationId}-${live?.updatedAt ?? "init"}`}
+              min={0}
+              name="currentBatteryCount"
+              required
+              type="number"
+            />
+          </label>
+          <label className="station-count-edit-field">
+            <span>가용</span>
+            <input
+              className="input"
+              defaultValue={availableBatteryCount}
+              key={`available-${pin.stationId}-${live?.updatedAt ?? "init"}`}
+              min={0}
+              name="availableBatteryCount"
+              required
+              type="number"
+            />
+          </label>
+        </div>
+        <label className="station-count-edit-field-wide">
+          <span>변경 사유 (선택)</span>
+          <input
+            className="input"
+            maxLength={100}
+            name="reason"
+            placeholder="예: 배터리 5개 신규 입고"
+            type="text"
+          />
+        </label>
+        <div className="station-count-edit-actions">
+          <button
+            className="button-primary"
+            disabled={countUpdateOutcome.phase === "submitting"}
+            type="submit"
+          >
+            {countUpdateOutcome.phase === "submitting" ? "갱신 중…" : "카운트 갱신"}
+          </button>
+        </div>
+        {countUpdateOutcome.phase === "error" ? (
+          <p className="action-feedback" role="status">{countUpdateOutcome.notice}</p>
+        ) : null}
+        {countUpdateOutcome.phase === "success" ? (
+          <p className="action-feedback" role="status">카운트가 갱신되었습니다.</p>
+        ) : null}
+      </form>
     </aside>
   );
+}
+
+function numberOrNull(value: FormDataEntryValue | null): number | null {
+  if (value === null) return null;
+  const text = String(value).trim();
+  if (!text) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+}
+
+function stringOrNull(value: FormDataEntryValue | null): string | null {
+  if (value === null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
 }
 
 function DetailRow({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

- 충전소 디테일 패널 안에서 max / current / available 배터리 카운트를 직접 변경 가능.
- 마커 클릭 → 패널 → 폼 입력 → 즉시 반영 (페이지 이동 없이).
- 백엔드 검증 실패 (가용 > 현재 > 최대 위반 등) 는 한글 안내로 폼 위에 노출.

## Trace

- Target issue: EVNSolution/thundercrew-domain#150
- Change-control issue: EVNSolution/clever-change-control#129
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #147 (StationDetailPanel skeleton).

## Scope

Frontend-only.

Included:
- 새 Next.js POST 라우트 \`/api/dashboard/battery-station/[stationId]/battery-counts\` (sanitize + 서비스-API 호출).
- StationDetailPanel inline 폼 (max/current/available + 사유) + countUpdate state.
- 응답 station 데이터로 패널 즉시 갱신 — polling 다음 사이클 기다리지 않음.
- 새 \`.station-count-edit-*\` CSS 토큰 (기존 \`--rm-*\` palette 사용).

Excluded:
- 카운트 변경 이력 (\`station_battery_count_logs\`) 표시.
- 충전소 메타 (이름/주소/상태) 변경 (기존 \`/stations/{id}/edit\` 사용).
- 일괄 변경.

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run test:service-ops\` | ✅ 120 / 120 pass |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 + 어드민 로그인 후 충전소 마커 클릭 → 패널에 카운트 입력 폼 노출, 현재 카운트가 미리 채워짐.
- [ ] max/current/available 합리적 값 입력 후 제출 → 패널이 닫히지 않고 카운트 row 가 즉시 새 값으로 갱신.
- [ ] 가용 > 현재 입력 시 폼 위에 "가용 수량은 현재 보관 수량을 넘을 수 없습니다" 안내.
- [ ] 백엔드 미구성 / 세션 없음 시 폼 제출 시 에러 안내.
- [ ] DevTools Network → 폼 제출마다 \`POST /api/dashboard/battery-station/{id}/battery-counts\` 1회 호출 + 응답에 갱신된 station 객체.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #150 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- 라이더 등록/수정 폼에 교육 입력 통합 (one-shot 등록).
- 충전소 카운트 변경 이력 표시 (디테일 패널 안 또는 별도 화면).
- vendor 문서 도착 시 Slice F-2 — 실 vendor 구현체.
