### PR TITLE
Map marker visual tuning: 30px dots + amber BSS color

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -22,7 +22,7 @@ const DEFAULT_ZOOM = 13;
 // 보다 3배 키운 30px 로 두어서 한국 지도 시점에서 점 하나하나가 잘 보이게
 // 한다. opacity 0.5 + 흰색 1px stroke 는 그대로 — 점이 겹치면 alpha
 // 합성으로 색이 짙어져 자연스러운 밀도 시각화가 유지된다. 색만 우리 테마
-// 토큰 (`--rm-accent`, `--rm-battery-high`) 으로 바꿔 적용.
+// 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔 적용.
 const DOT_PX = 30;
 const DOT_ANCHOR = DOT_PX / 2;
 const LABEL_VISIBLE_ZOOM = 12;
@@ -380,11 +380,12 @@ function dotMarkup(fillVar: string): string {
 }
 
 /**
- * BSS 마커 — DotMap 스타일 녹색 dot. 줌 ≥ 12 에서 스테이션 이름 라벨 노출.
- * 라벨은 별도 div 라 dot 의 opacity 0.5 영향 안 받음 (가독성 유지).
+ * BSS 마커 — DotMap 스타일 노란 dot (`--rm-battery-mid` = amber #F59E0B).
+ * 차량(--rm-accent: blue/mint) 과 색상 대비가 명확해서 한 지도에서 두 종류
+ * 핀을 한눈에 구분할 수 있다. 줌 ≥ 12 에서 스테이션 이름 라벨 노출.
  */
 function stationMarkerHtml(pin: FrontendDashboardStationPin, showLabel: boolean): string {
-  const dot = dotMarkup("--rm-battery-high");
+  const dot = dotMarkup("--rm-battery-mid");
   if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
   return [
     `<div style="position:relative;pointer-events:auto;">`,

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -18,11 +18,12 @@ const NCP_STYLE_ID_DARK = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK;
 const SEOUL_DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 const DEFAULT_ZOOM = 13;
 
-// NCP `visualization.DotMap` 의 기본값을 그대로 따른다: 반지름 5px (= 직경
-// 10px), 흰색 1px stroke, opacity 0.5. opacity 0.5 가 핵심 — 두 점이 같은
-// 자리에 겹치면 alpha 합성으로 색이 짙어져 자연스럽게 밀도 시각화가 된다.
-// 색만 우리 테마 토큰 (`--rm-accent`, `--rm-battery-high`) 으로 바꿔 적용.
-const DOT_PX = 10;
+// NCP `visualization.DotMap` 스펙을 옮긴 dot 마커. 기본 radius 5(=직경 10)
+// 보다 3배 키운 30px 로 두어서 한국 지도 시점에서 점 하나하나가 잘 보이게
+// 한다. opacity 0.5 + 흰색 1px stroke 는 그대로 — 점이 겹치면 alpha
+// 합성으로 색이 짙어져 자연스러운 밀도 시각화가 유지된다. 색만 우리 테마
+// 토큰 (`--rm-accent`, `--rm-battery-high`) 으로 바꿔 적용.
+const DOT_PX = 30;
 const DOT_ANCHOR = DOT_PX / 2;
 const LABEL_VISIBLE_ZOOM = 12;
 


### PR DESCRIPTION
## Summary
Promote PRs #210 and #211 to production — two small marker tweaks that ship together.

**PR #210 — Larger dots**
- \`DOT_PX\` 10 → 30 (3×). Single point reads clearly at Seoul-overview zoom while the DotMap overlap-darkening still works on a bigger canvas.

**PR #211 — Yellow BSS marker**
- Station dot fill: \`--rm-battery-high\` (green) → \`--rm-battery-mid\` (amber #F59E0B). Stronger contrast against the bike marker (\`--rm-accent\`, blue/mint) so the two pin types separate at a glance.

Stroke / opacity / label behavior unchanged.

## Test plan
- [ ] Bike dots render large (~30px) translucent blue/mint
- [ ] Station dots render large (~30px) translucent amber
- [ ] Overlapping dots still darken via opacity composing
- [ ] Bike click → BikeDetailPanel; station click → StationDetailPanel
- [ ] Zoom ≥ 12: plate / station-name labels readable
- [ ] Light / dark theme: dot colors swap via CSS vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)