### PR TITLE
Seed default admin account on production

### DIFF
--- a/development/front-admin-web/app/login/page.tsx
+++ b/development/front-admin-web/app/login/page.tsx
@@ -2,6 +2,9 @@ import { Field } from "@/components/ui/FormField";
 import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
 import { signInAdmin } from "./actions";
 
+// 로그인 실패 / 만료 상태별 안내. 게이트(미들웨어) 가 보낸 status 도
+// 여기서 같은 자리에 표시한다. 운영자 친화적인 한 줄이라 inline 메시지만
+// 살리고 본문 설명·기능 안내 같은 텍스트는 다 떼어냈다.
 const statusMessage: Record<string, string> = {
   "missing-env": "Supabase 환경변수가 아직 연결되지 않았습니다.",
   "auth-error": "로그인에 실패했습니다. 테스트 관리자 이메일/비밀번호를 확인하세요.",
@@ -18,34 +21,24 @@ export default async function LoginPage({ searchParams }: { searchParams: Promis
 
   return (
     <div className="page-container">
-      <section className="hero">
-        <p className="hero-kicker">Admin Auth</p>
-        <h1 className="hero-title">관리자 로그인</h1>
-        <p className="hero-description">
-          {serviceOpsMode
-            ? "Spring Boot service-ops-api 관리자 로그인으로 HTTP-only 세션 쿠키를 발급합니다."
-            : "Supabase Auth email/password 로그인으로 연결했습니다. 테스트 관리자 계정은 로컬 `.env.local`에만 저장합니다."}
-        </p>
-      </section>
-      <form action={signInAdmin} className="card" style={{ maxWidth: 480, margin: "0 auto 80px" }}>
+      <form action={signInAdmin} className="card" style={{ maxWidth: 480, margin: "80px auto" }}>
         <Field label={serviceOpsMode ? "로그인 ID 또는 이메일" : "이메일"}>
           <input
             autoComplete="username"
             className="input"
             name="loginId"
-            placeholder={serviceOpsMode ? "admin" : "admin@thundercrew-domain.local"}
             required
             type={serviceOpsMode ? "text" : "email"}
           />
-        </Field><br />
-        <Field label="비밀번호"><input className="input" name="password" type="password" placeholder="로컬 테스트 비밀번호" required /></Field>
+        </Field>
+        <br />
+        <Field label="비밀번호">
+          <input className="input" name="password" type="password" required />
+        </Field>
         {message ? <div className="notice" style={{ marginTop: 16 }}>{message}</div> : null}
-        <div className="notice" style={{ marginTop: 16 }}>
-          {serviceOpsMode
-            ? "로그인 성공 시 토큰은 브라우저 입력값이나 공개 파일이 아니라 HTTP-only 쿠키로만 보관합니다."
-            : "SERVICE_OPS_API_BASE_URL이 없으면 기존 Supabase Auth 경로를 유지합니다. 백엔드 연결 시 service-ops-api 로그인으로 자동 전환됩니다."}
+        <div className="form-actions">
+          <button className="button-primary" type="submit">로그인</button>
         </div>
-        <div className="form-actions"><button className="button-primary" type="submit">로그인</button></div>
       </form>
     </div>
   );

--- a/development/service-ops-api/src/main/resources/db/migration/V20__seed_default_ops_admin.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V20__seed_default_ops_admin.sql
@@ -1,0 +1,38 @@
+-- Bootstrap a default operator login so the deployed admin web is
+-- usable without depending on the systemd EnvironmentFile having the
+-- THUNDERCREW_ADMIN_SEED_* variables filled in. AdminSeedRunner only
+-- creates / updates a user when those env values are present, and on
+-- the current EC2 host they are blank, so /login had no usable
+-- credentials. This migration drops in a known account directly.
+--
+-- login_id : admin
+-- password : admin1234
+--
+-- The hash below was produced with Spring Security's BCryptPasswordEncoder
+-- (strength 10) — verified via `bcrypt.checkpw("admin1234", "$2b$10$...")`.
+-- Spring's matcher accepts $2a$ and $2b$ prefixes interchangeably.
+--
+-- Idempotency: the unique partial index on (login_id) where deleted_at is
+-- null acts as the arbiter, and `on conflict do nothing` lets the
+-- migration re-run safely on environments that already seeded `admin`
+-- through other means (e.g. systemd env). Operators can rotate the
+-- password later through the admin self-service flow (or via the seed
+-- runner if THUNDERCREW_ADMIN_SEED_PASSWORD is set, since the runner
+-- updates the existing row).
+
+insert into admin_users (
+    id,
+    login_id,
+    email,
+    password_hash,
+    display_name,
+    enabled
+) values (
+    '22222222-0000-4000-8000-000000000001',
+    'admin',
+    null,
+    '$2b$10$sZiJ336rQyJbGysltAAnZuBNC.WFUE8Qxzpgyoefns88lrU59URB.',
+    'Ops Admin',
+    true
+)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
Promote PR #187 to production.

Adds Flyway migration \`V20__seed_default_ops_admin.sql\` that inserts a default \`admin\` row with BCrypt-hashed password \`admin1234\` so the freshly-deployed \`/login\` gate (from PR #186) has a usable account.

- BCrypt hash verified (\`bcrypt.checkpw(\"admin1234\", ...)\` → True)
- \`on conflict do nothing\` keeps it idempotent and compatible with any future systemd-side \`THUNDERCREW_ADMIN_SEED_*\` env

## Test plan
- [ ] Deploy reaches Flyway, V20 applies, EC2 service restarts cleanly
- [ ] \`POST /login\` with \`admin\` / \`admin1234\` succeeds and bounces to \`/overview\`
- [ ] \`/overview\` renders with data after sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)