### PR TITLE
Surface ignition-block toggle in /dashboard BikeDetailPanel

### DIFF
--- a/development/front-admin-web/app/dashboard/actions.ts
+++ b/development/front-admin-web/app/dashboard/actions.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+/**
+ * `/dashboard` 의 `BikeDetailPanel` 에서 호출하는 시동 방지 토글 액션.
+ * `/overview` 쪽 동명 액션과 동작은 같지만 redirect / revalidate 가
+ * `/dashboard` 컨텍스트로 맞춰져 있다 — 운영자가 지도에서 마커 클릭한
+ * 상태로 토글을 눌렀을 때 `/overview?tab=riders` 로 끌려가지 않고 그 자리에
+ * 머무르도록.
+ *
+ * 성공 시 redirect 하지 않고 그냥 revalidate 만 한다 — 폴링 다음 tick
+ * 에 새 ignitionBlocked 값이 반영되고, optimistic state 가 그 사이를
+ * 메워준다.
+ */
+export async function setVehicleIgnitionBlockFromDashboardAction(
+  vehicleId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    return;
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const nextBlocked = String(formData.get("blocked") ?? "").toLowerCase() === "true";
+
+  try {
+    await client.setVehicleIgnitionBlock(vehicleId, { blocked: nextBlocked });
+  } catch {
+    // 실패 시 호출 측의 optimistic state 가 다음 폴링/리렌더에서
+    // 서버 진실값으로 정정된다. 별도 status flag 는 안 박는다 —
+    // /dashboard 는 query string 기반 notice 채널이 없고, 운영자에게는
+    // "변경이 안 됐다" 라는 시각적 정정만으로 충분.
+    return;
+  }
+
+  revalidatePath("/dashboard");
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -282,6 +282,11 @@ button, input, select, textarea { font: inherit; }
 .bike-detail-panel-header p { margin: 0; font-size: 13px; color: var(--rm-text-secondary); }
 .bike-detail-panel-close { width: 28px; height: 28px; padding: 0; border: 0; border-radius: 8px; background: var(--rm-bg-active); color: var(--rm-text-primary); font-size: 14px; cursor: pointer; }
 .bike-detail-panel-close:hover { background: var(--rm-line-active); }
+/* 헤더 우측 컨트롤 묶음: 시동 제어 토글 + 닫기 버튼. align-items: flex-start
+   로 장문의 모델명이 들어가도 토글이 위에 붙어 있게 한다. */
+.bike-detail-panel-controls { display: flex; align-items: flex-start; gap: 8px; }
+.bike-detail-panel-ignition { display: flex; align-items: center; gap: 8px; padding: 4px 10px; border-radius: 10px; background: var(--color-bg-soft); }
+.bike-detail-panel-ignition .detail-field-label { font-size: 11px; }
 .bike-detail-panel-body { display: grid; gap: 6px; margin: 0; padding: 12px 0 0; border-top: 1px solid var(--rm-line-subtle); }
 .bike-detail-panel-row { display: grid; grid-template-columns: 96px 1fr; gap: 10px; align-items: baseline; padding: 4px 0; }
 .bike-detail-panel-row dt { margin: 0; font-size: 12px; font-weight: 600; color: var(--rm-text-secondary); }

--- a/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 
+import { setVehicleIgnitionBlockFromDashboardAction } from "@/app/dashboard/actions";
 import type { BikeCurrentStateResult } from "@/lib/services/bike-current-state-data";
 import type { BikeSnapshotResult } from "@/lib/services/dashboard-bike-snapshot-data";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
@@ -96,6 +97,29 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
   const snapshotLoading = !isSnapshotFresh || snapshot.data.phase === "idle";
   const snap = snapshotResult?.data;
 
+  // 시동 제어 토글 — 라이더 상세 다이얼로그의 토글과 같은 패턴.
+  // optimistic state 로 즉시 시각 반영, server action 이 끝나면 다음
+  // 폴링/리렌더에서 진실값이 들어와 자동으로 정정된다. 다른 차량을
+  // 클릭했을 때 이전 차량의 optimistic 이 남지 않도록 부모(DashboardCanvas)
+  // 가 `key={pin.bikeId}` 로 컴포넌트를 재마운트시켜 useState 가 자연스럽게
+  // 리셋되도록 한다 (effect 안에서 setState 하는 패턴 회피).
+  const [ignitionPending, startIgnitionTransition] = useTransition();
+  const [ignitionBlockedOptimistic, setIgnitionBlockedOptimistic] = useState<boolean | null>(null);
+
+  const ignitionBlockedFromServer = snapshotResult?.ignitionBlocked ?? false;
+  const effectiveIgnitionBlocked = ignitionBlockedOptimistic ?? ignitionBlockedFromServer;
+
+  const handleIgnitionToggle = () => {
+    if (ignitionPending) return;
+    const next = !effectiveIgnitionBlocked;
+    setIgnitionBlockedOptimistic(next);
+    const fd = new FormData();
+    fd.append("blocked", next ? "true" : "false");
+    startIgnitionTransition(() => {
+      void setVehicleIgnitionBlockFromDashboardAction(pin.bikeId, fd);
+    });
+  };
+
   // Telemetry derived values (snapshot does not bundle telemetry — see PR #133).
   const lastReceivedAt = live?.lastReceivedAt ?? pin.lastReceivedAt;
   const connectionStatus = live?.connectionStatus ?? pin.connectionStatus;
@@ -119,14 +143,37 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
           <h2>{pin.plateNumber}</h2>
           <p>{pin.modelName ?? "모델 미지정"}</p>
         </div>
-        <button
-          type="button"
-          className="bike-detail-panel-close"
-          onClick={onClose}
-          aria-label="닫기"
-        >
-          ✕
-        </button>
+        {/* 헤더 오른쪽: 시동 제어 토글 + 닫기 버튼. 라이더 상세 다이얼로그의
+            패턴과 동일 — 운영자가 패널 어디로 스크롤하든 상시 보이는 위치에
+            토글을 두기 위함. 토글 텍스트는 액션 지향(누르면 일어날 동작)이라
+            현재 OFF(허용) 일 때는 "방지", ON(차단) 일 때는 "허용" 으로 보여줌. */}
+        <div className="bike-detail-panel-controls">
+          <div className="detail-field bike-detail-panel-ignition">
+            <span className="detail-field-label">시동 제어</span>
+            <button
+              type="button"
+              className={`toggle-switch${effectiveIgnitionBlocked ? " is-on" : ""}`}
+              role="switch"
+              aria-checked={effectiveIgnitionBlocked}
+              aria-label="시동 제어 토글"
+              disabled={ignitionPending}
+              onClick={handleIgnitionToggle}
+            >
+              <span className="toggle-switch-thumb" aria-hidden="true" />
+              <span className="toggle-switch-text">
+                {effectiveIgnitionBlocked ? "허용" : "방지"}
+              </span>
+            </button>
+          </div>
+          <button
+            type="button"
+            className="bike-detail-panel-close"
+            onClick={onClose}
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
       </header>
 
       <Section title="텔레메트리">

--- a/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
+++ b/development/front-admin-web/components/dashboard/BikeDetailPanel.tsx
@@ -144,9 +144,10 @@ export function BikeDetailPanel({ pin, onClose }: BikeDetailPanelProps) {
           <p>{pin.modelName ?? "모델 미지정"}</p>
         </div>
         {/* 헤더 오른쪽: 시동 제어 토글 + 닫기 버튼. 라이더 상세 다이얼로그의
-            패턴과 동일 — 운영자가 패널 어디로 스크롤하든 상시 보이는 위치에
-            토글을 두기 위함. 토글 텍스트는 액션 지향(누르면 일어날 동작)이라
-            현재 OFF(허용) 일 때는 "방지", ON(차단) 일 때는 "허용" 으로 보여줌. */}
+            토글과 라벨 / 동작이 완전히 동일하다 — 토글 텍스트는 누르면 일어날
+            동작을 표시한다. 현재 시동 방지 OFF 상태면 "방지" (= 누르면 방지
+            ON), ON 상태면 "허용" (= 누르면 다시 허용). 상태 자체는 배경색·
+            thumb 위치·aria-checked 로 전달. */}
         <div className="bike-detail-panel-controls">
           <div className="detail-field bike-detail-panel-ignition">
             <span className="detail-field-label">시동 제어</span>

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -125,7 +125,13 @@ export function DashboardCanvas({
         </div>
       ) : null}
       {selectedBikePin ? (
-        <BikeDetailPanel pin={selectedBikePin} onClose={handleBikePanelClose} />
+        // key 로 컴포넌트를 재마운트시켜 차량 전환 시 토글 optimistic state
+        // 등 내부 useState 가 자연스럽게 초기화되도록 한다.
+        <BikeDetailPanel
+          key={selectedBikePin.bikeId}
+          pin={selectedBikePin}
+          onClose={handleBikePanelClose}
+        />
       ) : null}
       {selectedStationPin ? (
         <StationDetailPanel pin={selectedStationPin} onClose={handleStationPanelClose} />

--- a/development/front-admin-web/lib/services/dashboard-bike-snapshot-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-bike-snapshot-data.ts
@@ -8,6 +8,13 @@ import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-o
 export type BikeSnapshotResult = {
   bikeId: string;
   data: ServiceOpsBikeSnapshot | null;
+  /**
+   * "시동 방지" 토글의 현재 상태. snapshot endpoint 가 자체적으로 안 내려주므로
+   * 별도로 vehicle 조회해서 받아 와서 합친다. 조회 실패 시 false 로 두면
+   * 운영자가 토글을 켜서 다시 박을 수 있게 된다 — 패널이 "잘 모름" 상태로
+   * 멈추는 것보단 낫다.
+   */
+  ignitionBlocked: boolean;
   source: "service-ops" | "mock";
   notice?: string;
 };
@@ -23,6 +30,7 @@ export async function loadBikeSnapshot(bikeId: string): Promise<BikeSnapshotResu
     return {
       bikeId,
       data: null,
+      ignitionBlocked: false,
       source: "mock"
     };
   }
@@ -32,23 +40,42 @@ export async function loadBikeSnapshot(bikeId: string): Promise<BikeSnapshotResu
     return {
       bikeId,
       data: null,
+      ignitionBlocked: false,
       source: "mock",
       notice:
         "관리자 세션이 없어 차량 상세 데이터를 표시할 수 없습니다."
     };
   }
 
-  try {
-    const data = await client.getBikeSnapshot(bikeId);
-    return { bikeId, data, source: "service-ops" };
-  } catch (error) {
+  // snapshot 과 vehicle 을 병렬로 받는다. vehicle 은 `ignitionBlocked` 단일
+  // 필드만 필요하지만 별도 가벼운 엔드포인트가 없어 전체 객체를 받는다 —
+  // 한 번의 round-trip 이라 비용은 무시 가능. vehicle 실패는 snapshot 의
+  // 성공/실패와 독립적으로 처리해서, 둘 중 한 쪽이 실패해도 가능한 만큼
+  // 정보를 보여준다.
+  const [snapshotSettled, vehicleSettled] = await Promise.allSettled([
+    client.getBikeSnapshot(bikeId),
+    client.getVehicle(bikeId)
+  ]);
+
+  const ignitionBlocked =
+    vehicleSettled.status === "fulfilled" ? vehicleSettled.value.ignitionBlocked ?? false : false;
+
+  if (snapshotSettled.status === "fulfilled") {
     return {
       bikeId,
-      data: null,
-      source: "mock",
-      notice: `차량 상세 조회 실패.${formatServiceOpsError(error)}`
+      data: snapshotSettled.value,
+      ignitionBlocked,
+      source: "service-ops"
     };
   }
+
+  return {
+    bikeId,
+    data: null,
+    ignitionBlocked,
+    source: "mock",
+    notice: `차량 상세 조회 실패.${formatServiceOpsError(snapshotSettled.reason)}`
+  };
 }
 
 function formatServiceOpsError(error: unknown): string {


### PR DESCRIPTION
## Summary
- \`loadBikeSnapshot\` now parallel-fetches snapshot + vehicle (Promise.allSettled) and surfaces \`ignitionBlocked\` on \`BikeSnapshotResult\`
- New \`setVehicleIgnitionBlockFromDashboardAction\` does the same PATCH as the overview action but revalidates \`/dashboard\` and stays put — no redirect to \`/overview?tab=riders\`
- \`BikeDetailPanel\` header right-cluster now hosts the toggle alongside the close button; reuses \`.toggle-switch\` styles
- Switching pins remounts the panel via \`key={bikeId}\` on \`DashboardCanvas\` so optimistic state resets cleanly

## Test plan
- [ ] Click a bike marker → panel opens with toggle in top-right showing current ignition-block state
- [ ] Toggle on → action runs, state stays "on" (optimistic); refresh → still on (persisted)
- [ ] Click a different bike → its own toggle state shown (no leak from previous bike)
- [ ] Click "허용/방지" while pending → button disabled, no double-fire
- [ ] Same toggle on \`/overview\` rider detail dialog still works