### PR TITLE
Hotfix: clean .next before typecheck on EC2 deploy

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -118,6 +118,13 @@ jobs:
 
           npm ci
           npm run lint
+          # Stale `.next/types/validator.ts` from a previous deploy can
+          # reference routes that the current commit has deleted, which
+          # makes `tsc --noEmit` fail with TS2307 even though every route
+          # in the new tree typechecks fine. Wipe Next.js build output
+          # before typechecking and rebuilding so the validator is
+          # regenerated against the current route tree.
+          rm -rf development/front-admin-web/.next
           npm run typecheck
           npm run build
 


### PR DESCRIPTION
## Summary
Retry of PR #182's promotion + hotfix for the deploy failure it surfaced.

PR #182 reached EC2 but `npm run typecheck` died with ~40 `TS2307` errors against `.next/types/validator.ts` — a stale Next.js-generated file from the previous deploy that still referenced routes cc-141-minimal-shell-cleanup had stripped (contract-templates, contracts, devices, equipment, insurance, integrity, riders, settings, stations, vehicles). `tsconfig.json` includes `.next/types/**/*.ts`, so the stale validator was typechecked.

PR #183 (now on dev) adds `rm -rf development/front-admin-web/.next` between `npm run lint` and `npm run typecheck` in `.github/workflows/aws-ec2-deploy.yml` so `npm run build` regenerates the validator against the current route tree.

## Test plan
- [ ] Deploy workflow reaches `npm run build` cleanly
- [ ] `systemctl is-active thundercrew-service-ops-api / thundercrew-front-admin-web / nginx / postgresql` all return active
- [ ] `/overview` renders with seeded data over the public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)