### PR TITLE
C:/Program Files/Git/monitoring search box + 15px dots

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -273,6 +273,20 @@ button, input, select, textarea { font: inherit; }
 .map-shell-notice span { color: var(--rm-text-secondary); font-size: 13px; line-height: 1.55; }
 .map-shell-notice code { padding: 2px 6px; border-radius: 6px; background: var(--rm-bg-active); font-family: var(--font-sans); font-size: 12px; }
 .dashboard-map-notice { position: fixed; right: 24px; bottom: 24px; max-width: 360px; display: grid; gap: 4px; padding: 12px 16px; border-radius: var(--rm-radius-md); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 20; font-size: 13px; line-height: 1.45; }
+/* /monitoring 의 floating 검색 박스: 지도 좌상단 상시 노출. dropdown 은 input
+   focus + 결과 존재 시에만 펼쳐진다. z-index 는 지도(0) 보다 위, 상세 패널
+   (30) 보다 아래 — 검색 결과 클릭 후 상세 패널이 위로 떠야 하니까. */
+.monitoring-search { position: absolute; top: 16px; left: 16px; width: 320px; z-index: 25; }
+.monitoring-search-input { width: 100%; height: 38px; padding: 0 14px; border-radius: 10px; border: 1px solid var(--rm-line-subtle); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); font-size: 13px; font-family: var(--font-sans); box-shadow: var(--shadow-panel); }
+.monitoring-search-input:focus { outline: 2px solid var(--rm-accent); outline-offset: 0; border-color: transparent; }
+.monitoring-search-dropdown { list-style: none; margin: 6px 0 0; padding: 4px; border-radius: 10px; border: 1px solid var(--rm-line-subtle); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); box-shadow: var(--shadow-panel); max-height: 360px; overflow-y: auto; }
+.monitoring-search-item { display: grid; grid-template-columns: 36px 1fr auto; gap: 8px; align-items: baseline; padding: 8px 10px; border-radius: 6px; cursor: pointer; }
+.monitoring-search-item:hover { background: var(--rm-bg-section); }
+.monitoring-search-item-type { font-size: 10px; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; color: var(--rm-text-secondary); }
+.monitoring-search-item-type--bike { color: var(--rm-accent); }
+.monitoring-search-item-type--station { color: var(--rm-battery-mid); }
+.monitoring-search-item-label { font-size: 13px; font-weight: 700; color: var(--rm-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.monitoring-search-item-sub { font-size: 11px; color: var(--rm-text-secondary); text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
 .dashboard-map-notice strong { font-size: 12px; font-weight: 700; color: var(--rm-text-secondary); letter-spacing: .02em; }
 .dashboard-map-notice span { color: var(--rm-text-primary); }
 .bike-detail-panel { position: fixed; right: 24px; top: 50%; transform: translateY(-50%); width: 360px; max-height: calc(100vh - 96px); display: grid; gap: 16px; padding: 20px 22px; border-radius: var(--rm-radius-lg); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 30; overflow: auto; }

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BikeDetailPanel } from "@/components/dashboard/BikeDetailPanel";
 import { MapShell } from "@/components/dashboard/MapShell";
+import {
+  MonitoringSearch,
+  SEARCH_TARGET_ZOOM,
+  type MonitoringSearchMatch
+} from "@/components/dashboard/MonitoringSearch";
 import { StationDetailPanel } from "@/components/dashboard/StationDetailPanel";
 import type { DashboardMapStateResult } from "@/lib/services/dashboard-map-state-data";
 
@@ -31,6 +36,9 @@ export function DashboardCanvas({
   const [state, setState] = useState<DashboardMapStateResult>(initial);
   const [selectedBikeId, setSelectedBikeId] = useState<string | null>(null);
   const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
+  // 검색 결과 선택 시 MapShell 에 넘길 팬 좌표. 매 선택마다 새 객체를 박아
+  // identity 변경으로 effect 재발화를 유도 (같은 결과 두 번 눌러도 다시 팬).
+  const [searchTarget, setSearchTarget] = useState<{ lat: number; lng: number; zoom?: number } | null>(null);
   const pollIntervalRef = useRef(pollIntervalMs);
 
   useEffect(() => {
@@ -110,6 +118,19 @@ export function DashboardCanvas({
     setSelectedStationId(null);
   }, []);
 
+  // 검색 결과 클릭: (1) 지도 팬/줌 — 매번 새 객체로 박아 MapShell effect 재발화
+  // (2) 해당 종류의 상세 패널을 동시에 열어서 운영자가 즉시 디테일 확인 가능.
+  const handleSearchSelect = useCallback((match: MonitoringSearchMatch) => {
+    setSearchTarget({ lat: match.latitude, lng: match.longitude, zoom: SEARCH_TARGET_ZOOM });
+    if (match.type === "bike") {
+      setSelectedStationId(null);
+      setSelectedBikeId(match.id);
+    } else {
+      setSelectedBikeId(null);
+      setSelectedStationId(match.id);
+    }
+  }, []);
+
   return (
     <>
       <MapShell
@@ -117,6 +138,12 @@ export function DashboardCanvas({
         stationPins={state.data.stationPins}
         onBikeSelect={handleBikeSelect}
         onStationSelect={handleStationSelect}
+        targetLocation={searchTarget}
+      />
+      <MonitoringSearch
+        bikePins={state.data.bikePins}
+        stationPins={state.data.stationPins}
+        onSelect={handleSearchSelect}
       />
       {state.notice ? (
         <div className="dashboard-map-notice" role="status" aria-live="polite">

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -19,11 +19,12 @@ const SEOUL_DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 const DEFAULT_ZOOM = 13;
 
 // NCP `visualization.DotMap` 스펙을 옮긴 dot 마커. 기본 radius 5(=직경 10)
-// 보다 3배 키운 30px 로 두어서 한국 지도 시점에서 점 하나하나가 잘 보이게
-// 한다. opacity 0.5 + 흰색 1px stroke 는 그대로 — 점이 겹치면 alpha
-// 합성으로 색이 짙어져 자연스러운 밀도 시각화가 유지된다. 색만 우리 테마
-// 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔 적용.
-const DOT_PX = 30;
+// 보다 약간 키운 15px 로 두어서 한국 지도 시점에서 점이 잘 보이되, 너무
+// 부풀어 보이지 않도록 균형을 잡았다. opacity 0.5 + 흰색 1px stroke 는 그대로
+// — 점이 겹치면 alpha 합성으로 색이 짙어져 자연스러운 밀도 시각화가
+// 유지된다. 색만 우리 테마 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔
+// 적용.
+const DOT_PX = 15;
 const DOT_ANCHOR = DOT_PX / 2;
 const LABEL_VISIBLE_ZOOM = 12;
 
@@ -67,6 +68,12 @@ export interface MapShellProps {
   stationPins?: FrontendDashboardStationPin[];
   onBikeSelect?: (bikeId: string) => void;
   onStationSelect?: (stationId: string) => void;
+  /**
+   * 검색 결과 선택 시 해당 좌표로 지도를 팬/줌. 같은 좌표를 두 번 누르면
+   * 객체 identity 가 매번 새로 생겨 effect 가 다시 발화하도록 부모에서
+   * 새 객체로 넘긴다. null 이면 아무 동작 없음.
+   */
+  targetLocation?: { lat: number; lng: number; zoom?: number } | null;
 }
 
 export function MapShell({
@@ -77,6 +84,7 @@ export function MapShell({
   stationPins = [],
   onBikeSelect,
   onStationSelect,
+  targetLocation = null,
 }: MapShellProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<NaverMapInstance | null>(null);
@@ -237,6 +245,20 @@ export function MapShell({
       if (listener) naver.maps.Event.removeListener(listener);
     };
   }, [sdkReady, mapVersion]);
+
+  // Pan/zoom to a search target when the parent supplies one. Each click on
+  // a search result hands us a freshly-constructed object so this effect
+  // re-fires even when the operator picks the same pin twice in a row.
+  useEffect(() => {
+    if (!sdkReady || !targetLocation) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map?.setCenter || !naver?.maps?.LatLng) return;
+    map.setCenter(new naver.maps.LatLng(targetLocation.lat, targetLocation.lng));
+    if (targetLocation.zoom !== undefined && map.setZoom) {
+      map.setZoom(targetLocation.zoom);
+    }
+  }, [sdkReady, targetLocation, mapVersion]);
 
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
   // 겹치는 점은 alpha 합성으로 색이 짙어져 밀도 시각화. 줌 무관 고정 크기.

--- a/development/front-admin-web/components/dashboard/MonitoringSearch.tsx
+++ b/development/front-admin-web/components/dashboard/MonitoringSearch.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type {
+  FrontendDashboardBikePin,
+  FrontendDashboardStationPin
+} from "@/lib/services/service-ops-api";
+
+/**
+ * 운영자가 차량 번호 또는 BSS 이름/주소를 빠르게 찾기 위한 검색 박스. 지도
+ * 위에 floating 으로 떠 있고, 입력에 따라 client-side 로 현재 폴링된 핀
+ * 집합을 substring 매칭으로 필터링한다. 결과 클릭 시 부모(`DashboardCanvas`)
+ * 가 해당 핀으로 지도를 팬/줌 + 상세 패널 열기를 처리한다.
+ *
+ * 의도된 한계:
+ * - 백엔드 호출 없음. 폴링으로 들고 있는 핀만 검색 대상 — 화면에 보일 수
+ *   있는 모든 차량 / BSS 가 이미 stationPins / bikePins 에 들어 있다.
+ * - 라벨이 비어 있는 핀은 자동으로 매칭 후보에서 빠진다. 가령 plateNumber
+ *   가 빈 문자열인 경우.
+ */
+
+export type MonitoringSearchMatch = {
+  type: "bike" | "station";
+  id: string;
+  label: string;
+  sublabel?: string;
+  latitude: number;
+  longitude: number;
+};
+
+const MAX_RESULTS = 8;
+// 검색 결과 클릭 시 줌을 이 레벨로 맞춰 핀이 시야 정중앙에 또렷이 들어오게
+// 한다. 14~16 범위에서 골랐고, 15 가 동/거리 단위 시점으로 적당.
+export const SEARCH_TARGET_ZOOM = 15;
+
+export interface MonitoringSearchProps {
+  bikePins: ReadonlyArray<FrontendDashboardBikePin>;
+  stationPins: ReadonlyArray<FrontendDashboardStationPin>;
+  onSelect: (match: MonitoringSearchMatch) => void;
+}
+
+export function MonitoringSearch({ bikePins, stationPins, onSelect }: MonitoringSearchProps) {
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+
+  const matches = useMemo<MonitoringSearchMatch[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    const bikeMatches: MonitoringSearchMatch[] = bikePins
+      .filter((pin) => pin.plateNumber && pin.plateNumber.toLowerCase().includes(q))
+      .map((pin) => ({
+        type: "bike" as const,
+        id: pin.bikeId,
+        label: pin.plateNumber,
+        sublabel: pin.modelName || undefined,
+        latitude: pin.latitude,
+        longitude: pin.longitude
+      }));
+    const stationMatches: MonitoringSearchMatch[] = stationPins
+      .filter((pin) => {
+        const name = pin.name?.toLowerCase() ?? "";
+        const address = pin.address?.toLowerCase() ?? "";
+        return name.includes(q) || address.includes(q);
+      })
+      .map((pin) => ({
+        type: "station" as const,
+        id: pin.stationId,
+        label: pin.name,
+        sublabel: pin.address || undefined,
+        latitude: pin.latitude,
+        longitude: pin.longitude
+      }));
+    return [...bikeMatches, ...stationMatches].slice(0, MAX_RESULTS);
+  }, [query, bikePins, stationPins]);
+
+  const handleSelect = (match: MonitoringSearchMatch) => {
+    onSelect(match);
+    // 선택 직후 입력 초기화해서 다음 검색이 깨끗하게 시작되도록 한다.
+    setQuery("");
+    setFocused(false);
+  };
+
+  // 드롭다운은 (1) input 이 포커스 상태이고 (2) 결과가 있을 때만 노출.
+  // 결과 항목의 onMouseDown 은 input 의 onBlur 보다 먼저 실행되므로
+  // 클릭이 안전하게 도달한다 (onClick 으로 두면 blur → 드롭다운 사라짐
+  // → 클릭 미스 가능성).
+  const showDropdown = focused && matches.length > 0;
+
+  return (
+    <div className="monitoring-search" role="search">
+      <input
+        className="monitoring-search-input"
+        type="search"
+        placeholder="차량 번호 또는 BSS 이름 / 주소"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        aria-label="지도 검색"
+      />
+      {showDropdown ? (
+        <ul className="monitoring-search-dropdown" role="listbox">
+          {matches.map((match) => (
+            <li
+              key={`${match.type}-${match.id}`}
+              className="monitoring-search-item"
+              role="option"
+              aria-selected="false"
+              onMouseDown={(event) => {
+                event.preventDefault();
+                handleSelect(match);
+              }}
+            >
+              <span
+                className={`monitoring-search-item-type monitoring-search-item-type--${match.type}`}
+              >
+                {match.type === "bike" ? "차량" : "BSS"}
+              </span>
+              <span className="monitoring-search-item-label">{match.label}</span>
+              {match.sublabel ? (
+                <span className="monitoring-search-item-sub">{match.sublabel}</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Promote PR #213 to production.

**Search box (new)** — Floating client-side input at top-left of \`/monitoring\` filters polled pins by plate number / BSS name / address. Picking a result pans the map to the pin, zooms to level 15, and opens the matching \`BikeDetailPanel\` / \`StationDetailPanel\`.

**Dot resize** — \`DOT_PX\` 30 → 15. Markers now stay distinct under typical fleet density while overlap-darkening still works.

## Test plan
- [ ] \`/monitoring\` shows search box top-left
- [ ] Plate search → bike rows with "차량" chip
- [ ] BSS name/address search → station rows with "BSS" chip
- [ ] Click result: map pans, zoom 15, detail panel opens
- [ ] Markers visibly smaller (15px), still translucent
- [ ] Light/dark theme renders both correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)