### PR TITLE
Revert KPI to top row; slot map between KPI and tabs

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -480,27 +480,6 @@ textarea { padding-top: 10px; min-height: 96px; }
 .kpi-group-heading { margin: 0 0 16px; font-size: 13px; font-weight: 800; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
 .kpi-group-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)); gap: 12px; }
 
-/* /overview 상단의 KPI 사이드바 + 지도 영역 가로 묶음. 좁은 폭에선 자연스럽게
-   세로 쌓임으로 fallback. */
-.overview-top-row { display: flex; gap: 16px; align-items: stretch; margin: 20px 0 12px; }
-.overview-top-row .overview-map-section { flex: 1 1 auto; min-width: 0; margin: 0; }
-.overview-kpi-sidebar {
-  flex: 0 0 200px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-/* 사이드바에 들어간 KPI 카드는 더 컴팩트하게: 패딩 줄이고 폰트도 작게. */
-.kpi-group--stacked { padding: 14px 16px; }
-.kpi-group--stacked .kpi-group-heading { margin-bottom: 10px; font-size: 12px; }
-.kpi-group-metrics--stacked { display: flex; flex-direction: column; gap: 10px; }
-.kpi-group-metrics--stacked .metric-label { font-size: 12px; }
-.kpi-group-metrics--stacked .metric-value { font-size: 22px; margin-top: 4px; }
-@media (max-width: 880px) {
-  .overview-top-row { flex-direction: column; }
-  .overview-kpi-sidebar { flex-basis: auto; flex-direction: row; flex-wrap: wrap; }
-  .overview-kpi-sidebar .kpi-group { flex: 1 1 240px; }
-}
 .overview-tabs-row { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 16px; border-bottom: 1px solid var(--color-divider); }
 /* 관리(탭 nav 가 있는 섹션) 와 다르게 계약/보험 섹션은 단일 카드라 탭 자리에
    섹션명만 두고 우측에 신규 등록 버튼 한 개를 정렬. .overview-section-heading

--- a/development/front-admin-web/app/overview/page.tsx
+++ b/development/front-admin-web/app/overview/page.tsx
@@ -227,54 +227,52 @@ export default async function OverviewPage({
         </p>
       ) : null}
 
-      {/* 상단 영역: KPI 사이드바(좌) + 지도 보기 토글 / 캔버스(우). 두 블록이
-          같은 row 에 들어가 있으므로 지도가 켜지든 꺼지든 KPI 가 가운데에서
-          상시 보인다 — 운영자가 차량/라이더 수를 화면 어디로 옮겨가서
-          확인할지 고민 안 하도록. */}
-      <div className="overview-top-row">
-        <aside className="overview-kpi-sidebar" aria-label="요약 지표">
-          <article className="kpi-group kpi-group--stacked">
-            <h3 className="kpi-group-heading">차량 현황</h3>
-            <div className="kpi-group-metrics kpi-group-metrics--stacked">
-              <div>
-                <p className="metric-label">전체 차량</p>
-                <p className="metric-value">{formatCount(summary.totalBikes)}</p>
-              </div>
-              <div>
-                <p className="metric-label">시동 차량</p>
-                <p className="metric-value">{formatCount(ignitionOnCount)}</p>
-              </div>
-              <div>
-                <p className="metric-label">보험 차량</p>
-                <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
-              </div>
+      {/* 페이지 상단 KPI 두 카드(차량 현황 / 라이더 현황) — 원래대로 풀폭
+          가로 row 로 복원. */}
+      <div className="overview-kpi-groups">
+        <article className="kpi-group">
+          <h3 className="kpi-group-heading">차량 현황</h3>
+          <div className="kpi-group-metrics">
+            <div>
+              <p className="metric-label">전체 차량</p>
+              <p className="metric-value">{formatCount(summary.totalBikes)}</p>
             </div>
-          </article>
-
-          <article className="kpi-group kpi-group--stacked">
-            <h3 className="kpi-group-heading">라이더 현황</h3>
-            <div className="kpi-group-metrics kpi-group-metrics--stacked">
-              <div>
-                <p className="metric-label">전체 라이더</p>
-                <p className="metric-value">{formatCount(totalRiders)}</p>
-              </div>
-              <div>
-                <p className="metric-label">구독 인원</p>
-                <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
-              </div>
-              <div>
-                <p className="metric-label">렌탈 인원</p>
-                <p className="metric-value">{formatCount(rentalRiderCount)}</p>
-              </div>
+            <div>
+              <p className="metric-label">시동 차량</p>
+              <p className="metric-value">{formatCount(ignitionOnCount)}</p>
             </div>
-          </article>
-        </aside>
+            <div>
+              <p className="metric-label">보험 차량</p>
+              <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+            </div>
+          </div>
+        </article>
 
-        <OverviewMapBanner
-          bikePins={mapState.data.bikePins}
-          stationPins={mapState.data.stationPins}
-        />
+        <article className="kpi-group">
+          <h3 className="kpi-group-heading">라이더 현황</h3>
+          <div className="kpi-group-metrics">
+            <div>
+              <p className="metric-label">전체 라이더</p>
+              <p className="metric-value">{formatCount(totalRiders)}</p>
+            </div>
+            <div>
+              <p className="metric-label">구독 인원</p>
+              <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+            </div>
+            <div>
+              <p className="metric-label">렌탈 인원</p>
+              <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+            </div>
+          </div>
+        </article>
       </div>
+
+      {/* 지도 보기 토글 + 캔버스는 KPI 와 탭(관리 섹션) 사이에 위치. 운영자가
+          숫자 → 지도 → 표로 자연스럽게 눈을 내려갈 수 있도록 한 단계 정렬. */}
+      <OverviewMapBanner
+        bikePins={mapState.data.bikePins}
+        stationPins={mapState.data.stationPins}
+      />
 
       <h2 className="overview-section-heading">관리</h2>
       <div className="overview-tabs-row">


### PR DESCRIPTION
## Summary
- KPI 두 카드(차량 현황 / 라이더 현황)를 **원래 풀폭 가로 row** 로 복원 (#230 에서 도입한 좌측 사이드바 변형은 운영자 검토 후 되돌림)
- `지도 보기` 토글 + 캔버스 위치를 **KPI 와 \`관리\` 탭 사이**로 이동. 시선 흐름이 KPI 숫자 → 지도 → 표 순으로 자연스럽게 내려감
- `.overview-top-row` / `.overview-kpi-sidebar` / `.kpi-group--stacked` 선택자 제거 (다른 화면에서 참조 없음)

## Test plan
- [ ] `/overview` 최상단에 차량 현황 + 라이더 현황 카드가 풀폭 row 로 표시
- [ ] KPI row 아래에 \`지도 보기\` 토글이 위치, 토글 ON 시 캔버스가 KPI 와 탭 사이에 표시
- [ ] 토글 OFF 시 KPI 바로 아래에 \`관리\` 탭이 이어지는지 확인
- [ ] 탭 전환 시 지도 토글 상태 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)