### PR TITLE
Release: EVN-mirror vehicles panel + Chrome tab title

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -381,21 +381,36 @@ textarea { padding-top: 10px; min-height: 96px; }
    (.table tr:hover td 의 mint-04 와 동일 톤) + 커서 포인터. */
 .table-row-clickable { cursor: pointer; }
 
-/* /overview vehicles 패널 ─ EVN 차량 현황 페이지 참고. 필터 바 + 8컬럼
-   테이블 + (옵션) 우측 지도 분할. */
+/* /overview vehicles 패널 ─ EVN 차량 현황 페이지 레이아웃을 mirror.
+   2줄 필터 + 액션 버튼 row + 12컬럼 테이블 (+ 옵션 지도 분할). 색은 우리
+   `--rm-*` 토큰만 사용. */
 .vehicles-panel { display: flex; flex-direction: column; gap: 12px; }
-.vehicles-filter-bar { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; padding: 10px 12px; border-radius: 10px; background: var(--color-bg-soft); }
-.vehicles-filter-bar .vehicles-filter-search { flex: 1 1 200px; min-width: 160px; height: 32px; padding: 0 12px; border: 0; border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-family: inherit; }
-.vehicles-filter-bar .vehicles-filter-select { height: 32px; padding: 0 8px; border: 0; border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-family: inherit; }
-.vehicles-filter-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--color-text-secondary); cursor: pointer; user-select: none; }
-.vehicles-filter-toggle input[type="checkbox"] { width: 14px; height: 14px; accent-color: var(--rm-accent); cursor: pointer; }
+.vehicles-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; padding: 10px 0; }
+.vehicles-filter-search-wrap { position: relative; flex: 0 1 220px; min-width: 180px; }
+.vehicles-filter-search { width: 100%; height: 38px; padding: 0 36px 0 12px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; }
+.vehicles-filter-search:focus { outline: 2px solid var(--rm-accent); outline-offset: -1px; border-color: transparent; }
+.vehicles-filter-search-icon { position: absolute; right: 10px; top: 50%; transform: translateY(-50%); font-size: 14px; opacity: 0.55; pointer-events: none; }
+.vehicles-filter-select { flex: 0 1 160px; min-width: 130px; height: 38px; padding: 0 10px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; cursor: pointer; }
+.vehicles-filter-select:disabled { opacity: 0.5; cursor: not-allowed; }
+.vehicles-filter-toggle { display: inline-flex; align-items: center; gap: 8px; padding: 0 10px; font-size: 13px; color: var(--color-text-primary); cursor: pointer; user-select: none; }
+.vehicles-filter-toggle input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--rm-accent); cursor: pointer; }
+.vehicles-filter-toggle--disabled { opacity: 0.5; cursor: not-allowed; }
+.vehicles-filter-toggle--disabled input[type="checkbox"] { cursor: not-allowed; }
 .vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
-/* 본문: 리스트 단독 (full width) 또는 리스트 + 지도 (50:50). split 모드에서
-   table-card 의 고정 높이(240px) 는 그대로 유지하고 지도가 그 옆에 같은 높이로 붙음. */
+/* 액션 버튼 row (EVN 의 lime 톤 → 우리 rm-accent 톤으로 치환) */
+.vehicles-action-row { display: flex; align-items: center; gap: 12px; padding: 4px 0; }
+.vehicles-action-button { height: 38px; padding: 0 18px; border: 1px solid var(--rm-accent-outline); border-radius: 8px; background: var(--rm-accent-soft); color: var(--rm-accent); font-size: 13px; font-weight: 700; cursor: pointer; font-family: inherit; }
+.vehicles-action-button:hover:not(:disabled) { background: var(--rm-accent-halo-strong); }
+.vehicles-action-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.vehicles-action-hint { margin-left: auto; font-size: 12px; color: var(--color-text-muted); }
+/* 본문: 리스트 단독 또는 리스트 + 지도 (50:50). */
 .vehicles-panel-body { display: grid; grid-template-columns: 1fr; gap: 12px; }
 .vehicles-panel--split .vehicles-panel-body { grid-template-columns: 1fr 1fr; }
