### PR TITLE
Gate admin web behind /login via Next.js middleware

### DIFF
--- a/development/front-admin-web/lib/services/service-ops-session-core.ts
+++ b/development/front-admin-web/lib/services/service-ops-session-core.ts
@@ -1,5 +1,8 @@
 import type { ServiceOpsApiClient, ServiceOpsAuthResponse } from "./service-ops-api";
 
+// 이 두 쿠키 이름은 `middleware.ts` 가 Edge runtime 제약 때문에 인라인
+// 으로 복사해서 쓴다. 값을 바꿀 때 미들웨어도 같이 맞춰야 게이트가
+// 새 쿠키를 인식한다.
 export const SERVICE_OPS_ACCESS_TOKEN_COOKIE = "thundercrew_ops_access_token";
 export const SERVICE_OPS_REFRESH_TOKEN_COOKIE = "thundercrew_ops_refresh_token";
 

--- a/development/front-admin-web/middleware.ts
+++ b/development/front-admin-web/middleware.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+// 미들웨어는 Next.js Edge runtime 에서 돌기 때문에 Node-only API 를
+// 트랜지티브로 끌어올 수 있는 import 는 일부러 피한다. 쿠키 이름은 두
+// 군데에서 같이 쓰이지만 게이트가 알아야 하는 정보는 이 두 줄뿐이라
+// 인라인이 명료하다 (`service-ops-session-core` 와 변경 시 같이
+// 맞춰야 한다는 주의 코멘트는 그쪽에도 둔다).
+const SERVICE_OPS_ACCESS_TOKEN_COOKIE = "thundercrew_ops_access_token";
+const SERVICE_OPS_REFRESH_TOKEN_COOKIE = "thundercrew_ops_refresh_token";
+
+/**
+ * 운영자 콘솔 입장 게이트. 인증 쿠키 (access / refresh) 가 둘 다 없으면
+ * `/login` 으로 보낸다. 로그인 후 어디로 갈지는 signInAdmin 이 결정하고
+ * 항상 `/overview` 로 리다이렉트하므로 여기서 `from=` 같은 복귀 경로는
+ * 굳이 보존하지 않는다 — UX 가 단순해지고 미들웨어/로그인 액션 사이의
+ * 책임이 명확해진다.
+ *
+ * 이미 로그인된 사용자가 다시 `/login` 으로 진입하면 `/overview` 로
+ * 돌려보낸다. 그래야 운영자가 로그아웃 직후 다시 들어왔을 때나
+ * 북마크로 `/login` 을 눌렀을 때 헷갈리지 않는다.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const accessToken = request.cookies.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = request.cookies.get(SERVICE_OPS_REFRESH_TOKEN_COOKIE)?.value;
+  const authenticated = Boolean(accessToken || refreshToken);
+
+  if (pathname === "/login") {
+    if (authenticated) {
+      return NextResponse.redirect(new URL("/overview", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (!authenticated) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+/**
+ * matcher 는 negative-lookahead 로 정적 자산과 Next.js 내부 경로를
+ * 비껴서 미들웨어가 모든 페이지 / 서버 액션 요청만 가로채도록 한다.
+ * - `_next/static` / `_next/image` : Next.js 내부 빌드 자산.
+ * - `favicon.ico` / 확장자가 있는 정적 파일 : 직접 서빙 대상.
+ */
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)"]
+};


### PR DESCRIPTION
## Summary
- Add \`middleware.ts\` that redirects every page / server-action route to \`/login\` when the access + refresh cookies are both missing, and bounces authenticated visitors away from \`/login\` to \`/overview\`
- Inline the two cookie names instead of importing them from \`service-ops-session-core\` to keep the Edge runtime bundle minimal; add a sync-warning comment on the canonical constants
- Matcher excludes \`_next/static\`, \`_next/image\`, \`favicon.ico\`, and anything that looks like a file (has a dot) so static assets bypass the gate

Local probe against \`localhost:3000\`:
- \`GET /overview\` (no cookie) → \`307 Location: /login\`
- \`GET /login\` (no cookie) → \`200\`
- \`tsc --noEmit\` and \`eslint .\` pass

## Test plan
- [ ] After dev → main promotion, hit \`https://thundercrew-domain.43.201.57.147.sslip.io/\` and confirm the bounce to \`/login\`
- [ ] Sign in with the seeded admin and confirm landing on \`/overview\` with data
- [ ] Logout and confirm bounce back to \`/login\`
- [ ] Make sure \`THUNDERCREW_ADMIN_SEED_*\` env on EC2 has a valid login_id / password so an admin actually exists (check \`/etc/systemd/system/thundercrew-service-ops-api.service.d/*.env\` or the EnvironmentFile referenced by the systemd unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)