### PR TITLE
Shift /monitoring search box right of the sidebar rail

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -273,10 +273,12 @@ button, input, select, textarea { font: inherit; }
 .map-shell-notice span { color: var(--rm-text-secondary); font-size: 13px; line-height: 1.55; }
 .map-shell-notice code { padding: 2px 6px; border-radius: 6px; background: var(--rm-bg-active); font-family: var(--font-sans); font-size: 12px; }
 .dashboard-map-notice { position: fixed; right: 24px; bottom: 24px; max-width: 360px; display: grid; gap: 4px; padding: 12px 16px; border-radius: var(--rm-radius-md); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 20; font-size: 13px; line-height: 1.45; }
-/* /monitoring 의 floating 검색 박스: 지도 좌상단 상시 노출. dropdown 은 input
-   focus + 결과 존재 시에만 펼쳐진다. z-index 는 지도(0) 보다 위, 상세 패널
-   (30) 보다 아래 — 검색 결과 클릭 후 상세 패널이 위로 떠야 하니까. */
-.monitoring-search { position: absolute; top: 16px; left: 16px; width: 320px; z-index: 25; }
+/* /monitoring 의 floating 검색 박스: 지도 좌상단 상시 노출. left 는 사이드바
+   (left: 16px, width: 64px, 즉 우측 끝이 80px) 와 안 겹치게 ~96px 부터 시작.
+   dropdown 은 input focus + 결과 존재 시에만 펼쳐진다. z-index 는 지도(0)
+   보다 위, 상세 패널(30) 보다 아래 — 검색 결과 클릭 후 상세 패널이 위로
+   떠야 하니까. */
+.monitoring-search { position: absolute; top: 16px; left: 96px; width: 320px; z-index: 25; }
 .monitoring-search-input { width: 100%; height: 38px; padding: 0 14px; border-radius: 10px; border: 1px solid var(--rm-line-subtle); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); font-size: 13px; font-family: var(--font-sans); box-shadow: var(--shadow-panel); }
 .monitoring-search-input:focus { outline: 2px solid var(--rm-accent); outline-offset: 0; border-color: transparent; }
 .monitoring-search-dropdown { list-style: none; margin: 6px 0 0; padding: 4px; border-radius: 10px; border: 1px solid var(--rm-line-subtle); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); box-shadow: var(--shadow-panel); max-height: 360px; overflow-y: auto; }


### PR DESCRIPTION
## Summary
- \`.monitoring-search { left: 16px }\` → \`left: 96px\`
- Sidebar is \`position: fixed; left: 16px; width: 64px;\` (spans 16–80px) with z-index 80, so the search input at the same x-coordinate was sliding under the sidebar
- 96px = 80 (sidebar right edge) + 16 (breathing gap)

## Test plan
- [ ] Search box is fully visible right of the sidebar rail
- [ ] No overlap with sidebar at any sidebar item hover state
- [ ] Dropdown still opens / closes correctly