### PR TITLE
Force /dashboard to dynamic (fixes SSR 500)

### DIFF
--- a/development/front-admin-web/app/dashboard/page.tsx
+++ b/development/front-admin-web/app/dashboard/page.tsx
@@ -1,6 +1,14 @@
 import { DashboardCanvas } from "@/components/dashboard/DashboardCanvas";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 
+// `loadDashboardMapState` 가 `cookies()` 기반의 인증 클라이언트를 사용한다.
+// Next.js 의 자동 dynamic 감지가 어떤 빌드 경로에선 이 페이지를 정적
+// 렌더 대상으로 잡고 — request time 에 `DYNAMIC_SERVER_USAGE` 로 throw 한다
+// (`prod` /dashboard 가 500 으로 떨어지던 원인). `/overview` 와 동일하게
+// 명시적으로 force-dynamic 선언해서 어떤 빌드/배포 조합에서도 항상 dynamic
+// 렌더로 잠근다.
+export const dynamic = "force-dynamic";
+
 export default async function MonitoringPage() {
   const initial = await loadDashboardMapState();
 


### PR DESCRIPTION
## Symptom
Production \`/dashboard\` returns 500 Internal Server Error. \`/var/log/thundercrew/front-admin-web.err.log\` shows repeating:

\`\`\`
[Error: An error occurred in the Server Components render. ...]
digest: 'DYNAMIC_SERVER_USAGE'
\`\`\`

## Cause
\`MonitoringPage\` → \`loadDashboardMapState\` → \`createAuthenticatedServiceOpsApiClient\` → \`cookies()\`. Next.js's automatic dynamic-detection should pull this page out of static gen, but in this build/runtime combo it treats the page as static and throws \`DYNAMIC_SERVER_USAGE\` at request time.

\`/overview\` is unaffected because it carries an explicit \`export const dynamic = "force-dynamic"\`. \`/dashboard\` never had that.

## Fix
Add \`export const dynamic = "force-dynamic"\` to \`/dashboard\`. One line, matches \`/overview\`'s convention.

## Test plan
- [ ] After dev → main, hit \`https://thcr.cleversystem.ai/dashboard\` → 200 with map shell
- [ ] err.log no longer accumulating DYNAMIC_SERVER_USAGE entries
- [ ] Marker click still opens BikeDetailPanel