### PR TITLE
Pin page scroll while opening detail dialogs

### DIFF
--- a/development/front-admin-web/components/management/RiderDetailDialog.tsx
+++ b/development/front-admin-web/components/management/RiderDetailDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useRef, useState, useTransition } from "react";
 
 import { PhoneNumberInput } from "@/components/management/PhoneNumberInput";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
@@ -9,6 +9,7 @@ import {
   setVehicleIgnitionBlockFromOverviewAction,
   updateRiderFromOverviewAction
 } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendRider } from "@/lib/services/service-ops-api";
 
 /**
@@ -59,13 +60,11 @@ export function RiderDetailDialog({
   // row prop 이 갱신되면 자동으로 정정된다.
   const [ignitionBlockedOptimistic, setIgnitionBlockedOptimistic] = useState<boolean | null>(null);
 
-  // 다이얼로그를 native <dialog> 모달로 띄우거나 닫기만 한다. mode 초기화나
-  // 입력 상태 리셋은 effect 가 아니라 부모에서 `key={rider id}` 로 컴포넌트를
-  // 재마운트해 자연스럽게 처리한다 (react-hooks/set-state-in-effect 회피).
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  // 다이얼로그를 native <dialog> 모달로 띄우거나 닫기만 한다. 자동 포커스로
+  // 인한 페이지 스크롤 점프는 훅 안에서 잡는다. mode 초기화나 입력 상태
+  // 리셋은 effect 가 아니라 부모에서 `key={rider id}` 로 컴포넌트를 재마운트해
+  // 자연스럽게 처리한다 (react-hooks/set-state-in-effect 회피).
+  useScrollLockedDialog(dialogRef, row !== null);
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();

--- a/development/front-admin-web/components/management/StationDetailDialog.tsx
+++ b/development/front-admin-web/components/management/StationDetailDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { AddressSearchButton } from "@/components/management/AddressSearchButton";
 import { updateStationFromOverviewAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { BatteryStation } from "@/types/domain";
 
 /**
@@ -34,10 +35,7 @@ export function StationDetailDialog({
   const [maxValue, setMaxValue] = useState(row ? String(row.max) : "");
   const [availableValue, setAvailableValue] = useState(row ? String(row.available) : "");
 
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  useScrollLockedDialog(dialogRef, row !== null);
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import { updateVehicleFromOverviewAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 
@@ -40,12 +41,9 @@ export function VehicleDetailDialog({
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
 
-  // 모달 open/close 만 effect 에서 처리. 상태 리셋은 부모의 key prop 으로
-  // 재마운트해 useState 초기값이 새로 잡히도록 한다.
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  // 모달 open/close + scroll 보존을 공유 훅으로 위임. 상태 리셋은 부모의
+  // key prop 으로 재마운트해 useState 초기값이 새로 잡히도록 한다.
+  useScrollLockedDialog(dialogRef, row !== null);
 
   // 차량이 바뀌면 단말기 정보도 새로 받아온다. 부모(`VehiclesPanel`) 가
   // `key={vehicleId}` 로 다이얼로그를 remount 시키므로 row 가 null → row 로

--- a/development/front-admin-web/lib/hooks/use-scroll-locked-dialog.ts
+++ b/development/front-admin-web/lib/hooks/use-scroll-locked-dialog.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Native `<dialog>` + `showModal()` 패턴이 가진 부작용을 잡는 훅.
+ *
+ * 브라우저는 `showModal()` 직후 다이얼로그 내부 첫 focusable 요소(보통
+ * input) 에 자동 포커스를 옮긴다. 그 요소가 viewport 밖이면 브라우저가
+ * scroll-into-view 휴리스틱으로 페이지를 위로 끌어올려서 다이얼로그를
+ * 띄울 때 운영자가 보던 표의 행이 함께 밀려나간다.
+ *
+ * 두 단계로 막는다:
+ *   1) `showModal()` 직전에 `window.scrollY` 를 저장하고, 호출 직후 다음
+ *      frame 에서 같은 값으로 다시 스크롤 복원. 어떤 브라우저가 자동
+ *      focus 로 스크롤을 옮기더라도 원위치로 잡아당긴다.
+ *   2) 다이얼로그 element 자체에 `focus({ preventScroll: true })` 를 호출
+ *      해 1) 의 스크롤 점프 자체를 최대한 줄인다. (Safari/Firefox 에서
+ *      효과적, Chromium 도 backup 역할.)
+ *
+ * 닫힐 때는 `close()` 만 호출 — page scroll 은 그대로 살아 있다.
+ *
+ * `open` 상태가 바뀔 때마다 effect 가 한 번 발화하도록 호출 측에서
+ * boolean 으로 명시. (예: `row !== null`)
+ */
+export function useScrollLockedDialog(
+  dialogRef: RefObject<HTMLDialogElement | null>,
+  open: boolean
+): void {
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open) {
+      // 이미 열려 있으면(중복 effect 발화 등) 다시 열지 않는다 — 두 번째
+      // `showModal()` 호출은 InvalidStateError 를 던진다.
+      if (dialog.open) return;
+      const savedScrollY = typeof window !== "undefined" ? window.scrollY : 0;
+      dialog.showModal();
+      // dialog 자체에 포커스를 잡아 두면 내부 input 으로의 자동 포커스가
+      // 일어나도 그 단계가 사용자 가시 영역 안쪽이 된다. tabindex 가 명시
+      // 안 되어 있으면 native dialog 는 focusable 이 아닐 수 있어 부드러운
+      // fallback 차원으로만 시도.
+      try {
+        (dialog as HTMLElement).focus({ preventScroll: true });
+      } catch {
+        /* focus 가 실패해도 1) 단계 scroll 복원으로 충분히 메꿔진다. */
+      }
+      // 다음 frame 에서 scroll 복원. `showModal()` 후 브라우저가 focus 를
+      // 잡는 시점이 microtask 다음에 오는 frame 이라 rAF 안에서 잡아주면
+      // 거의 모든 케이스가 잡힌다.
+      if (typeof window !== "undefined") {
+        const handle = window.requestAnimationFrame(() => {
+          if (Math.abs(window.scrollY - savedScrollY) > 1) {
+            window.scrollTo({ top: savedScrollY, left: 0, behavior: "instant" as ScrollBehavior });
+          }
+        });
+        return () => window.cancelAnimationFrame(handle);
+      }
+    } else {
+      if (dialog.open) dialog.close();
+    }
+  }, [dialogRef, open]);
+}


