### PR TITLE
Add optional initial insurance link to rider create form (#154)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -286,6 +286,9 @@ button, input, select, textarea { font: inherit; }
 .rider-form-education { display: grid; gap: 12px; margin: 24px 0 0; padding: 16px 18px; border: 1px dashed var(--rm-line-subtle); border-radius: var(--rm-radius-md); background: var(--rm-bg-section); }
 .rider-form-education legend { padding: 0 8px; font-size: 13px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
 .rider-form-education-hint { margin: 0; font-size: 12px; color: var(--rm-text-secondary); line-height: 1.55; }
+.rider-form-insurance { display: grid; gap: 12px; margin: 16px 0 0; padding: 16px 18px; border: 1px dashed var(--rm-line-subtle); border-radius: var(--rm-radius-md); background: var(--rm-bg-section); }
+.rider-form-insurance legend { padding: 0 8px; font-size: 13px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
+.rider-form-insurance-hint { margin: 0; font-size: 12px; color: var(--rm-text-secondary); line-height: 1.55; }
 .map-empty-panel { position: relative; width: min(520px, calc(100% - 48px)); margin: 0 auto; top: 50%; transform: translateY(45vh); padding: 24px; border-radius: 16px; background: color-mix(in srgb, var(--color-surface) 86%, transparent); backdrop-filter: blur(16px); box-shadow: var(--shadow-panel); text-align: center; }
 .map-empty-panel h1 { margin: 14px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.8px; }
 .map-empty-panel p { margin: 0; color: var(--color-text-secondary); line-height: 1.65; }

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -26,6 +26,36 @@ const statusMessage: Record<string, string> = {
   updated: "라이더 정보가 수정되었습니다."
 };
 
+/**
+ * Slice ④-1c expanded the rider create flow with optional sidecar steps
+ * (education + insurance). Each sidecar reports independent ok / fail / skip,
+ * and the action encodes the trio as `created-x-e<code>-i<code>`. Resolve the
+ * compact code here so the detail page can show a single, plainly-Korean
+ * flash describing what actually happened.
+ */
+function resolveCompositeCreatedStatus(status: string | undefined): string | null {
+  if (!status) return null;
+  const match = status.match(/^created-x-e(ok|fail|skip)-i(ok|fail|skip)$/);
+  if (!match) return null;
+  const [, education, insurance] = match;
+  const educationLabel = sidecarOutcomeLabel("교육 이력", education);
+  const insuranceLabel = sidecarOutcomeLabel("보험 연결", insurance);
+  return ["라이더가 등록되었습니다.", educationLabel, insuranceLabel]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function sidecarOutcomeLabel(label: string, code: string): string | null {
+  switch (code) {
+    case "ok":
+      return `${label}도 함께 등록되었습니다.`;
+    case "fail":
+      return `${label} 저장은 실패했습니다 — 라이더 상세에서 다시 등록해 주세요.`;
+    default:
+      return null;
+  }
+}
+
 export default async function RiderDetailPage({
   params,
   searchParams
@@ -41,7 +71,7 @@ export default async function RiderDetailPage({
   }
 
   const { contracts, insurance, notice, rider } = detail;
-  const message = status ? statusMessage[status] : null;
+  const message = (status ? statusMessage[status] : null) ?? resolveCompositeCreatedStatus(status);
   const deleteAction = deleteRiderAction.bind(null, rider.slug);
   const riderId = rider.id ?? rider.slug;
   const educationResult = await loadRiderEducationRecords(riderId);

--- a/development/front-admin-web/app/riders/actions.ts
+++ b/development/front-admin-web/app/riders/actions.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import {
   type RiderCreateInput,
   type RiderEducationRecordCreateInput,
+  type RiderInsuranceCreateInput,
   type ServiceOpsRiderEducationType,
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
@@ -33,8 +34,9 @@ export async function createRiderAction(formData: FormData): Promise<void> {
   // intentionally skipped. A failure here does NOT roll the rider back —
   // the rider already exists, so the operator can retry from the rider
   // detail page using the dedicated education form.
-  const educationPayload = toInitialEducationPayload(rider.id ?? rider.slug, formData);
-  let educationOutcome: "none" | "created" | "failed" = "none";
+  const riderId = rider.id ?? rider.slug;
+  const educationPayload = toInitialEducationPayload(riderId, formData);
+  let educationOutcome: SidecarOutcome = "none";
   if (educationPayload) {
     try {
       await client.createRiderEducationRecord(educationPayload);
@@ -44,15 +46,43 @@ export async function createRiderAction(formData: FormData): Promise<void> {
     }
   }
 
+  // Slice ④-1c: optional initial rider-insurance link. Same fail-soft
+  // contract as the education sidecar — a failed insurance link does not
+  // roll back the rider (or the education record).
+  const insurancePayload = toInitialInsurancePayload(riderId, formData);
+  let insuranceOutcome: SidecarOutcome = "none";
+  if (insurancePayload) {
+    try {
+      await client.createRiderInsurance(insurancePayload);
+      insuranceOutcome = "created";
+    } catch {
+      insuranceOutcome = "failed";
+    }
+  }
+
   revalidatePath("/riders");
-  const status = createdStatusFor(educationOutcome);
+  const status = createdStatusFor(educationOutcome, insuranceOutcome);
   redirect(`/riders/${rider.slug}?status=${status}`);
 }
 
-function createdStatusFor(outcome: "none" | "created" | "failed"): string {
-  if (outcome === "created") return "created-with-education";
-  if (outcome === "failed") return "created-education-failed";
-  return "created";
+type SidecarOutcome = "none" | "created" | "failed";
+
+function createdStatusFor(
+  education: SidecarOutcome,
+  insurance: SidecarOutcome
+): string {
+  // Compact status code: e=education state, i=insurance state, both single
+  // letters mapping to the SidecarOutcome union. The detail page resolves
+  // the code into a Korean message. Keeping the codes short keeps the URL
+  // readable in dev tooling and analytics.
+  if (education === "none" && insurance === "none") return "created";
+  return `created-x-e${shortCode(education)}-i${shortCode(insurance)}`;
+}
+
+function shortCode(outcome: SidecarOutcome): string {
+  if (outcome === "created") return "ok";
+  if (outcome === "failed") return "fail";
+  return "skip";
 }
 
 function toInitialEducationPayload(
@@ -78,6 +108,25 @@ function toInitialEducationPayload(
     issuingAuthority: optionalText(formData.get("initialEducationIssuingAuthority")),
     evidenceUrl: null,
     memo: null
+  };
+}
+
+function toInitialInsurancePayload(
+  riderId: string,
+  formData: FormData
+): RiderInsuranceCreateInput | null {
+  const insuranceItemId = String(formData.get("initialInsuranceItemId") ?? "").trim();
+  if (!insuranceItemId) {
+    return null;
+  }
+  return {
+    riderId,
+    insuranceItemId,
+    memo: optionalText(formData.get("initialInsuranceMemo")),
+    enabled: true,
+    startsAt: toIsoTimestamp(formData.get("initialInsuranceStartsAt")) ?? null,
+    endsAt: toIsoTimestamp(formData.get("initialInsuranceEndsAt")) ?? null,
+    riderBikeContractId: null
   };
 }
 

--- a/development/front-admin-web/app/riders/new/page.tsx
+++ b/development/front-admin-web/app/riders/new/page.tsx
@@ -2,13 +2,17 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
 import { RiderForm } from "@/components/riders/RiderForm";
 import { createRiderAction } from "@/app/riders/actions";
+import { loadInsuranceOptions } from "@/lib/services/insurance-options-data";
 
 const statusMessage: Record<string, string> = {
   "save-error": "라이더 저장에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요."
 };
 
 export default async function NewRiderPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
-  const { status } = await searchParams;
+  const [{ status }, insuranceOptions] = await Promise.all([
+    searchParams,
+    loadInsuranceOptions()
+  ]);
 
   return (
     <div className="page-container">
@@ -17,6 +21,9 @@ export default async function NewRiderPage({ searchParams }: { searchParams: Pro
       <RiderForm
         action={createRiderAction}
         includeInitialEducation
+        includeInitialInsurance
+        insuranceOptions={insuranceOptions.options}
+        insuranceOptionsNotice={insuranceOptions.notice}
         statusMessage={status ? statusMessage[status] : null}
       />
     </div>

--- a/development/front-admin-web/components/riders/RiderForm.tsx
+++ b/development/front-admin-web/components/riders/RiderForm.tsx
@@ -11,6 +11,12 @@ type RiderFormValues = {
   teamName?: string | null;
 };
 
+export type RiderFormInsuranceOption = {
+  id: string;
+  name: string;
+  category?: string;
+};
+
 type RiderFormProps = {
   action: (formData: FormData) => void | Promise<void>;
   cancelHref?: string;
@@ -21,6 +27,15 @@ type RiderFormProps = {
    * education through the dedicated detail-page section.
    */
   includeInitialEducation?: boolean;
+  /**
+   * Slice ④-1c: include the optional "first insurance link" block. The
+   * caller must pass {@code insuranceOptions} loaded server-side from the
+   * insurance catalog; passing an empty list disables the section with a
+   * notice instead of rendering an empty select.
+   */
+  includeInitialInsurance?: boolean;
+  insuranceOptions?: RiderFormInsuranceOption[];
+  insuranceOptionsNotice?: string | null;
   mode?: "등록" | "수정";
   statusMessage?: string | null;
 };
@@ -33,6 +48,9 @@ export function RiderForm({
   cancelHref = "/riders",
   defaultValues,
   includeInitialEducation = false,
+  includeInitialInsurance = false,
+  insuranceOptions = [],
+  insuranceOptionsNotice = null,
   mode = "등록",
   statusMessage
 }: RiderFormProps) {
@@ -58,12 +76,73 @@ export function RiderForm({
       <br />
       <Field label="메모"><textarea className="input" defaultValue={defaultValues?.memo ?? ""} name="memo" placeholder="운영자가 볼 내부 메모" rows={4} /></Field>
       {includeInitialEducation ? <InitialEducationFields /> : null}
+      {includeInitialInsurance ? (
+        <InitialInsuranceFields
+          options={insuranceOptions}
+          notice={insuranceOptionsNotice}
+        />
+      ) : null}
       {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
       <div className="form-actions">
         <Link className="button-secondary" href={cancelHref}>취소</Link>
         <button className="button-primary" type="submit">라이더 {mode}</button>
       </div>
     </form>
+  );
+}
+
+function InitialInsuranceFields({
+  options,
+  notice
+}: {
+  options: RiderFormInsuranceOption[];
+  notice: string | null;
+}) {
+  if (options.length === 0) {
+    return (
+      <fieldset className="rider-form-insurance">
+        <legend>초기 보험 (선택)</legend>
+        <p className="rider-form-insurance-hint">
+          {notice
+            ?? "보험 항목 catalog 가 비어 있어 등록 단계에서는 보험을 연결할 수 없습니다. 라이더 등록 후 라이더 상세에서 추가하세요."}
+        </p>
+      </fieldset>
+    );
+  }
+  return (
+    <fieldset className="rider-form-insurance">
+      <legend>초기 보험 (선택)</legend>
+      <p className="rider-form-insurance-hint">
+        보험 항목을 선택하면 라이더 등록 직후 첫 보험 연결도 함께 만들어집니다.
+        선택하지 않으면 라이더만 등록되고 보험은 라이더 상세에서 추가로 연결할 수 있습니다.
+      </p>
+      <div className="form-grid">
+        <Field label="보험 항목">
+          <select className="select" defaultValue="" name="initialInsuranceItemId">
+            <option value="">미선택</option>
+            {options.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name} {option.category ? `(${option.category})` : ""}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="시작일 (선택)">
+          <input className="input" name="initialInsuranceStartsAt" type="date" />
+        </Field>
+        <Field label="종료일 (선택)">
+          <input className="input" name="initialInsuranceEndsAt" type="date" />
+        </Field>
+      </div>
+      <Field label="메모 (선택)">
+        <input
+          className="input"
+          maxLength={200}
+          name="initialInsuranceMemo"
+          placeholder="예: 운영자 메모"
+        />
+      </Field>
+    </fieldset>
   );
 }
 

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -353,6 +353,9 @@ export type RiderInsuranceCreateInput = {
   insuranceItemId: string;
   memo?: string | null;
   enabled?: boolean | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  riderBikeContractId?: string | null;
 };
 
 export type RiderInsuranceUpdateInput = {


### PR DESCRIPTION
## Summary

- 라이더 등록 폼에 "초기 보험 (선택)" fieldset 추가 — 보험 catalog 에서 항목 선택 + 시작일/종료일/메모.
- 한 화면에서 라이더 + (선택) 교육 + (선택) 보험 모두 등록 가능 (one-shot UX).
- 각 단계 fail-soft — 라이더 생성은 보험/교육 실패가 절대 되돌리지 않음.
- redirect status 코드가 결과 조합을 한글 composite 메시지로 노출.

## Trace

- Target issue: EVNSolution/thundercrew-domain#154
- Change-control issue: EVNSolution/clever-change-control#131
- Root project-start: EVNSolution/clever-change-control#45
- Builds on (merged): #137 / #149 / #153 (라이더 + 교육 흐름), #141 (보험 항목 폼).

## Scope

Frontend-only.

Included:
- 보험 catalog server-side fetch (\`loadInsuranceOptions\` 재사용).
- RiderForm \`includeInitialInsurance\` / \`insuranceOptions\` props.
- \`InitialInsuranceFields\` fieldset.
- createRiderAction 의 라이더 + (선택) 교육 + (선택) 보험 흐름.
- composite status code (\`created-x-e<ok|fail|skip>-i<ok|fail|skip>\`) + 라이더 상세 페이지의 \`resolveCompositeCreatedStatus\` 매핑.
- \`RiderInsuranceCreateInput\` 에 startsAt / endsAt / riderBikeContractId 필드 추가.

Excluded:
- 다중 보험 동시 등록 (메인 + 부가).
- 라이더 수정 폼 통합.
- 보험 시작 시점에 contract 가 없으니 contract 연결은 폼에서 빠짐 (백엔드 nullable).

## Validation

| 항목 | 결과 |
|------|------|
| \`npx tsc --noEmit\` | ✅ clean |
| \`npm run lint\` | ✅ clean |
| \`npm run test:service-ops\` | ✅ 120 / 120 pass |
| \`npm run build\` | ✅ BUILD SUCCESSFUL |

## Test plan

- [ ] 로컬 + 시드 + 어드민 로그인 후 \`/riders/new\` → 폼 하단에 "초기 교육 이력 (선택)" 과 "초기 보험 (선택)" 두 fieldset 노출.
- [ ] 보험 항목만 선택하고 라이더 등록 → 라이더 + 보험 연결 동시 생성, status flash "라이더가 등록되었습니다. 보험 연결도 함께 등록되었습니다.".
- [ ] 보험 항목 + 시작일 + 종료일 모두 입력 → 라이더-보험 행에 starts_at/ends_at 채워짐.
- [ ] 교육 + 보험 둘 다 입력 → 두 sidecar 모두 등록, status flash 가 둘 다 합쳐서 표시.
- [ ] 보험 catalog 비어있는 상태에서 페이지 진입 → "보험 항목 catalog 가 비어 있어..." 안내 노출 + 보험 select 미렌더.
- [ ] (의도적) 보험 단계만 백엔드에서 거부되는 케이스 → 라이더는 생성됨 + flash "보험 연결 저장은 실패했습니다 — 라이더 상세에서 다시 등록해 주세요.".

## Concurrent work gate

- Decision: \`allowed-with-non-overlap\`.
- Open target issues at PR open: #154 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 슬라이스로 라이더 등록 화면이 라이더 + (선택) 교육 + (선택) 보험까지 한 번에 처리하는 one-shot UX 마무리.

다음 추천 후속:

- 충전소 카운트 변경 이력 표시 — (사용자가 스킵).
- vendor 문서 도착 시 Slice F-2 — 실 vendor 구현체.
- 다중 보험 동시 등록 (PRIMARY + ADDON) — 운영자가 라이더 등록 시점부터 부가 보험까지 묶어 등록할 필요가 생기면.
