### PR TITLE
Inline 초기 계약 (vehicle matching) on rider create form

### DIFF
--- a/development/front-admin-web/app/riders/[slug]/page.tsx
+++ b/development/front-admin-web/app/riders/[slug]/page.tsx
@@ -39,20 +39,22 @@ const statusMessage: Record<string, string> = {
 };
 
 /**
- * Slice ④-1c expanded the rider create flow with optional sidecar steps
- * (education + insurance). Each sidecar reports independent ok / fail / skip,
- * and the action encodes the trio as `created-x-e<code>-i<code>`. Resolve the
- * compact code here so the detail page can show a single, plainly-Korean
- * flash describing what actually happened.
+ * Slice ④-1c/d expanded the rider create flow with optional sidecar steps
+ * (education + insurance + contract). Each sidecar reports independent
+ * ok / fail / skip, and the action encodes the trio as
+ * `created-x-e<code>-i<code>-c<code>`. Resolve the compact code here so
+ * the detail page can show a single, plainly-Korean flash describing
+ * what actually happened.
  */
 function resolveCompositeCreatedStatus(status: string | undefined): string | null {
   if (!status) return null;
-  const match = status.match(/^created-x-e(ok|fail|skip)-i(ok|fail|skip)$/);
+  const match = status.match(/^created-x-e(ok|fail|skip)-i(ok|fail|skip)-c(ok|fail|skip)$/);
   if (!match) return null;
-  const [, education, insurance] = match;
+  const [, education, insurance, contract] = match;
   const educationLabel = sidecarOutcomeLabel("교육 이력", education);
   const insuranceLabel = sidecarOutcomeLabel("보험 연결", insurance);
-  return ["라이더가 등록되었습니다.", educationLabel, insuranceLabel]
+  const contractLabel = sidecarOutcomeLabel("계약", contract);
+  return ["라이더가 등록되었습니다.", educationLabel, insuranceLabel, contractLabel]
     .filter(Boolean)
     .join(" ");
 }

--- a/development/front-admin-web/app/riders/actions.ts
+++ b/development/front-admin-web/app/riders/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import {
+  type RiderBikeContractCreateInput,
   type RiderCreateInput,
   type RiderEducationRecordCreateInput,
   type RiderInsuranceCreateInput,
@@ -60,8 +61,24 @@ export async function createRiderAction(formData: FormData): Promise<void> {
     }
   }
 
+  // Slice ④-1d: optional initial rider-bike contract (= vehicle matching).
+  // Mirrors the insurance sidecar: vehicle + template + start date all
+  // required, otherwise we treat the section as skipped. Fail-soft — a
+  // failed contract create does not roll back the rider, education or
+  // insurance rows the action already produced.
+  const contractPayload = toInitialContractPayload(riderId, formData);
+  let contractOutcome: SidecarOutcome = "none";
+  if (contractPayload) {
+    try {
+      await client.createRiderBikeContract(contractPayload);
+      contractOutcome = "created";
+    } catch {
+      contractOutcome = "failed";
+    }
+  }
+
   revalidatePath("/riders");
-  const status = createdStatusFor(educationOutcome, insuranceOutcome);
+  const status = createdStatusFor(educationOutcome, insuranceOutcome, contractOutcome);
   redirect(`/riders/${rider.slug}?status=${status}`);
 }
 