### PR DESCRIPTION
## Summary
- 운영자가 표를 스크롤한 뒤 행을 클릭해 상세 다이얼로그를 열 때 페이지 스크롤이 위로 튀는 문제 해결
- 원인은 native \`<dialog>.showModal()\` 호출 후 브라우저가 자동으로 첫 focusable 요소(보통 input)에 포커스를 옮기면서 viewport 밖에 있던 그 요소를 보이게 하려고 페이지를 스크롤하는 휴리스틱
- 새 훅 \`useScrollLockedDialog\` 가 두 단계로 막음:
  1. \`showModal()\` 직전 \`window.scrollY\` 저장 → 다음 frame 에 차이 있으면 \`scrollTo\` 로 복원 (Chromium 자동 포커스 경로)
  2. \`dialog.focus({ preventScroll: true })\` 시도 — Safari/Firefox 의 scroll-into-view 단계 회피
- 적용: Vehicle / Rider / Station 상세 다이얼로그 3개 (Create 계열은 페이지 상단에서 열리므로 증상이 없어 제외, 필요 시 동일 훅 확장)

## Test plan
- [ ] 차량 / 라이더 / BSS 표를 스크롤해서 중간 행 클릭 → 상세 다이얼로그가 뜨면서 페이지 스크롤이 그 자리 유지되는지 확인
- [ ] 상세 다이얼로그 닫은 후 원래 보던 행 그대로 자리에 있는지 확인
- [ ] "수정" 모드로 전환했을 때 첫 input 으로 포커스가 자연스럽게 들어가는지 (단순히 입력 시작은 정상 동작) 확인
- [ ] ESC 또는 닫기 버튼으로 닫는 흐름이 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)