### PR TITLE
Inline rider contract management on /riders/[slug] (Stage 3)

### DIFF
--- a/development/front-admin-web/app/riders/[slug]/contracts/[contractId]/edit/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/contracts/[contractId]/edit/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+
+import { updateRiderContractAction } from "@/app/riders/[slug]/contracts/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderContractForm } from "@/components/riders/RiderContractForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadRiderContractDetail } from "@/lib/services/rider-contract-detail-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "계약 수정에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요."
+};
+
+export default async function EditRiderContractPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string; contractId: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug, contractId }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const recordResult = await loadRiderContractDetail(contractId);
+  if (!recordResult.data) {
+    return (
+      <div className="page-container">
+        <BackToListLink href={`/riders/${detail.rider.slug}`} />
+        <PageHeader
+          title="계약 수정"
+          description={`${detail.rider.name} (${detail.rider.phone}) 의 계약 정보를 불러오지 못했습니다.`}
+        />
+        {recordResult.notice ? <p className="notice">{recordResult.notice}</p> : null}
+      </div>
+    );
+  }
+
+  const record = recordResult.data;
+  const message = status ? statusMessage[status] : null;
+  const action = updateRiderContractAction.bind(null, detail.rider.slug, record.id);
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="계약 수정"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 계약 메모를 수정합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderContractForm
+        action={action}
+        backHref={`/riders/${detail.rider.slug}`}
+        mode="수정"
+        defaultValues={{ memo: record.memo }}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/contracts/actions.ts
+++ b/development/front-admin-web/app/riders/[slug]/contracts/actions.ts
@@ -1,0 +1,133 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  type RiderBikeContractCreateInput,
+  type RiderBikeContractUpdateInput,
+  type RiderBikeContractTerminateInput,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export async function createRiderContractAction(
+  riderSlug: string,
+  riderId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  let payload: RiderBikeContractCreateInput;
+  try {
+    payload = toContractCreatePayload(riderId, formData);
+  } catch {
+    redirect(`/riders/${riderSlug}/contracts/new?status=validation-error`);
+  }
+
+  try {
+    await client.createRiderBikeContract(payload);
+  } catch {
+    redirect(`/riders/${riderSlug}/contracts/new?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=contract-created`);
+}
+
+export async function updateRiderContractAction(
+  riderSlug: string,
+  contractId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const payload: RiderBikeContractUpdateInput = {
+    memo: optionalText(formData.get("memo"))
+  };
+
+  try {
+    await client.updateRiderBikeContract(contractId, payload);
+  } catch {
+    redirect(`/riders/${riderSlug}/contracts/${contractId}/edit?status=save-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=contract-updated`);
+}
+
+export async function terminateRiderContractAction(
+  riderSlug: string,
+  contractId: string
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect(`/riders/${riderSlug}?status=mock-saved`);
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const payload: RiderBikeContractTerminateInput = {
+    terminatedAt: new Date().toISOString()
+  };
+
+  try {
+    await client.terminateRiderBikeContract(contractId, payload);
+  } catch {
+    redirect(`/riders/${riderSlug}?status=contract-terminate-error`);
+  }
+
+  revalidatePath(`/riders/${riderSlug}`);
+  redirect(`/riders/${riderSlug}?status=contract-terminated`);
+}
+
+function toContractCreatePayload(
+  riderId: string,
+  formData: FormData
+): RiderBikeContractCreateInput {
+  const bikeId = String(formData.get("bikeId") ?? "").trim();
+  const contractTemplateId = String(formData.get("contractTemplateId") ?? "").trim();
+  const startAtIso = toIsoTimestamp(formData.get("startAt"));
+  if (!bikeId || !contractTemplateId || !startAtIso) {
+    throw new Error("bikeId, contractTemplateId, startAt are all required");
+  }
+  return {
+    riderId,
+    bikeId,
+    contractTemplateId,
+    startAt: startAtIso,
+    memo: optionalText(formData.get("memo"))
+  };
+}
+
+function optionalText(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
+function toIsoTimestamp(value: FormDataEntryValue | null): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const [year, month, day] = text.split("-").map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  return date.toISOString();
+}

--- a/development/front-admin-web/app/riders/[slug]/contracts/new/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/contracts/new/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from "next/navigation";
+
+import { createRiderContractAction } from "@/app/riders/[slug]/contracts/actions";
+import { BackToListLink } from "@/components/layout/BackToListLink";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RiderContractForm } from "@/components/riders/RiderContractForm";
+import { loadRiderDetail } from "@/lib/services/rider-data";
+import { loadRiderContractFormOptions } from "@/lib/services/rider-contract-form-options-data";
+
+const statusMessage: Record<string, string> = {
+  "save-error": "계약 저장에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요.",
+  "validation-error": "차량 / 계약 양식 / 시작일을 모두 입력해야 합니다."
+};
+
+export default async function NewRiderContractPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const [{ slug }, { status }] = await Promise.all([params, searchParams]);
+  const detail = await loadRiderDetail(slug);
+  if (!detail) {
+    notFound();
+  }
+
+  const options = await loadRiderContractFormOptions();
+  const message = status ? statusMessage[status] : null;
+  const action = createRiderContractAction.bind(
+    null,
+    detail.rider.slug,
+    detail.rider.id ?? detail.rider.slug
+  );
+
+  return (
+    <div className="page-container">
+      <BackToListLink href={`/riders/${detail.rider.slug}`} />
+      <PageHeader
+        title="계약 등록"
+        description={`${detail.rider.name} (${detail.rider.phone}) 의 차량 매칭 계약을 등록합니다.`}
+      />
+      {message ? <p className="action-feedback" role="status">{message}</p> : null}
+      <RiderContractForm
+        action={action}
+        backHref={`/riders/${detail.rider.slug}`}
+        mode="등록"
+        vehicleOptions={options.vehicles}
+        templateOptions={options.templates}
+        optionsNotice={options.notice}
+      />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { terminateRiderContractAction } from "@/app/riders/[slug]/contracts/actions";
 import {
   deleteRiderEducationRecordAction
 } from "@/app/riders/[slug]/education-records/actions";
@@ -9,6 +10,7 @@ import { deleteRiderAction } from "@/app/riders/actions";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BackToListLink } from "@/components/layout/BackToListLink";
 import { Badge } from "@/components/ui/Badge";
+import { loadRiderContracts, type RiderContractRow } from "@/lib/services/rider-contract-data";
 import { loadRiderDetail } from "@/lib/services/rider-data";
 import { loadRiderEducationRecords } from "@/lib/services/rider-education-data";
 import { loadRiderInsurances, type RiderInsuranceRow } from "@/lib/services/rider-insurance-data";
@@ -23,6 +25,10 @@ const statusMessage: Record<string, string> = {
   "education-deleted": "교육 이력이 삭제되었습니다.",
   "education-delete-error": "교육 이력 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
   "education-updated": "교육 이력이 수정되었습니다.",
+  "contract-created": "계약이 등록되었습니다.",
+  "contract-terminated": "계약이 종료 처리되었습니다.",
+  "contract-terminate-error": "계약 종료 처리에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
+  "contract-updated": "계약 정보가 수정되었습니다.",
   "insurance-created": "보험이 등록되었습니다.",
   "insurance-deleted": "보험이 비활성 삭제 처리되었습니다.",
   "insurance-delete-error": "보험 삭제에 실패했습니다. 백엔드 연결 상태를 확인하세요.",
@@ -76,13 +82,14 @@ export default async function RiderDetailPage({
     notFound();
   }
 
-  const { contracts, notice, rider } = detail;
+  const { notice, rider } = detail;
   const message = (status ? statusMessage[status] : null) ?? resolveCompositeCreatedStatus(status);
   const deleteAction = deleteRiderAction.bind(null, rider.slug);
   const riderId = rider.id ?? rider.slug;
-  const [educationResult, insuranceResult] = await Promise.all([
+  const [educationResult, insuranceResult, contractsResult] = await Promise.all([
     loadRiderEducationRecords(riderId),
-    loadRiderInsurances(riderId)
+    loadRiderInsurances(riderId),
+    loadRiderContracts(riderId)
   ]);
 
   return (
@@ -104,12 +111,10 @@ export default async function RiderDetailPage({
             <div className="detail-row"><span>가입일</span><strong>{rider.joinedAt}</strong></div>
             <div className="detail-row"><span>표시 순번</span><strong>{rider.idx ?? "mock"}</strong></div>
             <div className="detail-row"><span>앱 계정</span><strong>{rider.appLinkStatus ?? (rider.status === "활동" ? "LINKED" : "UNLINKED")}</strong></div>
-            <div className="detail-row"><span>계약</span><strong>{contracts.join(", ") || "연결 없음"}</strong></div>
             <div className="detail-row"><span>메모</span><strong>{rider.memo || "없음"}</strong></div>
           </div>
           <div className="form-actions">
             <Link className="button-secondary" href="/riders">목록</Link>
-            <Link className="button-secondary" href="/contracts/new">계약 등록</Link>
           </div>
         </div>
         <aside className="detail-panel">
@@ -128,12 +133,89 @@ export default async function RiderDetailPage({
         notice={educationResult.notice}
         nowMs={educationResult.nowMs}
       />
+      <RiderContractSection
+        riderSlug={rider.slug}
+        rows={contractsResult.rows}
+        notice={contractsResult.notice}
+      />
       <RiderInsuranceSection
         riderSlug={rider.slug}
         rows={insuranceResult.rows}
         notice={insuranceResult.notice}
       />
     </div>
+  );
+}
+
+function RiderContractSection({
+  riderSlug,
+  rows,
+  notice
+}: {
+  riderSlug: string;
+  rows: RiderContractRow[];
+  notice: string | undefined;
+}) {
+  return (
+    <section className="card" aria-label="라이더 계약">
+      <header className="card-header">
+        <h2>계약</h2>
+        <Link className="button-primary" href={`/riders/${riderSlug}/contracts/new`}>
+          계약 등록
+        </Link>
+      </header>
+      {notice ? <p className="notice">{notice}</p> : null}
+      {rows.length === 0 ? (
+        <p className="muted">등록된 계약 없음</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>차량</th>
+              <th>계약 양식</th>
+              <th>시작</th>
+              <th>종료</th>
+              <th>상태</th>
+              <th>메모</th>
+              <th>작업</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const terminateAction = terminateRiderContractAction.bind(null, riderSlug, row.id);
+              return (
+                <tr key={row.id}>
+                  <td>{row.bikeLabel ?? "차량 연결 확인 필요"}</td>
+                  <td>{row.templateName ?? "계약 양식 연결 확인 필요"}</td>
+                  <td>{formatDate(row.startAt)}</td>
+                  <td>{row.terminatedAt ? formatDate(row.terminatedAt) : (row.endAt ? formatDate(row.endAt) : "—")}</td>
+                  <td>
+                    <Badge tone={row.status === "활성" ? "active" : "muted"}>{row.status}</Badge>
+                  </td>
+                  <td>{row.memo || "—"}</td>
+                  <td>
+                    <Link
+                      className="button-link"
+                      href={`/riders/${riderSlug}/contracts/${row.id}/edit`}
+                    >
+                      수정
+                    </Link>
+                    {row.status === "활성" ? (
+                      <>
+                        <span aria-hidden="true"> · </span>
+                        <form action={terminateAction} style={{ display: "inline" }}>
+                          <button className="button-link" type="submit">종료</button>
+                        </form>
+                      </>
+                    ) : null}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
   );
 }
 

--- a/development/front-admin-web/components/riders/RiderContractForm.tsx
+++ b/development/front-admin-web/components/riders/RiderContractForm.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link";
+
+import { Field } from "@/components/ui/FormField";
+import type { RiderContractFormOption } from "@/lib/services/rider-contract-form-options-data";
+
+type RiderContractFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  backHref: string;
+  mode: "등록" | "수정";
+  /** Required on create — vehicle + template options. */
+  vehicleOptions?: RiderContractFormOption[];
+  templateOptions?: RiderContractFormOption[];
+  optionsNotice?: string | null;
+  /** Used on edit — `RiderBikeContractUpdateInput` only mutates memo. */
+  defaultValues?: {
+    memo?: string | null;
+  };
+};
+
+/**
+ * Rider-scoped contract form. The rider id is bound to the action so
+ * the form does not need a rider select - the URL already pins it.
+ *
+ * Create mode renders the vehicle + template selects, the start date
+ * and the optional memo. Update mode renders only the memo since
+ * {@link RiderBikeContractUpdateInput} does not accept bike swaps,
+ * template swaps, or start-date moves. Termination is a separate
+ * action triggered from the rider detail page row.
+ */
+export function RiderContractForm({
+  action,
+  backHref,
+  mode,
+  vehicleOptions = [],
+  templateOptions = [],
+  optionsNotice = null,
+  defaultValues
+}: RiderContractFormProps) {
+  return (
+    <form action={action} className="card" aria-label={`라이더 계약 ${mode} 폼`}>
+      {mode === "등록" ? (
+        <CreateFields
+          vehicles={vehicleOptions}
+          templates={templateOptions}
+          notice={optionsNotice}
+        />
+      ) : (
+        <UpdateFields defaultValues={defaultValues} />
+      )}
+      <div className="form-actions">
+        <Link className="button-secondary" href={backHref}>취소</Link>
+        <button className="button-primary" type="submit">계약 {mode}</button>
+      </div>
+    </form>
+  );
+}
+
+function CreateFields({
+  vehicles,
+  templates,
+  notice
+}: {
+  vehicles: RiderContractFormOption[];
+  templates: RiderContractFormOption[];
+  notice: string | null;
+}) {
+  if (vehicles.length === 0 || templates.length === 0) {
+    return (
+      <p className="rider-form-insurance-hint">
+        {notice
+          ?? "차량 또는 계약 양식이 없어 계약을 등록할 수 없습니다. 먼저 차량과 계약 양식을 등록한 뒤 다시 시도하세요."}
+      </p>
+    );
+  }
+  return (
+    <>
+      <div className="form-grid">
+        <Field label="차량">
+          <select className="select" defaultValue="" name="bikeId" required>
+            <option value="" disabled>
+              차량을 선택하세요
+            </option>
+            {vehicles.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+                {option.helper ? ` · ${option.helper}` : ""}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="계약 양식">
+          <select className="select" defaultValue="" name="contractTemplateId" required>
+            <option value="" disabled>
+              계약 양식을 선택하세요
+            </option>
+            {templates.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="시작일">
+          <input className="input" name="startAt" required type="date" />
+        </Field>
+      </div>
+      <br />
+      <Field label="메모 (선택)">
+        <textarea
+          className="input"
+          maxLength={200}
+          name="memo"
+          placeholder="운영자가 볼 내부 메모"
+          rows={4}
+        />
+      </Field>
+    </>
+  );
+}
+
+function UpdateFields({
+  defaultValues
+}: {
+  defaultValues?: { memo?: string | null };
+}) {
+  return (
+    <Field label="메모 (선택)">
+      <textarea
+        className="input"
+        defaultValue={defaultValues?.memo ?? ""}
+        maxLength={200}
+        name="memo"
+        placeholder="운영자가 볼 내부 메모"
+        rows={4}
+      />
+    </Field>
+  );
+}

--- a/development/front-admin-web/lib/services/rider-contract-data.ts
+++ b/development/front-admin-web/lib/services/rider-contract-data.ts
@@ -1,0 +1,89 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsContractTemplate,
+  type ServiceOpsRiderBikeContract,
+  type FrontendVehicle,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderContractRow = ServiceOpsRiderBikeContract & {
+  bikeLabel: string | null;
+  templateName: string | null;
+  status: "활성" | "종료";
+};
+
+export type RiderContractsResult = {
+  riderId: string;
+  rows: RiderContractRow[];
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/**
+ * Loader for the rider's bike contracts, used inline on
+ * `/riders/[slug]`. Filters `/rider-bike-contracts` client-side and
+ * enriches each row with the vehicle plate/model and the contract
+ * template name so the section table can display human-readable
+ * labels without the page component issuing a second fetch.
+ */
+export async function loadRiderContracts(riderId: string): Promise<RiderContractsResult> {
+  if (!serviceOpsApiConfigured()) {
+    return { riderId, rows: [], source: "mock" };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      riderId,
+      rows: [],
+      source: "mock",
+      notice: "관리자 세션이 없어 계약 정보를 표시할 수 없습니다."
+    };
+  }
+
+  try {
+    const [contractPage, vehiclePage, templatePage] = await Promise.all([
+      client.listRiderBikeContracts({ page: 0, size: 200 }),
+      client.listVehicles({ page: 0, size: 200 }),
+      client.listContractTemplates({ page: 0, size: 200 })
+    ]);
+    const bikes = new Map<string, FrontendVehicle>(
+      vehiclePage.items.map((vehicle) => [vehicle.id ?? vehicle.slug, vehicle])
+    );
+    const templates = new Map<string, ServiceOpsContractTemplate>(
+      templatePage.items.map((template) => [template.id, template])
+    );
+    const rows: RiderContractRow[] = contractPage.items
+      .filter((contract) => contract.riderId === riderId)
+      .map((contract) => {
+        const bike = bikes.get(contract.bikeId);
+        const template = templates.get(contract.contractTemplateId);
+        return {
+          ...contract,
+          bikeLabel: bike ? `${bike.plateNumber} · ${bike.model}` : null,
+          templateName: template?.name ?? null,
+          status: contract.terminatedAt ? "종료" : "활성"
+        };
+      });
+    return { riderId, rows, source: "service-ops" };
+  } catch (error) {
+    return {
+      riderId,
+      rows: [],
+      source: "mock",
+      notice: `계약 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/rider-contract-detail-data.ts
+++ b/development/front-admin-web/lib/services/rider-contract-detail-data.ts
@@ -1,0 +1,55 @@
+import {
+  type ServiceOpsApiError,
+  type ServiceOpsRiderBikeContract,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderContractDetailResult = {
+  contractId: string;
+  data: ServiceOpsRiderBikeContract | null;
+  source: "service-ops" | "mock";
+  notice?: string;
+};
+
+/** Single-record loader for the rider contract edit page. */
+export async function loadRiderContractDetail(
+  contractId: string
+): Promise<RiderContractDetailResult> {
+  if (!serviceOpsApiConfigured()) {
+    return { contractId, data: null, source: "mock" };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      contractId,
+      data: null,
+      source: "mock",
+      notice: "관리자 세션이 없어 계약 정보를 불러올 수 없습니다."
+    };
+  }
+
+  try {
+    const data = await client.getRiderBikeContract(contractId);
+    return { contractId, data, source: "service-ops" };
+  } catch (error) {
+    return {
+      contractId,
+      data: null,
+      source: "mock",
+      notice: `계약 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}

--- a/development/front-admin-web/lib/services/rider-contract-form-options-data.ts
+++ b/development/front-admin-web/lib/services/rider-contract-form-options-data.ts
@@ -1,0 +1,76 @@
+import {
+  type ServiceOpsApiError,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+export type RiderContractFormOption = {
+  value: string;
+  label: string;
+  helper?: string;
+};
+
+export type RiderContractFormOptionsResult = {
+  vehicles: RiderContractFormOption[];
+  templates: RiderContractFormOption[];
+  notice?: string;
+};
+
+/**
+ * Loader for the rider-scoped contract create form. Returns the vehicle
+ * and contract template selection options - rider is excluded because
+ * it is bound from the URL on the rider-scoped contract page. Mirrors
+ * the option-loader pattern used elsewhere (e.g. loadInsuranceOptions)
+ * so the form component can stay purely presentational.
+ */
+export async function loadRiderContractFormOptions(): Promise<RiderContractFormOptionsResult> {
+  if (!serviceOpsApiConfigured()) {
+    return { vehicles: [], templates: [] };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) {
+    return {
+      vehicles: [],
+      templates: [],
+      notice: "관리자 세션이 없어 차량/계약 양식 선택지를 가져올 수 없습니다."
+    };
+  }
+
+  try {
+    const [vehiclePage, templatePage] = await Promise.all([
+      client.listVehicles({ page: 0, size: 200 }),
+      client.listContractTemplates({ page: 0, size: 200 })
+    ]);
+    const vehicles: RiderContractFormOption[] = vehiclePage.items.map((vehicle) => ({
+      value: vehicle.id ?? vehicle.slug,
+      label: `${vehicle.plateNumber} · ${vehicle.model}`,
+      helper: vehicle.status
+    }));
+    const templates: RiderContractFormOption[] = templatePage.items
+      .filter((template) => template.enabled)
+      .map((template) => ({
+        value: template.id,
+        label: template.name,
+        helper: template.description ?? undefined
+      }));
+    return { vehicles, templates };
+  } catch (error) {
+    return {
+      vehicles: [],
+      templates: [],
+      notice: `선택지 조회 실패.${formatServiceOpsError(error)}`
+    };
+  }
+}
+
+function formatServiceOpsError(error: unknown): string {
+  const apiError = error as Partial<ServiceOpsApiError> | undefined;
+  if (apiError?.code) {
+    return ` (${apiError.code})`;
+  }
+  if (error instanceof Error) {
+    return ` (${error.message})`;
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary

Stage 3 of the rider-centric refactor — the rider detail page now manages 계약 inline alongside the existing 교육 이력 and the just-landed 보험 (Stage 2 in #163).

**Stacked on #163.** Base is `cc-135-rider-insurance-inline` so the diff shows only Stage 3 changes. Once #163 merges to `dev`, change this PR's base to `dev` and it will retarget cleanly.

- New routes under `/riders/[slug]/contracts/`:
  - `new/page.tsx` — create form (vehicle select + contract template select + start date + memo). Rider id/slug bound to the action.
  - `[contractId]/edit/page.tsx` — edit form (memo-only; `RiderBikeContractUpdateInput` does not accept bike/template/start swaps).
  - `actions.ts` — create / update / terminate server actions. Termination uses the dedicated Terminate endpoint (sets `terminatedAt = now()`).
- New loaders:
  - `lib/services/rider-contract-data.ts` — list loader; filters `/rider-bike-contracts` client-side and joins vehicle plate/model + contract template name so the section table can render human labels without a second fetch.
  - `lib/services/rider-contract-detail-data.ts` — single-record loader for the edit page.
  - `lib/services/rider-contract-form-options-data.ts` — vehicles + templates for the create form (no rider picker since the URL pins the rider). Independent of the legacy `/contracts` loaders so Stage 4 can delete them cleanly.
- `components/riders/RiderContractForm.tsx` — mode-aware form. Create renders the full field set; update renders only memo.
- Rider detail page:
  - Dropped the text-only "계약" detail row and the "계약 등록" external button that targeted `/contracts/new`.
  - Added `<RiderContractSection>` between education and insurance — table with 차량 / 계약 양식 / 시작 / 종료 / 상태 / 메모, 수정 link, and 종료 form button (only for active rows).
  - `statusMessage` map gains `contract-created` / `-terminated` / `-terminate-error` / `-updated`.

## Trace

- Target issue: EVNSolution/thundercrew-domain#164
- Change-control issue: EVNSolution/clever-change-control#136
- Builds on: EVNSolution/thundercrew-domain#163 (Stage 2 — rider insurance inline).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:service-ops` 120/120 pass
- [x] `npm run build` succeeds (7 new rider-scoped routes registered)
- [ ] Manual QA: `/riders/[slug]` shows the new 계약 section between 교육 이력 and 보험; "계약 등록" navigates to `/riders/[slug]/contracts/new` and the form binds the rider; submit creates a contract and revalidates the detail page; 수정 opens the edit form for that contract only; 종료 sets `terminatedAt` and the row Badge flips to "종료" with the 종료 button hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