-.vehicles-panel-map { position: relative; height: 240px; border-radius: 10px; overflow: hidden; background: var(--rm-map-block); }
-.vehicles-cell-mono { font-family: var(--font-sans); font-variant-numeric: tabular-nums; }
+.vehicles-panel-map { position: relative; height: 480px; border-radius: 10px; overflow: hidden; background: var(--rm-map-block); }
+/* 12컬럼 테이블은 좁은 화면에선 가로 스크롤 — table-card 자체에 width 잠금. */
+.vehicles-table-scroll { height: 480px; overflow: auto; }
+.vehicles-table { min-width: 1280px; table-layout: auto; }
+.vehicles-cell-mono { font-family: var(--font-sans); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .vehicles-sort-button { display: inline-flex; align-items: center; gap: 4px; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; font-weight: 700; cursor: pointer; }
 .vehicles-sort-button.is-active { color: var(--rm-accent); }
 .vehicles-sort-arrow { font-size: 10px; opacity: 0.6; }
@@ -404,6 +419,16 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-soc--high { color: var(--rm-battery-high); }
 .vehicles-soc--mid { color: var(--rm-battery-mid); }
 .vehicles-soc--low { color: var(--rm-battery-low); }
+/* 상태 pill — EVN 의 톤색을 우리 토큰으로 매핑.
+   운영중 = battery-high(녹), 유휴 = muted, 운행중 = accent(파/민트),
+   시동 ON = battery-high, 시동 OFF = muted, 상태없음 = battery-low-soft */
+.vehicles-pill { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 11px; font-weight: 700; white-space: nowrap; line-height: 1.4; }
+.vehicles-pill--operating { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
+.vehicles-pill--idle { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
+.vehicles-pill--driving { background: var(--rm-accent-soft); color: var(--rm-accent); border: 1px solid var(--rm-accent-outline); }
+.vehicles-pill--ignition-on { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
+.vehicles-pill--ignition-off { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
+.vehicles-pill--unknown { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); border: 1px solid var(--rm-battery-low-line); }
 .table-row-clickable[draggable="true"] { cursor: grab; }
 .table-row-clickable[draggable="true"]:active { cursor: grabbing; }
 /* 인라인 매칭 등록 폼. 슬롯 두 개(라이더·차량) + 양식 select + 시작일 + 등록 버튼

--- a/development/front-admin-web/app/layout.tsx
+++ b/development/front-admin-web/app/layout.tsx
@@ -4,7 +4,7 @@ import { AppShell } from "@/components/layout/AppShell";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "thundercrew-domain",
+  title: "CLEVER 썬더크루",
   description: "전기 이륜차 관제 및 운영 관리 웹 서비스"
 };
 

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, type ReactNode } from "react";
 
-import { Badge } from "@/components/ui/Badge";
 import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
@@ -15,46 +14,58 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * `/overview?tab=vehicles` 의 차량 현황 패널. EVN Logistics 의 차량 현황
- * 페이지를 참고해 정리한 구조 — UI/UX 만 차용하고 도메인 모델은 우리 것
- * 그대로 사용:
+ * `/overview?tab=vehicles` 의 차량 현황 패널. EVN Logistics 차량 현황 UI 의
+ * 레이아웃 / 컴포넌트 배치를 그대로 옮기고 색상만 우리 테마 토큰을 사용.
  *
- * - 필터 바: 검색 (plate / VIN), 운영 상태, 라이더 배정, 저전압
- * - 컬럼: 호기(idx) / 차량번호 / VIN / 모델 / 운영 상태 / 라이더 / SOC / 작업
- * - 헤더 정렬 가능 (호기 / 차량번호 / 모델 / 운영상태 / 라이더명 / SOC)
- * - 지도 보기 토글: ON 이면 좌 리스트 / 우 지도 의 50:50 분할 — 우리 기존
- *   MapShell 을 그대로 임베드해서 monitoring 페이지와 같은 마커 시각화 사용
+ * 두 줄 필터 → 액션 버튼 row → 12컬럼 테이블 (+ 옵션 지도 분할) 구조.
  *
- * 필드 매핑:
- * - 호기 = FrontendVehicle.idx (DB 의 bigserial idx)
- * - VIN = FrontendVehicle.vin
- * - SOC = bikePin.batteryPercent (텔레메트리 — 없으면 "—")
- * - 운영상태 = FrontendVehicle.status (운행 / 대기) — badge 로 표시
+ * 데이터 매핑:
+ * - 호기 ← FrontendVehicle.idx
+ * - VIN ← FrontendVehicle.vin
+ * - 플릿 ← (도메인 없음, "—" 표시 + 필터 disabled)
+ * - 배치현황 ← operationStatus 매핑 (READY → 유휴, IN_SERVICE → 운영중).
+ *   수리·대기중 / 미출고 는 backend 가 아직 모르므로 필터 옵션엔 있지만
+ *   매칭되는 row 가 없다.
+ * - 운영 구분 ← (계약 도메인 매핑 미정, "—" + 필터 disabled)
+ * - 운전자 ← rider name (매칭된 라이더)
+ * - SOC ← bikePin.batteryPercent (텔레메트리)
+ * - 배터리 전압 ← (텔레메트리 필드 없음, "—" + 필터 disabled)
+ * - 운행 상태 ← bikePin.drivingStatus (DRIVING / PARKED → 운행중 / 유휴)
+ * - 차량 상태 ← bikePin.ignitionStatus + connectionStatus → 사람 친화 라벨
+ *
+ * 비활성 필터/액션 (다운로드, 업로드, 운행계획없음, 점검필요, 플릿 등) 은
+ * UI 만 두고 "준비 중" 으로 disabled — 백엔드 / 도메인 확장 시 활성화.
  */
 
+type DeploymentFilter = "ALL" | "OPERATING" | "IDLE" | "REPAIR" | "PRE_DEPLOY";
 type FilterState = {
   query: string;
-  operationStatus: "ALL" | "READY" | "IN_SERVICE";
-  riderAssignment: "ALL" | "ASSIGNED" | "UNASSIGNED";
-  lowBatteryOnly: boolean;
+  vehicleState: "ALL" | "IDLE" | "REPAIR" | "CHARGING";
+  fleet: "ALL"; // 도메인 없음, 단일 옵션
+  deployment: DeploymentFilter;
+  operationType: "ALL"; // 도메인 없음
+  socFilter: "ALL" | "LOW";
+  voltageFilter: "ALL"; // 도메인 없음
+  noPlanOnly: boolean; // 데이터 없음
+  needsCheckOnly: boolean; // 데이터 없음
 };
 
-type SortKey = "idx" | "plate" | "model" | "status" | "rider" | "soc";
+type SortKey = "idx" | "plate" | "model" | "deployment" | "rider" | "soc";
 type SortDir = "asc" | "desc";
 
 const DEFAULT_FILTERS: FilterState = {
   query: "",
-  operationStatus: "ALL",
-  riderAssignment: "ALL",
-  lowBatteryOnly: false
+  vehicleState: "ALL",
+  fleet: "ALL",
+  deployment: "ALL",
+  operationType: "ALL",
+  socFilter: "ALL",
+  voltageFilter: "ALL",
+  noPlanOnly: false,
+  needsCheckOnly: false
 };
 
 const LOW_BATTERY_THRESHOLD = 20;
-
-const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
-  READY: "대기",
-  IN_SERVICE: "운행"
-};
 
 export function VehiclesPanel({
   data,
@@ -65,7 +76,6 @@ export function VehiclesPanel({
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
-  /** 지도 보기 + SOC 컬럼 채우는데 쓰는 텔레메트리 핀. dashboard map-state 의 bikePins 그대로. */
   bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
@@ -74,7 +84,6 @@ export function VehiclesPanel({
   const [sortKey, setSortKey] = useState<SortKey>("idx");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
-  // bikeId → 텔레메트리 핀. SOC 노출 + 저전압 필터 + 지도 마커 필터링에 사용.
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
     for (const pin of bikePins ?? []) {
@@ -83,42 +92,46 @@ export function VehiclesPanel({
     return map;
   }, [bikePins]);
 
-  // filter + sort 를 한 번에 통과시킨 결과. 표 / 지도 둘 다 같은 집합 사용.
   const visibleVehicles = useMemo(() => {
     const q = filters.query.trim().toLowerCase();
     const filtered = data.vehicles.filter((vehicle) => {
-      // 검색: plate / VIN substring
       if (q) {
         const plateMatch = vehicle.plateNumber.toLowerCase().includes(q);
         const vinMatch = (vehicle.vin ?? "").toLowerCase().includes(q);
         if (!plateMatch && !vinMatch) return false;
       }
-      // 운영 상태
-      if (filters.operationStatus !== "ALL") {
-        const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
-        if (op !== filters.operationStatus) return false;
+      const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
+      // 배치현황 필터: OPERATING(=운영중) 은 IN_SERVICE, IDLE(=유휴) 는 READY.
+      // REPAIR / PRE_DEPLOY 는 우리 데이터에 매칭 row 가 없어서 항상 0건.
+      if (filters.deployment !== "ALL") {
+        if (filters.deployment === "OPERATING" && op !== "IN_SERVICE") return false;
+        if (filters.deployment === "IDLE" && op !== "READY") return false;
+        if (filters.deployment === "REPAIR") return false;
+        if (filters.deployment === "PRE_DEPLOY") return false;
       }
-      // 라이더 배정
-      if (filters.riderAssignment !== "ALL") {
-        const vehicleKey = vehicle.id ?? vehicle.slug;
-        const hasRider = Boolean(bikeActiveRiderById?.get(vehicleKey));
-        if (filters.riderAssignment === "ASSIGNED" && !hasRider) return false;
-        if (filters.riderAssignment === "UNASSIGNED" && hasRider) return false;
-      }
-      // 저전압: 텔레메트리가 있고 batteryPercent ≤ 20 인 차량만
-      if (filters.lowBatteryOnly) {
-        const vehicleKey = vehicle.id ?? vehicle.slug;
+      const vehicleKey = vehicle.id ?? vehicle.slug;
+      if (filters.socFilter === "LOW") {
         const pin = bikePinById.get(vehicleKey);
         if (pin?.batteryPercent === null || pin?.batteryPercent === undefined) return false;
         if (pin.batteryPercent > LOW_BATTERY_THRESHOLD) return false;
+      }
+      // 차량 상태(EVN: 유휴 차량 / 정비중 / 충전 필요) 우리 대응:
+      // 유휴 = drivingStatus PARKED, 충전 필요 = SOC ≤ threshold,
+      // 정비중 은 데이터 없음.
+      if (filters.vehicleState !== "ALL") {
+        const pin = bikePinById.get(vehicleKey);
+        if (filters.vehicleState === "IDLE" && pin?.drivingStatus !== "PARKED") return false;
+        if (filters.vehicleState === "CHARGING") {
+          if (pin?.batteryPercent === null || pin?.batteryPercent === undefined) return false;
+          if (pin.batteryPercent > LOW_BATTERY_THRESHOLD) return false;
+        }
+        if (filters.vehicleState === "REPAIR") return false;
       }
       return true;
     });
     return sortVehicles(filtered, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById);
   }, [data.vehicles, filters, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById]);
 
-  // 지도 보기에 넘길 마커 — 화면에 보이는 차량만 마커로. mapState 의 핀 중에서
-  // 매칭되는 것만 골라서 MapShell 의 입력으로.
   const visibleBikePins = useMemo(() => {
     if (!mapView) return [];
     const visibleIds = new Set(visibleVehicles.map((v) => v.id ?? v.slug));
@@ -136,7 +149,8 @@ export function VehiclesPanel({
 
   return (
     <div className={`vehicles-panel ${mapView ? "vehicles-panel--split" : ""}`}>
-      <div className="vehicles-filter-bar">
+      {/* 필터 행 1: 지도보기 / 검색 / 차량상태 / 플릿 / 배치현황 / 운영유형 / SOC */}
+      <div className="vehicles-filter-row">
         <label className="vehicles-filter-toggle">
           <input
             type="checkbox"
@@ -145,77 +159,115 @@ export function VehiclesPanel({
           />
           <span>지도 보기</span>
         </label>
-        <input
-          className="vehicles-filter-search"
-          type="search"
-          placeholder="차량번호 또는 VIN 검색"
-          value={filters.query}
-          onChange={(event) => setFilters({ ...filters, query: event.target.value })}
-        />
-        <select
-          className="vehicles-filter-select"
-          value={filters.operationStatus}
-          onChange={(event) =>
-            setFilters({ ...filters, operationStatus: event.target.value as FilterState["operationStatus"] })
-          }
-        >
-          <option value="ALL">운영 상태: 전체</option>
-          <option value="IN_SERVICE">운영중</option>
-          <option value="READY">대기</option>
-        </select>
-        <select
-          className="vehicles-filter-select"
-          value={filters.riderAssignment}
-          onChange={(event) =>
-            setFilters({ ...filters, riderAssignment: event.target.value as FilterState["riderAssignment"] })
-          }
-        >
-          <option value="ALL">라이더: 전체</option>
-          <option value="ASSIGNED">배정됨</option>
-          <option value="UNASSIGNED">미배정</option>
-        </select>
-        <label className="vehicles-filter-toggle">
+        <div className="vehicles-filter-search-wrap">
           <input
-            type="checkbox"
-            checked={filters.lowBatteryOnly}
-            onChange={(event) => setFilters({ ...filters, lowBatteryOnly: event.target.checked })}
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="차량번호, VIN"
+            value={filters.query}
+            onChange={(event) => setFilters({ ...filters, query: event.target.value })}
           />
-          <span>저전압만 (≤ {LOW_BATTERY_THRESHOLD}%)</span>
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+        <select
+          className="vehicles-filter-select"
+          value={filters.vehicleState}
+          onChange={(event) =>
+            setFilters({ ...filters, vehicleState: event.target.value as FilterState["vehicleState"] })
+          }
+        >
+          <option value="ALL">차량 상태</option>
+          <option value="IDLE">유휴 차량</option>
+          <option value="REPAIR" disabled>정비중 (준비중)</option>
+          <option value="CHARGING">충전 필요</option>
+        </select>
+        <select className="vehicles-filter-select" disabled value="ALL" title="플릿(운영사) 도메인 추가 후 활성화 예정">
+          <option value="ALL">플릿 (준비중)</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.deployment}
+          onChange={(event) =>
+            setFilters({ ...filters, deployment: event.target.value as DeploymentFilter })
+          }
+        >
+          <option value="ALL">배치 현황</option>
+          <option value="OPERATING">운영중</option>
+          <option value="IDLE">유휴</option>
+          <option value="REPAIR" disabled>수리/대기중 (준비중)</option>
+          <option value="PRE_DEPLOY" disabled>미출고 (준비중)</option>
+        </select>
+        <select className="vehicles-filter-select" disabled value="ALL" title="운영 유형(직영/구독/판매) 매핑 추가 후 활성화">
+          <option value="ALL">운영 유형 (준비중)</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.socFilter}
+          onChange={(event) =>
+            setFilters({ ...filters, socFilter: event.target.value as FilterState["socFilter"] })
+          }
+        >
+          <option value="ALL">배터리 SOC</option>
+          <option value="LOW">저전압 (≤ {LOW_BATTERY_THRESHOLD}%)</option>
+        </select>
+      </div>
+
+      {/* 필터 행 2: 배터리 전압 / 운행 계획 없음 / 점검 필요 */}
+      <div className="vehicles-filter-row">
+        <select className="vehicles-filter-select" disabled value="ALL" title="배터리 전압 telemetry 필드 추가 후 활성화">
+          <option value="ALL">배터리 전압 (준비중)</option>
+        </select>
+        <label className="vehicles-filter-toggle vehicles-filter-toggle--disabled" title="배송 계획 도메인 연동 후 활성화">
+          <input type="checkbox" disabled checked={filters.noPlanOnly} onChange={() => {}} />
+          <span>운행 계획 없음 (준비중)</span>
+        </label>
+        <label className="vehicles-filter-toggle vehicles-filter-toggle--disabled" title="단말기 진단 코드 도메인 연동 후 활성화">
+          <input type="checkbox" disabled checked={filters.needsCheckOnly} onChange={() => {}} />
+          <span>에러코드 또는 단말기 점검 필요 (준비중)</span>
         </label>
         <span className="vehicles-filter-count">
           {visibleVehicles.length} / {data.vehicles.length}
         </span>
       </div>
 
+      {/* 액션 버튼 row */}
+      <div className="vehicles-action-row">
+        <button type="button" className="vehicles-action-button" disabled title="CSV / XLSX 추출 API 추가 후 활성화">
+          다운로드
+        </button>
+        <button type="button" className="vehicles-action-button" disabled title="Bulk import API 추가 후 활성화">
+          업로드
+        </button>
+        {/* "새 차량 추가" 는 page tab-action 영역에 이미 마운트되어 있음 — 중복
+            방지를 위해 여기서는 안내 텍스트만. 위치 통일이 필요하면 다음
+            iteration 에서 page.tsx 의 tab-action 을 비우고 여기로 이동. */}
+        <span className="vehicles-action-hint">새 차량 추가 ↗ 우측 상단</span>
+      </div>
+
       <div className="vehicles-panel-body">
-        <div className="table-card">
-          <table className="table" style={{ tableLayout: "fixed" }}>
-            <colgroup>
-              <col style={{ width: "60px" }} />
-              <col />
-              <col />
-              <col />
-              <col style={{ width: "92px" }} />
-              <col />
-              <col style={{ width: "80px" }} />
-              <col style={{ width: "72px" }} />
-            </colgroup>
+        <div className="table-card vehicles-table-scroll">
+          <table className="table vehicles-table">
             <thead>
               <tr>
                 <SortableHeader label="호기" sortKey="idx" current={sortKey} dir={sortDir} onSort={handleSort} />
                 <SortableHeader label="차량번호" sortKey="plate" current={sortKey} dir={sortDir} onSort={handleSort} />
                 <th>VIN</th>
                 <SortableHeader label="모델" sortKey="model" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <SortableHeader label="운영 상태" sortKey="status" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <SortableHeader label="라이더" sortKey="rider" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <th>플릿</th>
+                <SortableHeader label="배치현황" sortKey="deployment" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <th>운영 구분</th>
+                <SortableHeader label="운전자" sortKey="rider" current={sortKey} dir={sortDir} onSort={handleSort} />
                 <SortableHeader label="SOC" sortKey="soc" current={sortKey} dir={sortDir} onSort={handleSort} />
+                <th>배터리 전압</th>
+                <th>운행 상태</th>
+                <th>차량 상태</th>
                 <th style={{ textAlign: "right" }}>작업</th>
               </tr>
             </thead>
             <tbody>
               {visibleVehicles.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className="table-empty-cell">
+                  <td colSpan={13} className="table-empty-cell">
                     조건에 맞는 차량 없음
                   </td>
                 </tr>
@@ -247,10 +299,15 @@ export function VehiclesPanel({
                     <td className="vehicles-cell-mono">{vehicle.idx ?? "—"}</td>
                     <td>{vehicle.plateNumber}</td>
                     <td className="vehicles-cell-mono">{vehicle.vin || <span className="muted">—</span>}</td>
-                    <td>{vehicle.model}</td>
-                    <td>{renderOperationBadge(op)}</td>
+                    <td>{vehicle.model || <span className="muted">—</span>}</td>
+                    <td><span className="muted">—</span></td>
+                    <td>{renderDeploymentBadge(op)}</td>
+                    <td><span className="muted">—</span></td>
                     <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
                     <td>{renderSoc(pin?.batteryPercent)}</td>
+                    <td><span className="muted">—</span></td>
+                    <td>{renderDrivingBadge(pin?.drivingStatus)}</td>
+                    <td>{renderIgnitionState(pin)}</td>
                     <td
                       style={{ textAlign: "right" }}
                       onClick={(event) => event.stopPropagation()}
@@ -309,9 +366,32 @@ function SortableHeader({
   );
 }
 
-function renderOperationBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
-  if (op === "IN_SERVICE") return <Badge tone="active">{STATUS_LABEL[op]}</Badge>;
-  return <Badge tone="muted">{STATUS_LABEL[op]}</Badge>;
+function renderDeploymentBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
+  const isOperating = op === "IN_SERVICE";
+  return (
+    <span className={`vehicles-pill vehicles-pill--${isOperating ? "operating" : "idle"}`}>
+      {isOperating ? "운영중" : "유휴"}
+    </span>
+  );
+}
+
+function renderDrivingBadge(drivingStatus: string | undefined): ReactNode {
+  if (!drivingStatus) return <span className="muted">—</span>;
+  if (drivingStatus === "DRIVING") {
+    return <span className="vehicles-pill vehicles-pill--driving">운행중</span>;
+  }
+  return <span className="vehicles-pill vehicles-pill--idle">유휴</span>;
+}
+
+function renderIgnitionState(pin: FrontendDashboardBikePin | undefined): ReactNode {
+  if (!pin) return <span className="vehicles-pill vehicles-pill--unknown">상태없음 (No Status)</span>;
+  if (pin.ignitionStatus === "ON") {
+    return <span className="vehicles-pill vehicles-pill--ignition-on">ON (시동이 켜진 상태)</span>;
+  }
+  if (pin.ignitionStatus === "OFF") {
+    return <span className="vehicles-pill vehicles-pill--ignition-off">OFF (시동이 꺼진 상태)</span>;
+  }
+  return <span className="vehicles-pill vehicles-pill--unknown">상태없음 (No Status)</span>;
 }
 
 function renderSoc(percent: number | null | undefined): ReactNode {
@@ -343,9 +423,6 @@ function sortVehicles(
   };
   const lookupSoc = (v: FrontendVehicle): number => {
     const pin = bikePinById.get(v.id ?? v.slug);
-    // 텔레메트리 없는 차량은 정렬상 최하단(asc) / 최상단(desc) 어디로 갈지
-    // 통일성 위해 큰 음수로 두어 asc 시 맨 위로 — "값 없음" 이 운영자에게는
-    // 잘 보여야 처치가 가능하니까.
     return pin?.batteryPercent ?? -1;
   };
   return [...vehicles].sort((a, b) => {
@@ -356,7 +433,7 @@ function sortVehicles(
         return a.plateNumber.localeCompare(b.plateNumber) * sign;
       case "model":
         return a.model.localeCompare(b.model) * sign;
-      case "status":
+      case "deployment":
         return (a.status === b.status ? 0 : a.status === "운행" ? -1 : 1) * sign;
       case "rider": {
         const an = lookupRider(a) ?? "";


### PR DESCRIPTION
## Summary
- Mirror EVN logistics' vehicle-list layout: 2-row filter bar (9 controls), 12-column table, action button row (#225)
- Set Chrome tab title to `CLEVER 썬더크루` so the browser tab matches the product label instead of the dev repo name (#226)

## Test plan
- [ ] `/overview?tab=vehicles` shows the 12-column EVN-mirror table with filters above and action buttons
- [ ] Filters and sorting work; placeholder/disabled controls are clearly disabled
- [ ] Map split toggle still renders both list and map together
- [ ] Chrome tab on any page reads `CLEVER 썬더크루`

🤖 Generated with [Claude Code](https://claude.com/claude-code)