### PR TITLE
Release: unified /overview page

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -161,43 +161,29 @@ button, input, select, textarea { font: inherit; }
 .app-main { min-height: 100vh; }
 .page-container { width: min(100% - 48px, 1200px); margin: 0 auto; padding-bottom: 96px; }
 
-/* Sidebar — designs/rider-position-monitor.pen Component/{Light,Dark}/SidebarRail.
-   Floats over the page content (no layout reservation) and sizes itself to
-   its children. Vertically centered so the rail looks anchored regardless
-   of viewport height. */
-.sidebar {
+/* Top-right floating action bar. 좌측 사이드바 레일을 걷어내고 테마 토글 +
+   로그아웃 두 액션만 한 곳에 모아 띄운다. fixed 라 레이아웃 폭을 잡아먹지
+   않아 본문은 페이지 가운데 정렬(1200px max-width) 그대로. */
+.top-actions {
   position: fixed;
-  top: 50%;
-  left: 16px;
-  transform: translateY(-50%);
+  top: 16px;
+  right: 16px;
   z-index: 80;
-  width: 64px;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 8px;
-  padding: 14px 8px;
+  gap: 6px;
+  padding: 6px 8px;
   background: var(--rm-bg-panel);
-  border-radius: 32px;
+  border-radius: 999px;
   backdrop-filter: blur(20px);
   box-shadow: 0 0 0 1px var(--rm-overlay-line-strong), 0 24px 64px var(--rm-shadow-strong);
 }
+.top-actions-form { margin: 0; display: flex; }
 
-.sidebar-brand {
-  display: grid; place-items: center;
-  width: 44px; height: 44px;
-  border-radius: var(--rm-radius-md);
-  background: var(--rm-accent-soft); color: var(--rm-accent);
-  text-decoration: none;
-  box-shadow: 0 0 0 1px var(--rm-accent-outline);
-}
-.brand-mark { font-size: 14px; font-weight: 900; letter-spacing: -0.04em; }
-
-.sidebar-nav {
-  display: flex; flex-direction: column; align-items: center; gap: 4px;
-  width: 100%;
-}
-
+/* .sidebar-link / -icon / -label 은 top-actions 안의 아이콘 버튼이 그대로
+   재사용한다 — 좌측 레일 시절의 시각 톤(원형 hover, 액티브 액센트)을 그대로
+   유지하기 위해 클래스명을 유지. */
 .sidebar-link {
   display: grid; place-items: center;
   width: 44px; height: 44px;
@@ -210,22 +196,10 @@ button, input, select, textarea { font: inherit; }
   transition: background .12s ease, color .12s ease, box-shadow .12s ease;
 }
 .sidebar-link:hover { background: var(--rm-bg-section); color: var(--rm-text-primary); }
-.sidebar-link.is-active,
-.sidebar-link[aria-current="page"] {
-  background: var(--rm-accent-soft);
-  color: var(--rm-accent);
-  box-shadow: 0 0 0 1px var(--rm-accent-outline);
-}
 .sidebar-icon { font-size: 18px; font-weight: 800; line-height: 1; }
 .sidebar-label {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
-}
-
-.sidebar-bottom {
-  display: flex; flex-direction: column; align-items: center; gap: 6px;
-  padding-top: 12px; border-top: 1px solid var(--rm-line-subtle);
-  width: 100%;
 }
 
 .management-subnav { display: flex; flex-wrap: wrap; gap: 8px; margin: -8px 0 20px; }
@@ -381,54 +355,40 @@ textarea { padding-top: 10px; min-height: 96px; }
    (.table tr:hover td 의 mint-04 와 동일 톤) + 커서 포인터. */
 .table-row-clickable { cursor: pointer; }
 
-/* /overview vehicles 패널 ─ EVN 차량 현황 페이지 레이아웃을 mirror.
-   2줄 필터 + 액션 버튼 row + 12컬럼 테이블 (+ 옵션 지도 분할). 색은 우리
-   `--rm-*` 토큰만 사용. */
+/* /overview vehicles 패널 — 10컬럼 단순 구조. 검색 한 줄 + 운영 상태 select
+   하나 + 카운트만. 색 토큰은 우리 `--rm-*` 그대로. */
 .vehicles-panel { display: flex; flex-direction: column; gap: 12px; }
 .vehicles-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; padding: 10px 0; }
-.vehicles-filter-search-wrap { position: relative; flex: 0 1 220px; min-width: 180px; }
+.vehicles-filter-search-wrap { position: relative; flex: 0 1 280px; min-width: 220px; }
 .vehicles-filter-search { width: 100%; height: 38px; padding: 0 36px 0 12px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; }
 .vehicles-filter-search:focus { outline: 2px solid var(--rm-accent); outline-offset: -1px; border-color: transparent; }
 .vehicles-filter-search-icon { position: absolute; right: 10px; top: 50%; transform: translateY(-50%); font-size: 14px; opacity: 0.55; pointer-events: none; }
 .vehicles-filter-select { flex: 0 1 160px; min-width: 130px; height: 38px; padding: 0 10px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; cursor: pointer; }
-.vehicles-filter-select:disabled { opacity: 0.5; cursor: not-allowed; }
-.vehicles-filter-toggle { display: inline-flex; align-items: center; gap: 8px; padding: 0 10px; font-size: 13px; color: var(--color-text-primary); cursor: pointer; user-select: none; }
-.vehicles-filter-toggle input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--rm-accent); cursor: pointer; }
-.vehicles-filter-toggle--disabled { opacity: 0.5; cursor: not-allowed; }
-.vehicles-filter-toggle--disabled input[type="checkbox"] { cursor: not-allowed; }
 .vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
-/* 액션 버튼 row (EVN 의 lime 톤 → 우리 rm-accent 톤으로 치환) */
-.vehicles-action-row { display: flex; align-items: center; gap: 12px; padding: 4px 0; }
-.vehicles-action-button { height: 38px; padding: 0 18px; border: 1px solid var(--rm-accent-outline); border-radius: 8px; background: var(--rm-accent-soft); color: var(--rm-accent); font-size: 13px; font-weight: 700; cursor: pointer; font-family: inherit; }
-.vehicles-action-button:hover:not(:disabled) { background: var(--rm-accent-halo-strong); }
-.vehicles-action-button:disabled { opacity: 0.5; cursor: not-allowed; }
-.vehicles-action-hint { margin-left: auto; font-size: 12px; color: var(--color-text-muted); }
-/* 본문: 리스트 단독 또는 리스트 + 지도 (50:50). */
-.vehicles-panel-body { display: grid; grid-template-columns: 1fr; gap: 12px; }
-.vehicles-panel--split .vehicles-panel-body { grid-template-columns: 1fr 1fr; }
-.vehicles-panel-map { position: relative; height: 480px; border-radius: 10px; overflow: hidden; background: var(--rm-map-block); }
-/* 12컬럼 테이블은 좁은 화면에선 가로 스크롤 — table-card 자체에 width 잠금. */
-.vehicles-table-scroll { height: 480px; overflow: auto; }
-.vehicles-table { min-width: 1280px; table-layout: auto; }
+/* 10컬럼 테이블은 좁은 화면에선 가로 스크롤. */
+.vehicles-table-scroll { max-height: 560px; overflow: auto; }
+.vehicles-table { min-width: 1080px; table-layout: auto; }
 .vehicles-cell-mono { font-family: var(--font-sans); font-variant-numeric: tabular-nums; white-space: nowrap; }
