### PR TITLE
Rebuild /overview vehicles panel: filter bar, 8 columns, map split

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -380,6 +380,30 @@ textarea { padding-top: 10px; min-height: 96px; }
 /* 행 전체에 클릭 핸들러가 달려있다는 시각적 단서. 호버 시 옅은 강조 배경
    (.table tr:hover td 의 mint-04 와 동일 톤) + 커서 포인터. */
 .table-row-clickable { cursor: pointer; }
+
+/* /overview vehicles 패널 ─ EVN 차량 현황 페이지 참고. 필터 바 + 8컬럼
+   테이블 + (옵션) 우측 지도 분할. */
+.vehicles-panel { display: flex; flex-direction: column; gap: 12px; }
+.vehicles-filter-bar { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; padding: 10px 12px; border-radius: 10px; background: var(--color-bg-soft); }
+.vehicles-filter-bar .vehicles-filter-search { flex: 1 1 200px; min-width: 160px; height: 32px; padding: 0 12px; border: 0; border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-family: inherit; }
+.vehicles-filter-bar .vehicles-filter-select { height: 32px; padding: 0 8px; border: 0; border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-family: inherit; }
+.vehicles-filter-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--color-text-secondary); cursor: pointer; user-select: none; }
+.vehicles-filter-toggle input[type="checkbox"] { width: 14px; height: 14px; accent-color: var(--rm-accent); cursor: pointer; }
+.vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+/* 본문: 리스트 단독 (full width) 또는 리스트 + 지도 (50:50). split 모드에서
+   table-card 의 고정 높이(240px) 는 그대로 유지하고 지도가 그 옆에 같은 높이로 붙음. */
+.vehicles-panel-body { display: grid; grid-template-columns: 1fr; gap: 12px; }
+.vehicles-panel--split .vehicles-panel-body { grid-template-columns: 1fr 1fr; }
+.vehicles-panel-map { position: relative; height: 240px; border-radius: 10px; overflow: hidden; background: var(--rm-map-block); }
+.vehicles-cell-mono { font-family: var(--font-sans); font-variant-numeric: tabular-nums; }
+.vehicles-sort-button { display: inline-flex; align-items: center; gap: 4px; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; font-weight: 700; cursor: pointer; }
+.vehicles-sort-button.is-active { color: var(--rm-accent); }
+.vehicles-sort-arrow { font-size: 10px; opacity: 0.6; }
+.vehicles-sort-button.is-active .vehicles-sort-arrow { opacity: 1; }
+.vehicles-soc { font-variant-numeric: tabular-nums; font-weight: 700; }
+.vehicles-soc--high { color: var(--rm-battery-high); }
+.vehicles-soc--mid { color: var(--rm-battery-mid); }
+.vehicles-soc--low { color: var(--rm-battery-low); }
 .table-row-clickable[draggable="true"] { cursor: grab; }
 .table-row-clickable[draggable="true"]:active { cursor: grabbing; }
 /* 인라인 매칭 등록 폼. 슬롯 두 개(라이더·차량) + 양식 select + 시작일 + 등록 버튼

--- a/development/front-admin-web/app/overview/page.tsx
+++ b/development/front-admin-web/app/overview/page.tsx
@@ -197,6 +197,7 @@ export default async function OverviewPage({
                 data={vehicleData}
                 bikeActiveRiderById={matching.bikeActiveRiderById}
                 riderInfoById={riderInfoById}
+                bikePins={mapState.data.bikePins}
               />
             ),
             notice: vehicleData.notice

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -1,98 +1,276 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
+import { MapShell } from "@/components/dashboard/MapShell";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
+import type {
+  FrontendDashboardBikePin,
+  FrontendVehicle,
+  ServiceOpsBikeOperationStatus
+} from "@/lib/services/service-ops-api";
 
 /**
- * Read-only table-card for the vehicle list on `/overview ?tab=vehicles`.
- * Columns: 차량번호 / 모델 / 이름 / 연락처 / 작업.
+ * `/overview?tab=vehicles` 의 차량 현황 패널. EVN Logistics 의 차량 현황
+ * 페이지를 참고해 정리한 구조 — UI/UX 만 차용하고 도메인 모델은 우리 것
+ * 그대로 사용:
  *
- * 시동 상태 컬럼은 사용자 요청으로 제거 — 동일 정보는 매칭된 라이더 상세
- * 다이얼로그에서 보여주고 거기서 "시동 방지" 토글도 함께 다룬다.
+ * - 필터 바: 검색 (plate / VIN), 운영 상태, 라이더 배정, 저전압
+ * - 컬럼: 호기(idx) / 차량번호 / VIN / 모델 / 운영 상태 / 라이더 / SOC / 작업
+ * - 헤더 정렬 가능 (호기 / 차량번호 / 모델 / 운영상태 / 라이더명 / SOC)
+ * - 지도 보기 토글: ON 이면 좌 리스트 / 우 지도 의 50:50 분할 — 우리 기존
+ *   MapShell 을 그대로 임베드해서 monitoring 페이지와 같은 마커 시각화 사용
  *
- * 행 클릭 시 상세 다이얼로그가 열리고 거기서 수정으로 전환할 수 있다.
+ * 필드 매핑:
+ * - 호기 = FrontendVehicle.idx (DB 의 bigserial idx)
+ * - VIN = FrontendVehicle.vin
+ * - SOC = bikePin.batteryPercent (텔레메트리 — 없으면 "—")
+ * - 운영상태 = FrontendVehicle.status (운행 / 대기) — badge 로 표시
  */