@@ -69,14 +86,15 @@ type SidecarOutcome = "none" | "created" | "failed";
 
 function createdStatusFor(
   education: SidecarOutcome,
-  insurance: SidecarOutcome
+  insurance: SidecarOutcome,
+  contract: SidecarOutcome
 ): string {
-  // Compact status code: e=education state, i=insurance state, both single
-  // letters mapping to the SidecarOutcome union. The detail page resolves
-  // the code into a Korean message. Keeping the codes short keeps the URL
-  // readable in dev tooling and analytics.
-  if (education === "none" && insurance === "none") return "created";
-  return `created-x-e${shortCode(education)}-i${shortCode(insurance)}`;
+  // Compact status code: e=education state, i=insurance state, c=contract
+  // state, each one of ok/fail/skip. The detail page resolves the code
+  // into a Korean message. Keeping the codes short keeps the URL readable
+  // in dev tooling and analytics.
+  if (education === "none" && insurance === "none" && contract === "none") return "created";
+  return `created-x-e${shortCode(education)}-i${shortCode(insurance)}-c${shortCode(contract)}`;
 }
 
 function shortCode(outcome: SidecarOutcome): string {
@@ -127,6 +145,26 @@ function toInitialInsurancePayload(
     startsAt: toIsoTimestamp(formData.get("initialInsuranceStartsAt")) ?? null,
     endsAt: toIsoTimestamp(formData.get("initialInsuranceEndsAt")) ?? null,
     riderBikeContractId: null
+  };
+}
+
+function toInitialContractPayload(
+  riderId: string,
+  formData: FormData
+): RiderBikeContractCreateInput | null {
+  const bikeId = String(formData.get("initialContractBikeId") ?? "").trim();
+  const contractTemplateId = String(formData.get("initialContractTemplateId") ?? "").trim();
+  const startAtIso = toIsoTimestamp(formData.get("initialContractStartAt"));
+  if (!bikeId || !contractTemplateId || !startAtIso) {
+    // Operator left the optional section partially blank — skip cleanly.
+    return null;
+  }
+  return {
+    riderId,
+    bikeId,
+    contractTemplateId,
+    startAt: startAtIso,
+    memo: optionalText(formData.get("initialContractMemo"))
   };
 }
 

--- a/development/front-admin-web/app/riders/new/page.tsx
+++ b/development/front-admin-web/app/riders/new/page.tsx
@@ -3,15 +3,17 @@ import { BackToListLink } from "@/components/layout/BackToListLink";
 import { RiderForm } from "@/components/riders/RiderForm";
 import { createRiderAction } from "@/app/riders/actions";
 import { loadInsuranceOptions } from "@/lib/services/insurance-options-data";
+import { loadRiderContractFormOptions } from "@/lib/services/rider-contract-form-options-data";
 
 const statusMessage: Record<string, string> = {
   "save-error": "라이더 저장에 실패했습니다. 필수값과 백엔드 연결 상태를 확인하세요."
 };
 
 export default async function NewRiderPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