-.vehicles-sort-button { display: inline-flex; align-items: center; gap: 4px; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; font-weight: 700; cursor: pointer; }
-.vehicles-sort-button.is-active { color: var(--rm-accent); }
-.vehicles-sort-arrow { font-size: 10px; opacity: 0.6; }
-.vehicles-sort-button.is-active .vehicles-sort-arrow { opacity: 1; }
 .vehicles-soc { font-variant-numeric: tabular-nums; font-weight: 700; }
 .vehicles-soc--high { color: var(--rm-battery-high); }
 .vehicles-soc--mid { color: var(--rm-battery-mid); }
 .vehicles-soc--low { color: var(--rm-battery-low); }
-/* 상태 pill — EVN 의 톤색을 우리 토큰으로 매핑.
-   운영중 = battery-high(녹), 유휴 = muted, 운행중 = accent(파/민트),
-   시동 ON = battery-high, 시동 OFF = muted, 상태없음 = battery-low-soft */
+/* 상태 pill — 운영중 = battery-high(녹), 유휴 = muted, 시동 ON = battery-high,
+   시동 OFF = muted, 신호 끊김/상태없음 = battery-low-soft. */
 .vehicles-pill { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 11px; font-weight: 700; white-space: nowrap; line-height: 1.4; }
 .vehicles-pill--operating { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
 .vehicles-pill--idle { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
-.vehicles-pill--driving { background: var(--rm-accent-soft); color: var(--rm-accent); border: 1px solid var(--rm-accent-outline); }
 .vehicles-pill--ignition-on { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
 .vehicles-pill--ignition-off { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
 .vehicles-pill--unknown { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); border: 1px solid var(--rm-battery-low-line); }
+
+/* 글로벌 "지도 보기" 토글 + 캔버스. 페이지 KPI/탭 위에 자리한다. */
+.overview-map-section { display: flex; flex-direction: column; gap: 10px; margin: 20px 0 12px; }
+.overview-map-toggle-row { display: flex; align-items: center; gap: 12px; }
+.overview-map-toggle { display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: var(--rm-accent-soft); color: var(--rm-accent); font-size: 13px; font-weight: 700; cursor: pointer; user-select: none; box-shadow: 0 0 0 1px var(--rm-accent-outline); }
+.overview-map-toggle input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--rm-accent); cursor: pointer; }
+.overview-map-toggle-hint { font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+.overview-map-canvas { position: relative; height: 520px; border-radius: 12px; overflow: hidden; background: var(--rm-map-block); box-shadow: 0 0 0 1px var(--rm-overlay-line-strong); }
 .table-row-clickable[draggable="true"] { cursor: grab; }
 .table-row-clickable[draggable="true"]:active { cursor: grabbing; }
 /* 인라인 매칭 등록 폼. 슬롯 두 개(라이더·차량) + 양식 select + 시작일 + 등록 버튼
@@ -473,6 +433,11 @@ textarea { padding-top: 10px; min-height: 96px; }
 .toggle-switch-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--color-surface); box-shadow: 0 1px 2px rgba(0,0,0,.12), 0 0 0 1px var(--color-border); transition: transform .15s ease; }
 .toggle-switch.is-on .toggle-switch-thumb { transform: translateX(0); background: var(--color-surface); }
 .toggle-switch-text { min-width: 24px; text-align: left; }
+/* 라이더 테이블 행 안에 들어가는 더 작은 인라인 토글. 패딩/뚝지 사이즈만
+   줄이고 색·동작은 기본 toggle-switch 와 동일. */
+.toggle-switch--compact { padding: 2px 10px 2px 2px; font-size: 11px; }
+.toggle-switch--compact .toggle-switch-thumb { width: 14px; height: 14px; }
+.toggle-switch--compact .toggle-switch-text { min-width: 20px; }
 /* Empty-state cell. Sits inside the same table as the data rows so the
    column headers stay visible above it. Height is the card (240px) minus
    the sticky thead row (40px) so the message lands in the visual centre
@@ -590,7 +555,6 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 
 /* Theme toggle and login button reuse the .sidebar-link rail layout. */
-.sidebar-action-form { margin: 0; display: flex; }
 
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 

--- a/development/front-admin-web/app/monitoring/page.tsx
+++ b/development/front-admin-web/app/monitoring/page.tsx
@@ -1,20 +1,12 @@
-import { DashboardCanvas } from "@/components/dashboard/DashboardCanvas";
-import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
+import { redirect } from "next/navigation";
 
-// `loadDashboardMapState` 가 `cookies()` 기반의 인증 클라이언트를 사용한다.
-// Next.js 의 자동 dynamic 감지가 어떤 빌드 경로에선 이 페이지를 정적
-// 렌더 대상으로 잡고 — request time 에 `DYNAMIC_SERVER_USAGE` 로 throw 한다
-// (`prod` /dashboard 가 500 으로 떨어지던 원인). `/overview` 와 동일하게
-// 명시적으로 force-dynamic 선언해서 어떤 빌드/배포 조합에서도 항상 dynamic
-// 렌더로 잠근다.
-export const dynamic = "force-dynamic";
-
-export default async function MonitoringPage() {
-  const initial = await loadDashboardMapState();
-
-  return (
-    <section className="control-map-page" aria-label="지도 기반 관제">
-      <DashboardCanvas initial={initial} />
-    </section>
-  );
+/**
+ * `/monitoring` 은 단일 페이지 통합 이후 폐기되어 `/overview` 로 영구
+ * 리다이렉트한다. 기존 북마크 / sidebar 링크 / 외부 공유 URL 이 그대로
+ * 살아 있도록 라우트는 유지하되 내용은 즉시 이동.
+ *
+ * 지도 자체는 `/overview` 의 글로벌 "지도 보기" 토글로 이동했다.
+ */
+export default function MonitoringPage() {
+  redirect("/overview");
 }

--- a/development/front-admin-web/app/overview/page.tsx
+++ b/development/front-admin-web/app/overview/page.tsx
@@ -8,6 +8,7 @@ import { CreateVehicleDialog } from "@/components/management/CreateVehicleDialog
 import { RidersPanel, type InsuranceOption } from "@/components/management/RidersPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
+import { OverviewMapBanner } from "@/components/overview/OverviewMapBanner";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 import { loadRiderList } from "@/lib/services/rider-data";
 import { loadRiderMatchingSnapshot } from "@/lib/services/rider-matching-snapshot-data";
@@ -23,6 +24,7 @@ import {
 } from "@/lib/services/service-ops-api";
 import { loadStationList } from "@/lib/services/station-data";
 import { loadVehicleList } from "@/lib/services/vehicle-data";
+import { loadVehicleDeviceMap } from "@/lib/services/vehicle-device-data";
 
 // Authenticated, per-admin loader. At build time the env-less mock fallback
 // returns synchronously without touching cookies, which lets Next.js
@@ -62,13 +64,25 @@ export default async function OverviewPage({
 }) {
   // Always fetch the cross-tab datasets so the panels can fill the lookup
   // columns and KPI tiles without a second round-trip on tab switch.
-  const [{ tab: tabParam, status: statusParam }, mapState, riderData, vehicleData, matching, opsExtra] = await Promise.all([
+  // `deviceMap` 은 차량 테이블의 IMEI 컬럼을 N+1 호출 없이 한 번에 채우는
+  // batch lookup. installations + devices 두 list 를 조인해 bikeId → deviceUid
+  // 사전 한 장으로 내려준다.
+  const [
+    { tab: tabParam, status: statusParam },
+    mapState,
+    riderData,
+    vehicleData,
+    matching,
+    opsExtra,
+    deviceMap
+  ] = await Promise.all([
     searchParams,
     loadDashboardMapState(),
     loadRiderList(),
     loadVehicleList(),
     loadRiderMatchingSnapshot(),
-    loadContractsAndInsurances()
+    loadContractsAndInsurances(),
+    loadVehicleDeviceMap()
   ]);
 
   const activeTab: TabKey = isValidTabKey(tabParam) ? tabParam : "vehicles";
@@ -198,6 +212,7 @@ export default async function OverviewPage({
                 bikeActiveRiderById={matching.bikeActiveRiderById}
                 riderInfoById={riderInfoById}
                 bikePins={mapState.data.bikePins}
+                deviceUidByBikeId={deviceMap.deviceUidByBikeId}
               />
             ),
             notice: vehicleData.notice
@@ -211,6 +226,13 @@ export default async function OverviewPage({
           {mapState.notice}
         </p>
       ) : null}
+
+      {/* 글로벌 "지도 보기" 토글. 차량 + BSS 마커를 한 지도에 띄우고, 탭 전환
+          간에도 client-state 가 보존되어 한 번 켜면 모든 탭에서 같이 보인다. */}
+      <OverviewMapBanner
+        bikePins={mapState.data.bikePins}
+        stationPins={mapState.data.stationPins}
+      />
 
       <div className="overview-kpi-groups">
         <article className="kpi-group">

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -1,74 +1,43 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
-import { SidebarPrimaryNav, type SidebarNavItem } from "@/components/layout/SidebarPrimaryNav";
 import { signOutAdmin } from "@/app/login/actions";
 import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
 
-// Overview is the unified management entry point - its tab nav covers
-// the five primary domain hubs (라이더 / 차량 / 스테이션 / 계약 / 보험)
-// so duplicating those entries in the sidebar would just send operators
-// to the same data via two paths. Direct deep-link routes (/riders,
-// /vehicles, etc.) still work via the "전체 관리 화면 →" button on each
-// /overview tab, bookmarks, and direct URL entry.
-//
-// Monitoring 의 아이콘은 "접힌 지도 위에 핀이 박혀 있는" 형태 (NAVER 지도
-// 의 장소 마커 시각화). 위쪽 핀(teardrop + 가운데 구멍) 과 아래쪽 사다리꼴
-// 베이스(원근 표현된 종이 지도) 의 두 path 조합. stroke 기반이라 사이드바
-// 의 currentColor + 1.8px 두께로 light/dark 테마 자동 적응.
-const PinIcon = (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.8"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M4 17l8-2 8 2v3l-8 2-8-2v-3z" />
-    <path d="M12 3a4 4 0 0 0-4 4c0 3 4 6 4 6s4-3 4-6a4 4 0 0 0-4-4z" />
-    <circle cx="12" cy="7" r="1.5" />
-  </svg>
-);
-
-const PRIMARY_NAV: ReadonlyArray<SidebarNavItem> = [
-  { href: "/overview", label: "Overview", icon: "▦" },
-  { href: "/monitoring", label: "Monitoring", icon: PinIcon },
-];
-
+/**
+ * 운영 콘솔의 외곽 셸. 한 화면(`/overview`) 으로 통합하면서 좌측 메뉴 레일을
+ * 없애고, 테마 전환과 로그아웃만 우상단에 floating 액션 바로 떠 있는 형태로
+ * 단순화했다. 다른 라우트(`/login` 등) 는 자체 레이아웃을 갖되 이 액션 바는
+ * 공통으로 따라온다.
+ *
+ * `.top-actions` 는 `position: fixed` 라 레이아웃 너비를 차지하지 않는다 —
+ * 본문(`main`) 의 가운데 정렬 기준이 사이드바 없을 때와 동일하게 유지됨.
+ */
 export async function AppShell({ children }: { children: ReactNode }) {
   const serviceOpsSessionActive = await serviceOpsSessionReady();
 
   return (
     <div className="app-frame">
-      <aside className="sidebar" aria-label="주요 메뉴">
-        <Link className="sidebar-brand" href="/overview" aria-label="Thundercrew 운영 화면">
-          <span className="brand-mark">TC</span>
-          <span className="sidebar-label">thundercrew-domain</span>
-        </Link>
-
-        <SidebarPrimaryNav items={PRIMARY_NAV} />
-
-        <div className="sidebar-bottom">
-          <ThemeToggle />
-          {serviceOpsSessionActive ? (
-            <form action={signOutAdmin} className="sidebar-action-form">
-              <button className="sidebar-link sidebar-button" type="submit" title="관리자 로그아웃" aria-label="관리자 로그아웃">
-                <span className="sidebar-icon" aria-hidden="true">↙</span>
-                <span className="sidebar-label">관리자 로그아웃</span>
-              </button>
-            </form>
-          ) : (
-            <Link className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
-              <span className="sidebar-icon" aria-hidden="true">↗</span>
-              <span className="sidebar-label">관리자 로그인</span>
-            </Link>
-          )}
-        </div>
-      </aside>
+      <div className="top-actions" aria-label="유틸리티">
+        <ThemeToggle />
+        {serviceOpsSessionActive ? (
+          <form action={signOutAdmin} className="top-actions-form">
+            <button
+              className="sidebar-link"
+              type="submit"
+              title="관리자 로그아웃"
+              aria-label="관리자 로그아웃"
+            >
+              <span className="sidebar-icon" aria-hidden="true">↙</span>
+              <span className="sidebar-label">관리자 로그아웃</span>
+            </button>
+          </form>
+        ) : (
+          <a className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
+            <span className="sidebar-icon" aria-hidden="true">↗</span>
+            <span className="sidebar-label">관리자 로그인</span>
+          </a>
+        )}
+      </div>
       <main className="app-main">{children}</main>
     </div>
   );

--- a/development/front-admin-web/components/management/IgnitionControlButton.tsx
+++ b/development/front-admin-web/components/management/IgnitionControlButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { setVehicleIgnitionBlockFromOverviewAction } from "@/app/overview/actions";
+
+/**
+ * 라이더 테이블의 "시동 제어" 컬럼에서 한 줄에 박히는 인라인 토글. 라이더에
+ * 매칭된 차량의 시동 방지(ignition_blocked) 운영자 의도를 켜고 끄는 작은
+ * 스위치. RiderDetailDialog 의 같은 컨트롤과 시각·동작 일치 — 거기서는 더
+ * 큰 크기로, 여기서는 행 안에 들어가는 작은 크기로만 차이.
+ *
+ * 매칭 없는 라이더(activeBikeId = null) 는 호출자가 이 컴포넌트를 마운트
+ * 안 하도록 함.
+ *
+ * Optimistic update — 누른 즉시 색이 바뀐다. 페이지 revalidate 후 props 가
+ * 새로 내려오면 자연스럽게 보정.
+ */
+export function IgnitionControlButton({
+  bikeId,
+  initialBlocked
+}: {
+  bikeId: string;
+  initialBlocked: boolean;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const blocked = optimistic ?? initialBlocked;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // 라이더 테이블의 행은 클릭 시 상세 다이얼로그를 여는 핸들러가 붙어
+    // 있으므로 시동 토글의 클릭이 행 클릭으로 전파되지 않도록 끊는다.
+    event.stopPropagation();
+    if (pending) return;
+    const next = !blocked;
+    setOptimistic(next);
+    const fd = new FormData();
+    fd.append("blocked", next ? "true" : "false");
+    startTransition(() => {
+      void setVehicleIgnitionBlockFromOverviewAction(bikeId, fd);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`toggle-switch toggle-switch--compact${blocked ? " is-on" : ""}`}
+      role="switch"
+      aria-checked={blocked}
+      aria-label="시동 제어 토글"
+      disabled={pending}
+      onClick={handleClick}
+    >
+      <span className="toggle-switch-thumb" aria-hidden="true" />
+      <span className="toggle-switch-text">방지</span>
+    </button>
+  );
+}

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
-import { DeleteRiderButton } from "@/components/management/DeleteRiderButton";
+import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { RiderDetailDialog, type RiderDetailRow } from "@/components/management/RiderDetailDialog";
 import { RIDER_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import type { RiderDataResult } from "@/lib/services/rider-data";
@@ -21,16 +21,21 @@ export interface InsuranceOption {
 
 /**
  * Read-only table-card for the rider list on `/overview ?tab=riders`.
- * Columns: 이름 / 연락처 / 교육 여부 / 차량 번호 / 구독·렌탈 / 형태 / 기간 / 보험.
+ * Columns: 이름 / 연락처 / 교육 / 차량 번호 / 구독·렌탈 / 형태 / 기간 / 보험 /
+ * 시동 상태 / 시동 제어.
  *
  * The contract-shape columns (차량 번호 + 구독·렌탈 + 형태 + 기간) all
  * come from the rider's most recent active contract. 차량 번호 needs a
  * separate map (`riderActiveBikePlate`) because the contract row only
  * carries the bikeId.
  *
- * 행 클릭 시 상세 다이얼로그가 열리고 거기서 수정으로 전환할 수 있다.
- * 작업 칼럼의 삭제 폼은 `onClick` 으로 이벤트 전파를 막아 행 클릭과
- * 충돌하지 않게 한다.
+ * 시동 상태 / 시동 제어 두 컬럼은 매칭된 차량의 telemetry + 운영자 의도
+ * (ignition_blocked) 를 행 안에서 보여주기 위한 컬럼. 매칭이 없는 라이더는
+ * 둘 다 "—" 로 폴백. 시동 제어 토글은 행 클릭(상세 다이얼로그) 와 충돌
+ * 안 하도록 자체적으로 `event.stopPropagation` 처리.
+ *
+ * 삭제 버튼은 상세 다이얼로그(view 모드) 안에서만 노출하도록 정리해 행
+ * 마지막 "작업" 컬럼은 더 이상 두지 않는다.
  */
 export function RidersPanel({
   data,
@@ -74,7 +79,8 @@ export function RidersPanel({
           <col />
           <col />
           <col />
-          <col style={{ width: "72px" }} />
+          <col style={{ width: "92px" }} />
+          <col style={{ width: "104px" }} />
         </colgroup>
         <thead>
           <tr>
@@ -86,13 +92,14 @@ export function RidersPanel({
             <th>형태</th>
             <th>기간</th>
             <th>보험</th>
-            <th style={{ textAlign: "right" }}>작업</th>
+            <th>시동 상태</th>
+            <th>시동 제어</th>
           </tr>
         </thead>
         <tbody>
           {data.riders.length === 0 ? (
             <tr>
-              <td colSpan={9} className="table-empty-cell">
+              <td colSpan={10} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
@@ -147,11 +154,13 @@ export function RidersPanel({
                 <td>{renderReturnType(contract?.returnType ?? null)}</td>
                 <td>{renderDuration(contract?.durationLabel ?? null)}</td>
                 <td>{renderPresence(hasInsurance)}</td>
-                <td
-                  style={{ textAlign: "right" }}
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <DeleteRiderButton riderId={riderKey} riderName={rider.name} />
+                <td>{renderIgnitionStatus(ignitionStatus)}</td>
+                <td onClick={(event) => event.stopPropagation()}>
+                  {activeBikeId ? (
+                    <IgnitionControlButton bikeId={activeBikeId} initialBlocked={ignitionBlocked} />
+                  ) : (
+                    <span className="muted">—</span>
+                  )}
                 </td>
               </tr>
             );
@@ -170,6 +179,12 @@ export function RidersPanel({
 
 function renderPresence(hasIt: boolean | null): ReactNode {
   if (hasIt) return <Badge tone="active">있음</Badge>;
+  return <span className="muted">—</span>;
+}
+
+function renderIgnitionStatus(status: string | null): ReactNode {
+  if (status === "ON") return <Badge tone="active">시동</Badge>;
+  if (status === "OFF") return <span className="muted">꺼짐</span>;
   return <span className="muted">—</span>;
 }
 

--- a/development/front-admin-web/components/management/StationsPanel.tsx
+++ b/development/front-admin-web/components/management/StationsPanel.tsx
@@ -2,16 +2,17 @@
 
 import { useState } from "react";
 
-import { DeleteStationButton } from "@/components/management/DeleteStationButton";
 import { StationDetailDialog, type StationDetailRow } from "@/components/management/StationDetailDialog";
 import type { StationDataResult } from "@/lib/services/station-data";
 import type { BatteryStation } from "@/types/domain";
 
 /**
  * Read-only table-card for the station list on `/overview ?tab=stations`.
- * Columns: 주소 / 잔여·총 / 작업.
+ * Columns: 주소 / 잔여·총.
  *
  * 행 클릭 시 상세 다이얼로그가 열리고 거기서 수정으로 전환할 수 있다.
+ * 삭제 동작은 상세 다이얼로그 안으로 옮겨 행 자체는 단순한 클릭 영역만
+ * 남긴다.
  *
  * `tableLayout: fixed` is required so the <col> widths actually take
  * effect; the default `auto` layout sizes columns by content and
@@ -27,25 +28,22 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
         <colgroup>
           <col />
           <col style={{ width: "120px" }} />
-          <col style={{ width: "72px" }} />
         </colgroup>
         <thead>
           <tr>
             <th>주소</th>
             <th style={{ textAlign: "center" }}>잔여/총</th>
-            <th style={{ textAlign: "right" }}>작업</th>
           </tr>
         </thead>
         <tbody>
           {data.stations.length === 0 ? (
             <tr>
-              <td colSpan={3} className="table-empty-cell">
+              <td colSpan={2} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
           ) : null}
           {data.stations.map((station) => {
-            const stationKey = station.id ?? station.slug;
             const available = availableCount(station);
             const max = maxCount(station);
             return (
@@ -59,12 +57,6 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
                   <strong>{available}</strong>
                   <span aria-hidden="true">/</span>
                   {max}
-                </td>
-                <td
-                  style={{ textAlign: "right" }}
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <DeleteStationButton stationId={stationKey} stationLabel={station.address} />
                 </td>
               </tr>
             );

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -2,10 +2,8 @@
 
 import { useMemo, useState, type ReactNode } from "react";
 
-import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
-import { MapShell } from "@/components/dashboard/MapShell";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type {
   FrontendDashboardBikePin,
@@ -14,55 +12,36 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * `/overview?tab=vehicles` 의 차량 현황 패널. EVN Logistics 차량 현황 UI 의
- * 레이아웃 / 컴포넌트 배치를 그대로 옮기고 색상만 우리 테마 토큰을 사용.
+ * `/overview?tab=vehicles` 의 차량 현황 패널. 운영자가 한 화면에서 차량 +
+ * 라이더 + 텔레메트리 + 단말기 정보를 한꺼번에 훑을 수 있도록 10개 컬럼만
+ * 남긴 단순 구조.
  *
- * 두 줄 필터 → 액션 버튼 row → 12컬럼 테이블 (+ 옵션 지도 분할) 구조.
+ * 컬럼:
+ *   차량번호 / 모델 / 운영 상태 / 이름 / 연락처 / IMEI / 연결 상태 / 시동 / 속도 / 잔량
  *
  * 데이터 매핑:
- * - 호기 ← FrontendVehicle.idx
- * - VIN ← FrontendVehicle.vin
- * - 플릿 ← (도메인 없음, "—" 표시 + 필터 disabled)
- * - 배치현황 ← operationStatus 매핑 (READY → 유휴, IN_SERVICE → 운영중).
- *   수리·대기중 / 미출고 는 backend 가 아직 모르므로 필터 옵션엔 있지만
- *   매칭되는 row 가 없다.
- * - 운영 구분 ← (계약 도메인 매핑 미정, "—" + 필터 disabled)
- * - 운전자 ← rider name (매칭된 라이더)
- * - SOC ← bikePin.batteryPercent (텔레메트리)
- * - 배터리 전압 ← (텔레메트리 필드 없음, "—" + 필터 disabled)
- * - 운행 상태 ← bikePin.drivingStatus (DRIVING / PARKED → 운행중 / 유휴)
- * - 차량 상태 ← bikePin.ignitionStatus + connectionStatus → 사람 친화 라벨
+ * - 차량번호 / 모델 / 운영 상태 ← FrontendVehicle (이 패널 데이터)
+ * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
+ * - IMEI ← deviceUidByBikeId (페이지 진입 시 batch-load)
+ * - 연결 상태 / 시동 / 속도 / 잔량 ← bikePinById (텔레메트리 핀)
  *
- * 비활성 필터/액션 (다운로드, 업로드, 운행계획없음, 점검필요, 플릿 등) 은
- * UI 만 두고 "준비 중" 으로 disabled — 백엔드 / 도메인 확장 시 활성화.
+ * 지도 보기 토글은 페이지 최상단의 글로벌 토글로 이동했으므로 이 패널에서는
+ * 다루지 않는다. 필터는 차량번호/모델/IMEI 검색 한 줄만.
  */
 
-type DeploymentFilter = "ALL" | "OPERATING" | "IDLE" | "REPAIR" | "PRE_DEPLOY";
 type FilterState = {
   query: string;
-  vehicleState: "ALL" | "IDLE" | "REPAIR" | "CHARGING";
-  fleet: "ALL"; // 도메인 없음, 단일 옵션
-  deployment: DeploymentFilter;
-  operationType: "ALL"; // 도메인 없음
-  socFilter: "ALL" | "LOW";
-  voltageFilter: "ALL"; // 도메인 없음
-  noPlanOnly: boolean; // 데이터 없음
-  needsCheckOnly: boolean; // 데이터 없음
+  operationStatus: "ALL" | "READY" | "IN_SERVICE";
 };
-
-type SortKey = "idx" | "plate" | "model" | "deployment" | "rider" | "soc";
-type SortDir = "asc" | "desc";
 
 const DEFAULT_FILTERS: FilterState = {
   query: "",
-  vehicleState: "ALL",
-  fleet: "ALL",
-  deployment: "ALL",
-  operationType: "ALL",
-  socFilter: "ALL",
-  voltageFilter: "ALL",
-  noPlanOnly: false,
-  needsCheckOnly: false
+  operationStatus: "ALL"
+};
+
+const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
+  READY: "대기",
+  IN_SERVICE: "운행"
 };
 
 const LOW_BATTERY_THRESHOLD = 20;
@@ -71,19 +50,21 @@ export function VehiclesPanel({
   data,
   bikeActiveRiderById,
   riderInfoById,
-  bikePins
+  bikePins,
+  deviceUidByBikeId
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
+  /** 텔레메트리 핀 — 연결 상태 / 시동 / 속도 / 잔량 컬럼이 참조. */
   bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
+  /** 차량 → 부착된 단말기 IMEI 사전. /overview 페이지가 batch loader 로 받아서 내려준다. */
+  deviceUidByBikeId?: Map<string, string>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
-  const [mapView, setMapView] = useState(false);
-  const [sortKey, setSortKey] = useState<SortKey>("idx");
-  const [sortDir, setSortDir] = useState<SortDir>("asc");
 
+  // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
     for (const pin of bikePins ?? []) {
@@ -94,76 +75,31 @@ export function VehiclesPanel({
 
   const visibleVehicles = useMemo(() => {
     const q = filters.query.trim().toLowerCase();
-    const filtered = data.vehicles.filter((vehicle) => {
+    return data.vehicles.filter((vehicle) => {
+      const vehicleKey = vehicle.id ?? vehicle.slug;
       if (q) {
         const plateMatch = vehicle.plateNumber.toLowerCase().includes(q);
-        const vinMatch = (vehicle.vin ?? "").toLowerCase().includes(q);
-        if (!plateMatch && !vinMatch) return false;
+        const modelMatch = (vehicle.model ?? "").toLowerCase().includes(q);
+        const imei = deviceUidByBikeId?.get(vehicleKey) ?? "";
+        const imeiMatch = imei.toLowerCase().includes(q);
+        if (!plateMatch && !modelMatch && !imeiMatch) return false;
       }
-      const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
-      // 배치현황 필터: OPERATING(=운영중) 은 IN_SERVICE, IDLE(=유휴) 는 READY.
-      // REPAIR / PRE_DEPLOY 는 우리 데이터에 매칭 row 가 없어서 항상 0건.
-      if (filters.deployment !== "ALL") {
-        if (filters.deployment === "OPERATING" && op !== "IN_SERVICE") return false;
-        if (filters.deployment === "IDLE" && op !== "READY") return false;
-        if (filters.deployment === "REPAIR") return false;
-        if (filters.deployment === "PRE_DEPLOY") return false;
-      }
-      const vehicleKey = vehicle.id ?? vehicle.slug;
-      if (filters.socFilter === "LOW") {
-        const pin = bikePinById.get(vehicleKey);
-        if (pin?.batteryPercent === null || pin?.batteryPercent === undefined) return false;
-        if (pin.batteryPercent > LOW_BATTERY_THRESHOLD) return false;
-      }
-      // 차량 상태(EVN: 유휴 차량 / 정비중 / 충전 필요) 우리 대응:
-      // 유휴 = drivingStatus PARKED, 충전 필요 = SOC ≤ threshold,
-      // 정비중 은 데이터 없음.
-      if (filters.vehicleState !== "ALL") {
-        const pin = bikePinById.get(vehicleKey);
-        if (filters.vehicleState === "IDLE" && pin?.drivingStatus !== "PARKED") return false;
-        if (filters.vehicleState === "CHARGING") {
-          if (pin?.batteryPercent === null || pin?.batteryPercent === undefined) return false;
-          if (pin.batteryPercent > LOW_BATTERY_THRESHOLD) return false;
-        }
-        if (filters.vehicleState === "REPAIR") return false;
+      if (filters.operationStatus !== "ALL") {
+        const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
+        if (op !== filters.operationStatus) return false;
       }
       return true;
     });
-    return sortVehicles(filtered, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById);
-  }, [data.vehicles, filters, sortKey, sortDir, bikeActiveRiderById, riderInfoById, bikePinById]);
-
-  const visibleBikePins = useMemo(() => {
-    if (!mapView) return [];
-    const visibleIds = new Set(visibleVehicles.map((v) => v.id ?? v.slug));
-    return (bikePins ?? []).filter((pin) => visibleIds.has(pin.bikeId));
-  }, [mapView, visibleVehicles, bikePins]);
-
-  const handleSort = (key: SortKey) => {
-    if (sortKey === key) {
-      setSortDir((dir) => (dir === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(key);
-      setSortDir("asc");
-    }
-  };
+  }, [data.vehicles, filters, deviceUidByBikeId]);
 
   return (
-    <div className={`vehicles-panel ${mapView ? "vehicles-panel--split" : ""}`}>
-      {/* 필터 행 1: 지도보기 / 검색 / 차량상태 / 플릿 / 배치현황 / 운영유형 / SOC */}
+    <div className="vehicles-panel">
       <div className="vehicles-filter-row">
-        <label className="vehicles-filter-toggle">
-          <input
-            type="checkbox"
-            checked={mapView}
-            onChange={(event) => setMapView(event.target.checked)}
-          />
-          <span>지도 보기</span>
-        </label>
         <div className="vehicles-filter-search-wrap">
           <input
             className="vehicles-filter-search"
             type="search"
-            placeholder="차량번호, VIN"
+            placeholder="차량번호, 모델, IMEI 검색"
             value={filters.query}
             onChange={(event) => setFilters({ ...filters, query: event.target.value })}
           />
@@ -171,161 +107,84 @@ export function VehiclesPanel({
         </div>
         <select
           className="vehicles-filter-select"
-          value={filters.vehicleState}
+          value={filters.operationStatus}
           onChange={(event) =>
-            setFilters({ ...filters, vehicleState: event.target.value as FilterState["vehicleState"] })
+            setFilters({ ...filters, operationStatus: event.target.value as FilterState["operationStatus"] })
           }
         >
-          <option value="ALL">차량 상태</option>
-          <option value="IDLE">유휴 차량</option>
-          <option value="REPAIR" disabled>정비중 (준비중)</option>
-          <option value="CHARGING">충전 필요</option>
+          <option value="ALL">운영 상태: 전체</option>
+          <option value="IN_SERVICE">운행</option>
+          <option value="READY">대기</option>
         </select>
-        <select className="vehicles-filter-select" disabled value="ALL" title="플릿(운영사) 도메인 추가 후 활성화 예정">
-          <option value="ALL">플릿 (준비중)</option>
-        </select>
-        <select
-          className="vehicles-filter-select"
-          value={filters.deployment}
-          onChange={(event) =>
-            setFilters({ ...filters, deployment: event.target.value as DeploymentFilter })
-          }
-        >
-          <option value="ALL">배치 현황</option>
-          <option value="OPERATING">운영중</option>
-          <option value="IDLE">유휴</option>
-          <option value="REPAIR" disabled>수리/대기중 (준비중)</option>
-          <option value="PRE_DEPLOY" disabled>미출고 (준비중)</option>
-        </select>
-        <select className="vehicles-filter-select" disabled value="ALL" title="운영 유형(직영/구독/판매) 매핑 추가 후 활성화">
-          <option value="ALL">운영 유형 (준비중)</option>
-        </select>
-        <select
-          className="vehicles-filter-select"
-          value={filters.socFilter}
-          onChange={(event) =>
-            setFilters({ ...filters, socFilter: event.target.value as FilterState["socFilter"] })
-          }
-        >
-          <option value="ALL">배터리 SOC</option>
-          <option value="LOW">저전압 (≤ {LOW_BATTERY_THRESHOLD}%)</option>
-        </select>
-      </div>
-
-      {/* 필터 행 2: 배터리 전압 / 운행 계획 없음 / 점검 필요 */}
-      <div className="vehicles-filter-row">
-        <select className="vehicles-filter-select" disabled value="ALL" title="배터리 전압 telemetry 필드 추가 후 활성화">
-          <option value="ALL">배터리 전압 (준비중)</option>
-        </select>
-        <label className="vehicles-filter-toggle vehicles-filter-toggle--disabled" title="배송 계획 도메인 연동 후 활성화">
-          <input type="checkbox" disabled checked={filters.noPlanOnly} onChange={() => {}} />
-          <span>운행 계획 없음 (준비중)</span>
-        </label>
-        <label className="vehicles-filter-toggle vehicles-filter-toggle--disabled" title="단말기 진단 코드 도메인 연동 후 활성화">
-          <input type="checkbox" disabled checked={filters.needsCheckOnly} onChange={() => {}} />
-          <span>에러코드 또는 단말기 점검 필요 (준비중)</span>
-        </label>
         <span className="vehicles-filter-count">
           {visibleVehicles.length} / {data.vehicles.length}
         </span>
       </div>
 
-      {/* 액션 버튼 row */}
-      <div className="vehicles-action-row">
-        <button type="button" className="vehicles-action-button" disabled title="CSV / XLSX 추출 API 추가 후 활성화">
-          다운로드
-        </button>
-        <button type="button" className="vehicles-action-button" disabled title="Bulk import API 추가 후 활성화">
-          업로드
-        </button>
-        {/* "새 차량 추가" 는 page tab-action 영역에 이미 마운트되어 있음 — 중복
-            방지를 위해 여기서는 안내 텍스트만. 위치 통일이 필요하면 다음
-            iteration 에서 page.tsx 의 tab-action 을 비우고 여기로 이동. */}
-        <span className="vehicles-action-hint">새 차량 추가 ↗ 우측 상단</span>
-      </div>
-
-      <div className="vehicles-panel-body">
-        <div className="table-card vehicles-table-scroll">
-          <table className="table vehicles-table">
-            <thead>
+      <div className="table-card vehicles-table-scroll">
+        <table className="table vehicles-table">
+          <thead>
+            <tr>
+              <th>차량번호</th>
+              <th>모델</th>
+              <th>운영 상태</th>
+              <th>이름</th>
+              <th>연락처</th>
+              <th>IMEI</th>
+              <th>연결 상태</th>
+              <th>시동</th>
+              <th>속도</th>
+              <th>잔량</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleVehicles.length === 0 ? (
               <tr>
-                <SortableHeader label="호기" sortKey="idx" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <SortableHeader label="차량번호" sortKey="plate" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <th>VIN</th>
-                <SortableHeader label="모델" sortKey="model" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <th>플릿</th>
-                <SortableHeader label="배치현황" sortKey="deployment" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <th>운영 구분</th>
-                <SortableHeader label="운전자" sortKey="rider" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <SortableHeader label="SOC" sortKey="soc" current={sortKey} dir={sortDir} onSort={handleSort} />
-                <th>배터리 전압</th>
-                <th>운행 상태</th>
-                <th>차량 상태</th>
-                <th style={{ textAlign: "right" }}>작업</th>
+                <td colSpan={10} className="table-empty-cell">
+                  조건에 맞는 차량 없음
+                </td>
               </tr>
-            </thead>
-            <tbody>
-              {visibleVehicles.length === 0 ? (
-                <tr>
-                  <td colSpan={13} className="table-empty-cell">
-                    조건에 맞는 차량 없음
-                  </td>
+            ) : null}
+            {visibleVehicles.map((vehicle) => {
+              const vehicleKey = vehicle.id ?? vehicle.slug;
+              const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
+              const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
+              const pin = bikePinById.get(vehicleKey);
+              const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
+              const imei = deviceUidByBikeId?.get(vehicleKey) ?? null;
+              return (
+                <tr
+                  key={vehicle.slug}
+                  className="table-row-clickable"
+                  draggable={Boolean(vehicle.id)}
+                  onDragStart={(event) => {
+                    if (!vehicle.id) return;
+                    event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
+                    event.dataTransfer.effectAllowed = "copy";
+                  }}
+                  onClick={() =>
+                    setActiveRow({
+                      vehicle,
+                      riderName: riderInfo?.name ?? null,
+                      riderPhone: riderInfo?.phone ?? null
+                    })
+                  }
+                >
+                  <td>{vehicle.plateNumber}</td>
+                  <td>{vehicle.model || <span className="muted">—</span>}</td>
+                  <td>{renderOperationBadge(op)}</td>
+                  <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
+                  <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
+                  <td className="vehicles-cell-mono">{imei || <span className="muted">—</span>}</td>
+                  <td>{renderConnection(pin?.connectionStatus)}</td>
+                  <td>{renderIgnition(pin?.ignitionStatus)}</td>
+                  <td>{renderSpeed(pin?.speedKph)}</td>
+                  <td>{renderBattery(pin?.batteryPercent)}</td>
                 </tr>
-              ) : null}
-              {visibleVehicles.map((vehicle) => {
-                const vehicleKey = vehicle.id ?? vehicle.slug;
-                const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
-                const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
-                const pin = bikePinById.get(vehicleKey);
-                const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
-                return (
-                  <tr
-                    key={vehicle.slug}
-                    className="table-row-clickable"
-                    draggable={Boolean(vehicle.id)}
-                    onDragStart={(event) => {
-                      if (!vehicle.id) return;
-                      event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
-                      event.dataTransfer.effectAllowed = "copy";
-                    }}
-                    onClick={() =>
-                      setActiveRow({
-                        vehicle,
-                        riderName: riderInfo?.name ?? null,
-                        riderPhone: riderInfo?.phone ?? null
-                      })
-                    }
-                  >
-                    <td className="vehicles-cell-mono">{vehicle.idx ?? "—"}</td>
-                    <td>{vehicle.plateNumber}</td>
-                    <td className="vehicles-cell-mono">{vehicle.vin || <span className="muted">—</span>}</td>
-                    <td>{vehicle.model || <span className="muted">—</span>}</td>
-                    <td><span className="muted">—</span></td>
-                    <td>{renderDeploymentBadge(op)}</td>
-                    <td><span className="muted">—</span></td>
-                    <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
-                    <td>{renderSoc(pin?.batteryPercent)}</td>
-                    <td><span className="muted">—</span></td>
-                    <td>{renderDrivingBadge(pin?.drivingStatus)}</td>
-                    <td>{renderIgnitionState(pin)}</td>
-                    <td
-                      style={{ textAlign: "right" }}
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      <DeleteVehicleButton vehicleId={vehicleKey} plateNumber={vehicle.plateNumber} />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-
-        {mapView ? (
-          <div className="vehicles-panel-map">
-            <MapShell bikePins={visibleBikePins} />
-          </div>
-        ) : null}
+              );
+            })}
+          </tbody>
+        </table>
       </div>
 
       <VehicleDetailDialog
@@ -337,64 +196,46 @@ export function VehiclesPanel({
   );
 }
 
-function SortableHeader({
-  label,
-  sortKey,
-  current,
-  dir,
-  onSort
-}: {
-  label: string;
-  sortKey: SortKey;
-  current: SortKey;
-  dir: SortDir;
-  onSort: (key: SortKey) => void;
-}) {
-  const isActive = current === sortKey;
-  const arrow = !isActive ? "↕" : dir === "asc" ? "↑" : "↓";
-  return (
-    <th>
-      <button
-        type="button"
-        className={`vehicles-sort-button${isActive ? " is-active" : ""}`}
-        onClick={() => onSort(sortKey)}
-      >
-        {label}
-        <span className="vehicles-sort-arrow" aria-hidden="true">{arrow}</span>
-      </button>
-    </th>
-  );
+function statusToOperation(status: FrontendVehicle["status"]): ServiceOpsBikeOperationStatus {
+  return status === "운행" ? "IN_SERVICE" : "READY";
 }
 
-function renderDeploymentBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
+function renderOperationBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
   const isOperating = op === "IN_SERVICE";
   return (
     <span className={`vehicles-pill vehicles-pill--${isOperating ? "operating" : "idle"}`}>
-      {isOperating ? "운영중" : "유휴"}
+      {STATUS_LABEL[op]}
     </span>
   );
 }
 
-function renderDrivingBadge(drivingStatus: string | undefined): ReactNode {
-  if (!drivingStatus) return <span className="muted">—</span>;
-  if (drivingStatus === "DRIVING") {
-    return <span className="vehicles-pill vehicles-pill--driving">운행중</span>;
+// 연결 상태: telemetry 의 connectionStatus 그대로 사람 친화 라벨로. 핀이 없는
+// 차량(텔레메트리 한 번도 못 받음) 은 "—" — 단말기를 부착하지 않은 경우와
+// 단말기는 있는데 통신 끊긴 경우 둘 다 핀이 없을 수 있어 한 톤으로 표시.
+function renderConnection(status: string | undefined): ReactNode {
+  if (!status) return <span className="muted">—</span>;
+  if (status === "ONLINE") {
+    return <span className="vehicles-pill vehicles-pill--operating">온라인</span>;
   }
-  return <span className="vehicles-pill vehicles-pill--idle">유휴</span>;
+  if (status === "SIGNAL_LOST") {
+    return <span className="vehicles-pill vehicles-pill--unknown">신호 끊김</span>;
+  }
+  // 그 외(OFFLINE / PARKED_OFFLINE 등) 는 회색 톤으로 통일.
+  return <span className="vehicles-pill vehicles-pill--idle">오프라인</span>;
 }
 
-function renderIgnitionState(pin: FrontendDashboardBikePin | undefined): ReactNode {
-  if (!pin) return <span className="vehicles-pill vehicles-pill--unknown">상태없음 (No Status)</span>;
-  if (pin.ignitionStatus === "ON") {
-    return <span className="vehicles-pill vehicles-pill--ignition-on">ON (시동이 켜진 상태)</span>;
-  }
-  if (pin.ignitionStatus === "OFF") {
-    return <span className="vehicles-pill vehicles-pill--ignition-off">OFF (시동이 꺼진 상태)</span>;
-  }
-  return <span className="vehicles-pill vehicles-pill--unknown">상태없음 (No Status)</span>;
+function renderIgnition(status: string | undefined): ReactNode {
+  if (status === "ON") return <span className="vehicles-pill vehicles-pill--ignition-on">ON</span>;
+  if (status === "OFF") return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
+  return <span className="muted">—</span>;
 }
 
-function renderSoc(percent: number | null | undefined): ReactNode {
+function renderSpeed(speedKph: number | null | undefined): ReactNode {
+  if (speedKph === null || speedKph === undefined) return <span className="muted">—</span>;
+  return <span className="vehicles-cell-mono">{Math.round(speedKph)} km/h</span>;
+}
+
+function renderBattery(percent: number | null | undefined): ReactNode {
   if (percent === null || percent === undefined) return <span className="muted">—</span>;
   const tone = percent <= LOW_BATTERY_THRESHOLD ? "low" : percent <= 50 ? "mid" : "high";
   return (
@@ -403,50 +244,3 @@ function renderSoc(percent: number | null | undefined): ReactNode {
     </span>
   );
 }
-
-function statusToOperation(status: FrontendVehicle["status"]): ServiceOpsBikeOperationStatus {
-  return status === "운행" ? "IN_SERVICE" : "READY";
-}
-
-function sortVehicles(
-  vehicles: FrontendVehicle[],
-  key: SortKey,
-  dir: SortDir,
-  bikeActiveRiderById: Map<string, string> | undefined,
-  riderInfoById: Map<string, { name: string; phone: string }> | undefined,
-  bikePinById: Map<string, FrontendDashboardBikePin>
-): FrontendVehicle[] {
-  const sign = dir === "asc" ? 1 : -1;
-  const lookupRider = (v: FrontendVehicle): string | null => {
-    const riderId = bikeActiveRiderById?.get(v.id ?? v.slug) ?? null;
-    return riderId ? riderInfoById?.get(riderId)?.name ?? null : null;
-  };
-  const lookupSoc = (v: FrontendVehicle): number => {
-    const pin = bikePinById.get(v.id ?? v.slug);
-    return pin?.batteryPercent ?? -1;
-  };
-  return [...vehicles].sort((a, b) => {
-    switch (key) {
-      case "idx":
-        return ((a.idx ?? Number.MAX_SAFE_INTEGER) - (b.idx ?? Number.MAX_SAFE_INTEGER)) * sign;
-      case "plate":
-        return a.plateNumber.localeCompare(b.plateNumber) * sign;
-      case "model":
-        return a.model.localeCompare(b.model) * sign;
-      case "deployment":
-        return (a.status === b.status ? 0 : a.status === "운행" ? -1 : 1) * sign;
-      case "rider": {
-        const an = lookupRider(a) ?? "";
-        const bn = lookupRider(b) ?? "";
-        if (!an && !bn) return 0;
-        if (!an) return 1;
-        if (!bn) return -1;
-        return an.localeCompare(bn) * sign;
-      }
-      case "soc":
-        return (lookupSoc(a) - lookupSoc(b)) * sign;
-    }
-  });
-}
-
-export type { ReactNode };

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+import { MapShell } from "@/components/dashboard/MapShell";
+import type {
+  FrontendDashboardBikePin,
+  FrontendDashboardStationPin
+} from "@/lib/services/service-ops-api";
+
+/**
+ * `/overview` 페이지 최상단에 박히는 글로벌 "지도 보기" 토글 + 지도. 차량 /
+ * 라이더 / BSS 탭과 독립적으로 켰다 끌 수 있고, 켜면 차량 마커 + BSS 마커를
+ * 한 지도에 띄운다.
+ *
+ * 탭 전환은 Next.js Link 로 같은 라우트의 query string 만 바꾸므로 이 client
+ * 컴포넌트는 mount 가 유지되어 토글 상태도 보존된다. (탭마다 매번 다시
+ * 켜야 하는 불편 없음.)
+ *
+ * 토글 OFF 상태에선 MapShell 을 mount 하지 않아 NCP 지도 SDK 세션이 생기지
+ * 않는다 — 운영자가 지도가 필요 없을 때까지 API 미터를 잡지 않도록.
+ */
+export function OverviewMapBanner({
+  bikePins,
+  stationPins
+}: {
+  bikePins: ReadonlyArray<FrontendDashboardBikePin>;
+  stationPins: ReadonlyArray<FrontendDashboardStationPin>;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section className="overview-map-section" aria-label="지도 보기">
+      <div className="overview-map-toggle-row">
+        <label className="overview-map-toggle">
+          <input
+            type="checkbox"
+            checked={open}
+            onChange={(event) => setOpen(event.target.checked)}
+          />
+          <span>지도 보기</span>
+        </label>
+        <span className="overview-map-toggle-hint">
+          {bikePins.length}대 차량 · {stationPins.length}개 BSS
+        </span>
+      </div>
+      {open ? (
+        <div className="overview-map-canvas">
+          <MapShell bikePins={[...bikePins]} stationPins={[...stationPins]} />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/development/front-admin-web/lib/services/vehicle-device-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-device-data.ts
@@ -39,3 +39,52 @@ export async function loadVehicleDevice(bikeId: string): Promise<VehicleDeviceRe
     return empty;
   }
 }
+
+/**
+ * `/overview` 차량 테이블의 IMEI 컬럼이 N+1 호출 없이 한 번에 채워지도록
+ * 페이지 진입 시점에 모든 active 설치를 일괄 조회한다.
+ *
+ * 백엔드 `listBikeDeviceInstallations` 가 bikeId 필터를 받지 않으므로 한
+ * 페이지(200건)를 받아 클라이언트에서 매핑. `listDevices` 도 같은 방식으로
+ * id→deviceUid 사전을 구성해 두 결과를 조인한다. MVP 규모(< 200 단말기)에서
+ * 충분하고, 그 이상이 되기 전엔 서버 측 `?bikeId=` 필터를 추가해야 한다.
+ */
+export type VehicleDeviceMap = {
+  /** bikeId → 현재 부착된 단말기의 deviceUid (IMEI 노출용). */
+  deviceUidByBikeId: Map<string, string>;
+  /** bikeId → 활성 installation row id. (현재는 표시 용도는 없고 후속 detach 액션이 쓸 수 있게 보존.) */
+  installationIdByBikeId: Map<string, string>;
+};
+
+const EMPTY_DEVICE_MAP: VehicleDeviceMap = {
+  deviceUidByBikeId: new Map(),
+  installationIdByBikeId: new Map()
+};
+
+export async function loadVehicleDeviceMap(): Promise<VehicleDeviceMap> {
+  if (!serviceOpsApiConfigured()) return EMPTY_DEVICE_MAP;
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) return EMPTY_DEVICE_MAP;
+
+  try {
+    const [installationsPage, devicesPage] = await Promise.all([
+      client.listBikeDeviceInstallations({ page: 0, size: 200 }),
+      client.listDevices({ page: 0, size: 200 })
+    ]);
+    const deviceUidById = new Map<string, string>();
+    for (const device of devicesPage.items) {
+      deviceUidById.set(device.id, device.deviceUid);
+    }
+    const deviceUidByBikeId = new Map<string, string>();
+    const installationIdByBikeId = new Map<string, string>();
+    for (const installation of installationsPage.items) {
+      if (installation.removedAt) continue;
+      const uid = deviceUidById.get(installation.deviceId);
+      if (uid) deviceUidByBikeId.set(installation.bikeId, uid);
+      installationIdByBikeId.set(installation.bikeId, installation.id);
+    }
+    return { deviceUidByBikeId, installationIdByBikeId };
+  } catch {
+    return EMPTY_DEVICE_MAP;
+  }
+}


### PR DESCRIPTION
## Summary
- 좌측 사이드바 레일 제거 → 우상단 floating bar로 테마 + 로그아웃만 유지
- \`/monitoring\` → \`/overview\` 영구 리다이렉트
- \`/overview\` 최상단 글로벌 \"지도 보기\" 토글 — 차량 + BSS 마커 동시 표시
- 차량 테이블 10컬럼 재구성 (+ IMEI batch loader)
- 라이더 테이블에 시동 상태 / 시동 제어 인라인 컬럼 추가
- BSS 테이블 주소 / 잔여·총 2컬럼만 (#228)

## Test plan
- [ ] \`/overview\` 우상단에 테마·로그아웃만 떠 있고 사이드바 제거 확인
- [ ] \`/monitoring\` 진입 시 \`/overview\` 로 이동 확인
- [ ] 글로벌 지도 보기 토글 ON → 차량 + BSS 마커가 한 지도에 표시되는지 확인
- [ ] 탭 전환에도 지도 토글 상태 유지 확인
- [ ] 차량 10컬럼 (IMEI / 시동 / 속도 / 잔량) 채워지는지 확인
- [ ] 라이더 시동 제어 인라인 토글이 행 클릭과 충돌 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)