### PR TITLE
Surface IMEI in /overview vehicle detail

### DIFF
--- a/development/front-admin-web/app/api/overview/vehicle-device/[bikeId]/route.ts
+++ b/development/front-admin-web/app/api/overview/vehicle-device/[bikeId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { loadVehicleDevice } from "@/lib/services/vehicle-device-data";
+
+/**
+ * 차량 상세 다이얼로그가 open 시 호출하는 lazy fetch — 현재 부착된 단말기
+ * (IMEI = deviceUid) + 활성 installation id 를 반환. service-ops 쿠키는 서버
+ * 측에 그대로 두고 dashboard map-state 라우트들과 같은 패턴.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ bikeId: string }> }
+) {
+  const { bikeId } = await context.params;
+  const result = await loadVehicleDevice(bikeId);
+  return NextResponse.json(result, {
+    headers: { "Cache-Control": "no-store" }
+  });
+}

--- a/development/front-admin-web/app/overview/actions.ts
+++ b/development/front-admin-web/app/overview/actions.ts
@@ -218,6 +218,13 @@ export async function updateVehicleFromOverviewAction(
 
   const nextStatus = String(formData.get("operationStatus") ?? "") as ServiceOpsBikeOperationStatus;
   const currentStatus = String(formData.get("currentOperationStatus") ?? "") as ServiceOpsBikeOperationStatus;
+  // 단말기(IMEI) 변경 의도는 세 가지 값으로 표현:
+  //   - 새 IMEI 값 (string) → set / change
+  //   - 빈 문자열 + currentInstallationId 가 있음 → 기존 부착 해제
+  //   - 빈 문자열 + currentInstallationId 도 없음 → no-op
+  const nextDeviceUid = String(formData.get("deviceUid") ?? "").trim();
+  const currentInstallationId = String(formData.get("currentInstallationId") ?? "").trim();
+  const currentDeviceUid = String(formData.get("currentDeviceUid") ?? "").trim();
 
   try {
     // 차체 기본 정보 (plateNumber / modelName) 는 일반 update endpoint 로,
@@ -232,6 +239,39 @@ export async function updateVehicleFromOverviewAction(
         operationStatus: nextStatus,
         reason: "OPERATOR_EDIT"
       });
+    }
+    // IMEI 변경 처리는 위 두 호출이 성공한 다음에만 진행. 운영자가 IMEI 만
+    // 바꾸려고 같은 plateNumber 를 다시 저장해도 멱등 — backend 가 동일 값
+    // update 는 no-op 처리한다.
+    if (nextDeviceUid !== currentDeviceUid) {
+      if (!nextDeviceUid) {
+        // 비움 → 기존 installation 해제
+        if (currentInstallationId) {
+          await client.removeBikeDeviceInstallation(currentInstallationId, {
+            removedAt: new Date().toISOString(),
+            memo: "운영자 차량 상세에서 IMEI 해제"
+          });
+        }
+      } else {
+        // 새 IMEI → 기존 device 가 있으면 재사용, 없으면 생성 후 부착.
+        // backend 는 새 installation 생성 시 같은 bike 의 이전 active row 를
+        // 자동으로 close 하므로 별도로 detach 호출할 필요 없음.
+        let deviceId: string | null = null;
+        const devicePage = await client.listDevices({ page: 0, size: 200 });
+        const existing = devicePage.items.find((row) => row.deviceUid === nextDeviceUid);
+        if (existing) {
+          deviceId = existing.id;
+        } else {
+          const created = await client.createDevice({ deviceUid: nextDeviceUid, enabled: true });
+          deviceId = created.id;
+        }
+        await client.createBikeDeviceInstallation({
+          bikeId: vehicleId,
+          deviceId,
+          installedAt: new Date().toISOString(),
+          memo: "운영자 차량 상세에서 IMEI 부착"
+        });
+      }
     }
   } catch {
     redirect("/overview?tab=vehicles&status=update-error");

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -5,11 +5,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import { updateVehicleFromOverviewAction } from "@/app/overview/actions";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
+import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 
 /**
  * 차량 상세 + 편집 다이얼로그. 차체 기본 정보(plateNumber / modelName) 와
  * 운영 상태(operationStatus) 가 백엔드에서는 두 endpoint 로 분리되어 있지만
  * UI 에서는 "저장" 한 번으로 묶고, server action 안에서 두 호출을 순차 실행한다.
+ *
+ * IMEI(단말기 deviceUid) 도 같은 form 의 일부 — server action 이 device
+ * 생성/조회 + bike-device-installation 생성/해제를 자동으로 처리한다. 운영자
+ * 입장에선 차량 정보 / 운영 상태 / IMEI 세 가지를 한 번의 저장으로 묶는 것.
  */
 export interface VehicleDetailRow {
   vehicle: FrontendVehicle;
@@ -31,6 +36,9 @@ export function VehicleDetailDialog({
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [mode, setMode] = useState<"view" | "edit">("view");
+  // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
+  // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
+  const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
 
   // 모달 open/close 만 effect 에서 처리. 상태 리셋은 부모의 key prop 으로
   // 재마운트해 useState 초기값이 새로 잡히도록 한다.
@@ -38,6 +46,32 @@ export function VehicleDetailDialog({
     if (row) dialogRef.current?.showModal();
     else dialogRef.current?.close();
   }, [row]);
+
+  // 차량이 바뀌면 단말기 정보도 새로 받아온다. 부모(`VehiclesPanel`) 가
+  // `key={vehicleId}` 로 다이얼로그를 remount 시키므로 row 가 null → row 로
+  // 바뀌는 모든 케이스는 자동으로 useState 초기값(null) 에서 시작. 여기서는
+  // vehicleId 가 잡힐 때만 fetch 한다.
+  const vehicleIdForFetch = row?.vehicle.id ?? row?.vehicle.slug ?? null;
+  useEffect(() => {
+    if (!vehicleIdForFetch) return;
+    let cancelled = false;
+    fetch(`/api/overview/vehicle-device/${encodeURIComponent(vehicleIdForFetch)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => (response.ok ? ((await response.json()) as VehicleDeviceResult) : null))
+      .then((next) => {
+        if (cancelled) return;
+        setDeviceState(next ?? { bikeId: vehicleIdForFetch, deviceUid: null, installationId: null });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDeviceState({ bikeId: vehicleIdForFetch, deviceUid: null, installationId: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vehicleIdForFetch]);
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();
@@ -50,6 +84,8 @@ export function VehicleDetailDialog({
   const vehicleId = vehicle.id ?? vehicle.slug;
   const boundUpdate = updateVehicleFromOverviewAction.bind(null, vehicleId);
   const currentOperationStatus = vehicle.operationStatus ?? STATUS_TO_CODE[vehicle.status];
+  const currentDeviceUid = deviceState?.deviceUid ?? "";
+  const currentInstallationId = deviceState?.installationId ?? "";
 
   return (
     <dialog
@@ -66,6 +102,7 @@ export function VehicleDetailDialog({
           <DetailField label="운영 상태" value={vehicle.status} />
           <DetailField label="이름" value={row.riderName ?? "—"} />
           <DetailField label="연락처" value={row.riderPhone ?? "—"} />
+          <DetailField label="IMEI" value={currentDeviceUid || "—"} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>
               닫기
@@ -79,6 +116,10 @@ export function VehicleDetailDialog({
         <form action={boundUpdate}>
           {/* server action 이 두 endpoint 분기를 결정할 때 참고하는 현재 상태값. */}
           <input type="hidden" name="currentOperationStatus" value={currentOperationStatus} />
+          {/* IMEI / installation 의 "현재값" 도 server action 의 diff 판단에 쓴다 —
+              빈 값으로 저장하면 detach, 다른 값으로 저장하면 새로 attach. */}
+          <input type="hidden" name="currentDeviceUid" value={currentDeviceUid} />
+          <input type="hidden" name="currentInstallationId" value={currentInstallationId} />
           <label>
             차량번호
             <PlateNumberInput name="plateNumber" defaultValue={vehicle.plateNumber} required />
@@ -93,6 +134,17 @@ export function VehicleDetailDialog({
               <option value="READY">대기</option>
               <option value="IN_SERVICE">운행</option>
             </select>
+          </label>
+          <label>
+            IMEI
+            <input
+              name="deviceUid"
+              defaultValue={currentDeviceUid}
+              maxLength={64}
+              placeholder="단말기 IMEI 입력 (없음으로 두면 해제)"
+              autoComplete="off"
+              inputMode="numeric"
+            />
           </label>
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={() => setMode("view")}>
@@ -116,4 +168,3 @@ function DetailField({ label, value }: { label: string; value: string }) {
     </div>
   );
 }
-

--- a/development/front-admin-web/lib/services/vehicle-device-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-device-data.ts
@@ -1,0 +1,41 @@
+import { serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+/**
+ * `/overview` 의 차량 상세 다이얼로그가 현재 부착된 단말기(IMEI) 를 확인하기
+ * 위해 lazy 로 호출하는 loader. 차량 한 대에 활성 installation 은 1:1 이라는
+ * 백엔드 보장을 그대로 따른다.
+ *
+ * 현재 백엔드의 `listBikeDeviceInstallations` 가 bikeId 필터 파라미터를 안
+ * 받기 때문에 페이지 한 장(200개)을 받아 클라이언트 측에서 매칭한다. MVP
+ * 단말기 수에선 충분하지만, 단말기가 200대를 넘어가기 전에 backend 측에
+ * `?bikeId=` 필터 또는 `/bike-device-installations/by-bike/{bikeId}` 같은
+ * 전용 조회를 추가해야 한다.
+ */
+export type VehicleDeviceResult = {
+  bikeId: string;
+  /** 현재 부착된 단말기의 deviceUid (UI 상 "IMEI"). 없으면 null. */
+  deviceUid: string | null;
+  /** 현재 활성 installation 의 row id. 해제 시 이 id 로 `removeBikeDeviceInstallation` 호출. */
+  installationId: string | null;
+};
+
+export async function loadVehicleDevice(bikeId: string): Promise<VehicleDeviceResult> {
+  const empty: VehicleDeviceResult = { bikeId, deviceUid: null, installationId: null };
+  if (!serviceOpsApiConfigured()) return empty;
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return empty;
+
+  try {
+    const page = await client.listBikeDeviceInstallations({ page: 0, size: 200 });
+    const active = page.items.find((row) => row.bikeId === bikeId && row.removedAt === null);
+    if (!active) return empty;
+    const device = await client.getDevice(active.deviceId);
+    return { bikeId, deviceUid: device.deviceUid, installationId: active.id };
+  } catch {
+    // 조회 실패 = 잘 모름 상태. UI 는 "—" 로 표시하고 운영자가 새로 입력하면
+    // 부착 액션이 그 입력 대로 진행된다 — 백엔드가 어차피 active 1:1 보장이라
+    // 신규 attach 가 기존 attach 를 자동으로 close 한다.
+    return empty;
+  }
+}


### PR DESCRIPTION
## Summary
Promote PR #221 to production.

\`/overview?tab=vehicles\` detail dialog now exposes the attached device's IMEI (\`deviceUid\`) — view mode shows the current value, edit mode lets the operator change / clear it. One save handles plate / model / operation-status / IMEI together; server action figures out create-or-reuse-device + create-or-remove-installation against the existing backend endpoints.

- New \`lib/services/vehicle-device-data.ts\` + \`app/api/overview/vehicle-device/[bikeId]\` route for lazy lookup on dialog open
- \`updateVehicleFromOverviewAction\` grows the IMEI branch (no-op / detach / find-or-create device + create installation)

## Test plan
- [ ] Existing vehicle without device: IMEI shows "—"; saving with IMEI attaches the device
- [ ] Change IMEI: prior installation closes, new one opens
- [ ] Clear IMEI: installation marked \`removedAt\`
- [ ] Save without touching IMEI: no device-side calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)