### PR TITLE
Seed default 'admin' / 'admin1234' operator login

### DIFF
--- a/development/service-ops-api/src/main/resources/db/migration/V20__seed_default_ops_admin.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V20__seed_default_ops_admin.sql
@@ -1,0 +1,38 @@
+-- Bootstrap a default operator login so the deployed admin web is
+-- usable without depending on the systemd EnvironmentFile having the
+-- THUNDERCREW_ADMIN_SEED_* variables filled in. AdminSeedRunner only
+-- creates / updates a user when those env values are present, and on
+-- the current EC2 host they are blank, so /login had no usable
+-- credentials. This migration drops in a known account directly.
+--
+-- login_id : admin
+-- password : admin1234
+--
+-- The hash below was produced with Spring Security's BCryptPasswordEncoder
+-- (strength 10) — verified via `bcrypt.checkpw("admin1234", "$2b$10$...")`.
+-- Spring's matcher accepts $2a$ and $2b$ prefixes interchangeably.
+--
+-- Idempotency: the unique partial index on (login_id) where deleted_at is
+-- null acts as the arbiter, and `on conflict do nothing` lets the
+-- migration re-run safely on environments that already seeded `admin`
+-- through other means (e.g. systemd env). Operators can rotate the
+-- password later through the admin self-service flow (or via the seed
+-- runner if THUNDERCREW_ADMIN_SEED_PASSWORD is set, since the runner
+-- updates the existing row).
+
+insert into admin_users (
+    id,
+    login_id,
+    email,
+    password_hash,
+    display_name,
+    enabled
+) values (
+    '22222222-0000-4000-8000-000000000001',
+    'admin',
+    null,
+    '$2b$10$sZiJ336rQyJbGysltAAnZuBNC.WFUE8Qxzpgyoefns88lrU59URB.',
+    'Ops Admin',
+    true
+)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- Add Flyway migration \`V20__seed_default_ops_admin.sql\` that inserts an \`admin\` row with BCrypt-hashed password \`admin1234\` directly
- Hash generated with strength 10 (\`bcrypt.checkpw\` verified \`True\`)
- \`on conflict do nothing\` keeps it idempotent and compatible with environments that also have \`THUNDERCREW_ADMIN_SEED_*\` filled in
- Unblocks /login on EC2 where the systemd EnvironmentFile is missing those seed vars, so AdminSeedRunner currently short-circuits and no admin exists

## Test plan
- [ ] After dev → main, EC2 Flyway picks up V20 and inserts the row
- [ ] \`POST /login\` with \`admin\` / \`admin1234\` returns session cookies
- [ ] /overview reachable with seeded data after sign-in
- [ ] Re-running the migration on a host that already has \`admin\` is a no-op