### PR TITLE
Wipe .next before typecheck on EC2 deploy

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -118,6 +118,13 @@ jobs:
 
           npm ci
           npm run lint
+          # Stale `.next/types/validator.ts` from a previous deploy can
+          # reference routes that the current commit has deleted, which
+          # makes `tsc --noEmit` fail with TS2307 even though every route
+          # in the new tree typechecks fine. Wipe Next.js build output
+          # before typechecking and rebuilding so the validator is
+          # regenerated against the current route tree.
+          rm -rf development/front-admin-web/.next
           npm run typecheck
           npm run build
 


### PR DESCRIPTION
## Summary
- Production deploy of PR #182 failed at \`npm run typecheck\` because EC2 held a stale \`.next/types/validator.ts\` from the previous build that referenced routes the new commit had deleted (contract-templates, contracts, devices, equipment, insurance, integrity, riders, settings, stations, vehicles)
- \`tsconfig.json\` includes \`.next/types/**/*.ts\`, so \`tsc --noEmit\` typechecked the stale validator and emitted ~40 \`TS2307\` errors for non-existent route files
- Fix: \`rm -rf development/front-admin-web/.next\` before \`npm run typecheck\` so the validator is regenerated by the subsequent \`npm run build\` against the current route tree

## Test plan
- [ ] Merge dev → main, observe EC2 deploy reach \`npm run build\` cleanly
- [ ] Confirm \`/overview\` reachable after restart