### PR TITLE
Release: KPI sidebar + logout UX hardening

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -479,6 +479,28 @@ textarea { padding-top: 10px; min-height: 96px; }
 .kpi-group { padding: 20px; background: var(--color-surface); border-radius: 12px; box-shadow: var(--shadow-card); }
 .kpi-group-heading { margin: 0 0 16px; font-size: 13px; font-weight: 800; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
 .kpi-group-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)); gap: 12px; }
+
+/* /overview 상단의 KPI 사이드바 + 지도 영역 가로 묶음. 좁은 폭에선 자연스럽게
+   세로 쌓임으로 fallback. */
+.overview-top-row { display: flex; gap: 16px; align-items: stretch; margin: 20px 0 12px; }
+.overview-top-row .overview-map-section { flex: 1 1 auto; min-width: 0; margin: 0; }
+.overview-kpi-sidebar {
+  flex: 0 0 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+/* 사이드바에 들어간 KPI 카드는 더 컴팩트하게: 패딩 줄이고 폰트도 작게. */
+.kpi-group--stacked { padding: 14px 16px; }
+.kpi-group--stacked .kpi-group-heading { margin-bottom: 10px; font-size: 12px; }
+.kpi-group-metrics--stacked { display: flex; flex-direction: column; gap: 10px; }
+.kpi-group-metrics--stacked .metric-label { font-size: 12px; }
+.kpi-group-metrics--stacked .metric-value { font-size: 22px; margin-top: 4px; }
+@media (max-width: 880px) {
+  .overview-top-row { flex-direction: column; }
+  .overview-kpi-sidebar { flex-basis: auto; flex-direction: row; flex-wrap: wrap; }
+  .overview-kpi-sidebar .kpi-group { flex: 1 1 240px; }
+}
 .overview-tabs-row { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 16px; border-bottom: 1px solid var(--color-divider); }
 /* 관리(탭 nav 가 있는 섹션) 와 다르게 계약/보험 섹션은 단일 카드라 탭 자리에
    섹션명만 두고 우측에 신규 등록 버튼 한 개를 정렬. .overview-section-heading

--- a/development/front-admin-web/app/overview/page.tsx
+++ b/development/front-admin-web/app/overview/page.tsx
@@ -227,49 +227,53 @@ export default async function OverviewPage({
         </p>
       ) : null}
 
-      {/* 글로벌 "지도 보기" 토글. 차량 + BSS 마커를 한 지도에 띄우고, 탭 전환
-          간에도 client-state 가 보존되어 한 번 켜면 모든 탭에서 같이 보인다. */}
-      <OverviewMapBanner
-        bikePins={mapState.data.bikePins}
-        stationPins={mapState.data.stationPins}
-      />
+      {/* 상단 영역: KPI 사이드바(좌) + 지도 보기 토글 / 캔버스(우). 두 블록이
+          같은 row 에 들어가 있으므로 지도가 켜지든 꺼지든 KPI 가 가운데에서
+          상시 보인다 — 운영자가 차량/라이더 수를 화면 어디로 옮겨가서
+          확인할지 고민 안 하도록. */}
+      <div className="overview-top-row">
+        <aside className="overview-kpi-sidebar" aria-label="요약 지표">
+          <article className="kpi-group kpi-group--stacked">
+            <h3 className="kpi-group-heading">차량 현황</h3>
+            <div className="kpi-group-metrics kpi-group-metrics--stacked">
+              <div>
+                <p className="metric-label">전체 차량</p>
+                <p className="metric-value">{formatCount(summary.totalBikes)}</p>
+              </div>
+              <div>
+                <p className="metric-label">시동 차량</p>
+                <p className="metric-value">{formatCount(ignitionOnCount)}</p>
+              </div>
+              <div>
+                <p className="metric-label">보험 차량</p>
+                <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+              </div>
+            </div>
+          </article>
 
-      <div className="overview-kpi-groups">
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">차량 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 차량</p>
-              <p className="metric-value">{formatCount(summary.totalBikes)}</p>
+          <article className="kpi-group kpi-group--stacked">
+            <h3 className="kpi-group-heading">라이더 현황</h3>
+            <div className="kpi-group-metrics kpi-group-metrics--stacked">
+              <div>
+                <p className="metric-label">전체 라이더</p>
+                <p className="metric-value">{formatCount(totalRiders)}</p>
+              </div>
+              <div>
+                <p className="metric-label">구독 인원</p>
+                <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+              </div>
+              <div>
+                <p className="metric-label">렌탈 인원</p>
+                <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+              </div>
             </div>
