### PR TITLE
Inline rider insurance management on /riders/[slug] (Stage 2)

### DIFF
--- a/development/front-admin-web/app/riders/[slug]/insurance/[insuranceId]/edit/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/insurance/[insuranceId]/edit/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+
+import { updateRiderInsuranceAction } from "@/app/riders/[slug]/insurance/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderInsuranceForm } from "@/components/riders/RiderInsuranceForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadRiderInsuranceDetail } from "@/lib/services/rider-insurance-detail-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "보험 수정에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditRiderInsurancePage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string; insuranceId: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug, insuranceId }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const recordResult = await loadRiderInsuranceDetail(insuranceId);
+  if (!recordResult.data) {
+    return (
+      <div className="page-container">
+        <BackToListLink href={`/riders/${detail.rider.slug}`} />
+        <PageHeader
+          title="보험 수정"
+          description={`${detail.rider.name} (${detail.rider.phone}) 의 보험 정보를 불러오지 못했습니다.`}
+        />
+        {recordResult.notice ? <p className="notice">{recordResult.notice}</p> : null}
+      </div>
+    );
+  }
+
+  const record = recordResult.data;
+  const message = status ? statusMessage[status] : null;
+  const action = updateRiderInsuranceAction.bind(null, detail.rider.slug, record.id);
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="보험 수정"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 보험 가입을 수정합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderInsuranceForm
+        action={action}
+        backHref={`/riders/${detail.rider.slug}`}
+        mode="수정"
+        defaultValues={{ memo: record.memo, enabled: record.enabled }}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/insurance/actions.ts
+++ b/development/front-admin-web/app/riders/[slug]/insurance/actions.ts
@@ -1,0 +1,127 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  type RiderInsuranceCreateInput,
+  type RiderInsuranceUpdateInput,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export async function createRiderInsuranceAction(
+  riderSlug: string,
+  riderId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let payload: RiderInsuranceCreateInput;
+  try {
+    payload = toInsuranceCreatePayload(riderId, formData);
+  } catch {
+    redirect(`/riders/${riderSlug}/insurance/new?status=validation-error`);
+  }
+
+  try {
+    await client.createRiderInsurance(payload);
+  } catch {
+    redirect(`/riders/${riderSlug}/insurance/new?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=insurance-created`);
+}
+
+export async function updateRiderInsuranceAction(
+  riderSlug: string,
+  insuranceId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const payload: RiderInsuranceUpdateInput = {
+    memo: optionalText(formData.get("memo")),
+    enabled: String(formData.get("enabled") ?? "").toLowerCase() === "true"
+  };
+
+  try {
+    await client.updateRiderInsurance(insuranceId, payload);
+  } catch {
+    redirect(`/riders/${riderSlug}/insurance/${insuranceId}/edit?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=insurance-updated`);
+}
+
+export async function deleteRiderInsuranceAction(
+  riderSlug: string,
+  insuranceId: string
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-deleted`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteRiderInsurance(insuranceId);
+  } catch {
+    redirect(`/riders/${riderSlug}?status=insurance-delete-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=insurance-deleted`);
+}
+
+function toInsuranceCreatePayload(
+  riderId: string,
+  formData: FormData
+): RiderInsuranceCreateInput {
+  const insuranceItemId = String(formData.get("insuranceItemId") ?? "").trim();
+  if (!insuranceItemId) {
+    throw new Error("insuranceItemId is required");
+  }
+  return {
+    riderId,
+    insuranceItemId,
+    memo: optionalText(formData.get("memo")),
+    startsAt: toIsoTimestamp(formData.get("startsAt")),
+    endsAt: toIsoTimestamp(formData.get("endsAt"))
+  };
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function toIsoTimestamp(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const [year, month, day] = text.split("-").map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  return date.toISOString();
+}

--- a/development/front-admin-web/app/riders/[slug]/insurance/new/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/insurance/new/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from "next/navigation";
+
+import { createRiderInsuranceAction } from "@/app/riders/[slug]/insurance/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderInsuranceForm } from "@/components/riders/RiderInsuranceForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadInsuranceOptions } from "@/lib/services/insurance-options-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "보험 저장에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요.",
+  "validation-error": "보험 항목 선택이 누락되었습니다."
+};
+
+export default async function NewRiderInsurancePage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const insuranceOptions = await loadInsuranceOptions();
+  const message = status ? statusMessage[status] : null;
+  const action = createRiderInsuranceAction.bind(
+    null,
+    detail.rider.slug,
+    detail.rider.id ?? detail.rider.slug
+  );
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="보험 등록"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 보험 가입을 등록합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderInsuranceForm
+        action={action}
+        backHref={`/riders/${detail.rider.slug}`}
+        mode="등록"
+        itemOptions={insuranceOptions.options}
+        itemOptionsNotice={insuranceOptions.notice}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -4,12 +4,14 @@ import { notFound } from "next/navigation";
 import {
   deleteRiderEducationRecordAction
 } from "@/app/riders/[slug]/education-records/actions";
+import { deleteRiderInsuranceAction } from "@/app/riders/[slug]/insurance/actions";
 import { deleteRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
 import { loadRiderDetail } from "@/lib/services/rider-data";
 import { loadRiderEducationRecords } from "@/lib/services/rider-education-data";
+import { loadRiderInsurances, type RiderInsuranceRow } from "@/lib/services/rider-insurance-data";
 import type { ServiceOpsRiderEducationRecord } from "@/lib/services/service-ops-api";
 
 const statusMessage: Record<string, string> = {
@@ -21,6 +23,10 @@ const statusMessage: Record<string, string> = {
   "education-deleted": "교육 이력이 삭제되었습니다.",
   "education-delete-error": "교육 이력 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
   "education-updated": "교육 이력이 수정되었습니다.",
+  "insurance-created": "보험이 등록되었습니다.",
+  "insurance-deleted": "보험이 비활성 삭제 처리되었습니다.",
+  "insurance-delete-error": "보험 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  "insurance-updated": "보험 정보가 수정되었습니다.",
   "mock-deleted": "서비스 API가 연결되지 않아 삭제 처리를 mock 피드백으로만 처리했습니다.",
   "mock-saved": "서비스 API가 연결되지 않아 실제 저장 없이 mock 상세로 돌아왔습니다.",
   updated: "라이더 정보가 수정되었습니다."
@@ -70,11 +76,14 @@ export default async function RiderDetailPage({
     notFound();
   }
 
-  const { contracts, insurance, notice, rider } = detail;
+  const { contracts, notice, rider } = detail;
   const message = (status ? statusMessage[status] : null) ?? resolveCompositeCreatedStatus(status);
   const deleteAction = deleteRiderAction.bind(null, rider.slug);
   const riderId = rider.id ?? rider.slug;
-  const educationResult = await loadRiderEducationRecords(riderId);
+  const [educationResult, insuranceResult] = await Promise.all([
+    loadRiderEducationRecords(riderId),
+    loadRiderInsurances(riderId)
+  ]);
 
   return (
     <div className="page-container">
@@ -96,13 +105,11 @@ export default async function RiderDetailPage({
             <div className="detail-row"><span>표시 순번</span><strong>{rider.idx ?? "mock"}</strong></div>
             <div className="detail-row"><span>앱 계정</span><strong>{rider.appLinkStatus ?? (rider.status === "활동" ? "LINKED" : "UNLINKED")}</strong></div>
             <div className="detail-row"><span>계약</span><strong>{contracts.join(", ") || "연결 없음"}</strong></div>
-            <div className="detail-row"><span>보험</span><strong>{insurance.join(", ") || "연결 없음"}</strong></div>
             <div className="detail-row"><span>메모</span><strong>{rider.memo || "없음"}</strong></div>
           </div>
           <div className="form-actions">
             <Link className="button-secondary" href="/riders">목록</Link>
             <Link className="button-secondary" href="/contracts/new">계약 등록</Link>
-            <Link className="button-primary" href="/insurance/new">보험 등록</Link>
           </div>
         </div>
         <aside className="detail-panel">
@@ -121,7 +128,78 @@ export default async function RiderDetailPage({
         notice={educationResult.notice}
         nowMs={educationResult.nowMs}
       />
+      <RiderInsuranceSection
+        riderSlug={rider.slug}
+        rows={insuranceResult.rows}
+        notice={insuranceResult.notice}
+      />
     </div>
+  );
+}
+
+function RiderInsuranceSection({
+  riderSlug,
+  rows,
+  notice
+}: {
+  riderSlug: string;
+  rows: RiderInsuranceRow[];
+  notice: string | undefined;
+}) {
+  return (
+    <section className="card" aria-label="라이더 보험">
+      <header className="card-header">
+        <h2>보험</h2>
+        <Link className="button-primary" href={`/riders/${riderSlug}/insurance/new`}>
+          보험 등록
+        </Link>
+      </header>
+      {notice ? <p className="notice">{notice}</p> : null}
+      {rows.length === 0 ? (
+        <p className="muted">등록된 보험 없음</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>보험 항목</th>
+              <th>상태</th>
+              <th>메모</th>
+              <th>등록일</th>
+              <th>작업</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const deleteAction = deleteRiderInsuranceAction.bind(null, riderSlug, row.id);
+              return (
+                <tr key={row.id}>
+                  <td>{row.insuranceItemName ?? "보험 항목 연결 확인 필요"}</td>
+                  <td>
+                    <Badge tone={row.enabled ? "active" : "muted"}>
+                      {row.enabled ? "정상" : "비활성"}
+                    </Badge>
+                  </td>
+                  <td>{row.memo || "—"}</td>
+                  <td>{formatDate(row.createdAt)}</td>
+                  <td>
+                    <Link
+                      className="button-link"
+                      href={`/riders/${riderSlug}/insurance/${row.id}/edit`}
+                    >
+                      수정
+                    </Link>
+                    <span aria-hidden="true"> · </span>
+                    <form action={deleteAction} style={{ display: "inline" }}>
+                      <button className="button-link" type="submit">삭제</button>
+                    </form>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
   );
 }
 

--- a/development/front-admin-web/components/riders/RiderInsuranceForm.tsx
+++ b/development/front-admin-web/components/riders/RiderInsuranceForm.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+
+export type RiderInsuranceFormItemOption = {
+  id: string;
+  name: string;
+  category?: string;
+};
+
+type RiderInsuranceFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  backHref: string;
+  mode: "등록" | "수정";
+  /** Required on create — the insurance item catalog options. */
+  itemOptions?: RiderInsuranceFormItemOption[];
+  itemOptionsNotice?: string | null;
+  /** Editable fields on update (`memo`, `enabled`). */
+  defaultValues?: {
+    memo?: string | null;
+    enabled?: boolean;
+  };
+};
+
+/**
+ * Rider-scoped insurance form. The rider id is bound to the action so
+ * the form does not need a rider select — the URL already pins it.
+ *
+ * Create mode renders the full set of fields needed by
+ * {@link RiderInsuranceCreateInput} (item select + optional dates +
+ * memo). Update mode only renders the two backend-mutable fields
+ * (`memo`, `enabled`) since `RiderInsuranceUpdateInput` does not
+ * accept dates or item swaps.
+ */
+export function RiderInsuranceForm({
+  action,
+  backHref,
+  mode,
+  itemOptions = [],
+  itemOptionsNotice = null,
+  defaultValues
+}: RiderInsuranceFormProps) {
+  return (
+    <form action={action} className="card" aria-label={`라이더 보험 ${mode} 폼`}>
+      {mode === "등록" ? (
+        <CreateFields options={itemOptions} notice={itemOptionsNotice} />
+      ) : (
+        <UpdateFields defaultValues={defaultValues} />
+      )}
+      <div className="form-actions">
+        <Link className="button-secondary" href={backHref}>취소</Link>
+        <button className="button-primary" type="submit">보험 {mode}</button>
+      </div>
+    </form>
+  );
+}
+
+function CreateFields({
+  options,
+  notice
+}: {
+  options: RiderInsuranceFormItemOption[];
+  notice: string | null;
+}) {
+  if (options.length === 0) {
+    return (
+      <p className="rider-form-insurance-hint">
+        {notice
+          ?? "보험 항목 catalog 가 비어 있어 보험을 연결할 수 없습니다. 보험 항목을 먼저 등록한 뒤 다시 시도하세요."}
+      </p>
+    );
+  }
+  return (
+    <>
+      <div className="form-grid">
+        <Field label="보험 항목">
+          <select className="select" defaultValue="" name="insuranceItemId" required>
+            <option value="" disabled>
+              보험 항목을 선택하세요
+            </option>
+            {options.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name} {option.category ? `(${option.category})` : ""}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="시작일 (선택)">
+          <input className="input" name="startsAt" type="date" />
+        </Field>
+        <Field label="종료일 (선택)">
+          <input className="input" name="endsAt" type="date" />
+        </Field>
+      </div>
+      <br />
+      <Field label="메모 (선택)">
+        <textarea
+          className="input"
+          maxLength={200}
+          name="memo"
+          placeholder="운영자가 볼 내부 메모"
+          rows={4}
+        />
+      </Field>
+    </>
+  );
+}
+
+function UpdateFields({
+  defaultValues
+}: {
+  defaultValues?: { memo?: string | null; enabled?: boolean };
+}) {
+  const enabled = defaultValues?.enabled ?? true;
+  return (
+    <>
+      <Field label="상태">
+        <select className="select" defaultValue={enabled ? "true" : "false"} name="enabled">
+          <option value="true">정상 (활성)</option>
+          <option value="false">비활성</option>
+        </select>
+      </Field>
+      <br />
+      <Field label="메모 (선택)">
+        <textarea
+          className="input"
+          defaultValue={defaultValues?.memo ?? ""}
+          maxLength={200}
+          name="memo"
+          placeholder="운영자가 볼 내부 메모"
+          rows={4}
+        />
+      </Field>
+    </>
+  );
+}

--- a/development/front-admin-web/lib/services/rider-insurance-data.ts
+++ b/development/front-admin-web/lib/services/rider-insurance-data.ts
@@ -1,0 +1,77 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsInsuranceItem,
+  type ServiceOpsRiderInsurance,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderInsuranceRow = ServiceOpsRiderInsurance & {
+  insuranceItemName: string | null;
+};
+
+export type RiderInsurancesResult = {
+  riderId: string;
+  rows: RiderInsuranceRow[];
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Loader for the rider's insurance policies, used inline on
+ * `/riders/[slug]`. The backend does not expose a rider-scoped list
+ * endpoint yet, so we page through `/rider-insurances` (size 200) and
+ * filter client-side. Insurance item names are joined from the catalog
+ * lookup so the table can render "보험 항목" without a second fetch in
+ * the page component.
+ */
+export async function loadRiderInsurances(riderId: string): Promise<RiderInsurancesResult> {
+  if (!serviceOpsApiConfigured()) {
+    return { riderId, rows: [], source: "mock" };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      riderId,
+      rows: [],
+      source: "mock",
+      notice: "관리자 세션이 없어 보험 정보를 표시할 수 없습니다."
+    };
+  }
+
+  try {
+    const [policyPage, itemPage] = await Promise.all([
+      client.listRiderInsurances({ page: 0, size: 200 }),
+      client.listInsuranceItems({ page: 0, size: 200 })
+    ]);
+    const items = new Map<string, ServiceOpsInsuranceItem>(
+      itemPage.items.map((item) => [item.id, item])
+    );
+    const rows: RiderInsuranceRow[] = policyPage.items
+      .filter((policy) => policy.riderId === riderId)
+      .map((policy) => ({
+        ...policy,
+        insuranceItemName: items.get(policy.insuranceItemId)?.name ?? null
+      }));
+    return { riderId, rows, source: "service-ops" };
+  } catch (error) {
+    return {
+      riderId,
+      rows: [],
+      source: "mock",
+      notice: `보험 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/rider-insurance-detail-data.ts
+++ b/development/front-admin-web/lib/services/rider-insurance-detail-data.ts
@@ -1,0 +1,60 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsRiderInsurance,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderInsuranceDetailResult = {
+  insuranceId: string;
+  data: ServiceOpsRiderInsurance | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Single-record loader for the rider insurance edit page. Returns
+ * {@code data: null} on every fallback path (no API base, no session,
+ * fetch failed, 404) so the page can render a "조회 실패" notice instead
+ * of crashing.
+ */
+export async function loadRiderInsuranceDetail(
+  insuranceId: string
+): Promise<RiderInsuranceDetailResult> {
+  if (!serviceOpsApiConfigured()) {
+    return { insuranceId, data: null, source: "mock" };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      insuranceId,
+      data: null,
+      source: "mock",
+      notice: "관리자 세션이 없어 보험 정보를 불러올 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getRiderInsurance(insuranceId);
+    return { insuranceId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      insuranceId,
+      data: null,
+      source: "mock",
+      notice: `보험 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary

Stage 2 of the rider-centric refactor — replace the read-only "보험" detail row + external `보험 등록` button on `/riders/[slug]` with a full inline CRUD section that mirrors the existing education-record pattern.

- New routes under `/riders/[slug]/insurance/`:
  - `new/page.tsx` — create form (insurance item select + optional dates + memo). The rider id/slug is bound to the action so the form skips the rider picker.
  - `[insuranceId]/edit/page.tsx` — edit form (memo + enabled — the only fields `RiderInsuranceUpdateInput` accepts).
  - `actions.ts` — create / update / delete server actions with the same validation + UTC date coercion the education-record actions use.
- New loaders:
  - `lib/services/rider-insurance-data.ts` — list loader for the detail-page section. Filters `/rider-insurances` client-side because the backend has no rider-scoped list endpoint yet, and joins insurance item names from the catalog so the table can render "보험 항목" without a second fetch.
  - `lib/services/rider-insurance-detail-data.ts` — single-record loader for the edit page.
- `components/riders/RiderInsuranceForm.tsx` — single shared form with a `mode` prop. Create renders the full field set; update renders only the two backend-mutable fields.
- Rider detail page (`app/riders/[slug]/page.tsx`):
  - Dropped the text-only "보험" detail row and the "보험 등록" external button that targeted `/insurance/new`.
  - Added `<RiderInsuranceSection>` alongside `<RiderEducationSection>` — table + EmptyState + per-row 수정 link + 비활성 삭제 form.
  - `statusMessage` map gains `insurance-created` / `-updated` / `-deleted` / `-delete-error`.

The `/insurance` hub + `/new` + `/[slug]` sub-pages stay alive for now; Stage 4 will remove them once Stage 3 lands rider-scoped contract management.

## Trace

- Target issue: EVNSolution/thundercrew-domain#162
- Change-control issue: EVNSolution/clever-change-control#135
- Builds on: EVNSolution/thundercrew-domain#161 (Stage 1 — sidebar + overview refactor).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:service-ops` 120/120 pass
- [x] `npm run build` succeeds
- [x] Manual QA: `/riders/[slug]` shows the new 보험 section with empty state when the rider has no policies; "보험 등록" navigates to `/riders/[slug]/insurance/new` and the form binds the rider; submit creates a policy and revalidates the detail page; per-row 수정 opens the edit form for that policy only; 삭제 deactivates the policy and the row disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
