### PR TITLE
Add admin user NCP map toggle preference (#156, Slice C-1)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AdminPreferencesController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AdminPreferencesController.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.auth.controller;
+
+import com.thundercrew.opsapi.auth.dto.AdminPreferencesResponse;
+import com.thundercrew.opsapi.auth.dto.AdminPreferencesUpdateRequest;
+import com.thundercrew.opsapi.auth.service.AdminPreferencesService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin-users/me/preferences")
+public class AdminPreferencesController {
+
+    private final AdminPreferencesService preferencesService;
+
+    public AdminPreferencesController(AdminPreferencesService preferencesService) {
+        this.preferencesService = preferencesService;
+    }
+
+    @GetMapping
+    AdminPreferencesResponse get(@AuthenticationPrincipal Jwt jwt) {
+        return preferencesService.getMine(currentAdminId(jwt));
+    }
+
+    @PatchMapping
+    AdminPreferencesResponse update(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody AdminPreferencesUpdateRequest request
+    ) {
+        return preferencesService.updateMine(currentAdminId(jwt), request.ncpMapEnabled());
+    }
+
+    private static UUID currentAdminId(Jwt jwt) {
+        // The admin auth flow stores the admin uuid as the JWT subject claim.
+        return UUID.fromString(jwt.getSubject());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPreferencesResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPreferencesResponse.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import java.util.UUID;
+
+/**
+ * Per-admin runtime preference snapshot. Currently a single field — the NCP
+ * Maps SDK toggle (Slice C-1) — but shaped as a record so future preferences
+ * can land here without breaking client code.
+ */
+public record AdminPreferencesResponse(
+        UUID adminId,
+        boolean ncpMapEnabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPreferencesUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPreferencesUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AdminPreferencesUpdateRequest(
+        @NotNull Boolean ncpMapEnabled
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccount.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccount.java
@@ -7,6 +7,7 @@ public record AdminUserAccount(
         String loginId,
         String email,
         String passwordHash,
-        String displayName
+        String displayName,
+        boolean ncpMapEnabled
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
@@ -18,7 +18,7 @@ public class AdminUserAccountRepository {
 
     public Optional<AdminUserAccount> findEnabledActiveByLoginId(String loginId) {
         return jdbcTemplate.query("""
-                        select id, login_id, email, password_hash, display_name
+                        select id, login_id, email, password_hash, display_name, ncp_map_enabled
                         from admin_users
                         where login_id = ?
                           and enabled = true
@@ -31,7 +31,7 @@ public class AdminUserAccountRepository {
 
     public Optional<AdminUserAccount> findEnabledActiveById(UUID id) {
         return jdbcTemplate.query("""
-                        select id, login_id, email, password_hash, display_name
+                        select id, login_id, email, password_hash, display_name, ncp_map_enabled
                         from admin_users
                         where id = ?
                           and enabled = true
@@ -42,13 +42,25 @@ public class AdminUserAccountRepository {
         ).stream().findFirst();
     }
 
+    public int updateNcpMapEnabled(UUID id, boolean ncpMapEnabled) {
+        return jdbcTemplate.update("""
+                update admin_users
+                set ncp_map_enabled = ?,
+                    updated_at = now()
+                where id = ?
+                  and enabled = true
+                  and deleted_at is null
+                """, ncpMapEnabled, id);
+    }
+
     private AdminUserAccount mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
         return new AdminUserAccount(
                 resultSet.getObject("id", UUID.class),
                 resultSet.getString("login_id"),
                 resultSet.getString("email"),
                 resultSet.getString("password_hash"),
-                resultSet.getString("display_name")
+                resultSet.getString("display_name"),
+                resultSet.getBoolean("ncp_map_enabled")
         );
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminPreferencesService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminPreferencesService.java
@@ -1,0 +1,44 @@
+package com.thundercrew.opsapi.auth.service;
+
+import com.thundercrew.opsapi.auth.dto.AdminPreferencesResponse;
+import com.thundercrew.opsapi.auth.repository.AdminUserAccount;
+import com.thundercrew.opsapi.auth.repository.AdminUserAccountRepository;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and updates per-admin runtime preferences. Currently surfaces the
+ * NCP Maps SDK toggle only, but the service stays in the auth domain because
+ * the data lives on the admin account itself.
+ *
+ * <p>Both methods identify the operator via the JWT subject claim — the
+ * controller never accepts a path-param admin id, so one operator cannot
+ * read or mutate another operator's preferences.</p>
+ */
+@Service
+public class AdminPreferencesService {
+
+    private final AdminUserAccountRepository accountRepository;
+
+    public AdminPreferencesService(AdminUserAccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public AdminPreferencesResponse getMine(UUID adminId) {
+        AdminUserAccount account = accountRepository.findEnabledActiveById(adminId)
+                .orElseThrow(() -> new ResourceNotFoundException("AdminUser", adminId));
+        return new AdminPreferencesResponse(account.id(), account.ncpMapEnabled());
+    }
+
+    @Transactional
+    public AdminPreferencesResponse updateMine(UUID adminId, boolean ncpMapEnabled) {
+        int updated = accountRepository.updateNcpMapEnabled(adminId, ncpMapEnabled);
+        if (updated == 0) {
+            throw new ResourceNotFoundException("AdminUser", adminId);
+        }
+        return new AdminPreferencesResponse(adminId, ncpMapEnabled);
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V10__add_admin_users_ncp_map_enabled.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V10__add_admin_users_ncp_map_enabled.sql
@@ -1,0 +1,11 @@
+-- Per-admin toggle for NCP Maps SDK loading on the dashboard. Replaces the
+-- frontend hostname-based guard so an operator can flip the SDK on or off
+-- from any browser/PC and have the choice survive across visits.
+--
+-- Default TRUE keeps every existing admin in the same observable state as
+-- before this change rolls out (NCP loaded in production). Operators who
+-- want to suppress NCP billing during low-traffic windows toggle the flag
+-- to FALSE on the admin settings page.
+
+alter table admin_users
+    add column ncp_map_enabled boolean not null default true;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AdminPreferencesApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AdminPreferencesApiTests.java
@@ -1,0 +1,173 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Slice C-1: backend admin preferences endpoint. Verifies the per-admin
+ * NCP map toggle stores on admin_users, defaults to TRUE for fresh rows,
+ * and is mutable via PATCH /api/v1/admin-users/me/preferences using only
+ * the JWT subject (no path-param admin id).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminPreferencesApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from admin_auth_sessions");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    @Test
+    void getMinePreferencesReturnsDefaultsForNewlySeededAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.adminId").value(ADMIN_ID.toString()))
+                .andExpect(jsonPath("$.ncpMapEnabled").value(true));
+    }
+
+    @Test
+    void patchMinePreferencesTogglesNcpMapEnabledAndPersists() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"ncpMapEnabled": false}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.adminId").value(ADMIN_ID.toString()))
+                .andExpect(jsonPath("$.ncpMapEnabled").value(false));
+
+        mockMvc.perform(get("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ncpMapEnabled").value(false));
+
+        Boolean storedValue = jdbcTemplate.queryForObject(
+                "select ncp_map_enabled from admin_users where id = ?",
+                Boolean.class,
+                ADMIN_ID);
+        assertThat(storedValue).isFalse();
+    }
+
+    @Test
+    void patchMinePreferencesAcceptsToggleBackToTrue() throws Exception {
+        // Toggle to false then back to true.
+        mockMvc.perform(patch("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"ncpMapEnabled": false}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"ncpMapEnabled": true}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ncpMapEnabled").value(true));
+    }
+
+    @Test
+    void patchMinePreferencesRejectsMissingNcpMapEnabledField() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin-users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void preferencesEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/admin-users/me/preferences"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+
+        mockMvc.perform(patch("/api/v1/admin-users/me/preferences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"ncpMapEnabled": false}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void migrationDefaultsExistingAdminsToTrue() throws Exception {
+        // The migration's default value must apply to admin rows that were
+        // already in the table when V10 ran. We verify the column reflects
+        // the default for our seeded admin.
+        Boolean storedValue = jdbcTemplate.queryForObject(
+                "select ncp_map_enabled from admin_users where id = ?",
+                Boolean.class,
+                ADMIN_ID);
+        assertThat(storedValue).isTrue();
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -153,10 +153,17 @@ class ArchitectureBoundaryTests {
     }
 
     private static boolean isAllowedAuthCommand(JavaMethod method) {
-        return method.getOwner().getName().equals("com.thundercrew.opsapi.auth.controller.AuthController")
+        if (method.getOwner().getName().equals("com.thundercrew.opsapi.auth.controller.AuthController")
                 && (method.getName().equals("login")
                 || method.getName().equals("refresh")
-                || method.getName().equals("logout"));
+                || method.getName().equals("logout"))) {
+            return true;
+        }
+        // Slice C-1: PATCH /api/v1/admin-users/me/preferences. Lives in the
+        // auth domain because it stores per-admin runtime preferences on the
+        // admin_users row itself.
+        return method.getOwner().getName().equals("com.thundercrew.opsapi.auth.controller.AdminPreferencesController")
+                && method.getName().equals("update");
     }
 
     private static boolean isRiderCommand(JavaMethod method) {


### PR DESCRIPTION
## Summary

- 어드민별 NCP Maps SDK 호출 토글을 백엔드에 영구 저장. 어떤 PC/브라우저로 접속해도 동일한 토글 상태 유지 (Slice C-1).
- 컬럼 default `TRUE` — 마이그레이션 직후 기존 운영자는 이전과 같은 동작 (NCP 호출 ON).
- `GET / PATCH /api/v1/admin-users/me/preferences` — JWT subject 로만 본인 setting 접근. path-param 없음.

## Trace

- Target issue: EVNSolution/thundercrew-domain#156
- Change-control issue: EVNSolution/clever-change-control#132
- Root project-start: EVNSolution/clever-change-control#45
- Builds on: 어드민 인증 도메인 (기존 `auth` 패키지).
- Follow-up: Slice C-2 (front-admin-web MapShell 가드 + 설정 페이지 토글).

## Scope

Backend-only.

Included:
- Flyway V10 — `admin_users.ncp_map_enabled BOOLEAN NOT NULL DEFAULT TRUE`.
- `AdminUserAccount` record + Repository select / update 갱신.
- `AdminPreferencesController` (GET + PATCH) + `AdminPreferencesService` + DTO 2종.
- ArchUnit issue_70 화이트리스트.
- 통합 테스트 `AdminPreferencesApiTests` (6 케이스).

Excluded:
- 다른 종류 setting (현재는 NCP 토글 한 개만).
- 운영자 간 setting 조회/수정 (본인 것만).
- 프론트 변경 (별도 슬라이스 C-2).

## API

```
GET /api/v1/admin-users/me/preferences
→ 200 { "adminId": "...", "ncpMapEnabled": true }

PATCH /api/v1/admin-users/me/preferences
  Body: { "ncpMapEnabled": false }
→ 200 { "adminId": "...", "ncpMapEnabled": false }
```

미인증 호출은 401 + `code: AUTHENTICATION_FAILED`. `ncpMapEnabled` 누락은 400 + `code: VALIDATION_FAILED`.

## Validation

| 항목 | 결과 |
|------|------|
| `./gradlew compileJava compileTestJava` | ✅ BUILD SUCCESSFUL (16s) |
| `./gradlew test --tests ArchitectureBoundaryTests --tests ScaffoldPackageSkeletonTests` | ✅ BUILD SUCCESSFUL (19s) |
| Testcontainers 통합 테스트 (전체) | ⚠️ Docker 미설치로 sandbox 미실행. 리뷰어/IDE 환경 검증 필요. |

## Test plan

- [ ] IDE에서 `./gradlew test` 전체 실행 → `AdminPreferencesApiTests` 6 케이스 통과 + 기존 인증 / 어드민 흐름 회귀 없음.
- [ ] dev DB 마이그레이션 후 `select count(*) from admin_users where ncp_map_enabled = true` 가 모든 행에 적용되는지.
- [ ] 어드민 로그인 후 `GET /api/v1/admin-users/me/preferences` → 본인 toggle 노출.
- [ ] `PATCH` false 후 다른 브라우저 / 다른 기기에서 같은 어드민으로 로그인 → 같은 false 값.
- [ ] `PATCH` 시 missing/wrong field → 400.
- [ ] 다른 어드민의 setting 을 우회로 조회/수정 시도 → 불가능 (path-param 없음).

## Concurrent work gate

- Decision: `allowed-with-non-overlap`.
- Open target issues at PR open: #156 (이 PR 타깃).
- Open target PRs at PR open: none.
- Open clever-change-control issues: #100 / #24 / #23 (delivery server / msa-platform — 무관).

## Note

이번 PR 머지 후 후속 슬라이스 C-2:

- MapShell 의 hostname 기반 가드 제거.
- 어드민 로그인 후 server-side 에서 preferences fetch → MapShell 에 prop 전달.
- 어드민 설정 페이지(`/settings`) 에 토글 위젯 + server action.