-            <div>
-              <p className="metric-label">시동 차량</p>
-              <p className="metric-value">{formatCount(ignitionOnCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">보험 차량</p>
-              <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
-            </div>
-          </div>
-        </article>
+          </article>
+        </aside>
 
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">라이더 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 라이더</p>
-              <p className="metric-value">{formatCount(totalRiders)}</p>
-            </div>
-            <div>
-              <p className="metric-label">구독 인원</p>
-              <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">렌탈 인원</p>
-              <p className="metric-value">{formatCount(rentalRiderCount)}</p>
-            </div>
-          </div>
-        </article>
+        <OverviewMapBanner
+          bikePins={mapState.data.bikePins}
+          stationPins={mapState.data.stationPins}
+        />
       </div>
 
       <h2 className="overview-section-heading">관리</h2>

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -1,9 +1,19 @@
 import { redirect } from "next/navigation";
 
+import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
+
 /**
- * Minimal-shell redirect — there is no standalone landing page in this
- * iteration; `/` immediately bounces to the operator's overview screen.
+ * 루트 진입은 세션 유무에 따라 분기. 로그인 안 된 상태면 바로 `/login` 으로
+ * 보내 운영자가 "어디로 가야 하지?" 를 고민하지 않게 한다. 세션이 살아
+ * 있으면 단일 운영 페이지(`/overview`) 로 이동.
+ *
+ * `serviceOpsSessionReady` 가 API 환경이 설정되어 있고 access / refresh 쿠키
+ * 가 유효한지 확인하므로, 만료된 세션은 자동으로 false 반환 → `/login` 으로
+ * 떨어진다.
  */
-export default function RootPage() {
-  redirect("/overview");
+export const dynamic = "force-dynamic";
+
+export default async function RootPage() {
+  const sessionActive = await serviceOpsSessionReady();
+  redirect(sessionActive ? "/overview" : "/login");
 }

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
-import { signOutAdmin } from "@/app/login/actions";
+import { LogoutButton } from "@/components/layout/LogoutButton";
 import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
 
 /**
@@ -11,6 +11,10 @@ import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
  *
  * `.top-actions` 는 `position: fixed` 라 레이아웃 너비를 차지하지 않는다 —
  * 본문(`main`) 의 가운데 정렬 기준이 사이드바 없을 때와 동일하게 유지됨.
+ *
+ * 로그인 안 된 상태에서 노출되는 "관리자 로그인" 링크는 별도 confirm 이
+ * 필요 없는 단순 네비게이션이라 그대로 anchor 로 둔다. 로그아웃 만 client-
+ * side confirm 다이얼로그를 끼우기 위해 LogoutButton 으로 분리.
  */
 export async function AppShell({ children }: { children: ReactNode }) {
   const serviceOpsSessionActive = await serviceOpsSessionReady();
@@ -20,17 +24,7 @@ export async function AppShell({ children }: { children: ReactNode }) {
       <div className="top-actions" aria-label="유틸리티">
         <ThemeToggle />
         {serviceOpsSessionActive ? (
-          <form action={signOutAdmin} className="top-actions-form">
-            <button
-              className="sidebar-link"
-              type="submit"
-              title="관리자 로그아웃"
-              aria-label="관리자 로그아웃"
-            >
-              <span className="sidebar-icon" aria-hidden="true">↙</span>
-              <span className="sidebar-label">관리자 로그아웃</span>
-            </button>
-          </form>
+          <LogoutButton />
         ) : (
           <a className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
             <span className="sidebar-icon" aria-hidden="true">↗</span>

--- a/development/front-admin-web/components/layout/LogoutButton.tsx
+++ b/development/front-admin-web/components/layout/LogoutButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useRef } from "react";
+
+import { signOutAdmin } from "@/app/login/actions";
+
+/**
+ * 우상단 floating action bar 의 로그아웃 버튼. 클릭 즉시 세션이 끊기는 것은
+ * 운영자에게 위험하므로 `window.confirm` 으로 1 단계 의사 확인을 끼운다.
+ *
+ * 아이콘은 "문 + 바깥쪽 화살표" SVG — 운영자가 흔히 본 로그아웃 시각 언어를
+ * 그대로 옮긴 것. stroke 기반이라 sidebar-link 의 currentColor + light/dark
+ * 테마에 자동 적응한다.
+ *
+ * 폼이 server action 으로 직접 submit 되어야 쿠키가 서버에서 안전하게 지워
+ * 지므로, confirm 결과를 onSubmit 단계에서 처리 — 취소 시 `preventDefault`
+ * 로 막고, OK 시 그대로 통과해 server action 이 실행된다.
+ */
+export function LogoutButton() {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  return (
+    <form
+      ref={formRef}
+      action={signOutAdmin}
+      className="top-actions-form"
+      onSubmit={(event) => {
+        if (!window.confirm("로그아웃 하시겠습니까?")) {
+          event.preventDefault();
+        }
+      }}
+    >
+      <button
+        className="sidebar-link"
+        type="submit"
+        title="관리자 로그아웃"
+        aria-label="관리자 로그아웃"
+      >
+        <LogoutIcon />
+        <span className="sidebar-label">관리자 로그아웃</span>
+      </button>
+    </form>
+  );
+}
+
+// 문 + 바깥쪽 화살표. 운영자가 첨부한 reference 이미지의 형태 그대로 —
+// 왼쪽에 열린 문(직사각형 + 손잡이 점) + 오른쪽 바깥으로 향하는 화살표.
+function LogoutIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {/* 문틀 (왼쪽 직사각형) */}
+      <path d="M9 4H5a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h4" />
+      {/* 손잡이 점 */}
+      <circle cx="8.2" cy="12" r="0.6" fill="currentColor" stroke="none" />
+      {/* 바깥으로 향하는 화살표 */}
+      <path d="M11 12h10" />
+      <path d="M17 8l4 4-4 4" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- KPI 카드(차량 현황 / 라이더 현황)를 지도 보기 좌측 사이드바로 재배치
- 로그아웃 아이콘을 문+화살표 SVG 로 교체, 클릭 시 confirm 다이얼로그 노출
- 루트 `/` 진입을 세션 유무로 분기 — 미세션 → `/login`, 세션 → `/overview` (#230)

## Test plan
- [ ] 미로그인 상태로 도메인 진입 시 `/login` 으로 바로 이동 확인
- [ ] 로그인 상태 진입 시 `/overview` 노출 확인
- [ ] KPI 두 카드가 지도 보기 영역 좌측 사이드바로 노출
- [ ] 좁은 폭(< 880px)에서 사이드바가 row 위로 빠져나오는지 확인
- [ ] 로그아웃 클릭 시 confirm 후 실행되는지 확인 (취소 시 세션 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)