+
+type FilterState = {
+  query: string;
+  operationStatus: "ALL" | "READY" | "IN_SERVICE";
+  riderAssignment: "ALL" | "ASSIGNED" | "UNASSIGNED";
+  lowBatteryOnly: boolean;
+};
+
+type SortKey = "idx" | "plate" | "model" | "status" | "rider" | "soc";
+type SortDir = "asc" | "desc";
+
+const DEFAULT_FILTERS: FilterState = {
+  query: "",
+  operationStatus: "ALL",
+  riderAssignment: "ALL",
+  lowBatteryOnly: false
+};
+
+const LOW_BATTERY_THRESHOLD = 20;
+
+const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
+  READY: "대기",
+  IN_SERVICE: "운행"
+};
+
 export function VehiclesPanel({
   data,
   bikeActiveRiderById,
-  riderInfoById
+  riderInfoById,
+  bikePins
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
+  /** 지도 보기 + SOC 컬럼 채우는데 쓰는 텔레메트리 핀. dashboard map-state 의 bikePins 그대로. */
+  bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const [mapView, setMapView] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>("idx");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  // bikeId → 텔레메트리 핀. SOC 노출 + 저전압 필터 + 지도 마커 필터링에 사용.
+  const bikePinById = useMemo(() => {
+    const map = new Map<string, FrontendDashboardBikePin>();
+    for (const pin of bikePins ?? []) {
+      map.set(pin.bikeId, pin);
+    }
+    return map;
+  }, [bikePins]);
+
+  // filter + sort 를 한 번에 통과시킨 결과. 표 / 지도 둘 다 같은 집합 사용.
+  const visibleVehicles = useMemo(() => {
+    const q = filters.query.trim().toLowerCase();
+    const filtered = data.vehicles.filter((vehicle) => {
+      // 검색: plate / VIN substring
+      if (q) {
+        const plateMatch = vehicle.plateNumber.toLowerCase().includes(q);
+        const vinMatch = (vehicle.vin ?? "").toLowerCase().includes(q);
+        if (!plateMatch && !vinMatch) return false;
+      }
+      // 운영 상태
+      if (filters.operationStatus !== "ALL") {
+        const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
+        if (op !== filters.operationStatus) return false;
+      }
+      // 라이더 배정
+      if (filters.riderAssignment !== "ALL") {
+        const vehicleKey = vehicle.id ?? vehicle.slug;
+        const hasRider = Boolean(bikeActiveRiderById?.get(vehicleKey));
+        if (filters.riderAssignment === "ASSIGNED" && !hasRider) return false;
+        if (filters.riderAssignment === "UNASSIGNED" && hasRider) return false;
+      }
+      // 저전압: 텔레메트리가 있고 batteryPercent ≤ 20 인 차량만
+      if (filters.lowBatteryOnly) {
+        const vehicleKey = vehicle.id ?? vehicle.slug;
+        const pin = bikePinById.get(vehicleKey);
+        if (pin?.batteryPercent === null || pin?.batteryPercent === undefined) return false;
+        if (pin.batteryPercent > LOW_BATTERY_THRESHOLD) return false;
+      }
+      return true;
+    });
+    return sortVehicles(filtered, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById);
+  }, [data.vehicles, filters, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById]);
+
+  // 지도 보기에 넘길 마커 — 화면에 보이는 차량만 마커로. mapState 의 핀 중에서
+  // 매칭되는 것만 골라서 MapShell 의 입력으로.
+  const visibleBikePins = useMemo(() => {
+    if (!mapView) return [];
+    const visibleIds = new Set(visibleVehicles.map((v) => v.id ?? v.slug));
+    return (bikePins ?? []).filter((pin) => visibleIds.has(pin.bikeId));
+  }, [mapView, visibleVehicles, bikePins]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((dir) => (dir === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
 
   return (
-    <div className="table-card">
-      <table className="table" style={{ tableLayout: "fixed" }}>
-        <colgroup>
-          <col />
-          <col />
-          <col />
-          <col />
-          <col style={{ width: "72px" }} />
-        </colgroup>
-        <thead>
-          <tr>
-            <th>차량번호</th>
-            <th>모델</th>
-            <th>이름</th>
-            <th>연락처</th>
-            <th style={{ textAlign: "right" }}>작업</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.vehicles.length === 0 ? (
-            <tr>
-              <td colSpan={5} className="table-empty-cell">
-                데이터 없음
-              </td>
-            </tr>
-          ) : null}
-          {data.vehicles.map((vehicle) => {
-            const vehicleKey = vehicle.id ?? vehicle.slug;
-            const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
-            const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
-            return (
-              <tr
-                key={vehicle.slug}
-                className="table-row-clickable"
-                draggable={Boolean(vehicle.id)}
-                onDragStart={(event) => {
-                  if (!vehicle.id) return;
-                  // ContractMatchingForm 의 차량 슬롯이 같은 식별자를 받을 때만 drop 허용.
-                  event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
-                  event.dataTransfer.effectAllowed = "copy";
-                }}
-                onClick={() =>
-                  setActiveRow({
-                    vehicle,
-                    riderName: riderInfo?.name ?? null,
-                    riderPhone: riderInfo?.phone ?? null
-                  })
-                }
-              >
-                <td>{vehicle.plateNumber}</td>
-                <td>{vehicle.model}</td>
-                <td>{riderInfo ? riderInfo.name : <span className="muted">—</span>}</td>
-                <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
-                <td
-                  style={{ textAlign: "right" }}
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <DeleteVehicleButton vehicleId={vehicleKey} plateNumber={vehicle.plateNumber} />
-                </td>
+    <div className={`vehicles-panel ${mapView ? "vehicles-panel--split" : ""}`}>
+      <div className="vehicles-filter-bar">
+        <label className="vehicles-filter-toggle">
+          <input
+            type="checkbox"
+            checked={mapView}
+            onChange={(event) => setMapView(event.target.checked)}
+          />
+          <span>지도 보기</span>
+        </label>
+        <input
+          className="vehicles-filter-search"
+          type="search"
+          placeholder="차량번호 또는 VIN 검색"
+          value={filters.query}
+          onChange={(event) => setFilters({ ...filters, query: event.target.value })}
+        />
+        <select
+          className="vehicles-filter-select"
+          value={filters.operationStatus}
+          onChange={(event) =>
+            setFilters({ ...filters, operationStatus: event.target.value as FilterState["operationStatus"] })
+          }
+        >
+          <option value="ALL">운영 상태: 전체</option>
+          <option value="IN_SERVICE">운영중</option>
+          <option value="READY">대기</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.riderAssignment}
+          onChange={(event) =>
+            setFilters({ ...filters, riderAssignment: event.target.value as FilterState["riderAssignment"] })
+          }
+        >
+          <option value="ALL">라이더: 전체</option>
+          <option value="ASSIGNED">배정됨</option>
+          <option value="UNASSIGNED">미배정</option>
+        </select>
+        <label className="vehicles-filter-toggle">
+          <input
+            type="checkbox"
+            checked={filters.lowBatteryOnly}
+            onChange={(event) => setFilters({ ...filters, lowBatteryOnly: event.target.checked })}
+          />
+          <span>저전압만 (≤ {LOW_BATTERY_THRESHOLD}%)</span>
+        </label>
+        <span className="vehicles-filter-count">
+          {visibleVehicles.length} / {data.vehicles.length}
+        </span>
+      </div>
+
+      <div className="vehicles-panel-body">
+        <div className="table-card">
+          <table className="table" style={{ tableLayout: "fixed" }}>
+            <colgroup>
+              <col style={{ width: "60px" }} />
+              <col />
+              <col />
+              <col />
+              <col style={{ width: "92px" }} />
+              <col />
+              <col style={{ width: "80px" }} />
+              <col style={{ width: "72px" }} />
+            </colgroup>
+            <thead>
+              <tr>
+                <SortableHeader label="호기" sortKey="idx" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <SortableHeader label="차량번호" sortKey="plate" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <th>VIN</th>
+                <SortableHeader label="모델" sortKey="model" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <SortableHeader label="운영 상태" sortKey="status" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <SortableHeader label="라이더" sortKey="rider" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <SortableHeader label="SOC" sortKey="soc" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <th style={{ textAlign: "right" }}>작업</th>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            </thead>
+            <tbody>
+              {visibleVehicles.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="table-empty-cell">
+                    조건에 맞는 차량 없음
+                  </td>
+                </tr>
+              ) : null}
+              {visibleVehicles.map((vehicle) => {
+                const vehicleKey = vehicle.id ?? vehicle.slug;
+                const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
+                const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
+                const pin = bikePinById.get(vehicleKey);
+                const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
+                return (
+                  <tr
+                    key={vehicle.slug}
+                    className="table-row-clickable"
+                    draggable={Boolean(vehicle.id)}
+                    onDragStart={(event) => {
+                      if (!vehicle.id) return;
+                      event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
+                      event.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onClick={() =>
+                      setActiveRow({
+                        vehicle,
+                        riderName: riderInfo?.name ?? null,
+                        riderPhone: riderInfo?.phone ?? null
+                      })
+                    }
+                  >
+                    <td className="vehicles-cell-mono">{vehicle.idx ?? "—"}</td>
+                    <td>{vehicle.plateNumber}</td>
+                    <td className="vehicles-cell-mono">{vehicle.vin || <span className="muted">—</span>}</td>
+                    <td>{vehicle.model}</td>
+                    <td>{renderOperationBadge(op)}</td>
+                    <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
+                    <td>{renderSoc(pin?.batteryPercent)}</td>
+                    <td
+                      style={{ textAlign: "right" }}
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <DeleteVehicleButton vehicleId={vehicleKey} plateNumber={vehicle.plateNumber} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {mapView ? (
+          <div className="vehicles-panel-map">
+            <MapShell bikePins={visibleBikePins} />
+          </div>
+        ) : null}
+      </div>
+
       <VehicleDetailDialog
         key={activeRow ? (activeRow.vehicle.id ?? activeRow.vehicle.slug) : "none"}
         row={activeRow}
@@ -102,6 +280,96 @@ export function VehiclesPanel({
   );
 }
 
-// Note: VehiclesPanel 은 더 이상 ignition status 도 보험 상태도 직접 표시하지
-// 않는다. 매칭 → 라이더 상세 다이얼로그에서 통합 노출.
+function SortableHeader({
+  label,
+  sortKey,
+  current,
+  dir,
+  onSort
+}: {
+  label: string;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+}) {
+  const isActive = current === sortKey;
+  const arrow = !isActive ? "↕" : dir === "asc" ? "↑" : "↓";
+  return (
+    <th>
+      <button
+        type="button"
+        className={`vehicles-sort-button${isActive ? " is-active" : ""}`}
+        onClick={() => onSort(sortKey)}
+      >
+        {label}
+        <span className="vehicles-sort-arrow" aria-hidden="true">{arrow}</span>
+      </button>
+    </th>
+  );
+}
+
+function renderOperationBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
+  if (op === "IN_SERVICE") return <Badge tone="active">{STATUS_LABEL[op]}</Badge>;
+  return <Badge tone="muted">{STATUS_LABEL[op]}</Badge>;
+}
+
+function renderSoc(percent: number | null | undefined): ReactNode {
+  if (percent === null || percent === undefined) return <span className="muted">—</span>;
+  const tone = percent <= LOW_BATTERY_THRESHOLD ? "low" : percent <= 50 ? "mid" : "high";
+  return (
+    <span className={`vehicles-soc vehicles-soc--${tone}`}>
+      {percent.toFixed(0)}%
+    </span>
+  );
+}
+
+function statusToOperation(status: FrontendVehicle["status"]): ServiceOpsBikeOperationStatus {
+  return status === "운행" ? "IN_SERVICE" : "READY";
+}
+
+function sortVehicles(
+  vehicles: FrontendVehicle[],
+  key: SortKey,
+  dir: SortDir,
+  bikeActiveRiderById: Map<string, string> | undefined,
+  riderInfoById: Map<string, { name: string; phone: string }> | undefined,
+  bikePinById: Map<string, FrontendDashboardBikePin>
+): FrontendVehicle[] {
+  const sign = dir === "asc" ? 1 : -1;
+  const lookupRider = (v: FrontendVehicle): string | null => {
+    const riderId = bikeActiveRiderById?.get(v.id ?? v.slug) ?? null;
+    return riderId ? riderInfoById?.get(riderId)?.name ?? null : null;
+  };
+  const lookupSoc = (v: FrontendVehicle): number => {
+    const pin = bikePinById.get(v.id ?? v.slug);
+    // 텔레메트리 없는 차량은 정렬상 최하단(asc) / 최상단(desc) 어디로 갈지
+    // 통일성 위해 큰 음수로 두어 asc 시 맨 위로 — "값 없음" 이 운영자에게는
+    // 잘 보여야 처치가 가능하니까.
+    return pin?.batteryPercent ?? -1;
+  };
+  return [...vehicles].sort((a, b) => {
+    switch (key) {
+      case "idx":
+        return ((a.idx ?? Number.MAX_SAFE_INTEGER) - (b.idx ?? Number.MAX_SAFE_INTEGER)) * sign;
+      case "plate":
+        return a.plateNumber.localeCompare(b.plateNumber) * sign;
+      case "model":
+        return a.model.localeCompare(b.model) * sign;
+      case "status":
+        return (a.status === b.status ? 0 : a.status === "운행" ? -1 : 1) * sign;
+      case "rider": {
+        const an = lookupRider(a) ?? "";
+        const bn = lookupRider(b) ?? "";
+        if (!an && !bn) return 0;
+        if (!an) return 1;
+        if (!bn) return -1;
+        return an.localeCompare(bn) * sign;
+      }
+      case "soc":
+        return (lookupSoc(a) - lookupSoc(b)) * sign;
+    }
+  });
+}
+
 export type { ReactNode };


### PR DESCRIPTION
## Summary
EVN Logistics 의 "차량 현황" UI 를 참고해 /overview?tab=vehicles 패널을 정리. 데이터 모델은 그대로, UI/UX 만 차용.

### Filter bar (5)
- 검색 (차량번호 / VIN substring)
- 운영 상태 dropdown (전체 / 운영중 / 대기)
- 라이더 배정 filter (전체 / 배정됨 / 미배정)
- 저전압 toggle (≤ 20% SOC, 텔레메트리 없으면 제외)
- 지도 보기 토글
- 우측 count chip (e.g., "38 / 105")

### Columns 5 → 8
\`호기 (idx) / 차량번호 / VIN / 모델 / 운영 상태 / 라이더 / SOC / 작업\`
- 정렬 가능: 호기 / 차량번호 / 모델 / 운영상태 / 라이더 / SOC
- 운영 상태 badge tone (active = green, muted = grey)
- SOC 임계값 색상 (high green / mid amber / low red, \`--rm-battery-*\`)

### 지도 보기 분할
- ON: 50/50 그리드, 좌 리스트, 우 \`MapShell\` 임베드
- 필터가 표 + 지도 마커 둘 다에 동시 적용 (visible bike pins 만 마커)
- \`/monitoring\` 페이지는 그대로 — 흡수/제거는 별도 PR 에서 결정

### 데이터 와이어링
- \`page.tsx\` 가 \`mapState.data.bikePins\` 를 \`<VehiclesPanel bikePins={...} />\` 로 전달
- VehiclesPanel 내부에서 \`Map<bikeId, BikePin>\` 으로 fold 해 SOC + 지도 마커 lookup

### 의도적으로 빠진 (스키마 / 백엔드 필요)
- 플릿 컬럼 + 필터 (운영사 도메인 추가 필요)
- 운영 유형 (직영 / 구독 / 판매 — 계약 도메인 매핑 별도)
- 배터리 전압 컬럼 (텔레메트리 필드 추가)
- 다운로드 / 업로드 버튼 (백엔드 endpoint)
- 정비 / 사고 / 변경 이력 탭

## Test plan
- [ ] /overview?tab=vehicles 가 새 8컬럼으로 뜨고 데이터 정상
- [ ] 검색에 차량번호 / VIN 일부 입력 → 즉시 필터링
- [ ] 운영 상태 / 라이더 / 저전압 필터 각각 동작 + 조합
- [ ] count chip 이 filter 결과 / 전체 비율 표시
- [ ] 헤더 클릭 시 정렬 (↑↓ 토글)
- [ ] 지도 보기 ON 시 우측에 지도 + 필터된 차량 마커만
- [ ] row 클릭 시 기존 VehicleDetailDialog 그대로 작동