### PR TITLE
Geocode BSS address on register/update so it pins on the map

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -34,11 +34,11 @@ jobs:
       NCP_MAP_CLIENT_ID: ${{ vars.NCP_MAP_CLIENT_ID }}
       NCP_MAP_STYLE_ID_LIGHT: ${{ vars.NCP_MAP_STYLE_ID_LIGHT }}
       NCP_MAP_STYLE_ID_DARK: ${{ vars.NCP_MAP_STYLE_ID_DARK }}
-      # NCP Geocoding (server-only). 운영자가 등록한 BSS 주소를 위경도로 변환해
-      # 지도에 마커가 뜨도록 한다. Maps Client ID 와 다른 별도 API Gateway
-      # 자격 쌍이고, 브라우저에 노출되면 안 되니 Secrets 로 다룬다.
-      NCP_GEOCODE_API_KEY_ID: ${{ secrets.NCP_GEOCODE_API_KEY_ID }}
-      NCP_GEOCODE_API_KEY: ${{ secrets.NCP_GEOCODE_API_KEY }}
+      # NCP Maps Client Secret (server-only). Geocoding REST 호출에 같은
+      # Application 의 Client ID + Client Secret 쌍을 그대로 쓴다. Client ID
+      # 는 위 Variables 에 있고 (어차피 브라우저 노출), Secret 만 여기 와서
+      # 서버에 머무른다. 따로 API Gateway 서비스 어카운트 발급 불필요.
+      NCP_MAP_CLIENT_SECRET: ${{ secrets.NCP_MAP_CLIENT_SECRET }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -123,8 +123,7 @@ jobs:
              NCP_MAP_CLIENT_ID='${NCP_MAP_CLIENT_ID}' \
              NCP_MAP_STYLE_ID_LIGHT='${NCP_MAP_STYLE_ID_LIGHT}' \
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
-             NCP_GEOCODE_API_KEY_ID='${NCP_GEOCODE_API_KEY_ID}' \
-             NCP_GEOCODE_API_KEY='${NCP_GEOCODE_API_KEY}' \
+             NCP_MAP_CLIENT_SECRET='${NCP_MAP_CLIENT_SECRET}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -146,8 +145,7 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_CLIENT_ID=${NCP_MAP_CLIENT_ID}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=${NCP_MAP_STYLE_ID_LIGHT}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
-          NCP_GEOCODE_API_KEY_ID=${NCP_GEOCODE_API_KEY_ID}
-          NCP_GEOCODE_API_KEY=${NCP_GEOCODE_API_KEY}
+          NCP_MAP_CLIENT_SECRET=${NCP_MAP_CLIENT_SECRET}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can

--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -34,6 +34,11 @@ jobs:
       NCP_MAP_CLIENT_ID: ${{ vars.NCP_MAP_CLIENT_ID }}
       NCP_MAP_STYLE_ID_LIGHT: ${{ vars.NCP_MAP_STYLE_ID_LIGHT }}
       NCP_MAP_STYLE_ID_DARK: ${{ vars.NCP_MAP_STYLE_ID_DARK }}
+      # NCP Geocoding (server-only). 운영자가 등록한 BSS 주소를 위경도로 변환해
+      # 지도에 마커가 뜨도록 한다. Maps Client ID 와 다른 별도 API Gateway
+      # 자격 쌍이고, 브라우저에 노출되면 안 되니 Secrets 로 다룬다.
+      NCP_GEOCODE_API_KEY_ID: ${{ secrets.NCP_GEOCODE_API_KEY_ID }}
+      NCP_GEOCODE_API_KEY: ${{ secrets.NCP_GEOCODE_API_KEY }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -118,6 +123,8 @@ jobs:
              NCP_MAP_CLIENT_ID='${NCP_MAP_CLIENT_ID}' \
              NCP_MAP_STYLE_ID_LIGHT='${NCP_MAP_STYLE_ID_LIGHT}' \
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
+             NCP_GEOCODE_API_KEY_ID='${NCP_GEOCODE_API_KEY_ID}' \
+             NCP_GEOCODE_API_KEY='${NCP_GEOCODE_API_KEY}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -139,6 +146,8 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_CLIENT_ID=${NCP_MAP_CLIENT_ID}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=${NCP_MAP_STYLE_ID_LIGHT}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
+          NCP_GEOCODE_API_KEY_ID=${NCP_GEOCODE_API_KEY_ID}
+          NCP_GEOCODE_API_KEY=${NCP_GEOCODE_API_KEY}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can

--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -15,6 +15,14 @@ NEXT_PUBLIC_NCP_MAP_CLIENT_ID=<ncp-maps-client-id>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=<ncp-style-editor-light-uuid>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 
+# NCP Geocoding (server-only). Converts the station address entered via the
+# Daum/Kakao postcode popup into lat/lng so /dashboard pins the BSS on the
+# real map. Issue these from NCP Console → API Gateway service account; they
+# are a separate credential pair from the Maps client ID. Do NOT prefix with
+# NEXT_PUBLIC_ — these stay in server actions only.
+NCP_GEOCODE_API_KEY_ID=<ncp-apigw-api-key-id>
+NCP_GEOCODE_API_KEY=<ncp-apigw-api-key>
+
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres

--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -15,13 +15,11 @@ NEXT_PUBLIC_NCP_MAP_CLIENT_ID=<ncp-maps-client-id>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=<ncp-style-editor-light-uuid>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 
-# NCP Geocoding (server-only). Converts the station address entered via the
-# Daum/Kakao postcode popup into lat/lng so /dashboard pins the BSS on the
-# real map. Issue these from NCP Console → API Gateway service account; they
-# are a separate credential pair from the Maps client ID. Do NOT prefix with
-# NEXT_PUBLIC_ — these stay in server actions only.
-NCP_GEOCODE_API_KEY_ID=<ncp-apigw-api-key-id>
-NCP_GEOCODE_API_KEY=<ncp-apigw-api-key>
+# NCP Maps Client Secret (server-only). Pairs with NEXT_PUBLIC_NCP_MAP_CLIENT_ID
+# from the same Maps Application; both go into the Geocoding REST headers
+# (x-ncp-apigw-api-key-id / x-ncp-apigw-api-key) to convert BSS addresses to
+# lat/lng. Do NOT prefix with NEXT_PUBLIC_ — the secret must stay server-side.
+NCP_MAP_CLIENT_SECRET=<ncp-maps-application-client-secret>
 
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>

--- a/development/front-admin-web/app/overview/actions.ts
+++ b/development/front-admin-web/app/overview/actions.ts
@@ -10,6 +10,7 @@ import {
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { geocodeAddress } from "@/lib/services/ncp-geocoder";
 
 /**
  * /overview tab create actions. Each posts a single backend create call,
@@ -259,12 +260,19 @@ export async function updateStationFromOverviewAction(
   const currentMax = parseNumber(formData.get("currentMaxBatteryCapacity"), maxBatteryCapacity);
   const currentAvailable = parseNumber(formData.get("currentAvailableBatteryCount"), availableBatteryCount);
 
+  // 주소가 바뀌었으면 좌표도 같이 갱신해줘야 지도 마커가 새 위치로 이동한다.
+  // env 미설정 / geocode 실패 시엔 좌표를 안 보내고 기존 값을 유지한다
+  // (undefined 면 백엔드가 해당 필드를 안 건드림).
+  const geocoded = await geocodeAddress(address);
+
   try {
     // /overview 에서 station 의 식별 키는 주소다 (name 도 동일하게 동기화).
     // 주소만 바뀌어도 둘 다 같이 갱신해야 한다.
     await client.updateBatteryStation(stationId, {
       name: address,
-      address
+      address,
+      latitude: geocoded?.latitude ?? undefined,
+      longitude: geocoded?.longitude ?? undefined
     });
     if (maxBatteryCapacity !== currentMax || availableBatteryCount !== currentAvailable) {
       await client.updateBatteryStationCounts(stationId, {
@@ -424,12 +432,18 @@ export async function createStationFromOverviewAction(formData: FormData): Promi
   const maxBatteryCapacity = parseNumber(formData.get("maxBatteryCapacity"), 0);
   const availableBatteryCount = parseNumber(formData.get("availableBatteryCount"), 0);
 
+  // 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 NCP geocoding 으로
+  // 주소 → 위경도 변환을 따로 한다. NCP env 미설정이거나 응답 실패면
+  // null 이라 (0, 0) 폴백 — 등록 자체는 막지 않고, 운영자가 나중에 직접
+  // 좌표를 손볼 수 있도록 한다. 지도엔 안 떠도 row 는 존재하는 상태.
+  const geocoded = await geocodeAddress(address);
+
   try {
     await client.createBatteryStation({
       name: address, // operator identifies station by address; can be edited later.
       address,
-      latitude: 0, // placeholder — operator updates after geocoding.
-      longitude: 0,
+      latitude: geocoded?.latitude ?? 0,
+      longitude: geocoded?.longitude ?? 0,
       status: "ACTIVE" as ServiceOpsStationStatus,
       maxBatteryCapacity,
       currentBatteryCount: availableBatteryCount,

--- a/development/front-admin-web/lib/services/ncp-geocoder.ts
+++ b/development/front-admin-web/lib/services/ncp-geocoder.ts
@@ -4,9 +4,13 @@
  * 있게 한다. 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 이 보완이
  * 필요하다.
  *
- * 인증: NCP API Gateway 자격 — Maps 클라이언트 ID 와는 별개의 service-account
- * 키 쌍이다. 서버 액션에서만 호출하므로 NEXT_PUBLIC_ 접두사를 붙이지 않고,
- * 브라우저로 흘러나가지 않게 둔다.
+ * 인증: 같은 NCP Maps Application 의 Client ID + Client Secret 쌍을 그대로
+ * `x-ncp-apigw-api-key-id` / `x-ncp-apigw-api-key` 헤더에 박는다. 따로
+ * API Gateway 서비스 어카운트를 발급할 필요 없이 클라이언트 SDK 와 같은
+ * 인증서를 재사용 — Client ID 는 어차피 NEXT_PUBLIC_ 으로 브라우저에 노출
+ * 되고, 진짜 보안은 Client Secret 의 비밀성 + NCP 콘솔의 origin
+ * allowlist 가 담당한다. Client Secret 만 NEXT_PUBLIC_ 접두사 없이 서버에
+ * 머무르게 한다.
  *
  * 실패 시 정책: 호출 측이 graceful degradation 을 결정한다 — 본 모듈은 null
  * 을 돌려주고, 호출 측이 (0, 0) placeholder 로 폴백할지 등록을 거부할지
@@ -36,9 +40,9 @@ export async function geocodeAddress(address: string): Promise<GeocodedCoordinat
   const trimmed = address.trim();
   if (!trimmed) return null;
 
-  const keyId = process.env.NCP_GEOCODE_API_KEY_ID;
-  const key = process.env.NCP_GEOCODE_API_KEY;
-  if (!keyId || !key) {
+  const clientId = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
+  const clientSecret = process.env.NCP_MAP_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
     // env 미설정 시 호출 자체를 안 한다. 호출 측이 null 을 받아 polyfill
     // 로 갈 수 있게 — 콘솔 노이즈도 안 만들고, env 가 빠진 dev/sandbox
     // 에서 BSS 등록이 막히지 않도록.
@@ -51,8 +55,8 @@ export async function geocodeAddress(address: string): Promise<GeocodedCoordinat
     response = await fetch(url, {
       method: "GET",
       headers: {
-        "X-NCP-APIGW-API-KEY-ID": keyId,
-        "X-NCP-APIGW-API-KEY": key,
+        "x-ncp-apigw-api-key-id": clientId,
+        "x-ncp-apigw-api-key": clientSecret,
         Accept: "application/json"
       },
       // 운영자 폼 submit 한 번에 한 번만 호출하니까 캐시는 의미 없고,

--- a/development/front-admin-web/lib/services/ncp-geocoder.ts
+++ b/development/front-admin-web/lib/services/ncp-geocoder.ts
@@ -1,0 +1,86 @@
+/**
+ * NCP Maps Geocoding (server-side). 운영자가 다음 우편번호로 고른 주소를
+ * 위경도로 변환해서 BSS 등록 시 (0, 0) placeholder 대신 실제 좌표를 박을 수
+ * 있게 한다. 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 이 보완이
+ * 필요하다.
+ *
+ * 인증: NCP API Gateway 자격 — Maps 클라이언트 ID 와는 별개의 service-account
+ * 키 쌍이다. 서버 액션에서만 호출하므로 NEXT_PUBLIC_ 접두사를 붙이지 않고,
+ * 브라우저로 흘러나가지 않게 둔다.
+ *
+ * 실패 시 정책: 호출 측이 graceful degradation 을 결정한다 — 본 모듈은 null
+ * 을 돌려주고, 호출 측이 (0, 0) placeholder 로 폴백할지 등록을 거부할지
+ * 정한다. 운영자에게 등록이 통째로 실패하는 것보다는 일단 row 가 들어가고
+ * 좌표를 나중에 손볼 수 있는 쪽이 덜 답답하다.
+ */
+export interface GeocodedCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+const NCP_GEOCODE_ENDPOINT = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode";
+
+interface NcpGeocodeAddress {
+  /** 경도 (longitude). 문자열로 내려온다. */
+  x: string;
+  /** 위도 (latitude). 문자열로 내려온다. */
+  y: string;
+}
+
+interface NcpGeocodeResponse {
+  status: string;
+  addresses?: NcpGeocodeAddress[];
+}
+
+export async function geocodeAddress(address: string): Promise<GeocodedCoordinates | null> {
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+
+  const keyId = process.env.NCP_GEOCODE_API_KEY_ID;
+  const key = process.env.NCP_GEOCODE_API_KEY;
+  if (!keyId || !key) {
+    // env 미설정 시 호출 자체를 안 한다. 호출 측이 null 을 받아 polyfill
+    // 로 갈 수 있게 — 콘솔 노이즈도 안 만들고, env 가 빠진 dev/sandbox
+    // 에서 BSS 등록이 막히지 않도록.
+    return null;
+  }
+
+  const url = `${NCP_GEOCODE_ENDPOINT}?query=${encodeURIComponent(trimmed)}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "X-NCP-APIGW-API-KEY-ID": keyId,
+        "X-NCP-APIGW-API-KEY": key,
+        Accept: "application/json"
+      },
+      // 운영자 폼 submit 한 번에 한 번만 호출하니까 캐시는 의미 없고,
+      // Next.js fetch 가 기본적으로 캐시를 시도하는 것 자체가 불필요한
+      // 노이즈라 명시적으로 비활성화한다.
+      cache: "no-store"
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) return null;
+
+  let body: NcpGeocodeResponse;
+  try {
+    body = (await response.json()) as NcpGeocodeResponse;
+  } catch {
+    return null;
+  }
+
+  if (body.status !== "OK" || !body.addresses || body.addresses.length === 0) {
+    return null;
+  }
+
+  const first = body.addresses[0];
+  const longitude = Number.parseFloat(first.x);
+  const latitude = Number.parseFloat(first.y);
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) return null;
+
+  return { latitude, longitude };
+}


### PR DESCRIPTION
## Summary
- New \`lib/services/ncp-geocoder.ts\` calls NCP \`/map-geocode/v2/geocode\` server-side
- \`createStationFromOverviewAction\` geocodes the picked address → real lat/lng instead of \`(0, 0)\`
- \`updateStationFromOverviewAction\` re-geocodes when the operator edits the address
- Workflow forwards new \`NCP_GEOCODE_API_KEY_ID\` / \`NCP_GEOCODE_API_KEY\` Secrets through SSH and into \`.env.local\` (no \`NEXT_PUBLIC_\` so they stay server-only)
- Graceful degradation: missing env or geocoding failure leaves the existing fallback (registration succeeds, station shows in tables, map marker omitted) instead of blocking the register button

## Pre-merge activation steps
1. **NCP Console** → Services → AI·NAVER API → **Maps** → enable Geocoding sub-product (Reverse Geocoding 도 같이 켜둘 수 있음)
2. NCP Console → 계정 관리 → 인증키 관리 → 새 인증키 발급 (API Gateway 자격) → \`Access Key ID\` 와 \`Secret Key\` 메모
3. **GitHub Secrets** (https://github.com/EVNSolution/thundercrew-domain/settings/secrets/actions) 에 등록:
   - \`NCP_GEOCODE_API_KEY_ID\` ← Access Key ID
   - \`NCP_GEOCODE_API_KEY\` ← Secret Key
4. Merge dev → main → deploy 자동 실행

## Test plan
- [ ] 새 BSS 등록 → \`/dashboard\` 에 해당 주소 자리에 마커가 뜸
- [ ] 기존 \`(0, 0)\` station 의 주소를 \`/overview\` 상세에서 수정 → 마커 위치가 새 주소로 이동
- [ ] NCP env 빼고 등록 시 → 등록은 되지만 마커는 \`(0, 0)\` (graceful degrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)