### PR TITLE
Expand /overview tab columns: contract-template detail + 보험·교육 여부

### DIFF
--- a/development/front-admin-web/app/overview/page.tsx
+++ b/development/front-admin-web/app/overview/page.tsx
@@ -6,7 +6,10 @@ import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 import { loadRiderList } from "@/lib/services/rider-data";
-import { loadRiderMatchingSnapshot } from "@/lib/services/rider-matching-snapshot-data";
+import {
+  loadRiderMatchingSnapshot,
+  type RiderMatchingSnapshot
+} from "@/lib/services/rider-matching-snapshot-data";
 import { loadStationList } from "@/lib/services/station-data";
 import { loadVehicleList } from "@/lib/services/vehicle-data";
 
@@ -83,11 +86,13 @@ export default async function OverviewPage({
               data={riderData}
               matchedRiderIds={matching.matchedRiderIds}
               insuredRiderIds={matching.insuredRiderIds}
+              educatedRiderIds={matching.educatedRiderIds}
+              riderActiveContractById={matching.riderActiveContractById}
             />
           ),
           notice: riderData.notice
         }
-      : await loadOtherTabContent(activeTab);
+      : await loadOtherTabContent(activeTab, matching);
 
   return (
     <div className="page-container">
@@ -179,12 +184,22 @@ export default async function OverviewPage({
 // (vehicles / stations). The riders tab reuses the data the parent
 // component already fetched for the KPI matched-count calculations.
 async function loadOtherTabContent(
-  tab: Exclude<TabKey, "riders">
+  tab: Exclude<TabKey, "riders">,
+  matching: RiderMatchingSnapshot
 ): Promise<{ panel: ReactNode; notice: string | undefined }> {
   switch (tab) {
     case "vehicles": {
       const data = await loadVehicleList();
-      return { panel: <VehiclesPanel data={data} />, notice: data.notice };
+      return {
+        panel: (
+          <VehiclesPanel
+            data={data}
+            insuredRiderIds={matching.insuredRiderIds}
+            bikeActiveRiderById={matching.bikeActiveRiderById}
+          />
+        ),
+        notice: data.notice
+      };
     }
     case "stations": {
       const data = await loadStationList();

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -78,8 +78,8 @@ export function RidersPanel({
 }
 
 function renderPresence(hasIt: boolean | null): ReactNode {
-  if (hasIt === null) return <span className="muted">—</span>;
-  return hasIt ? <Badge tone="active">있음</Badge> : <Badge tone="muted">없음</Badge>;
+  if (hasIt) return <Badge tone="active">있음</Badge>;
+  return <span className="muted">—</span>;
 }
 
 function renderCategory(category: RiderActiveContractSummary["category"]): ReactNode {

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -1,20 +1,31 @@
+import type { ReactNode } from "react";
+
 import { Badge } from "@/components/ui/Badge";
 import { EmptyState } from "@/components/ui/EmptyState";
 import type { RiderDataResult } from "@/lib/services/rider-data";
+import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 
 /**
  * Read-only table-card for the rider list on `/overview ?tab=riders`.
- * The minimal-shell redesign has no rider detail page to drill into,
- * so the table is purely informational.
+ * Columns: 이름 / 연락처 / 계약 / 구독|렌탈 / 형태 / 기간 / 보험 여부 / 교육 여부.
+ *
+ * The four contract-shape columns (계약 / 구독·렌탈 / 형태 / 기간) all
+ * come from `riderActiveContractById` - the rider's most recent active
+ * contract resolved to its template. When the rider has no active
+ * contract those four cells render `—`.
  */
 export function RidersPanel({
   data,
   matchedRiderIds,
-  insuredRiderIds
+  insuredRiderIds,
+  educatedRiderIds,
+  riderActiveContractById
 }: {
   data: RiderDataResult;
   matchedRiderIds?: Set<string>;
   insuredRiderIds?: Set<string>;
+  educatedRiderIds?: Set<string>;
+  riderActiveContractById?: Map<string, RiderActiveContractSummary>;
 }) {
   if (!data.riders.length) {
     return (
@@ -33,7 +44,11 @@ export function RidersPanel({
             <th>이름</th>
             <th>연락처</th>
             <th>계약</th>
-            <th>보험</th>
+            <th>구독/렌탈</th>
+            <th>형태</th>
+            <th>기간</th>
+            <th>보험 여부</th>
+            <th>교육 여부</th>
           </tr>
         </thead>
         <tbody>
@@ -41,12 +56,18 @@ export function RidersPanel({
             const riderKey = rider.id ?? rider.slug;
             const hasContract = matchedRiderIds ? matchedRiderIds.has(riderKey) : null;
             const hasInsurance = insuredRiderIds ? insuredRiderIds.has(riderKey) : null;
+            const hasEducation = educatedRiderIds ? educatedRiderIds.has(riderKey) : null;
+            const contract = riderActiveContractById?.get(riderKey) ?? null;
             return (
               <tr key={rider.slug}>
                 <td>{rider.name}</td>
                 <td>{rider.phone}</td>
                 <td>{renderPresence(hasContract)}</td>
+                <td>{renderCategory(contract?.category ?? null)}</td>
+                <td>{renderReturnType(contract?.returnType ?? null)}</td>
+                <td>{renderDuration(contract?.durationLabel ?? null)}</td>
                 <td>{renderPresence(hasInsurance)}</td>
+                <td>{renderPresence(hasEducation)}</td>
               </tr>
             );
           })}
@@ -56,11 +77,25 @@ export function RidersPanel({
   );
 }
 
-function renderPresence(hasIt: boolean | null) {
+function renderPresence(hasIt: boolean | null): ReactNode {
   if (hasIt === null) return <span className="muted">—</span>;
-  return hasIt ? (
-    <Badge tone="active">있음</Badge>
-  ) : (
-    <Badge tone="muted">없음</Badge>
-  );
+  return hasIt ? <Badge tone="active">있음</Badge> : <Badge tone="muted">없음</Badge>;
+}
+
+function renderCategory(category: RiderActiveContractSummary["category"]): ReactNode {
+  if (category === "SUBSCRIPTION") return "구독";
+  if (category === "RENTAL") return "렌탈";
+  if (category === "CUSTOM") return "커스텀";
+  return <span className="muted">—</span>;
+}
+
+function renderReturnType(returnType: RiderActiveContractSummary["returnType"]): ReactNode {
+  if (returnType === "TAKEOVER") return "인수형";
+  if (returnType === "RETURN") return "반납형";
+  return <span className="muted">—</span>;
+}
+
+function renderDuration(durationLabel: string | null): ReactNode {
+  if (!durationLabel) return <span className="muted">—</span>;
+  return durationLabel;
 }

--- a/development/front-admin-web/components/management/StationsPanel.tsx
+++ b/development/front-admin-web/components/management/StationsPanel.tsx
@@ -4,8 +4,7 @@ import type { BatteryStation } from "@/types/domain";
 
 /**
  * Read-only table-card for the station list on `/overview ?tab=stations`.
- * No drill-down link — minimal-shell redesign keeps the panel purely
- * informational.
+ * Columns: 스테이션 / 주소 / 가능/최대.
  */
 export function StationsPanel({ data }: { data: StationDataResult }) {
   if (!data.stations.length) {
@@ -24,8 +23,7 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
           <tr>
             <th>스테이션</th>
             <th>주소</th>
-            <th>가능</th>
-            <th>최대</th>
+            <th>가능/최대</th>
           </tr>
         </thead>
         <tbody>
@@ -33,8 +31,11 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
             <tr key={station.slug}>
               <td>{station.name}</td>
               <td>{station.address}</td>
-              <td><strong>{availableCount(station)}</strong></td>
-              <td>{maxCount(station)}</td>
+              <td>
+                <strong>{availableCount(station)}</strong>
+                <span aria-hidden="true">/</span>
+                {maxCount(station)}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -73,6 +73,6 @@ export function VehiclesPanel({
 }
 
 function renderInsurance(hasInsurance: boolean | null): ReactNode {
-  if (hasInsurance === null) return <span className="muted">—</span>;
-  return hasInsurance ? <Badge tone="active">있음</Badge> : <Badge tone="muted">없음</Badge>;
+  if (hasInsurance) return <Badge tone="active">있음</Badge>;
+  return <span className="muted">—</span>;
 }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -1,13 +1,28 @@
+import type { ReactNode } from "react";
+
 import { Badge } from "@/components/ui/Badge";
 import { EmptyState } from "@/components/ui/EmptyState";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data-core";
 
 /**
  * Read-only table-card for the vehicle list on `/overview ?tab=vehicles`.
- * No drill-down link — minimal-shell redesign keeps the panel purely
- * informational.
+ * Columns: 차량번호 / 모델 / 차체 상태 / 보험 / 배정.
+ *
+ * The 보험 column reports whether the rider currently driving this
+ * vehicle has an active rider-insurance row. The lookup walks
+ * vehicle id → active contract's riderId (`bikeActiveRiderById`) →
+ * insured set membership (`insuredRiderIds`). Vehicles with no active
+ * contract show `—`.
  */
-export function VehiclesPanel({ data }: { data: VehicleDataResult }) {
+export function VehiclesPanel({
+  data,
+  insuredRiderIds,
+  bikeActiveRiderById
+}: {
+  data: VehicleDataResult;
+  insuredRiderIds?: Set<string>;
+  bikeActiveRiderById?: Map<string, string>;
+}) {
   if (!data.vehicles.length) {
     return (
       <EmptyState
@@ -25,26 +40,39 @@ export function VehiclesPanel({ data }: { data: VehicleDataResult }) {
             <th>차량번호</th>
             <th>모델</th>
             <th>차체 상태</th>
+            <th>보험</th>
             <th>배정</th>
           </tr>
         </thead>
         <tbody>
-          {data.vehicles.map((vehicle) => (
-            <tr key={vehicle.slug}>
-              <td>{vehicle.plateNumber}</td>
-              <td>{vehicle.model}</td>
-              <td>
-                <Badge
-                  tone={vehicle.status === "운행 중" ? "active" : vehicle.status === "대기" ? "muted" : "outline"}
-                >
-                  {vehicle.status}
-                </Badge>
-              </td>
-              <td>{vehicle.riderName ?? vehicle.assignmentStatus}</td>
-            </tr>
-          ))}
+          {data.vehicles.map((vehicle) => {
+            const vehicleKey = vehicle.id ?? vehicle.slug;
+            const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
+            const hasInsurance =
+              activeRiderId && insuredRiderIds ? insuredRiderIds.has(activeRiderId) : null;
+            return (
+              <tr key={vehicle.slug}>
+                <td>{vehicle.plateNumber}</td>
+                <td>{vehicle.model}</td>
+                <td>
+                  <Badge
+                    tone={vehicle.status === "운행 중" ? "active" : vehicle.status === "대기" ? "muted" : "outline"}
+                  >
+                    {vehicle.status}
+                  </Badge>
+                </td>
+                <td>{renderInsurance(hasInsurance)}</td>
+                <td>{vehicle.riderName ?? vehicle.assignmentStatus}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
   );
+}
+
+function renderInsurance(hasInsurance: boolean | null): ReactNode {
+  if (hasInsurance === null) return <span className="muted">—</span>;
+  return hasInsurance ? <Badge tone="active">있음</Badge> : <Badge tone="muted">없음</Badge>;
 }

--- a/development/front-admin-web/lib/services/rider-matching-snapshot-data.ts
+++ b/development/front-admin-web/lib/services/rider-matching-snapshot-data.ts
@@ -1,31 +1,52 @@
-import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import {
+  type ServiceOpsContractCategory,
+  type ServiceOpsContractDurationUnit,
+  type ServiceOpsContractReturnType,
+  serviceOpsApiConfigured
+} from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 
+export type RiderActiveContractSummary = {
+  category: ServiceOpsContractCategory | null;
+  returnType: ServiceOpsContractReturnType | null;
+  durationLabel: string | null;
+  includesInsurance: boolean | null;
+};
+
 export type RiderMatchingSnapshot = {
-  /** Total number of active rider-bike contracts (= matched pairs). */
+  /** Total active rider-bike contracts (= matched pairs). */
   activeContractCount: number;
-  /** rider ids that have at least one active rider-bike contract. */
+  /** rider ids with ≥1 active rider-bike contract. */
   matchedRiderIds: Set<string>;
-  /** rider ids that have at least one active rider-insurance row. */
+  /** rider ids with ≥1 active rider-insurance row. */
   insuredRiderIds: Set<string>;
+  /** rider ids with ≥1 rider-education-record row. */
+  educatedRiderIds: Set<string>;
+  /**
+   * Per-rider summary of the rider's primary active contract's template
+   * (category / returnType / duration / includesInsurance). When a
+   * rider has multiple active contracts we keep the most recent one,
+   * which is the natural "current arrangement" for table display.
+   */
+  riderActiveContractById: Map<string, RiderActiveContractSummary>;
+  /** Map<bikeId, riderId> for active contracts - lets VehiclesPanel
+   *  look up the rider currently driving a vehicle. */
+  bikeActiveRiderById: Map<string, string>;
 };
 
 /**
- * Aggregate /overview needs to render both the "매칭" KPI tile and the
- * 계약/보험 columns on the riders tab in a single render. Backend has no
- * rider-keyed aggregate endpoint yet, so we page the two list endpoints
- * once (size 200) and bucket by riderId here. Replaces the earlier
- * `loadActiveRiderBikeContractsCount` loader which only returned a
- * scalar count.
- *
- * Returns empty snapshot on every fallback path (no env, no session, API
- * error) so the page can render KPI 0 and "없음" badges cleanly.
+ * Aggregate /overview needs to render the KPI tile + the three tab
+ * panels' badge / template-summary columns in a single render. Pages
+ * 200 rows from each list endpoint and buckets by id here.
  */
 export async function loadRiderMatchingSnapshot(): Promise<RiderMatchingSnapshot> {
   const empty: RiderMatchingSnapshot = {
     activeContractCount: 0,
     matchedRiderIds: new Set(),
-    insuredRiderIds: new Set()
+    insuredRiderIds: new Set(),
+    educatedRiderIds: new Set(),
+    riderActiveContractById: new Map(),
+    bikeActiveRiderById: new Map()
   };
 
   if (!serviceOpsApiConfigured()) return empty;
@@ -33,26 +54,91 @@ export async function loadRiderMatchingSnapshot(): Promise<RiderMatchingSnapshot
   if (!client) return empty;
 
   try {
-    const [contractPage, insurancePage] = await Promise.all([
+    const [contractPage, insurancePage, educationPage, templatePage] = await Promise.all([
       client.listRiderBikeContracts({ page: 0, size: 200 }),
-      client.listRiderInsurances({ page: 0, size: 200 })
+      client.listRiderInsurances({ page: 0, size: 200 }),
+      client.listRiderEducationRecords({ page: 0, size: 200 }),
+      client.listContractTemplates({ page: 0, size: 200 })
     ]);
+
+    const templates = new Map<string, RiderActiveContractSummary>();
+    for (const template of templatePage.items) {
+      templates.set(template.id, {
+        category: template.category ?? null,
+        returnType: template.returnType ?? null,
+        durationLabel: formatDurationLabel(
+          template.unlimited,
+          template.durationUnit ?? null,
+          template.durationValue ?? null
+        ),
+        includesInsurance: template.includesInsurance ?? null
+      });
+    }
+
     const matchedRiderIds = new Set<string>();
+    const bikeActiveRiderById = new Map<string, string>();
+    const riderActiveContractById = new Map<string, RiderActiveContractSummary>();
     let activeContractCount = 0;
-    for (const contract of contractPage.items) {
-      if (contract.terminatedAt === null) {
-        activeContractCount += 1;
-        matchedRiderIds.add(contract.riderId);
+    // Sort by createdAt desc so the per-rider map ends up with the most
+    // recent active contract when a rider has more than one in flight.
+    const sortedActive = contractPage.items
+      .filter((contract) => contract.terminatedAt === null)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    for (const contract of sortedActive) {
+      activeContractCount += 1;
+      matchedRiderIds.add(contract.riderId);
+      bikeActiveRiderById.set(contract.bikeId, contract.riderId);
+      if (!riderActiveContractById.has(contract.riderId)) {
+        const tpl = templates.get(contract.contractTemplateId);
+        riderActiveContractById.set(
+          contract.riderId,
+          tpl ?? {
+            category: null,
+            returnType: null,
+            durationLabel: null,
+            includesInsurance: null
+          }
+        );
       }
     }
+
     const insuredRiderIds = new Set<string>();
     for (const policy of insurancePage.items) {
-      if (policy.enabled) {
-        insuredRiderIds.add(policy.riderId);
-      }
+      if (policy.enabled) insuredRiderIds.add(policy.riderId);
     }
-    return { activeContractCount, matchedRiderIds, insuredRiderIds };
+
+    const educatedRiderIds = new Set<string>();
+    for (const record of educationPage.items) {
+      educatedRiderIds.add(record.riderId);
+    }
+
+    return {
+      activeContractCount,
+      matchedRiderIds,
+      insuredRiderIds,
+      educatedRiderIds,
+      riderActiveContractById,
+      bikeActiveRiderById
+    };
   } catch {
     return empty;
   }
+}
+
+function formatDurationLabel(
+  unlimited: boolean | undefined,
+  unit: ServiceOpsContractDurationUnit | null | undefined,
+  value: number | null | undefined
+): string | null {
+  if (unlimited) return "무제한";
+  if (!unit || value === null || value === undefined) return null;
+  const suffix: Record<ServiceOpsContractDurationUnit, string> = {
+    DAY: "일",
+    WEEK: "주",
+    MONTH: "개월",
+    QUARTER: "분기",
+    HALF_YEAR: "반기",
+    YEAR: "년"
+  };
+  return `${value}${suffix[unit] ?? ""}`;
 }

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -838,6 +838,7 @@ export type ServiceOpsApiClient = {
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
   updateRider: (id: string, request: RiderUpdateInput) => Promise<FrontendRider>;
   deleteRider: (id: string) => Promise<void>;
+  listRiderEducationRecords: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsRiderEducationRecord>>;
   listRiderEducationRecordsByRider: (
     riderId: string,
     params?: { page?: number; size?: number; sort?: string }
@@ -1235,6 +1236,12 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     deleteRider: async (id) => {
       await request<void>(`/riders/${encodeURIComponent(id)}`, { method: "DELETE" });
     },
+    listRiderEducationRecords: ({ page = 0, size = 20, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsRiderEducationRecord>>(
+        "/rider-education-records",
+        { method: "GET" },
+        { page, size, sort }
+      ),
     listRiderEducationRecordsByRider: (riderId, { page = 0, size = 20, sort } = {}) =>
       request<ServiceOpsPage<ServiceOpsRiderEducationRecord>>(
         `/riders/${encodeURIComponent(riderId)}/education-records`,


### PR DESCRIPTION
## Summary

Operator wants richer at-a-glance data on the /overview tab panels.

- **라이더** (8 cols): 이름 / 연락처 / 계약 / 구독·렌탈 / 형태 / 기간 / 보험 여부 / 교육 여부
- **차량** (5 cols): 차량번호 / 모델 / 차체 상태 / 보험 / 배정
- **스테이션** (3 cols): 스테이션 / 주소 / 가능/최대

`loadRiderMatchingSnapshot` extended with three new sets/maps (`educatedRiderIds`, `riderActiveContractById`, `bikeActiveRiderById`) derived from four paged fetches. Added `listRiderEducationRecords` (list-all) to the service-ops client - backend already exposes the endpoint.

Closes EVNSolution/thundercrew-domain#175 cleanup follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)