### PR TITLE
Follow selected bike + restored pill-style marker labels

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -273,6 +273,31 @@ button, input, select, textarea { font: inherit; }
 .map-shell-notice span { color: var(--rm-text-secondary); font-size: 13px; line-height: 1.55; }
 .map-shell-notice code { padding: 2px 6px; border-radius: 6px; background: var(--rm-bg-active); font-family: var(--font-sans); font-size: 12px; }
 .dashboard-map-notice { position: fixed; right: 24px; bottom: 24px; max-width: 360px; display: grid; gap: 4px; padding: 12px 16px; border-radius: var(--rm-radius-md); background: color-mix(in srgb, var(--rm-bg-panel-soft) 96%, transparent); color: var(--rm-text-primary); box-shadow: var(--shadow-panel); z-index: 20; font-size: 13px; line-height: 1.45; }
+/* dot 마커 위에 띄우는 pill 라벨 — 줌 ≥ 12 에서 노출. dot 중심 위로 4px gap.
+   pointer-events: none 으로 두어 클릭은 dot 본체가 받는다. backdrop-filter +
+   소프트 shadow 로 지도 위에서도 떠 있는 느낌. translateX(-50%) 로 dot 중앙
+   에 정렬, translateY(-100%) 로 dot 위쪽으로 띄움. */
+.map-marker-label {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 4px);
+  transform: translateX(-50%);
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
+  border: 1px solid var(--rm-line-subtle);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--rm-text-primary);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+}
 /* /monitoring 의 floating 검색 박스: 지도 좌상단 상시 노출. left 는 사이드바
    (left: 16px, width: 64px, 즉 우측 끝이 80px) 와 안 겹치게 ~96px 부터 시작.
    dropdown 은 input focus + 결과 존재 시에만 펼쳐진다. z-index 는 지도(0)

--- a/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
+++ b/development/front-admin-web/components/dashboard/DashboardCanvas.tsx
@@ -131,6 +131,33 @@ export function DashboardCanvas({
     }
   }, []);
 
+  // 선택된 차량 따라가기: 폴링으로 그 차량의 좌표가 바뀌면(텔레메트리 갱신)
+  // 지도 중심을 새 좌표로 옮긴다. 줌은 명시적으로 안 박아서 운영자가 직접
+  // 조정한 줌 레벨을 보존한다. 초기 선택은 handleSearchSelect / 마커 클릭에서
+  // 이미 처리되므로 ref 로 이전 좌표 추적해서 (a) 신규 선택 (b) 좌표 무변경
+  // 두 경우는 패스 — "움직였을 때만 따라가기".
+  const previousFollowedBikeRef = useRef<{ bikeId: string; lat: number; lng: number } | null>(null);
+  useEffect(() => {
+    if (!selectedBikePin) {
+      previousFollowedBikeRef.current = null;
+      return;
+    }
+    const prev = previousFollowedBikeRef.current;
+    const current = {
+      bikeId: selectedBikePin.bikeId,
+      lat: selectedBikePin.latitude,
+      lng: selectedBikePin.longitude
+    };
+    previousFollowedBikeRef.current = current;
+    // 신규 선택: 초기 화면 배치는 호출 측이 책임 (search-select 는 zoom+pan,
+    // marker-click 은 그대로 두기) — 여기서 다시 팬하면 zoom 을 덮어쓰거나
+    // 사용자가 안 원하는 이동을 만들 수 있음.
+    if (!prev || prev.bikeId !== current.bikeId) return;
+    // 좌표 무변경: 폴링은 됐지만 차량은 안 움직임.
+    if (prev.lat === current.lat && prev.lng === current.lng) return;
+    setSearchTarget({ lat: current.lat, lng: current.lng });
+  }, [selectedBikePin]);
+
   return (
     <>
       <MapShell

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -23,10 +23,11 @@ const DEFAULT_ZOOM = 13;
 // 부풀어 보이지 않도록 균형을 잡았다. opacity 0.5 + 흰색 1px stroke 는 그대로
 // — 점이 겹치면 alpha 합성으로 색이 짙어져 자연스러운 밀도 시각화가
 // 유지된다. 색만 우리 테마 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔
-// 적용. 라벨(번호판/스테이션 이름) 은 클릭 시 상세 패널에서 확인 가능하므로
-// 지도 위 직접 노출은 생략 — DotMap 본연의 점-분포 인상을 흐트리지 않는다.
+// 적용. 줌 ≥ LABEL_VISIBLE_ZOOM 이면 dot 위에 pill 형태의 라벨(번호판 /
+// 스테이션 이름) 이 같이 노출되어 확대 시 식별이 가능하다.
 const DOT_PX = 15;
 const DOT_ANCHOR = DOT_PX / 2;
+const LABEL_VISIBLE_ZOOM = 12;
 
 // Two-step load: base SDK first, then the GL companion. The official
 // `submodules=gl` shortcut races with the auto-injected GL bundle whenever
@@ -228,6 +229,22 @@ export function MapShell({
     };
   }, [sdkReady, styleId, initialCenter.lat, initialCenter.lng, initialZoom]);
 
+  // 현재 줌 추적. 라벨 표시 임계값(LABEL_VISIBLE_ZOOM) 위/아래 전환 시
+  // 마커 effect 가 재실행되어 HTML 컨텐츠를 다시 그린다.
+  const [currentZoom, setCurrentZoom] = useState(initialZoom);
+  useEffect(() => {
+    if (!sdkReady) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.Event) return;
+    const listener = naver.maps.Event.addListener(map, "zoom_changed", (zoom: unknown) => {
+      setCurrentZoom(typeof zoom === "number" ? zoom : Number(zoom));
+    });
+    return () => {
+      if (listener) naver.maps.Event.removeListener(listener);
+    };
+  }, [sdkReady, mapVersion]);
+
   // Pan/zoom to a search target when the parent supplies one. Each click on
   // a search result hands us a freshly-constructed object so this effect
   // re-fires even when the operator picks the same pin twice in a row.
@@ -253,10 +270,11 @@ export function MapShell({
     const cache = bikeMarkerCacheRef.current;
     const incomingIds = new Set<string>();
 
+    const showLabel = currentZoom >= LABEL_VISIBLE_ZOOM;
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = bikeMarkerHtml();
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
       const icon = {
         content: html,
         anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
@@ -289,7 +307,7 @@ export function MapShell({
         cache.delete(bikeId);
       }
     }
-  }, [sdkReady, bikePins, mapVersion]);
+  }, [sdkReady, bikePins, mapVersion, currentZoom]);
 
   // Station markers — 차량과 동일한 DotMap 스타일, 색만 `--rm-battery-high`
   // (녹색) 으로 구분.
@@ -302,10 +320,11 @@ export function MapShell({
     const cache = stationMarkerCacheRef.current;
     const incomingIds = new Set<string>();
 
+    const showLabel = currentZoom >= LABEL_VISIBLE_ZOOM;
     for (const pin of stationPins) {
       incomingIds.add(pin.stationId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = stationMarkerHtml();
+      const html = stationMarkerHtml(pin.name, showLabel);
       const icon = {
         content: html,
         anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
@@ -338,7 +357,7 @@ export function MapShell({
         cache.delete(stationId);
       }
     }
-  }, [sdkReady, stationPins, mapVersion]);
+  }, [sdkReady, stationPins, mapVersion, currentZoom]);
 
   if (!NCP_CLIENT_ID) {
     return (
@@ -383,12 +402,30 @@ function dotMarkup(fillVar: string): string {
   return `<div style="width:${DOT_PX}px;height:${DOT_PX}px;border-radius:50%;background:var(${fillVar});border:1px solid #ffffff;box-sizing:border-box;opacity:0.5;"></div>`;
 }
 
-/** BSS 마커 — DotMap 스타일 노란 dot. 라벨은 클릭 시 상세 패널에서. */
-function stationMarkerHtml(): string {
-  return `<div style="pointer-events:auto;">${dotMarkup("--rm-battery-mid")}</div>`;
+/**
+ * 마커 위에 띄우는 pill 형태 라벨. CSS 는 globals.css 의 `.map-marker-label`
+ * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. dot 의
+ * `pointer-events: auto` 와 충돌하지 않게 라벨 자체는 `pointer-events: none`.
+ */
+function labelMarkup(text: string): string {
+  // 텍스트는 안전하게 inner text 만 노출 — operator-입력 plate / station name
+  // 이 HTML 을 포함할 가능성은 거의 없지만 escape 처리해서 안전망.
+  const safe = text.replace(/[&<>"]/g, (ch) =>
+    ch === "&" ? "&amp;" : ch === "<" ? "&lt;" : ch === ">" ? "&gt;" : "&quot;"
+  );
+  return `<span class="map-marker-label">${safe}</span>`;
 }
 
-/** 차량 마커 — DotMap 스타일 dot (`--rm-accent` 색). 라벨은 상세 패널에서. */
-function bikeMarkerHtml(): string {
-  return `<div style="pointer-events:auto;">${dotMarkup("--rm-accent")}</div>`;
+/** BSS 마커 — DotMap 스타일 노란 dot + (옵션) 라벨. */
+function stationMarkerHtml(name: string, showLabel: boolean): string {
+  const dot = dotMarkup("--rm-battery-mid");
+  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
+  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(name)}${dot}</div>`;
+}
+
+/** 차량 마커 — DotMap 스타일 dot (`--rm-accent` 색) + (옵션) 번호판 라벨. */
+function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
+  const dot = dotMarkup("--rm-accent");
+  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
+  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(plateNumber)}${dot}</div>`;
 }


### PR DESCRIPTION
## Summary
Promote PRs #218 and #219 to production.

**PR #218 — Follow selected bike**
- New \`useEffect\` in \`DashboardCanvas\` that re-pans the map to the selected bike's latest coords whenever they change (telemetry updates).
- Reuses \`searchTarget\` → \`MapShell.targetLocation\` → \`map.setCenter\` pipeline.
- Follow updates are pan-only (no zoom override) so operator's chosen zoom level is preserved.
- \`previousFollowedBikeRef\` skips initial selection (lets \`handleSearchSelect\`'s zoom=15 win) and skips no-op polling refreshes.
- Stations not followed (they don't move).

**PR #219 — Pill-style marker labels (restored)**
- Plate / station-name labels back at zoom ≥ 12 with a new design: pill shape, translucent panel background, soft shadow, \`backdrop-filter: blur(8px)\`, 11px / weight 700 typography.
- Centered above the dot; \`pointer-events: none\` so clicks still hit the dot.
- New \`.map-marker-label\` CSS class + restored \`currentZoom\` tracking + \`LABEL_VISIBLE_ZOOM = 12\`.

## Test plan
- [ ] Marker click → panel opens, follow primed
- [ ] Wait for polling + bike movement → map pans to new coords (zoom preserved)
- [ ] Close panel → follow stops
- [ ] Zoom out below 12 → only dots
- [ ] Zoom in ≥ 12 → labels appear centered above dots
- [ ] Light / dark theme both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)