-  const [{ status }, insuranceOptions] = await Promise.all([
+  const [{ status }, insuranceOptions, contractOptions] = await Promise.all([
     searchParams,
-    loadInsuranceOptions()
+    loadInsuranceOptions(),
+    loadRiderContractFormOptions()
   ]);
 
   return (
@@ -24,6 +26,10 @@ export default async function NewRiderPage({ searchParams }: { searchParams: Pro
         includeInitialInsurance
         insuranceOptions={insuranceOptions.options}
         insuranceOptionsNotice={insuranceOptions.notice}
+        includeInitialContract
+        contractVehicleOptions={contractOptions.vehicles}
+        contractTemplateOptions={contractOptions.templates}
+        contractOptionsNotice={contractOptions.notice}
         statusMessage={status ? statusMessage[status] : null}
       />
     </div>

--- a/development/front-admin-web/components/riders/RiderForm.tsx
+++ b/development/front-admin-web/components/riders/RiderForm.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { Field } from "@/components/ui/FormField";
+import type { RiderContractFormOption } from "@/lib/services/rider-contract-form-options-data";
 
 type RiderFormValues = {
   areaName?: string | null;
@@ -36,6 +37,16 @@ type RiderFormProps = {
   includeInitialInsurance?: boolean;
   insuranceOptions?: RiderFormInsuranceOption[];
   insuranceOptionsNotice?: string | null;
+  /**
+   * Slice ④-1d: include the optional "first contract (= vehicle match)"
+   * block. The caller must pass {@code contractVehicleOptions} +
+   * {@code contractTemplateOptions} loaded server-side; an empty list
+   * disables the section with a notice instead of rendering empty selects.
+   */
+  includeInitialContract?: boolean;
+  contractVehicleOptions?: RiderContractFormOption[];
+  contractTemplateOptions?: RiderContractFormOption[];
+  contractOptionsNotice?: string | null;
   mode?: "등록" | "수정";
   statusMessage?: string | null;
 };
@@ -51,6 +62,10 @@ export function RiderForm({
   includeInitialInsurance = false,
   insuranceOptions = [],
   insuranceOptionsNotice = null,
+  includeInitialContract = false,
+  contractVehicleOptions = [],
+  contractTemplateOptions = [],
+  contractOptionsNotice = null,
   mode = "등록",
   statusMessage
 }: RiderFormProps) {
@@ -80,6 +95,13 @@ export function RiderForm({
         <InitialInsuranceFields
           options={insuranceOptions}
           notice={insuranceOptionsNotice}
+        />
+      ) : null}
+      {includeInitialContract ? (
+        <InitialContractFields
+          vehicles={contractVehicleOptions}
+          templates={contractTemplateOptions}
+          notice={contractOptionsNotice}
         />
       ) : null}
       {statusMessage ? <p className="action-feedback" role="status">{statusMessage}</p> : null}
@@ -139,6 +161,71 @@ function InitialInsuranceFields({
           className="input"
           maxLength={200}
           name="initialInsuranceMemo"
+          placeholder="예: 운영자 메모"
+        />
+      </Field>
+    </fieldset>
+  );
+}
+
+function InitialContractFields({
+  vehicles,
+  templates,
+  notice
+}: {
+  vehicles: RiderContractFormOption[];
+  templates: RiderContractFormOption[];
+  notice: string | null;
+}) {
+  if (vehicles.length === 0 || templates.length === 0) {
+    return (
+      <fieldset className="rider-form-insurance">
+        <legend>초기 계약 (선택)</legend>
+        <p className="rider-form-insurance-hint">
+          {notice
+            ?? "차량 또는 계약 양식이 없어 등록 단계에서는 계약을 연결할 수 없습니다. 라이더 등록 후 라이더 상세에서 추가하세요."}
+        </p>
+      </fieldset>
+    );
+  }
+  return (
+    <fieldset className="rider-form-insurance">
+      <legend>초기 계약 (선택)</legend>
+      <p className="rider-form-insurance-hint">
+        차량 / 계약 양식 / 시작일을 모두 입력하면 라이더 등록 직후 첫 계약(차량 매칭)도 함께 만들어집니다.
+        하나라도 비어 있으면 라이더만 등록되고 계약은 라이더 상세에서 추가로 연결할 수 있습니다.
+      </p>
+      <div className="form-grid">
+        <Field label="차량">
+          <select className="select" defaultValue="" name="initialContractBikeId">
+            <option value="">미선택</option>
+            {vehicles.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+                {option.helper ? ` · ${option.helper}` : ""}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="계약 양식">
+          <select className="select" defaultValue="" name="initialContractTemplateId">
+            <option value="">미선택</option>
+            {templates.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="시작일">
+          <input className="input" name="initialContractStartAt" type="date" />
+        </Field>
+      </div>
+      <Field label="메모 (선택)">
+        <input
+          className="input"
+          maxLength={200}
+          name="initialContractMemo"
           placeholder="예: 운영자 메모"
         />
       </Field>


### PR DESCRIPTION
## Summary

Final piece of the rider-centric model. The rider create form already had optional 초기 교육 and 초기 보험 sections; this PR adds the missing 초기 계약 (vehicle matching) so an operator can register a rider and pair them with a bike + contract template in one submission — the workflow the user articulated as '계약/보험은 라이더 등록할 때 같이 하는 것'.

- `RiderForm` gains `includeInitialContract` prop + `InitialContractFields` fieldset (차량 select + 계약 양식 select + 시작일 + 메모).
- `createRiderAction` gains a third fail-soft sidecar alongside education + insurance. Status code extended to `created-x-e?-i?-c?`.
- Rider detail page's `resolveCompositeCreatedStatus` updated for the new three-letter code with a 계약 label.
- `/riders/new` loads the rider-contract form options (vehicles + templates) alongside the existing insurance options.

## Trace

- Target issue: EVNSolution/thundercrew-domain#169
- Change-control issue: EVNSolution/clever-change-control#138
- Builds on: EVNSolution/thundercrew-domain#168 (Stages 3 + 4 landed in dev)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:service-ops` passes
- [x] `npm run build` succeeds
- [ ] Manual QA: `/riders/new` shows three optional inline sections (교육 / 보험 / 계약); submitting with all three filled creates the rider plus three sidecar rows in one action; partial sidecar failure (e.g. 계약만 실패) renders the resolved composite flash on the rider detail page (`라이더가 등록되었습니다. ... 계약 저장은 실패했습니다 ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)