### PR TITLE
Set Chrome tab title to "CLEVER 썬더크루"

### DIFF
--- a/development/front-admin-web/app/layout.tsx
+++ b/development/front-admin-web/app/layout.tsx
@@ -4,7 +4,7 @@ import { AppShell } from "@/components/layout/AppShell";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "thundercrew-domain",
+  title: "CLEVER 썬더크루",
   description: "전기 이륜차 관제 및 운영 관리 웹 서비스"
 };
 


### PR DESCRIPTION
## Summary
- Replace the dev-facing repo name `thundercrew-domain` in `<title>` with the product label `CLEVER 썬더크루` so the browser tab matches what users expect.

## Test plan
- [ ] Visit any page on the deployed site and confirm the Chrome tab reads `CLEVER 썬더크루`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)