### PR TITLE
Auto zoom-to-layer: fit map to all markers on first open

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -259,6 +259,47 @@ export function MapShell({
     }
   }, [sdkReady, targetLocation, mapVersion]);
 
+  // 지도 첫 표시 시 모든 마커(차량 + BSS) 가 한 화면에 들어오도록 zoom-to-layer.
+  // `hasFittedRef` 로 1회만 발화 — 폴링으로 핀이 추가/제거되어도 운영자의
+  // 현재 시점을 잡아챘다가 다시 fit 하지 않는다. 테마 토글로 NCP map 이
+  // 재생성되면(mapVersion 증가) 그땐 새 인스턴스에 다시 한 번 fit.
+  const hasFittedRef = useRef(false);
+  useEffect(() => {
+    hasFittedRef.current = false;
+  }, [mapVersion]);
+  useEffect(() => {
+    if (!sdkReady || hasFittedRef.current) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map?.fitBounds || !naver?.maps?.LatLng || !naver.maps.LatLngBounds) return;
+
+    const all: { lat: number; lng: number }[] = [];
+    for (const pin of bikePins) all.push({ lat: pin.latitude, lng: pin.longitude });
+    for (const pin of stationPins) all.push({ lat: pin.latitude, lng: pin.longitude });
+    if (all.length === 0) return;
+
+    if (all.length === 1) {
+      // 핀 한 개면 fitBounds 가 max-zoom 까지 끌어버려 너무 가까워진다 —
+      // 그냥 중심만 옮기고 기본 줌을 유지.
+      const only = all[0];
+      map.setCenter?.(new naver.maps.LatLng(only.lat, only.lng));
+      hasFittedRef.current = true;
+      return;
+    }
+
+    const first = all[0];
+    const bounds = new naver.maps.LatLngBounds(
+      new naver.maps.LatLng(first.lat, first.lng),
+      new naver.maps.LatLng(first.lat, first.lng)
+    );
+    for (let i = 1; i < all.length; i++) {
+      bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
+    }
+    // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
+    map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
+    hasFittedRef.current = true;
+  }, [sdkReady, bikePins, stationPins, mapVersion]);
+
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
   // 겹치는 점은 alpha 합성으로 색이 짙어져 밀도 시각화. 줌 무관 고정 크기.
   useEffect(() => {

--- a/development/front-admin-web/types/naver-maps.d.ts
+++ b/development/front-admin-web/types/naver-maps.d.ts
@@ -17,7 +17,9 @@ interface NaverGlobal {
 interface NaverMapsNamespace {
   Map: NaverMapConstructor;
   LatLng: NaverLatLngConstructor;
+  LatLngBounds: NaverLatLngBoundsConstructor;
   Point: NaverPointConstructor;
+  PointBounds: NaverPointBoundsConstructor;
   Size: NaverSizeConstructor;
   Marker: NaverMarkerConstructor;
   Polygon: NaverPolygonConstructor;
@@ -27,6 +29,24 @@ interface NaverMapsNamespace {
    * NCP exposes these as numeric enum values on `naver.maps.Position`.
    */
   Position: NaverMapsPositionEnum;
+}
+
+interface NaverLatLngBoundsConstructor {
+  new (sw: NaverLatLng, ne: NaverLatLng): NaverLatLngBounds;
+}
+
+export interface NaverLatLngBounds {
+  extend(latLng: NaverLatLng): NaverLatLngBounds;
+  hasLatLng(latLng: NaverLatLng): boolean;
+  isEmpty(): boolean;
+}
+
+interface NaverPointBoundsConstructor {
+  new (min: NaverPoint, max: NaverPoint): NaverPointBounds;
+}
+
+export interface NaverPointBounds {
+  extend(point: NaverPoint): NaverPointBounds;
 }
 
 interface NaverMapsPositionEnum {
@@ -81,6 +101,15 @@ export interface NaverMapInstance {
   setOptions?(options: Partial<NaverMapOptions>): void;
   setCenter?(latLng: NaverLatLng): void;
   setZoom?(zoom: number): void;
+  /**
+   * Adjust center + zoom so the given bounds fit the current viewport.
+   * The optional `margins` argument lets us reserve padding around the
+   * fitted region so the dots don't sit flush against the edges.
+   */
+  fitBounds?(
+    bounds: NaverLatLngBounds,
+    margins?: { top?: number; right?: number; bottom?: number; left?: number } | number
+  ): void;
 }
 
 interface NaverPointConstructor {


### PR DESCRIPTION
## Summary
- 지도 보기 토글 ON 시 차량 + BSS 마커 전체가 한 화면에 들어오도록 `fitBounds` 자동 호출 (zoom-to-layer)
- 사방 48px 패딩으로 가장자리 dot/label 이 잘리지 않도록 보정
- 핀이 1개면 `fitBounds` 가 max zoom 까지 끌어버리므로 중심만 옮기고 기본 줌 유지
- 1회만 발화 — 폴링으로 핀이 추가/제거되어도 운영자가 팬한 시점을 그대로 유지
- 테마 토글로 NCP map 인스턴스가 재생성되면(`mapVersion` 증가) 새 인스턴스에 다시 한 번 fit
- `LatLngBounds` / `fitBounds` 타입 선언 추가

## Test plan
- [ ] 지도 보기 토글 ON 시 모든 차량 + BSS 마커가 한 번에 화면에 보이는지 확인
- [ ] 가장자리 마커가 캔버스 끝에 붙지 않고 약간 여백이 있는지 확인
- [ ] 운영자가 줌/팬으로 시점을 옮긴 후 다음 폴링 tick 에서 시점이 유지되는지 확인 (fit 재실행 X)
- [ ] 핀이 없는 빈 상태에서 지도 보기 ON 시 서울 기본 중심이 유지되는지 확인
- [ ] 다크 모드 토글 후 지도가 다시 fit 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)