### PR TITLE
Hotfix: force /dashboard to dynamic (fixes SSR 500)

### DIFF
--- a/development/front-admin-web/app/dashboard/page.tsx
+++ b/development/front-admin-web/app/dashboard/page.tsx
@@ -1,6 +1,14 @@
 import { DashboardCanvas } from "@/components/dashboard/DashboardCanvas";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 
+// `loadDashboardMapState` 가 `cookies()` 기반의 인증 클라이언트를 사용한다.
+// Next.js 의 자동 dynamic 감지가 어떤 빌드 경로에선 이 페이지를 정적
+// 렌더 대상으로 잡고 — request time 에 `DYNAMIC_SERVER_USAGE` 로 throw 한다
+// (`prod` /dashboard 가 500 으로 떨어지던 원인). `/overview` 와 동일하게
+// 명시적으로 force-dynamic 선언해서 어떤 빌드/배포 조합에서도 항상 dynamic
+// 렌더로 잠근다.
+export const dynamic = "force-dynamic";
+
 export default async function MonitoringPage() {
   const initial = await loadDashboardMapState();
 


### PR DESCRIPTION
## Summary
Promote PR #201 to production.

Production \`/dashboard\` was returning 500 because Next.js was treating it as static-renderable while \`loadDashboardMapState\` → \`createAuthenticatedServiceOpsApiClient\` → \`cookies()\` requires dynamic context. \`err.log\` showed repeating \`digest: 'DYNAMIC_SERVER_USAGE'\`.

Adds explicit \`export const dynamic = "force-dynamic"\` to \`/dashboard/page.tsx\` to match \`/overview\`'s existing pattern.

## Test plan
- [ ] Deploy succeeds
- [ ] \`https://thcr.cleversystem.ai/dashboard\` returns 200 with the map shell
- [ ] \`/var/log/thundercrew/front-admin-web.err.log\` no longer accumulates \`DYNAMIC_SERVER_USAGE\` entries
- [ ] Bike marker click still opens \`BikeDetailPanel\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)