### PR TITLE
Geocode BSS pins + per-vehicle simulated bike fleet

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -34,11 +34,11 @@ jobs:
       NCP_MAP_CLIENT_ID: ${{ vars.NCP_MAP_CLIENT_ID }}
       NCP_MAP_STYLE_ID_LIGHT: ${{ vars.NCP_MAP_STYLE_ID_LIGHT }}
       NCP_MAP_STYLE_ID_DARK: ${{ vars.NCP_MAP_STYLE_ID_DARK }}
-      # NCP Geocoding (server-only). 운영자가 등록한 BSS 주소를 위경도로 변환해
-      # 지도에 마커가 뜨도록 한다. Maps Client ID 와 다른 별도 API Gateway
-      # 자격 쌍이고, 브라우저에 노출되면 안 되니 Secrets 로 다룬다.
-      NCP_GEOCODE_API_KEY_ID: ${{ secrets.NCP_GEOCODE_API_KEY_ID }}
-      NCP_GEOCODE_API_KEY: ${{ secrets.NCP_GEOCODE_API_KEY }}
+      # NCP Maps Client Secret (server-only). Geocoding REST 호출에 같은
+      # Application 의 Client ID + Client Secret 쌍을 그대로 쓴다. Client ID
+      # 는 위 Variables 에 있고 (어차피 브라우저 노출), Secret 만 여기 와서
+      # 서버에 머무른다. 따로 API Gateway 서비스 어카운트 발급 불필요.
+      NCP_MAP_CLIENT_SECRET: ${{ secrets.NCP_MAP_CLIENT_SECRET }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -123,8 +123,7 @@ jobs:
              NCP_MAP_CLIENT_ID='${NCP_MAP_CLIENT_ID}' \
              NCP_MAP_STYLE_ID_LIGHT='${NCP_MAP_STYLE_ID_LIGHT}' \
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
-             NCP_GEOCODE_API_KEY_ID='${NCP_GEOCODE_API_KEY_ID}' \
-             NCP_GEOCODE_API_KEY='${NCP_GEOCODE_API_KEY}' \
+             NCP_MAP_CLIENT_SECRET='${NCP_MAP_CLIENT_SECRET}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -146,8 +145,7 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_CLIENT_ID=${NCP_MAP_CLIENT_ID}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=${NCP_MAP_STYLE_ID_LIGHT}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
-          NCP_GEOCODE_API_KEY_ID=${NCP_GEOCODE_API_KEY_ID}
-          NCP_GEOCODE_API_KEY=${NCP_GEOCODE_API_KEY}
+          NCP_MAP_CLIENT_SECRET=${NCP_MAP_CLIENT_SECRET}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can

--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -34,6 +34,11 @@ jobs:
       NCP_MAP_CLIENT_ID: ${{ vars.NCP_MAP_CLIENT_ID }}
       NCP_MAP_STYLE_ID_LIGHT: ${{ vars.NCP_MAP_STYLE_ID_LIGHT }}
       NCP_MAP_STYLE_ID_DARK: ${{ vars.NCP_MAP_STYLE_ID_DARK }}
+      # NCP Geocoding (server-only). 운영자가 등록한 BSS 주소를 위경도로 변환해
+      # 지도에 마커가 뜨도록 한다. Maps Client ID 와 다른 별도 API Gateway
+      # 자격 쌍이고, 브라우저에 노출되면 안 되니 Secrets 로 다룬다.
+      NCP_GEOCODE_API_KEY_ID: ${{ secrets.NCP_GEOCODE_API_KEY_ID }}
+      NCP_GEOCODE_API_KEY: ${{ secrets.NCP_GEOCODE_API_KEY }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -118,6 +123,8 @@ jobs:
              NCP_MAP_CLIENT_ID='${NCP_MAP_CLIENT_ID}' \
              NCP_MAP_STYLE_ID_LIGHT='${NCP_MAP_STYLE_ID_LIGHT}' \
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
+             NCP_GEOCODE_API_KEY_ID='${NCP_GEOCODE_API_KEY_ID}' \
+             NCP_GEOCODE_API_KEY='${NCP_GEOCODE_API_KEY}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -139,6 +146,8 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_CLIENT_ID=${NCP_MAP_CLIENT_ID}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=${NCP_MAP_STYLE_ID_LIGHT}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
+          NCP_GEOCODE_API_KEY_ID=${NCP_GEOCODE_API_KEY_ID}
+          NCP_GEOCODE_API_KEY=${NCP_GEOCODE_API_KEY}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can

--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -39,6 +39,11 @@ jobs:
       # 는 위 Variables 에 있고 (어차피 브라우저 노출), Secret 만 여기 와서
       # 서버에 머무른다. 따로 API Gateway 서비스 어카운트 발급 불필요.
       NCP_MAP_CLIENT_SECRET: ${{ secrets.NCP_MAP_CLIENT_SECRET }}
+      # 실제 차량이 텔레메트리를 흘리기 전 시연 / QA 단계에서 지도에 더미
+      # 오토바이 핀을 띄울지 결정. "1" / "true" / "yes" / "on" 만 켜진 것으로
+      # 친다. 빈 문자열이거나 미설정이면 더미 비활성화. 실제 차량이 들어오면
+      # 값을 비우거나 변수를 제거하면 자동으로 사라진다.
+      SHOW_DUMMY_BIKES: ${{ vars.SHOW_DUMMY_BIKES }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -124,6 +129,7 @@ jobs:
              NCP_MAP_STYLE_ID_LIGHT='${NCP_MAP_STYLE_ID_LIGHT}' \
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
              NCP_MAP_CLIENT_SECRET='${NCP_MAP_CLIENT_SECRET}' \
+             SHOW_DUMMY_BIKES='${SHOW_DUMMY_BIKES}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -146,6 +152,7 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=${NCP_MAP_STYLE_ID_LIGHT}
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
           NCP_MAP_CLIENT_SECRET=${NCP_MAP_CLIENT_SECRET}
+          SHOW_DUMMY_BIKES=${SHOW_DUMMY_BIKES}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can

--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -15,6 +15,14 @@ NEXT_PUBLIC_NCP_MAP_CLIENT_ID=<ncp-maps-client-id>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=<ncp-style-editor-light-uuid>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 
+# NCP Geocoding (server-only). Converts the station address entered via the
+# Daum/Kakao postcode popup into lat/lng so /dashboard pins the BSS on the
+# real map. Issue these from NCP Console → API Gateway service account; they
+# are a separate credential pair from the Maps client ID. Do NOT prefix with
+# NEXT_PUBLIC_ — these stay in server actions only.
+NCP_GEOCODE_API_KEY_ID=<ncp-apigw-api-key-id>
+NCP_GEOCODE_API_KEY=<ncp-apigw-api-key>
+
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres

--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -21,6 +21,11 @@ NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 # lat/lng. Do NOT prefix with NEXT_PUBLIC_ — the secret must stay server-side.
 NCP_MAP_CLIENT_SECRET=<ncp-maps-application-client-secret>
 
+# Inject 8 dummy motorcycle pins onto /dashboard so the map UI is testable
+# while real vehicles are not yet streaming telemetry. Accepts 1/true/yes/on.
+# Remove (or set to anything else) once real bikes come online.
+SHOW_DUMMY_BIKES=1
+
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres

--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -15,13 +15,11 @@ NEXT_PUBLIC_NCP_MAP_CLIENT_ID=<ncp-maps-client-id>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT=<ncp-style-editor-light-uuid>
 NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 
-# NCP Geocoding (server-only). Converts the station address entered via the
-# Daum/Kakao postcode popup into lat/lng so /dashboard pins the BSS on the
-# real map. Issue these from NCP Console → API Gateway service account; they
-# are a separate credential pair from the Maps client ID. Do NOT prefix with
-# NEXT_PUBLIC_ — these stay in server actions only.
-NCP_GEOCODE_API_KEY_ID=<ncp-apigw-api-key-id>
-NCP_GEOCODE_API_KEY=<ncp-apigw-api-key>
+# NCP Maps Client Secret (server-only). Pairs with NEXT_PUBLIC_NCP_MAP_CLIENT_ID
+# from the same Maps Application; both go into the Geocoding REST headers
+# (x-ncp-apigw-api-key-id / x-ncp-apigw-api-key) to convert BSS addresses to
+# lat/lng. Do NOT prefix with NEXT_PUBLIC_ — the secret must stay server-side.
+NCP_MAP_CLIENT_SECRET=<ncp-maps-application-client-secret>
 
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>

--- a/development/front-admin-web/app/overview/actions.ts
+++ b/development/front-admin-web/app/overview/actions.ts
@@ -10,6 +10,7 @@ import {
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { geocodeAddress } from "@/lib/services/ncp-geocoder";
 
 /**
  * /overview tab create actions. Each posts a single backend create call,
@@ -259,12 +260,19 @@ export async function updateStationFromOverviewAction(
   const currentMax = parseNumber(formData.get("currentMaxBatteryCapacity"), maxBatteryCapacity);
   const currentAvailable = parseNumber(formData.get("currentAvailableBatteryCount"), availableBatteryCount);
 
+  // 주소가 바뀌었으면 좌표도 같이 갱신해줘야 지도 마커가 새 위치로 이동한다.
+  // env 미설정 / geocode 실패 시엔 좌표를 안 보내고 기존 값을 유지한다
+  // (undefined 면 백엔드가 해당 필드를 안 건드림).
+  const geocoded = await geocodeAddress(address);
+
   try {
     // /overview 에서 station 의 식별 키는 주소다 (name 도 동일하게 동기화).
     // 주소만 바뀌어도 둘 다 같이 갱신해야 한다.
     await client.updateBatteryStation(stationId, {
       name: address,
-      address
+      address,
+      latitude: geocoded?.latitude ?? undefined,
+      longitude: geocoded?.longitude ?? undefined
     });
     if (maxBatteryCapacity !== currentMax || availableBatteryCount !== currentAvailable) {
       await client.updateBatteryStationCounts(stationId, {
@@ -424,12 +432,18 @@ export async function createStationFromOverviewAction(formData: FormData): Promi
   const maxBatteryCapacity = parseNumber(formData.get("maxBatteryCapacity"), 0);
   const availableBatteryCount = parseNumber(formData.get("availableBatteryCount"), 0);
 
+  // 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 NCP geocoding 으로
+  // 주소 → 위경도 변환을 따로 한다. NCP env 미설정이거나 응답 실패면
+  // null 이라 (0, 0) 폴백 — 등록 자체는 막지 않고, 운영자가 나중에 직접
+  // 좌표를 손볼 수 있도록 한다. 지도엔 안 떠도 row 는 존재하는 상태.
+  const geocoded = await geocodeAddress(address);
+
   try {
     await client.createBatteryStation({
       name: address, // operator identifies station by address; can be edited later.
       address,
-      latitude: 0, // placeholder — operator updates after geocoding.
-      longitude: 0,
+      latitude: geocoded?.latitude ?? 0,
+      longitude: geocoded?.longitude ?? 0,
       status: "ACTIVE" as ServiceOpsStationStatus,
       maxBatteryCapacity,
       currentBatteryCount: availableBatteryCount,

--- a/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
@@ -99,7 +99,6 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
   // Telemetry derived values (snapshot does not bundle telemetry — see PR #133).
   const lastReceivedAt = live?.lastReceivedAt ?? pin.lastReceivedAt;
   const connectionStatus = live?.connectionStatus ?? pin.connectionStatus;
-  const drivingStatus = live?.drivingStatus ?? pin.drivingStatus;
   const batteryStatus = live?.batteryStatus ?? pin.batteryStatus;
   const batteryPercent = live?.batteryPercent ?? pin.batteryPercent;
   const speedKph = live?.speedKph ?? pin.speedKph;
@@ -132,7 +131,6 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
 
       <Section title="텔레메트리">
         <DetailRow label="연결 상태" value={connectionStatus} />
-        <DetailRow label="주행 상태" value={drivingStatus} />
         <DetailRow label="시동" value={ignitionStatus} />
         <DetailRow
           label="속도"
@@ -195,18 +193,6 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
           />
         )}
       </Section>
-
-      <Section title="장비">
-        {snap?.equipments && snap.equipments.length > 0 ? (
-          <EquipmentList equipments={snap.equipments} />
-        ) : (
-          <EmptySectionMessage
-            loading={snapshotLoading}
-            notice={snapshotResult?.notice}
-            empty="설치된 장비 없음"
-          />
-        )}
-      </Section>
     </aside>
   );
 }
@@ -248,27 +234,12 @@ function EmptySectionMessage({
 }
 
 function RiderSection({ rider }: { rider: NonNullable<NonNullable<BikeSnapshotResult["data"]>["rider"]> }) {
-  const educationLabel = rider.educationCompleted
-    ? rider.educationExpired
-      ? "만료"
-      : "완료"
-    : "미완료";
-  const educationDetail = rider.latestEducationCompletedAt
-    ? `${rider.latestEducationType ?? "—"} · ${formatDate(rider.latestEducationCompletedAt)}${
-        rider.latestEducationExpiresAt
-          ? ` (만료 ${formatDate(rider.latestEducationExpiresAt)})`
-          : ""
-      }`
-    : "이력 없음";
   return (
     <>
       <DetailRow label="이름" value={rider.name} />
       <DetailRow label="연락처" value={rider.phoneNumber} />
-      <DetailRow label="소속" value={rider.teamName ?? "—"} />
-      <DetailRow label="구역" value={rider.areaName ?? "—"} />
       <DetailRow label="앱 계정" value={rider.appLinkStatus} />
-      <DetailRow label="교육 상태" value={educationLabel} />
-      <DetailRow label="최근 교육" value={educationDetail} />
+      <DetailRow label="교육 상태" value={rider.latestEducationType ?? "—"} />
     </>
   );
 }
@@ -278,30 +249,17 @@ function ContractSection({
 }: {
   contract: NonNullable<NonNullable<BikeSnapshotResult["data"]>["activeContract"]>;
 }) {
-  const durationLabel = formatContractDuration(
-    contract.templateDurationUnit,
-    contract.templateDurationValue
-  );
   const periodLabel = `${formatDate(contract.startAt)} ~ ${
     contract.endAt ? formatDate(contract.endAt) : "무기한"
   }`;
   return (
     <>
       <DetailRow label="템플릿" value={contract.templateName} />
-      <DetailRow label="카테고리" value={contract.templateCategory} />
-      <DetailRow
-        label="형태"
-        value={contract.templateReturnType ?? "—"}
-      />
-      <DetailRow label="기간" value={durationLabel} />
       <DetailRow label="시작/종료" value={periodLabel} />
       <DetailRow
         label="보험 포함"
         value={contract.templateIncludesInsurance ? "예" : "아니오"}
       />
-      {contract.terminatedAt ? (
-        <DetailRow label="종료" value={`${formatDate(contract.terminatedAt)} · ${contract.terminatedReason ?? "—"}`} />
-      ) : null}
     </>
   );
 }
@@ -332,45 +290,7 @@ function InsuranceList({
   );
 }
 
-function EquipmentList({
-  equipments
-}: {
-  equipments: NonNullable<BikeSnapshotResult["data"]>["equipments"];
-}) {
-  return (
-    <div className="bike-detail-panel-list">
-      {equipments.map((row) => (
-        <div key={row.id} className="bike-detail-panel-list-item">
-          <div className="bike-detail-panel-list-title">
-            {row.equipmentLabel ?? row.typeName}
-          </div>
-          <div className="bike-detail-panel-list-meta">
-            {row.typeName}
-            {row.modelName ? ` · ${row.modelName}` : ""}
-            {row.serialNumber ? ` · ${row.serialNumber}` : ""}
-          </div>
-          <div className="bike-detail-panel-list-meta">
-            설치 {formatDate(row.installedAt)}
-            {row.managementDueDate ? ` · 점검 만료 ${row.managementDueDate}` : ""}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
 
-function formatContractDuration(unit: string | null, value: number | null): string {
-  if (!unit || value == null) return "—";
-  const unitLabel: Record<string, string> = {
-    DAY: "일",
-    WEEK: "주",
-    MONTH: "개월",
-    QUARTER: "분기",
-    HALF_YEAR: "반기",
-    YEAR: "년"
-  };
-  return `${value} ${unitLabel[unit] ?? unit}`;
-}
 
 function formatDate(iso: string): string {
   const ts = Date.parse(iso);

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -18,6 +18,17 @@ const NCP_STYLE_ID_DARK = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK;
 const SEOUL_DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 const DEFAULT_ZOOM = 13;
 
+// 마커 반경 5m를 현재 줌 레벨에서 픽셀로 변환.
+const MARKER_RADIUS_METERS = 5;
+const MIN_MARKER_PX = 4;
+const LABEL_VISIBLE_ZOOM = 12;
+
+function metersToPixels(meters: number, zoom: number, lat: number = 37.56): number {
+  const metersPerPx = (156543.03 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, zoom);
+  const px = meters / metersPerPx;
+  return Math.max(MIN_MARKER_PX, Math.round(px * 2)); // diameter
+}
+
 // Two-step load: base SDK first, then the GL companion. The official
 // `submodules=gl` shortcut races with the auto-injected GL bundle whenever
 // React mounts MapShell while other dev-mode scripts are still parsing,
@@ -182,9 +193,10 @@ export function MapShell({
 
     // Theme toggle path: the JSX below keys the canvas <div> on `styleId`,
     // so React already unmounted the old container and mounted a fresh one.
-    // The cache lookup above misses against the new container, so we fall
-    // through to building a new map.
+    // Destroy old markers so they don't linger on the dead map instance.
     if (existing) {
+      for (const m of bikeMarkerCacheRef.current.values()) m.setMap(null);
+      for (const m of stationMarkerCacheRef.current.values()) m.setMap(null);
       bikeMarkerCacheRef.current.clear();
       stationMarkerCacheRef.current.clear();
     }
@@ -210,28 +222,44 @@ export function MapShell({
     };
   }, [sdkReady, styleId, initialCenter.lat, initialCenter.lng, initialZoom]);
 
-  // Bike markers — diff against the cache so the same bikeId reuses its
-  // NaverMarker instance. This is the cheap path for polling: setPosition
-  // costs nothing compared to `new naver.maps.Marker(...)` which allocates a
-  // DOM node + event listeners every time.
+  // Track current zoom for marker sizing
+  const [currentZoom, setCurrentZoom] = useState(initialZoom);
+
+  // Listen to zoom changes to resize markers proportionally
+  useEffect(() => {
+    if (!sdkReady) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.Event) return;
+
+    const listener = naver.maps.Event.addListener(map, "zoom_changed", (zoom: unknown) => {
+      setCurrentZoom(typeof zoom === "number" ? zoom : Number(zoom));
+    });
+    return () => {
+      if (listener) naver.maps.Event.removeListener(listener);
+    };
+  }, [sdkReady, mapVersion]);
+
+  // Bike markers — halo ring + center dot, sized to 100m radius.
   useEffect(() => {
     if (!sdkReady) return;
     const map = mapRef.current;
     const naver = typeof window !== "undefined" ? window.naver : undefined;
     if (!map || !naver?.maps?.Marker) return;
 
+    const size = metersToPixels(MARKER_RADIUS_METERS, currentZoom);
+    const half = Math.round(size / 2);
     const cache = bikeMarkerCacheRef.current;
     const incomingIds = new Set<string>();
 
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
+      const html = bikeMarkerHtml(size, pin.pinLabel ?? pin.plateNumber, currentZoom >= LABEL_VISIBLE_ZOOM);
       const icon = {
-        content: bikeMarkerHtml(pin),
-        // NCP 마커는 anchor / size 가 plain object 가 아니라 `naver.maps.Point`
-        // / `Size` 인스턴스이어야 hit-test 가 제대로 잡힌다.
-        anchor: new naver.maps.Point(16, 16),
-        size: new naver.maps.Size(32, 32)
+        content: html,
+        anchor: new naver.maps.Point(half, half),
+        size: new naver.maps.Size(size, size)
       };
       const existing = cache.get(pin.bikeId);
       if (existing) {
@@ -260,31 +288,39 @@ export function MapShell({
         cache.delete(bikeId);
       }
     }
-  }, [sdkReady, bikePins, mapVersion]);
+  }, [sdkReady, bikePins, mapVersion, currentZoom]);
 
-  // Station markers — same diff strategy. Stations don't move, so the cache
-  // mostly catches set-once + occasional add/remove during ops.
+  // Station markers — dot + label card, dot sized to 100m radius.
   useEffect(() => {
     if (!sdkReady) return;
     const map = mapRef.current;
     const naver = typeof window !== "undefined" ? window.naver : undefined;
     if (!map || !naver?.maps?.Marker) return;
 
+    const dotSize = metersToPixels(MARKER_RADIUS_METERS, currentZoom);
     const cache = stationMarkerCacheRef.current;
     const incomingIds = new Set<string>();
 
     for (const pin of stationPins) {
       incomingIds.add(pin.stationId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
+      const html = stationMarkerHtml(pin, dotSize, currentZoom >= LABEL_VISIBLE_ZOOM);
+      const icon = {
+        content: html,
+        anchor: new naver.maps.Point(Math.round(dotSize / 2), Math.round(dotSize / 2)),
+        size: new naver.maps.Size(dotSize, dotSize)
+      };
       const existing = cache.get(pin.stationId);
       if (existing) {
         existing.setPosition?.(position);
+        existing.setIcon?.(icon);
         continue;
       }
       const marker = new naver.maps.Marker({
         position,
         map,
         title: pin.pinLabel ?? pin.name,
+        icon,
         clickable: Boolean(onStationSelectRef.current)
       });
       if (onStationSelectRef.current && naver.maps.Event) {
@@ -301,7 +337,7 @@ export function MapShell({
         cache.delete(stationId);
       }
     }
-  }, [sdkReady, stationPins, mapVersion]);
+  }, [sdkReady, stationPins, mapVersion, currentZoom]);
 
   if (!NCP_CLIENT_ID) {
     return (
@@ -337,16 +373,40 @@ export function MapShell({
 }
 
 /**
- * 오토바이 핀의 HTML 본문만 만들고, anchor / size 는 호출 측에서
- * `naver.maps.Point` / `Size` 인스턴스로 감싸서 마커에 넘긴다 — NCP 가
- * plain object 를 인자로 받으면 hit-test 가 깨지는 경우가 있어서.
- *
- * 운행 상태에 따라 배지 색을 바꿔 "운행중 / 대기" 를 한눈에 구분.
- * 운행중은 mint 계열, 대기는 회색. Material Symbols "two_wheeler" SVG
- * path 를 그대로 inline 해서 폰트/자산 의존성 없이 한 줄로 처리한다.
+ * BSS 마커 — designs/rider-position-monitor.pen Component/Dark/BatteryStation.
+ * 녹색 dot(pointCore) + 반투명 blur 라벨 카드(충전소명 + "n/m 보유").
+ * CSS 변수를 참조해 light/dark 자동 전환.
  */
-function bikeMarkerHtml(pin: { drivingStatus: string }): string {
-  const isDriving = pin.drivingStatus === "DRIVING";
-  const background = isDriving ? "#00B894" : "#64748B";
-  return `<div style="width:32px;height:32px;border-radius:50%;background:${background};border:2px solid #ffffff;box-shadow:0 2px 6px rgba(0,0,0,0.35);display:flex;align-items:center;justify-content:center;pointer-events:auto;"><svg width="20" height="20" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true"><path d="M19.44 9.03L15.41 5h-2v2h1.18l1.5 1.5H9.34L7.82 6H4.5v2h2.32l1.5 2H4c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4c0-.79-.24-1.52-.63-2.13l3.43 4.13V18h-2v2h6v-2h-2v-2.5L12.5 12H17v6h-2v2h6v-2h-2v-8h-2zM4 16c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm16 0c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"/></svg></div>`;
+function stationMarkerHtml(pin: FrontendDashboardStationPin, dotSize: number, showLabel: boolean): string {
+  const dot = `<div style="width:${dotSize}px;height:${dotSize}px;border-radius:50%;background:var(--rm-battery-high);"></div>`;
+  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
+  return [
+    `<div style="position:relative;pointer-events:auto;">`,
+    dot,
+    `<div style="position:absolute;bottom:100%;left:100%;margin-left:-2px;margin-bottom:-2px;padding:2px 5px;border-radius:4px;background:var(--color-text-primary);border:1px solid var(--rm-line-subtle);white-space:nowrap;line-height:1;">`,
+    `<span style="font-size:10px;font-weight:700;color:var(--color-bg);font-family:var(--font-sans);display:block;">${pin.name}</span>`,
+    `</div></div>`
+  ].join("");
+}
+
+/**
+ * 차량 마커 — 반경 5m 원 + 오른쪽 위 말풍선(번호판).
+ * 줌에 따라 dot 크기가 비례 변환. CSS 변수로 light/dark 자동 전환.
+ */
+function bikeMarkerHtml(size: number, plateNumber: string, showLabel: boolean): string {
+  const coreSize = Math.max(4, Math.round(size * 0.35));
+  const dotHtml = [
+    `<div style="width:${size}px;height:${size}px;position:relative;">`,
+    `<div style="position:absolute;inset:0;border-radius:50%;background:var(--rm-accent-halo-strong);border:1px solid var(--rm-accent);"></div>`,
+    `<div style="position:absolute;top:50%;left:50%;width:${coreSize}px;height:${coreSize}px;transform:translate(-50%,-50%);border-radius:50%;background:var(--rm-accent);"></div>`,
+    `</div>`
+  ].join("");
+  if (!showLabel) return `<div style="pointer-events:auto;">${dotHtml}</div>`;
+  return [
+    `<div style="position:relative;pointer-events:auto;">`,
+    dotHtml,
+    `<div style="position:absolute;bottom:100%;left:100%;margin-left:-2px;margin-bottom:-2px;padding:2px 5px;border-radius:4px;background:var(--color-text-primary);border:1px solid var(--rm-line-subtle);white-space:nowrap;line-height:1;">`,
+    `<span style="font-size:9px;font-weight:700;color:var(--color-bg);font-family:var(--font-sans);display:block;">${plateNumber}</span>`,
+    `</div></div>`
+  ].join("");
 }

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -226,15 +226,24 @@ export function MapShell({
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
+      const icon = {
+        content: bikeMarkerHtml(pin),
+        // NCP 마커는 anchor / size 가 plain object 가 아니라 `naver.maps.Point`
+        // / `Size` 인스턴스이어야 hit-test 가 제대로 잡힌다.
+        anchor: new naver.maps.Point(16, 16),
+        size: new naver.maps.Size(32, 32)
+      };
       const existing = cache.get(pin.bikeId);
       if (existing) {
         existing.setPosition?.(position);
+        existing.setIcon?.(icon);
         continue;
       }
       const marker = new naver.maps.Marker({
         position,
         map,
         title: pin.pinLabel ?? pin.plateNumber,
+        icon,
         clickable: Boolean(onBikeSelectRef.current)
       });
       if (onBikeSelectRef.current && naver.maps.Event) {
@@ -325,4 +334,19 @@ export function MapShell({
       {children}
     </>
   );
+}
+
+/**
+ * 오토바이 핀의 HTML 본문만 만들고, anchor / size 는 호출 측에서
+ * `naver.maps.Point` / `Size` 인스턴스로 감싸서 마커에 넘긴다 — NCP 가
+ * plain object 를 인자로 받으면 hit-test 가 깨지는 경우가 있어서.
+ *
+ * 운행 상태에 따라 배지 색을 바꿔 "운행중 / 대기" 를 한눈에 구분.
+ * 운행중은 mint 계열, 대기는 회색. Material Symbols "two_wheeler" SVG
+ * path 를 그대로 inline 해서 폰트/자산 의존성 없이 한 줄로 처리한다.
+ */
+function bikeMarkerHtml(pin: { drivingStatus: string }): string {
+  const isDriving = pin.drivingStatus === "DRIVING";
+  const background = isDriving ? "#00B894" : "#64748B";
+  return `<div style="width:32px;height:32px;border-radius:50%;background:${background};border:2px solid #ffffff;box-shadow:0 2px 6px rgba(0,0,0,0.35);display:flex;align-items:center;justify-content:center;pointer-events:auto;"><svg width="20" height="20" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true"><path d="M19.44 9.03L15.41 5h-2v2h1.18l1.5 1.5H9.34L7.82 6H4.5v2h2.32l1.5 2H4c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4c0-.79-.24-1.52-.63-2.13l3.43 4.13V18h-2v2h6v-2h-2v-2.5L12.5 12H17v6h-2v2h6v-2h-2v-8h-2zM4 16c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm16 0c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"/></svg></div>`;
 }

--- a/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/StationDetailPanel.tsx
@@ -78,12 +78,8 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
 
   const name = live?.name ?? pin.name;
   const address = live?.address ?? pin.address;
-  const status = live?.stationStatus ?? pin.status;
   const maxBatteryCapacity = live?.maxBatteryCapacity ?? pin.maxBatteryCapacity;
-  const currentBatteryCount = live?.currentBatteryCount ?? pin.currentBatteryCount;
   const availableBatteryCount = live?.availableBatteryCount ?? pin.availableBatteryCount;
-  const availableBatteryLabel = live?.availableBatteryLabel ?? pin.availableBatteryLabel;
-  const capacityPercentage = live?.capacityPercentage ?? pin.availableBatteryPercentage;
   const latitude = live?.latitude ?? pin.latitude;
   const longitude = live?.longitude ?? pin.longitude;
   const updatedAt = live?.updatedAt ?? null;
@@ -95,14 +91,15 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
     const stationId = pin.stationId;
     setCountUpdate({ stationId, outcome: { phase: "submitting" } });
     try {
+      const available = numberOrNull(formData.get("availableBatteryCount"));
       const response = await fetch(
         `/api/dashboard/battery-station/${encodeURIComponent(stationId)}/battery-counts`,
         {
           body: JSON.stringify({
             maxBatteryCapacity: numberOrNull(formData.get("maxBatteryCapacity")),
-            currentBatteryCount: numberOrNull(formData.get("currentBatteryCount")),
-            availableBatteryCount: numberOrNull(formData.get("availableBatteryCount")),
-            reason: stringOrNull(formData.get("reason"))
+            currentBatteryCount: available,
+            availableBatteryCount: available,
+            reason: null
           }),
           cache: "no-store",
           credentials: "same-origin",
@@ -154,11 +151,7 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
       </header>
 
       <dl className="bike-detail-panel-body">
-        <DetailRow label="상태" value={statusLabel(status)} />
-        <DetailRow label="가용 배터리" value={availableBatteryLabel} />
-        <DetailRow label="현재/최대" value={`${currentBatteryCount} / ${maxBatteryCapacity}`} />
-        <DetailRow label="가용 수량" value={`${availableBatteryCount}`} />
-        <DetailRow label="가용율" value={`${capacityPercentage}%`} />
+        <DetailRow label="잔여/총" value={`${availableBatteryCount} / ${maxBatteryCapacity}`} />
         <DetailRow label="위치" value={`${latitude.toFixed(5)}, ${longitude.toFixed(5)}`} />
         {updatedAt ? <DetailRow label="마지막 업데이트" value={formatRelative(updatedAt)} /> : null}
       </dl>
@@ -174,31 +167,7 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
         <h3 className="bike-detail-panel-section-title">배터리 카운트 변경</h3>
         <div className="station-count-edit-grid">
           <label className="station-count-edit-field">
-            <span>최대</span>
-            <input
-              className="input"
-              defaultValue={maxBatteryCapacity}
-              key={`max-${pin.stationId}-${live?.updatedAt ?? "init"}`}
-              min={0}
-              name="maxBatteryCapacity"
-              required
-              type="number"
-            />
-          </label>
-          <label className="station-count-edit-field">
-            <span>현재</span>
-            <input
-              className="input"
-              defaultValue={currentBatteryCount}
-              key={`current-${pin.stationId}-${live?.updatedAt ?? "init"}`}
-              min={0}
-              name="currentBatteryCount"
-              required
-              type="number"
-            />
-          </label>
-          <label className="station-count-edit-field">
-            <span>가용</span>
+            <span>잔여</span>
             <input
               className="input"
               defaultValue={availableBatteryCount}
@@ -209,17 +178,19 @@ export function StationDetailPanel({ pin, onClose }: StationDetailPanelProps) {
               type="number"
             />
           </label>
+          <label className="station-count-edit-field">
+            <span>총</span>
+            <input
+              className="input"
+              defaultValue={maxBatteryCapacity}
+              key={`max-${pin.stationId}-${live?.updatedAt ?? "init"}`}
+              min={0}
+              name="maxBatteryCapacity"
+              required
+              type="number"
+            />
+          </label>
         </div>
-        <label className="station-count-edit-field-wide">
-          <span>변경 사유 (선택)</span>
-          <input
-            className="input"
-            maxLength={100}
-            name="reason"
-            placeholder="예: 배터리 5개 신규 입고"
-            type="text"
-          />
-        </label>
         <div className="station-count-edit-actions">
           <button
             className="button-primary"
@@ -248,12 +219,6 @@ function numberOrNull(value: FormDataEntryValue | null): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function stringOrNull(value: FormDataEntryValue | null): string | null {
-  if (value === null) return null;
-  const text = String(value).trim();
-  return text ? text : null;
-}
-
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="bike-detail-panel-row">
@@ -261,25 +226,6 @@ function DetailRow({ label, value }: { label: string; value: string }) {
       <dd>{value}</dd>
     </div>
   );
-}
-
-function statusLabel(status: string): string {
-  switch (status) {
-    case "ACTIVE":
-      return "운영 중";
-    case "MAINTENANCE":
-      return "점검 중";
-    case "INACTIVE":
-      return "비활성";
-    case "운영":
-      return "운영 중";
-    case "점검":
-      return "점검 중";
-    case "비활성":
-      return "비활성";
-    default:
-      return status ?? "—";
-  }
 }
 
 function formatRelative(iso: string): string {

--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -1,0 +1,157 @@
+import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+
+/**
+ * 운영자가 실제 차량/텔레메트리가 아직 안 붙은 상태에서 지도 UI 가 제대로
+ * 동작하는지(아이콘, 클릭, 패널) 시연·확인할 수 있게 더미 오토바이 핀을
+ * 끼워 넣는 헬퍼. `loadDashboardMapState` 가 env(`SHOW_DUMMY_BIKES=1`) 가
+ * 켜져 있을 때만 호출한다 — 실제 차량이 텔레메트리를 흘리기 시작하면
+ * env 만 빼서 끄면 된다.
+ *
+ * 데이터는 결정적(deterministic) 이라 폴링이 돌아도 위치가 안 바뀐다 —
+ * "지도가 매번 흔들리는 것처럼 보임" 같은 시각적 노이즈를 방지한다. 실제
+ * 동선 데모가 필요하면 별도 함수로 시간 기반 보간을 추가하면 된다.
+ *
+ * 좌표 범위: 서울 시내. 강남·종로·홍대·강북 근방에 흩뿌렸다.
+ */
+
+interface DummyBikeSeed {
+  id: string;
+  plate: string;
+  model: string;
+  lat: number;
+  lng: number;
+  // "운행중" 시각화 vs "대기" 시각화를 골고루 보여주려고 둘 다 섞는다.
+  driving: "DRIVING" | "PARKED";
+  battery: number;
+  rider: string | null;
+}
+
+const DUMMY_SEEDS: ReadonlyArray<DummyBikeSeed> = [
+  {
+    id: "dummy-bike-01",
+    plate: "12가1001",
+    model: "Honda PCX",
+    lat: 37.498095,
+    lng: 127.02761,
+    driving: "DRIVING",
+    battery: 87,
+    rider: "김라이더"
+  },
+  {
+    id: "dummy-bike-02",
+    plate: "34나1002",
+    model: "Honda PCX",
+    lat: 37.514575,
+    lng: 127.0495,
+    driving: "PARKED",
+    battery: 62,
+    rider: null
+  },
+  {
+    id: "dummy-bike-03",
+    plate: "56다1003",
+    model: "Yamaha NMAX",
+    lat: 37.5704,
+    lng: 126.9821,
+    driving: "DRIVING",
+    battery: 41,
+    rider: "박배달"
+  },
+  {
+    id: "dummy-bike-04",
+    plate: "78라1004",
+    model: "Yamaha NMAX",
+    lat: 37.5535,
+    lng: 126.9224,
+    driving: "PARKED",
+    battery: 18,
+    rider: null
+  },
+  {
+    id: "dummy-bike-05",
+    plate: "90마1005",
+    model: "KYMCO Like",
+    lat: 37.541,
+    lng: 127.0696,
+    driving: "DRIVING",
+    battery: 73,
+    rider: "이배송"
+  },
+  {
+    id: "dummy-bike-06",
+    plate: "12바1006",
+    model: "KYMCO Like",
+    lat: 37.6396,
+    lng: 127.0257,
+    driving: "PARKED",
+    battery: 55,
+    rider: null
+  },
+  {
+    id: "dummy-bike-07",
+    plate: "34사1007",
+    model: "Honda PCX",
+    lat: 37.485,
+    lng: 126.918,
+    driving: "DRIVING",
+    battery: 92,
+    rider: "최운송"
+  },
+  {
+    id: "dummy-bike-08",
+    plate: "56아1008",
+    model: "Yamaha NMAX",
+    lat: 37.5219,
+    lng: 127.04,
+    driving: "PARKED",
+    battery: 8,
+    rider: null
+  }
+];
+
+/**
+ * 더미 핀 N 개. count 가 seed 배열 길이보다 크면 seed 만큼만 돌려준다 —
+ * 운영자에게 시드 단위로 안정적인 동일성을 보장하기 위함.
+ */
+export function generateDummyBikePins(count: number = DUMMY_SEEDS.length): FrontendDashboardBikePin[] {
+  const slice = DUMMY_SEEDS.slice(0, Math.min(count, DUMMY_SEEDS.length));
+  const generatedAt = new Date().toISOString();
+
+  return slice.map((seed) => {
+    const isDriving = seed.driving === "DRIVING";
+    const batteryStatus =
+      seed.battery <= 20 ? "LOW" : seed.battery <= 50 ? "MEDIUM" : "HEALTHY";
+
+    return {
+      bikeId: seed.id,
+      slug: seed.id,
+      bikeIdx: null,
+      plateNumber: seed.plate,
+      modelName: seed.model,
+      // /overview 의 운영 상태 narrow set(READY / IN_SERVICE) 과 일치.
+      operationStatus: isDriving ? "IN_SERVICE" : "READY",
+      activeRiderLabel: seed.rider,
+      deviceId: null,
+      lastReceivedAt: generatedAt,
+      latitude: seed.lat,
+      longitude: seed.lng,
+      speedKph: isDriving ? 38 : 0,
+      batteryPercent: seed.battery,
+      ignitionStatus: isDriving ? "ON" : "OFF",
+      // 텔레메트리 소스를 "DUMMY" 로 명시해서 운영자가 패널 열었을 때
+      // "이건 진짜가 아니구나" 라고 즉시 식별할 수 있게 한다.
+      telemetrySource: "DUMMY",
+      drivingStatus: isDriving ? "DRIVING" : "PARKED",
+      connectionStatus: "ONLINE",
+      batteryStatus,
+      pinLabel: `${seed.plate} (더미)`
+    };
+  });
+}
+
+export function dummyBikesEnabled(): boolean {
+  // "1" / "true" / "yes" 같은 흔한 truthy 표기를 다 받아준다. 다른 값은
+  // 안전하게 off 로 친다.
+  const raw = (process.env.SHOW_DUMMY_BIKES ?? "").toLowerCase().trim();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}

--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -1,157 +1,72 @@
-import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+import type { FrontendDashboardBikePin, FrontendVehicle } from "@/lib/services/service-ops-api";
 
 /**
- * 운영자가 실제 차량/텔레메트리가 아직 안 붙은 상태에서 지도 UI 가 제대로
- * 동작하는지(아이콘, 클릭, 패널) 시연·확인할 수 있게 더미 오토바이 핀을
- * 끼워 넣는 헬퍼. `loadDashboardMapState` 가 env(`SHOW_DUMMY_BIKES=1`) 가
- * 켜져 있을 때만 호출한다 — 실제 차량이 텔레메트리를 흘리기 시작하면
- * env 만 빼서 끄면 된다.
+ * 텔레메트리가 아직 없는 등록 차량에 대해 서울 근방 deterministic random
+ * 좌표를 생성해서 지도 핀으로 표시한다. bikeId를 seed로 쓰므로 폴링마다
+ * 위치가 튀지 않고, 서버 재시작해도 같은 차량은 같은 위치에 표시된다.
  *
- * 데이터는 결정적(deterministic) 이라 폴링이 돌아도 위치가 안 바뀐다 —
- * "지도가 매번 흔들리는 것처럼 보임" 같은 시각적 노이즈를 방지한다. 실제
- * 동선 데모가 필요하면 별도 함수로 시간 기반 보간을 추가하면 된다.
- *
- * 좌표 범위: 서울 시내. 강남·종로·홍대·강북 근방에 흩뿌렸다.
+ * 실제 텔레메트리가 들어오면 해당 차량은 이미 bikePins에 포함되므로
+ * 자동으로 이 로직을 건너뛴다.
  */
 
-interface DummyBikeSeed {
-  id: string;
-  plate: string;
-  model: string;
-  lat: number;
-  lng: number;
-  // "운행중" 시각화 vs "대기" 시각화를 골고루 보여주려고 둘 다 섞는다.
-  driving: "DRIVING" | "PARKED";
-  battery: number;
-  rider: string | null;
+// 서울 근방 좌표 범위
+const LAT_MIN = 37.44;
+const LAT_MAX = 37.65;
+const LNG_MIN = 126.87;
+const LNG_MAX = 127.10;
+
+/**
+ * 문자열을 seed로 0~1 사이 deterministic 숫자를 생성하는 간단한 해시.
+ * 암호학적 보안은 불필요 — 위치 분산만 되면 충분.
+ */
+function hashToFloat(seed: string, salt: number): number {
+  let h = salt;
+  for (let i = 0; i < seed.length; i++) {
+    h = ((h << 5) - h + seed.charCodeAt(i)) | 0;
+  }
+  return ((h >>> 0) % 10000) / 10000;
 }
 
-const DUMMY_SEEDS: ReadonlyArray<DummyBikeSeed> = [
-  {
-    id: "dummy-bike-01",
-    plate: "12가1001",
-    model: "Honda PCX",
-    lat: 37.498095,
-    lng: 127.02761,
-    driving: "DRIVING",
-    battery: 87,
-    rider: "김라이더"
-  },
-  {
-    id: "dummy-bike-02",
-    plate: "34나1002",
-    model: "Honda PCX",
-    lat: 37.514575,
-    lng: 127.0495,
-    driving: "PARKED",
-    battery: 62,
-    rider: null
-  },
-  {
-    id: "dummy-bike-03",
-    plate: "56다1003",
-    model: "Yamaha NMAX",
-    lat: 37.5704,
-    lng: 126.9821,
-    driving: "DRIVING",
-    battery: 41,
-    rider: "박배달"
-  },
-  {
-    id: "dummy-bike-04",
-    plate: "78라1004",
-    model: "Yamaha NMAX",
-    lat: 37.5535,
-    lng: 126.9224,
-    driving: "PARKED",
-    battery: 18,
-    rider: null
-  },
-  {
-    id: "dummy-bike-05",
-    plate: "90마1005",
-    model: "KYMCO Like",
-    lat: 37.541,
-    lng: 127.0696,
-    driving: "DRIVING",
-    battery: 73,
-    rider: "이배송"
-  },
-  {
-    id: "dummy-bike-06",
-    plate: "12바1006",
-    model: "KYMCO Like",
-    lat: 37.6396,
-    lng: 127.0257,
-    driving: "PARKED",
-    battery: 55,
-    rider: null
-  },
-  {
-    id: "dummy-bike-07",
-    plate: "34사1007",
-    model: "Honda PCX",
-    lat: 37.485,
-    lng: 126.918,
-    driving: "DRIVING",
-    battery: 92,
-    rider: "최운송"
-  },
-  {
-    id: "dummy-bike-08",
-    plate: "56아1008",
-    model: "Yamaha NMAX",
-    lat: 37.5219,
-    lng: 127.04,
-    driving: "PARKED",
-    battery: 8,
-    rider: null
-  }
-];
-
 /**
- * 더미 핀 N 개. count 가 seed 배열 길이보다 크면 seed 만큼만 돌려준다 —
- * 운영자에게 시드 단위로 안정적인 동일성을 보장하기 위함.
+ * 등록된 차량 목록과 현재 텔레메트리 핀 목록을 비교해서,
+ * 텔레메트리가 없는 차량에 대해 랜덤 좌표 핀을 생성한다.
  */
-export function generateDummyBikePins(count: number = DUMMY_SEEDS.length): FrontendDashboardBikePin[] {
-  const slice = DUMMY_SEEDS.slice(0, Math.min(count, DUMMY_SEEDS.length));
+export function generatePinsForUntrackedVehicles(
+  vehicles: FrontendVehicle[],
+  existingBikeIds: Set<string>
+): FrontendDashboardBikePin[] {
   const generatedAt = new Date().toISOString();
 
-  return slice.map((seed) => {
-    const isDriving = seed.driving === "DRIVING";
-    const batteryStatus =
-      seed.battery <= 20 ? "LOW" : seed.battery <= 50 ? "MEDIUM" : "HEALTHY";
+  return vehicles
+    .filter((v) => v.slug && !existingBikeIds.has(v.slug))
+    .map((vehicle) => {
+      const id = vehicle.slug;
+      const lat = LAT_MIN + hashToFloat(id, 1) * (LAT_MAX - LAT_MIN);
+      const lng = LNG_MIN + hashToFloat(id, 2) * (LNG_MAX - LNG_MIN);
+      const battery = Math.round(hashToFloat(id, 3) * 100);
+      const isDriving = hashToFloat(id, 4) > 0.5;
+      const batteryStatus = battery <= 20 ? "LOW" : battery <= 50 ? "MEDIUM" : "HEALTHY";
 
-    return {
-      bikeId: seed.id,
-      slug: seed.id,
-      bikeIdx: null,
-      plateNumber: seed.plate,
-      modelName: seed.model,
-      // /overview 의 운영 상태 narrow set(READY / IN_SERVICE) 과 일치.
-      operationStatus: isDriving ? "IN_SERVICE" : "READY",
-      activeRiderLabel: seed.rider,
-      deviceId: null,
-      lastReceivedAt: generatedAt,
-      latitude: seed.lat,
-      longitude: seed.lng,
-      speedKph: isDriving ? 38 : 0,
-      batteryPercent: seed.battery,
-      ignitionStatus: isDriving ? "ON" : "OFF",
-      // 텔레메트리 소스를 "DUMMY" 로 명시해서 운영자가 패널 열었을 때
-      // "이건 진짜가 아니구나" 라고 즉시 식별할 수 있게 한다.
-      telemetrySource: "DUMMY",
-      drivingStatus: isDriving ? "DRIVING" : "PARKED",
-      connectionStatus: "ONLINE",
-      batteryStatus,
-      pinLabel: `${seed.plate} (더미)`
-    };
-  });
-}
-
-export function dummyBikesEnabled(): boolean {
-  // "1" / "true" / "yes" 같은 흔한 truthy 표기를 다 받아준다. 다른 값은
-  // 안전하게 off 로 친다.
-  const raw = (process.env.SHOW_DUMMY_BIKES ?? "").toLowerCase().trim();
-  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+      return {
+        bikeId: id,
+        slug: id,
+        bikeIdx: vehicle.idx ?? null,
+        plateNumber: vehicle.plateNumber,
+        modelName: vehicle.model,
+        operationStatus: vehicle.operationStatus ?? "READY",
+        activeRiderLabel: null,
+        deviceId: null,
+        lastReceivedAt: generatedAt,
+        latitude: lat,
+        longitude: lng,
+        speedKph: isDriving ? Math.round(hashToFloat(id, 5) * 40 + 10) : 0,
+        batteryPercent: battery,
+        ignitionStatus: isDriving ? "ON" : "OFF",
+        telemetrySource: "SIMULATED",
+        drivingStatus: isDriving ? "DRIVING" : "PARKED",
+        connectionStatus: "ONLINE" as const,
+        batteryStatus,
+        pinLabel: vehicle.plateNumber
+      };
+    });
 }

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -4,6 +4,7 @@ import {
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+import { dummyBikesEnabled, generateDummyBikePins } from "@/lib/services/dashboard-dummy-bikes";
 
 export type DashboardMapStateResult = {
   data: FrontendDashboardMapState;
@@ -33,6 +34,37 @@ function emptyMapState(): FrontendDashboardMapState {
 }
 
 /**
+ * SHOW_DUMMY_BIKES=1 일 때 실제 핀 + 더미 핀을 합쳐 돌려준다. 실제
+ * bikePins 가 비어 있는 초기/시연 환경에서도 지도 마커가 보이게 하기
+ * 위함. summary 의 카운트도 같이 보정해서 KPI 카드와 핀 개수가 어긋나
+ * "운영자가 핀은 보이는데 숫자는 0" 같은 불일치를 안 만든다.
+ */
+function withDummyBikesIfEnabled(state: FrontendDashboardMapState): FrontendDashboardMapState {
+  if (!dummyBikesEnabled()) return state;
+
+  const dummy = generateDummyBikePins();
+  if (dummy.length === 0) return state;
+
+  const bikePins = [...state.bikePins, ...dummy];
+  const onlineDelta = dummy.filter((pin) => pin.connectionStatus === "ONLINE").length;
+  const lowBatteryDelta = dummy.filter(
+    (pin) => typeof pin.batteryPercent === "number" && pin.batteryPercent <= 20
+  ).length;
+
+  return {
+    ...state,
+    bikePins,
+    summary: {
+      ...state.summary,
+      totalBikes: state.summary.totalBikes + dummy.length,
+      bikePinCount: state.summary.bikePinCount + dummy.length,
+      onlineBikeCount: state.summary.onlineBikeCount + onlineDelta,
+      lowBatteryBikeCount: state.summary.lowBatteryBikeCount + lowBatteryDelta
+    }
+  };
+}
+
+/**
  * Mock fallback when the service-ops API is not configured or the session
  * cookie is missing. The dashboard renders an empty map (no pins) and a
  * notice. We do not fabricate fake bikes/stations because the operator could
@@ -45,7 +77,7 @@ export async function loadDashboardMapState(): Promise<DashboardMapStateResult> 
     // branches below (no session, API error) keep their notices because
     // those are operationally meaningful.
     return {
-      data: emptyMapState(),
+      data: withDummyBikesIfEnabled(emptyMapState()),
       source: "mock"
     };
   }
@@ -53,7 +85,7 @@ export async function loadDashboardMapState(): Promise<DashboardMapStateResult> 
   const client = await createAuthenticatedServiceOpsApiClient();
   if (!client) {
     return {
-      data: emptyMapState(),
+      data: withDummyBikesIfEnabled(emptyMapState()),
       source: "mock",
       notice:
         "서비스 API 세션 쿠키가 없어 빈 지도를 표시합니다. 관리자 로그인 후 실제 백엔드 데이터로 전환됩니다."
@@ -62,10 +94,10 @@ export async function loadDashboardMapState(): Promise<DashboardMapStateResult> 
 
   try {
     const data = await client.getDashboardMapState();
-    return { data, source: "service-ops" };
+    return { data: withDummyBikesIfEnabled(data), source: "service-ops" };
   } catch (error) {
     return {
-      data: emptyMapState(),
+      data: withDummyBikesIfEnabled(emptyMapState()),
       source: "mock",
       notice: `서비스 API 조회 실패로 빈 지도를 표시합니다.${formatServiceOpsError(error)}`
     };

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -4,7 +4,7 @@ import {
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
-import { dummyBikesEnabled, generateDummyBikePins } from "@/lib/services/dashboard-dummy-bikes";
+import { generatePinsForUntrackedVehicles } from "@/lib/services/dashboard-dummy-bikes";
 
 export type DashboardMapStateResult = {
   data: FrontendDashboardMapState;
@@ -34,50 +34,46 @@ function emptyMapState(): FrontendDashboardMapState {
 }
 
 /**
- * SHOW_DUMMY_BIKES=1 일 때 실제 핀 + 더미 핀을 합쳐 돌려준다. 실제
- * bikePins 가 비어 있는 초기/시연 환경에서도 지도 마커가 보이게 하기
- * 위함. summary 의 카운트도 같이 보정해서 KPI 카드와 핀 개수가 어긋나
- * "운영자가 핀은 보이는데 숫자는 0" 같은 불일치를 안 만든다.
+ * 등록된 차량 중 텔레메트리 핀이 없는 차량에 대해 시뮬레이션 좌표를
+ * 생성해서 합친다. 실제 텔레메트리가 들어오면 자동으로 건너뛴다.
  */
-function withDummyBikesIfEnabled(state: FrontendDashboardMapState): FrontendDashboardMapState {
-  if (!dummyBikesEnabled()) return state;
+async function withSimulatedPins(
+  state: FrontendDashboardMapState,
+  client: Awaited<ReturnType<typeof createAuthenticatedServiceOpsApiClient>>
+): Promise<FrontendDashboardMapState> {
+  if (!client) return state;
 
-  const dummy = generateDummyBikePins();
-  if (dummy.length === 0) return state;
+  try {
+    const vehiclePage = await client.listVehicles({ page: 0, size: 200 });
+    const totalRegistered = vehiclePage.page.totalItems;
+    const existingBikeIds = new Set(state.bikePins.map((p) => p.bikeId));
+    const simulated = generatePinsForUntrackedVehicles(vehiclePage.items, existingBikeIds);
 
-  const bikePins = [...state.bikePins, ...dummy];
-  const onlineDelta = dummy.filter((pin) => pin.connectionStatus === "ONLINE").length;
-  const lowBatteryDelta = dummy.filter(
-    (pin) => typeof pin.batteryPercent === "number" && pin.batteryPercent <= 20
-  ).length;
+    const bikePins = [...state.bikePins, ...simulated];
+    const lowBatteryDelta = simulated.filter(
+      (pin) => typeof pin.batteryPercent === "number" && pin.batteryPercent <= 20
+    ).length;
 
-  return {
-    ...state,
-    bikePins,
-    summary: {
-      ...state.summary,
-      totalBikes: state.summary.totalBikes + dummy.length,
-      bikePinCount: state.summary.bikePinCount + dummy.length,
-      onlineBikeCount: state.summary.onlineBikeCount + onlineDelta,
-      lowBatteryBikeCount: state.summary.lowBatteryBikeCount + lowBatteryDelta
-    }
-  };
+    return {
+      ...state,
+      bikePins,
+      summary: {
+        ...state.summary,
+        totalBikes: totalRegistered,
+        bikePinCount: bikePins.length,
+        onlineBikeCount: state.summary.onlineBikeCount + simulated.length,
+        lowBatteryBikeCount: state.summary.lowBatteryBikeCount + lowBatteryDelta
+      }
+    };
+  } catch {
+    return state;
+  }
 }
 
-/**
- * Mock fallback when the service-ops API is not configured or the session
- * cookie is missing. The dashboard renders an empty map (no pins) and a
- * notice. We do not fabricate fake bikes/stations because the operator could
- * mistake them for real fleet state — better to show "데이터 없음".
- */
 export async function loadDashboardMapState(): Promise<DashboardMapStateResult> {
   if (!serviceOpsApiConfigured()) {
-    // Env-less dev/sandbox path - the operator-facing notice ("backend
-    // missing, you'll see an empty map") was just dev noise. Other mock
-    // branches below (no session, API error) keep their notices because
-    // those are operationally meaningful.
     return {
-      data: withDummyBikesIfEnabled(emptyMapState()),
+      data: emptyMapState(),
       source: "mock"
     };
   }
@@ -85,7 +81,7 @@ export async function loadDashboardMapState(): Promise<DashboardMapStateResult> 
   const client = await createAuthenticatedServiceOpsApiClient();
   if (!client) {
     return {
-      data: withDummyBikesIfEnabled(emptyMapState()),
+      data: emptyMapState(),
       source: "mock",
       notice:
         "서비스 API 세션 쿠키가 없어 빈 지도를 표시합니다. 관리자 로그인 후 실제 백엔드 데이터로 전환됩니다."
@@ -94,10 +90,11 @@ export async function loadDashboardMapState(): Promise<DashboardMapStateResult> 
 
   try {
     const data = await client.getDashboardMapState();
-    return { data: withDummyBikesIfEnabled(data), source: "service-ops" };
+    const enriched = await withSimulatedPins(data, client);
+    return { data: enriched, source: "service-ops" };
   } catch (error) {
     return {
-      data: withDummyBikesIfEnabled(emptyMapState()),
+      data: emptyMapState(),
       source: "mock",
       notice: `서비스 API 조회 실패로 빈 지도를 표시합니다.${formatServiceOpsError(error)}`
     };

--- a/development/front-admin-web/lib/services/ncp-geocoder.ts
+++ b/development/front-admin-web/lib/services/ncp-geocoder.ts
@@ -4,9 +4,13 @@
  * 있게 한다. 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 이 보완이
  * 필요하다.
  *
- * 인증: NCP API Gateway 자격 — Maps 클라이언트 ID 와는 별개의 service-account
- * 키 쌍이다. 서버 액션에서만 호출하므로 NEXT_PUBLIC_ 접두사를 붙이지 않고,
- * 브라우저로 흘러나가지 않게 둔다.
+ * 인증: 같은 NCP Maps Application 의 Client ID + Client Secret 쌍을 그대로
+ * `x-ncp-apigw-api-key-id` / `x-ncp-apigw-api-key` 헤더에 박는다. 따로
+ * API Gateway 서비스 어카운트를 발급할 필요 없이 클라이언트 SDK 와 같은
+ * 인증서를 재사용 — Client ID 는 어차피 NEXT_PUBLIC_ 으로 브라우저에 노출
+ * 되고, 진짜 보안은 Client Secret 의 비밀성 + NCP 콘솔의 origin
+ * allowlist 가 담당한다. Client Secret 만 NEXT_PUBLIC_ 접두사 없이 서버에
+ * 머무르게 한다.
  *
  * 실패 시 정책: 호출 측이 graceful degradation 을 결정한다 — 본 모듈은 null
  * 을 돌려주고, 호출 측이 (0, 0) placeholder 로 폴백할지 등록을 거부할지
@@ -36,9 +40,9 @@ export async function geocodeAddress(address: string): Promise<GeocodedCoordinat
   const trimmed = address.trim();
   if (!trimmed) return null;
 
-  const keyId = process.env.NCP_GEOCODE_API_KEY_ID;
-  const key = process.env.NCP_GEOCODE_API_KEY;
-  if (!keyId || !key) {
+  const clientId = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
+  const clientSecret = process.env.NCP_MAP_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
     // env 미설정 시 호출 자체를 안 한다. 호출 측이 null 을 받아 polyfill
     // 로 갈 수 있게 — 콘솔 노이즈도 안 만들고, env 가 빠진 dev/sandbox
     // 에서 BSS 등록이 막히지 않도록.
@@ -51,8 +55,8 @@ export async function geocodeAddress(address: string): Promise<GeocodedCoordinat
     response = await fetch(url, {
       method: "GET",
       headers: {
-        "X-NCP-APIGW-API-KEY-ID": keyId,
-        "X-NCP-APIGW-API-KEY": key,
+        "x-ncp-apigw-api-key-id": clientId,
+        "x-ncp-apigw-api-key": clientSecret,
         Accept: "application/json"
       },
       // 운영자 폼 submit 한 번에 한 번만 호출하니까 캐시는 의미 없고,

--- a/development/front-admin-web/lib/services/ncp-geocoder.ts
+++ b/development/front-admin-web/lib/services/ncp-geocoder.ts
@@ -1,0 +1,86 @@
+/**
+ * NCP Maps Geocoding (server-side). 운영자가 다음 우편번호로 고른 주소를
+ * 위경도로 변환해서 BSS 등록 시 (0, 0) placeholder 대신 실제 좌표를 박을 수
+ * 있게 한다. 다음/카카오 우편번호 팝업은 좌표를 안 돌려주므로 이 보완이
+ * 필요하다.
+ *
+ * 인증: NCP API Gateway 자격 — Maps 클라이언트 ID 와는 별개의 service-account
+ * 키 쌍이다. 서버 액션에서만 호출하므로 NEXT_PUBLIC_ 접두사를 붙이지 않고,
+ * 브라우저로 흘러나가지 않게 둔다.
+ *
+ * 실패 시 정책: 호출 측이 graceful degradation 을 결정한다 — 본 모듈은 null
+ * 을 돌려주고, 호출 측이 (0, 0) placeholder 로 폴백할지 등록을 거부할지
+ * 정한다. 운영자에게 등록이 통째로 실패하는 것보다는 일단 row 가 들어가고
+ * 좌표를 나중에 손볼 수 있는 쪽이 덜 답답하다.
+ */
+export interface GeocodedCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+const NCP_GEOCODE_ENDPOINT = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode";
+
+interface NcpGeocodeAddress {
+  /** 경도 (longitude). 문자열로 내려온다. */
+  x: string;
+  /** 위도 (latitude). 문자열로 내려온다. */
+  y: string;
+}
+
+interface NcpGeocodeResponse {
+  status: string;
+  addresses?: NcpGeocodeAddress[];
+}
+
+export async function geocodeAddress(address: string): Promise<GeocodedCoordinates | null> {
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+
+  const keyId = process.env.NCP_GEOCODE_API_KEY_ID;
+  const key = process.env.NCP_GEOCODE_API_KEY;
+  if (!keyId || !key) {
+    // env 미설정 시 호출 자체를 안 한다. 호출 측이 null 을 받아 polyfill
+    // 로 갈 수 있게 — 콘솔 노이즈도 안 만들고, env 가 빠진 dev/sandbox
+    // 에서 BSS 등록이 막히지 않도록.
+    return null;
+  }
+
+  const url = `${NCP_GEOCODE_ENDPOINT}?query=${encodeURIComponent(trimmed)}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "X-NCP-APIGW-API-KEY-ID": keyId,
+        "X-NCP-APIGW-API-KEY": key,
+        Accept: "application/json"
+      },
+      // 운영자 폼 submit 한 번에 한 번만 호출하니까 캐시는 의미 없고,
+      // Next.js fetch 가 기본적으로 캐시를 시도하는 것 자체가 불필요한
+      // 노이즈라 명시적으로 비활성화한다.
+      cache: "no-store"
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) return null;
+
+  let body: NcpGeocodeResponse;
+  try {
+    body = (await response.json()) as NcpGeocodeResponse;
+  } catch {
+    return null;
+  }
+
+  if (body.status !== "OK" || !body.addresses || body.addresses.length === 0) {
+    return null;
+  }
+
+  const first = body.addresses[0];
+  const longitude = Number.parseFloat(first.x);
+  const latitude = Number.parseFloat(first.y);
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) return null;
+
+  return { latitude, longitude };
+}


### PR DESCRIPTION
## Summary
Two operator-facing dashboard fixes promoted together.

**BSS geocoding (PR #192)** — register / update station address now triggers an NCP \`/map-geocode\` call so the row gets real lat/lng instead of \`(0, 0)\`. Reuses the existing Maps Application's Client ID + adds the matching Client Secret. Graceful: missing env or geocode miss falls back to \`(0, 0)\` and registration still succeeds.

**Per-vehicle simulated bike pins (PR #193)** — until real telemetry is wired, the dashboard map populates from \`listVehicles\` and gives any vehicle without a live telemetry pin a hash-stable lat/lng inside the Seoul bounding box. Markers are now sized to a 5m physical radius (scales with zoom) and themed via CSS custom properties; station markers also redesigned to a green dot + label card.

When real telemetry arrives, a streaming vehicle drops out of the simulated set automatically — no env toggle to flip.

## Pre-merge activation
- [ ] \`NCP_MAP_CLIENT_SECRET\` registered at https://github.com/EVNSolution/thundercrew-domain/settings/secrets/actions
- [ ] NCP console "Web 서비스 URL" allowlist still includes \`https://thundercrew-domain.43.201.57.147.sslip.io\`
- [ ] NCP Maps Application has Geocoding sub-service enabled

## Test plan
- [ ] Deploy reaches \`npm run build\` cleanly
- [ ] Register a new BSS → pin shows up at correct address on \`/dashboard\`
- [ ] Existing registered vehicles render with halo+dot markers across Seoul
- [ ] Click a bike marker → \`BikeDetailPanel\` opens with \`telemetrySource: SIMULATED\`
- [ ] Theme toggle swaps marker colors via CSS variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)