### PR TITLE
Add optional initial education record to rider create form (#152)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -283,6 +283,9 @@ button, input, select, textarea { font: inherit; }
 .station-count-edit-field-wide input { font-size: 13px; padding: 6px 8px; }
 .station-count-edit-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .station-count-edit-actions button { padding: 6px 14px; font-size: 13px; }
+.rider-form-education { display: grid; gap: 12px; margin: 24px 0 0; padding: 16px 18px; border: 1px dashed var(--rm-line-subtle); border-radius: var(--rm-radius-md); background: var(--rm-bg-section); }
+.rider-form-education legend { padding: 0 8px; font-size: 13px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
+.rider-form-education-hint { margin: 0; font-size: 12px; color: var(--rm-text-secondary); line-height: 1.55; }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -14,6 +14,8 @@ import type { ServiceOpsRiderEducationRecord } from "@/lib/services/service-ops-
 
 const statusMessage: Record<string, string> = {
   created: "라이더가 등록되었습니다.",
+  "created-with-education": "라이더와 첫 교육 이력이 함께 등록되었습니다.",
+  "created-education-failed": "라이더는 등록되었지만 첫 교육 이력 저장에 실패했습니다. 아래 표에서 다시 등록해 주세요.",
   "delete-error": "라이더 비활성 삭제에 실패했습니다. 활성 계약/보험 연결이나 백엔드 연결 상태를 확인하세요.",
   "education-created": "교육 이력이 등록되었습니다.",
   "education-deleted": "교육 이력이 삭제되었습니다.",

--- a/development/front-admin-web/app/riders/actions.ts
+++ b/development/front-admin-web/app/riders/actions.ts
@@ -3,7 +3,12 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-import { type RiderCreateInput, serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import {
+  type RiderCreateInput,
+  type RiderEducationRecordCreateInput,
+  type ServiceOpsRiderEducationType,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 
 export async function createRiderAction(formData: FormData): Promise<void> {
@@ -23,8 +28,68 @@ export async function createRiderAction(formData: FormData): Promise<void> {
     redirect("/riders/new?status=save-error");
   }
 
+  // Slice ④-1b: optional initial education record. Both educationType and
+  // completedAt must be supplied; otherwise we treat the section as
+  // intentionally skipped. A failure here does NOT roll the rider back —
+  // the rider already exists, so the operator can retry from the rider
+  // detail page using the dedicated education form.
+  const educationPayload = toInitialEducationPayload(rider.id ?? rider.slug, formData);
+  let educationOutcome: "none" | "created" | "failed" = "none";
+  if (educationPayload) {
+    try {
+      await client.createRiderEducationRecord(educationPayload);
+      educationOutcome = "created";
+    } catch {
+      educationOutcome = "failed";
+    }
+  }
+
   revalidatePath("/riders");
-  redirect(`/riders/${rider.slug}?status=created`);
+  const status = createdStatusFor(educationOutcome);
+  redirect(`/riders/${rider.slug}?status=${status}`);
+}
+
+function createdStatusFor(outcome: "none" | "created" | "failed"): string {
+  if (outcome === "created") return "created-with-education";
+  if (outcome === "failed") return "created-education-failed";
+  return "created";
+}
+
+function toInitialEducationPayload(
+  riderId: string,
+  formData: FormData
+): RiderEducationRecordCreateInput | null {
+  const educationTypeRaw = String(formData.get("initialEducationType") ?? "").trim();
+  const completedAtIso = toIsoTimestamp(formData.get("initialEducationCompletedAt"));
+  if (!educationTypeRaw || !completedAtIso) {
+    // Operator left the optional section empty — skip cleanly.
+    return null;
+  }
+  if (educationTypeRaw !== "ONLINE" && educationTypeRaw !== "OFFLINE") {
+    return null;
+  }
+  return {
+    riderId,
+    educationType: educationTypeRaw as ServiceOpsRiderEducationType,
+    courseName: optionalText(formData.get("initialEducationCourseName")),
+    completedAt: completedAtIso,
+    expiresAt: toIsoTimestamp(formData.get("initialEducationExpiresAt")) ?? null,
+    certificateNo: optionalText(formData.get("initialEducationCertificateNo")),
+    issuingAuthority: optionalText(formData.get("initialEducationIssuingAuthority")),
+    evidenceUrl: null,
+    memo: null
+  };
+}
+
+function toIsoTimestamp(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const [year, month, day] = text.split("-").map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  return date.toISOString();
 }
 
 export async function updateRiderAction(riderId: string, formData: FormData): Promise<void> {

--- a/development/front-admin-web/app/riders/new/page.tsx
+++ b/development/front-admin-web/app/riders/new/page.tsx
@@ -14,7 +14,11 @@ export default async function NewRiderPage({ searchParams }: { searchParams: Pro
     <div className="page-container">
       <BackToListLink href="/riders" />
       <PageHeader title="라이더 등록" description="라이더 ID는 DB에서 자동 생성합니다. 사용자는 이름, 연락처, 소속과 담당 구역만 입력합니다." />
-      <RiderForm action={createRiderAction} statusMessage={status ? statusMessage[status] : null} />
+      <RiderForm
+        action={createRiderAction}
+        includeInitialEducation
+        statusMessage={status ? statusMessage[status] : null}
+      />
     </div>
   );
 }

--- a/development/front-admin-web/components/riders/RiderForm.tsx
+++ b/development/front-admin-web/components/riders/RiderForm.tsx
@@ -15,6 +15,12 @@ type RiderFormProps = {
   action: (formData: FormData) => void | Promise<void>;
   cancelHref?: string;
   defaultValues?: RiderFormValues;
+  /**
+   * Slice ④-1b: include the optional "first education record" block in the
+   * form. Only meaningful on rider create — the rider edit page handles
+   * education through the dedicated detail-page section.
+   */
+  includeInitialEducation?: boolean;
   mode?: "등록" | "수정";
   statusMessage?: string | null;
 };
@@ -22,7 +28,14 @@ type RiderFormProps = {
 const teamOptions = ["강남 1팀", "서초 2팀", "송파 1팀"];
 const areaOptions = ["강남/역삼", "서초/방배", "송파/잠실"];
 
-export function RiderForm({ action, cancelHref = "/riders", defaultValues, mode = "등록", statusMessage }: RiderFormProps) {
+export function RiderForm({
+  action,
+  cancelHref = "/riders",
+  defaultValues,
+  includeInitialEducation = false,
+  mode = "등록",
+  statusMessage
+}: RiderFormProps) {
   return (
     <form action={action} className="card" aria-label={`라이더 ${mode} 폼`}>
       <div className="form-grid">
@@ -44,11 +57,63 @@ export function RiderForm({ action, cancelHref = "/riders", defaultValues, mode 
       </div>
       <br />
       <Field label="메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={4} /></Field>
+      {includeInitialEducation ? <InitialEducationFields /> : null}
       {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
       <div className="form-actions">
         <Link className="button-secondary" href={cancelHref}>취소</Link>
         <button className="button-primary" type="submit">라이더 {mode}</button>
       </div>
     </form>
+  );
+}
+
+function InitialEducationFields() {
+  return (
+    <fieldset className="rider-form-education">
+      <legend>초기 교육 이력 (선택)</legend>
+      <p className="rider-form-education-hint">
+        교육 종류와 완료일을 모두 입력하면 라이더 등록 직후 첫 교육 이력도 함께 등록됩니다.
+        둘 중 하나라도 비어 있으면 라이더만 등록되고 교육 이력은 라이더 상세에서 추가로 등록할 수 있습니다.
+      </p>
+      <div className="form-grid">
+        <Field label="교육 종류">
+          <select className="select" defaultValue="" name="initialEducationType">
+            <option value="">미입력</option>
+            <option value="ONLINE">온라인 교육</option>
+            <option value="OFFLINE">오프라인 교육</option>
+          </select>
+        </Field>
+        <Field label="과정명">
+          <input
+            className="input"
+            maxLength={200}
+            name="initialEducationCourseName"
+            placeholder="예: 전기이륜차 안전 운행 교육 2026"
+          />
+        </Field>
+        <Field label="완료일">
+          <input className="input" name="initialEducationCompletedAt" type="date" />
+        </Field>
+        <Field label="만료일 (선택)">
+          <input className="input" name="initialEducationExpiresAt" type="date" />
+        </Field>
+        <Field label="수료증 번호 (선택)">
+          <input
+            className="input"
+            maxLength={100}
+            name="initialEducationCertificateNo"
+            placeholder="예: CRT-2026-00001"
+          />
+        </Field>
+        <Field label="발급 기관 (선택)">
+          <input
+            className="input"
+            maxLength={100}
+            name="initialEducationIssuingAuthority"
+            placeholder="예: 교통안전공단"
+          />
+        </Field>
+      </div>
+    </fieldset>
   );
 }


### PR DESCRIPTION
## Summary

- 라이더 등록 폼에 "초기 교육 이력 (선택)" 섹션 추가 — 한 화면에서 라이더 + 첫 교육 record 까지 동시 등록 가능.
- 교육 종류 / 완료일 둘 다 입력하면 백엔드 호출, 둘 중 하나라도 비어있으면 라이더만 등록.
- 교육 record 실패 시 라이더는 그대로 유지 + 라이더 상세 페이지의 status flash 가 "다시 등록" 안내.

## Trace

- Target issue: EVNSolution/thundercrew-domain#152
- Change-control issue: EVNSolution/clever-change-control#130
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #137 (Slice ④-1 — 라이더 교육 어드민), #149 (라이더 교육 수정 페이지).

## Scope

Frontend-only.

Included:
- RiderForm \`includeInitialEducation\` prop + InitialEducationFields fieldset.
- /riders/new 페이지가 prop true 로 전달.
- createRiderAction 의 라이더 + (선택) 교육 record 두 단계 호출.
- 결과별 status flash 3종 (\`created\` / \`created-with-education\` / \`created-education-failed\`).
- \`.rider-form-education\` CSS 토큰.

Excluded:
- 수정 폼 통합.
- 다중 교육 record 동시 등록.
- 보험 입력 통합.

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run test:service-ops\` | ✅ 120 / 120 pass |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 + 어드민 로그인 후 \`/riders/new\` → 폼 하단에 "초기 교육 이력 (선택)" fieldset 노출.
- [ ] 교육 섹션 모두 비우고 등록 → 라이더만 생성 + status flash "라이더가 등록되었습니다.".
- [ ] 교육 종류 + 완료일 + 일부 필드 입력 후 등록 → 라이더 + 교육 record 둘 다 생성 + flash "라이더와 첫 교육 이력이 함께 등록되었습니다.".
- [ ] 교육 종류만 입력하고 완료일 비워두고 등록 → 교육 skip + 라이더만 등록.
- [ ] (의도적 검증) 백엔드가 교육 record 만 거부하는 케이스 — 라이더 상세에 "라이더는 등록되었지만 첫 교육 이력 저장에 실패했습니다." flash + 라이더는 정상 생성.
- [ ] 백엔드 미구성 / 세션 없음 → mock-saved.

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #152 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

다음 추천 후속:

- 충전소 카운트 변경 이력 표시 (디테일 패널 또는 별도 화면).
- 라이더 등록 시 보험 입력 통합 (one-shot).
- vendor 문서 도착 시 Slice F-2.
