### PR TITLE
Release: map zoom-to-layer + dialog scroll fix

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -259,6 +259,47 @@ export function MapShell({
     }
   }, [sdkReady, targetLocation, mapVersion]);
 
+  // 지도 첫 표시 시 모든 마커(차량 + BSS) 가 한 화면에 들어오도록 zoom-to-layer.
+  // `hasFittedRef` 로 1회만 발화 — 폴링으로 핀이 추가/제거되어도 운영자의
+  // 현재 시점을 잡아챘다가 다시 fit 하지 않는다. 테마 토글로 NCP map 이
+  // 재생성되면(mapVersion 증가) 그땐 새 인스턴스에 다시 한 번 fit.
+  const hasFittedRef = useRef(false);
+  useEffect(() => {
+    hasFittedRef.current = false;
+  }, [mapVersion]);
+  useEffect(() => {
+    if (!sdkReady || hasFittedRef.current) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map?.fitBounds || !naver?.maps?.LatLng || !naver.maps.LatLngBounds) return;
+
+    const all: { lat: number; lng: number }[] = [];
+    for (const pin of bikePins) all.push({ lat: pin.latitude, lng: pin.longitude });
+    for (const pin of stationPins) all.push({ lat: pin.latitude, lng: pin.longitude });
+    if (all.length === 0) return;
+
+    if (all.length === 1) {
+      // 핀 한 개면 fitBounds 가 max-zoom 까지 끌어버려 너무 가까워진다 —
+      // 그냥 중심만 옮기고 기본 줌을 유지.
+      const only = all[0];
+      map.setCenter?.(new naver.maps.LatLng(only.lat, only.lng));
+      hasFittedRef.current = true;
+      return;
+    }
+
+    const first = all[0];
+    const bounds = new naver.maps.LatLngBounds(
+      new naver.maps.LatLng(first.lat, first.lng),
+      new naver.maps.LatLng(first.lat, first.lng)
+    );
+    for (let i = 1; i < all.length; i++) {
+      bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
+    }
+    // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
+    map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
+    hasFittedRef.current = true;
+  }, [sdkReady, bikePins, stationPins, mapVersion]);
+
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
   // 겹치는 점은 alpha 합성으로 색이 짙어져 밀도 시각화. 줌 무관 고정 크기.
   useEffect(() => {

--- a/development/front-admin-web/components/management/RiderDetailDialog.tsx
+++ b/development/front-admin-web/components/management/RiderDetailDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useRef, useState, useTransition } from "react";
 
 import { PhoneNumberInput } from "@/components/management/PhoneNumberInput";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
@@ -9,6 +9,7 @@ import {
   setVehicleIgnitionBlockFromOverviewAction,
   updateRiderFromOverviewAction
 } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendRider } from "@/lib/services/service-ops-api";
 
 /**
@@ -59,13 +60,11 @@ export function RiderDetailDialog({
   // row prop 이 갱신되면 자동으로 정정된다.
   const [ignitionBlockedOptimistic, setIgnitionBlockedOptimistic] = useState<boolean | null>(null);
 
-  // 다이얼로그를 native <dialog> 모달로 띄우거나 닫기만 한다. mode 초기화나
-  // 입력 상태 리셋은 effect 가 아니라 부모에서 `key={rider id}` 로 컴포넌트를
-  // 재마운트해 자연스럽게 처리한다 (react-hooks/set-state-in-effect 회피).
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  // 다이얼로그를 native <dialog> 모달로 띄우거나 닫기만 한다. 자동 포커스로
+  // 인한 페이지 스크롤 점프는 훅 안에서 잡는다. mode 초기화나 입력 상태
+  // 리셋은 effect 가 아니라 부모에서 `key={rider id}` 로 컴포넌트를 재마운트해
+  // 자연스럽게 처리한다 (react-hooks/set-state-in-effect 회피).
+  useScrollLockedDialog(dialogRef, row !== null);
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();

--- a/development/front-admin-web/components/management/StationDetailDialog.tsx
+++ b/development/front-admin-web/components/management/StationDetailDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { AddressSearchButton } from "@/components/management/AddressSearchButton";
 import { updateStationFromOverviewAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { BatteryStation } from "@/types/domain";
 
 /**
@@ -34,10 +35,7 @@ export function StationDetailDialog({
   const [maxValue, setMaxValue] = useState(row ? String(row.max) : "");
   const [availableValue, setAvailableValue] = useState(row ? String(row.available) : "");
 
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  useScrollLockedDialog(dialogRef, row !== null);
 
   const handleClose = useCallback(() => {
     dialogRef.current?.close();

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import { updateVehicleFromOverviewAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 
@@ -40,12 +41,9 @@ export function VehicleDetailDialog({
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
 
-  // 모달 open/close 만 effect 에서 처리. 상태 리셋은 부모의 key prop 으로
-  // 재마운트해 useState 초기값이 새로 잡히도록 한다.
-  useEffect(() => {
-    if (row) dialogRef.current?.showModal();
-    else dialogRef.current?.close();
-  }, [row]);
+  // 모달 open/close + scroll 보존을 공유 훅으로 위임. 상태 리셋은 부모의
+  // key prop 으로 재마운트해 useState 초기값이 새로 잡히도록 한다.
+  useScrollLockedDialog(dialogRef, row !== null);
 
   // 차량이 바뀌면 단말기 정보도 새로 받아온다. 부모(`VehiclesPanel`) 가
   // `key={vehicleId}` 로 다이얼로그를 remount 시키므로 row 가 null → row 로

--- a/development/front-admin-web/lib/hooks/use-scroll-locked-dialog.ts
+++ b/development/front-admin-web/lib/hooks/use-scroll-locked-dialog.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Native `<dialog>` + `showModal()` 패턴이 가진 부작용을 잡는 훅.
+ *
+ * 브라우저는 `showModal()` 직후 다이얼로그 내부 첫 focusable 요소(보통
+ * input) 에 자동 포커스를 옮긴다. 그 요소가 viewport 밖이면 브라우저가
+ * scroll-into-view 휴리스틱으로 페이지를 위로 끌어올려서 다이얼로그를
+ * 띄울 때 운영자가 보던 표의 행이 함께 밀려나간다.
+ *
+ * 두 단계로 막는다:
+ *   1) `showModal()` 직전에 `window.scrollY` 를 저장하고, 호출 직후 다음
+ *      frame 에서 같은 값으로 다시 스크롤 복원. 어떤 브라우저가 자동
+ *      focus 로 스크롤을 옮기더라도 원위치로 잡아당긴다.
+ *   2) 다이얼로그 element 자체에 `focus({ preventScroll: true })` 를 호출
+ *      해 1) 의 스크롤 점프 자체를 최대한 줄인다. (Safari/Firefox 에서
+ *      효과적, Chromium 도 backup 역할.)
+ *
+ * 닫힐 때는 `close()` 만 호출 — page scroll 은 그대로 살아 있다.
+ *
+ * `open` 상태가 바뀔 때마다 effect 가 한 번 발화하도록 호출 측에서
+ * boolean 으로 명시. (예: `row !== null`)
+ */
+export function useScrollLockedDialog(
+  dialogRef: RefObject<HTMLDialogElement | null>,
+  open: boolean
+): void {
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open) {
+      // 이미 열려 있으면(중복 effect 발화 등) 다시 열지 않는다 — 두 번째
+      // `showModal()` 호출은 InvalidStateError 를 던진다.
+      if (dialog.open) return;
+      const savedScrollY = typeof window !== "undefined" ? window.scrollY : 0;
+      dialog.showModal();
+      // dialog 자체에 포커스를 잡아 두면 내부 input 으로의 자동 포커스가
+      // 일어나도 그 단계가 사용자 가시 영역 안쪽이 된다. tabindex 가 명시
+      // 안 되어 있으면 native dialog 는 focusable 이 아닐 수 있어 부드러운
+      // fallback 차원으로만 시도.
+      try {
+        (dialog as HTMLElement).focus({ preventScroll: true });
+      } catch {
+        /* focus 가 실패해도 1) 단계 scroll 복원으로 충분히 메꿔진다. */
+      }
+      // 다음 frame 에서 scroll 복원. `showModal()` 후 브라우저가 focus 를
+      // 잡는 시점이 microtask 다음에 오는 frame 이라 rAF 안에서 잡아주면
+      // 거의 모든 케이스가 잡힌다.
+      if (typeof window !== "undefined") {
+        const handle = window.requestAnimationFrame(() => {
+          if (Math.abs(window.scrollY - savedScrollY) > 1) {
+            window.scrollTo({ top: savedScrollY, left: 0, behavior: "instant" as ScrollBehavior });
+          }
+        });
+        return () => window.cancelAnimationFrame(handle);
+      }
+    } else {
+      if (dialog.open) dialog.close();
+    }
+  }, [dialogRef, open]);
+}

--- a/development/front-admin-web/types/naver-maps.d.ts
+++ b/development/front-admin-web/types/naver-maps.d.ts
@@ -17,7 +17,9 @@ interface NaverGlobal {
 interface NaverMapsNamespace {
   Map: NaverMapConstructor;
   LatLng: NaverLatLngConstructor;
+  LatLngBounds: NaverLatLngBoundsConstructor;
   Point: NaverPointConstructor;
+  PointBounds: NaverPointBoundsConstructor;
   Size: NaverSizeConstructor;
   Marker: NaverMarkerConstructor;
   Polygon: NaverPolygonConstructor;
@@ -27,6 +29,24 @@ interface NaverMapsNamespace {
    * NCP exposes these as numeric enum values on `naver.maps.Position`.
    */
   Position: NaverMapsPositionEnum;
+}
+
+interface NaverLatLngBoundsConstructor {
+  new (sw: NaverLatLng, ne: NaverLatLng): NaverLatLngBounds;
+}
+
+export interface NaverLatLngBounds {
+  extend(latLng: NaverLatLng): NaverLatLngBounds;
+  hasLatLng(latLng: NaverLatLng): boolean;
+  isEmpty(): boolean;
+}
+
+interface NaverPointBoundsConstructor {
+  new (min: NaverPoint, max: NaverPoint): NaverPointBounds;
+}
+
+export interface NaverPointBounds {
+  extend(point: NaverPoint): NaverPointBounds;
 }
 
 interface NaverMapsPositionEnum {
@@ -81,6 +101,15 @@ export interface NaverMapInstance {
   setOptions?(options: Partial<NaverMapOptions>): void;
   setCenter?(latLng: NaverLatLng): void;
   setZoom?(zoom: number): void;
+  /**
+   * Adjust center + zoom so the given bounds fit the current viewport.
+   * The optional `margins` argument lets us reserve padding around the
+   * fitted region so the dots don't sit flush against the edges.
+   */
+  fitBounds?(
+    bounds: NaverLatLngBounds,
+    margins?: { top?: number; right?: number; bottom?: number; left?: number } | number
+  ): void;
 }
 
 interface NaverPointConstructor {


### PR DESCRIPTION
## Summary
- 지도 보기 토글 첫 ON 시 모든 차량 + BSS 마커가 한 화면에 들어오도록 \`fitBounds\` 자동 호출 (#235)
- 상세 다이얼로그 열 때 페이지 스크롤이 위로 튀는 문제 해결 — \`useScrollLockedDialog\` 훅으로 scrollY 보존 + \`preventScroll\` focus (#236)

## Test plan
- [ ] 지도 보기 ON 시 모든 마커가 한 화면에 보임 (가장자리 패딩 포함)
- [ ] 폴링 이후에도 운영자가 팬한 시점이 유지
- [ ] 차량 / 라이더 / BSS 표를 스크롤한 뒤 중간 행 클릭 → 상세 다이얼로그가 뜨면서 페이지 스크롤이 그 자리 유지
- [ ] 다이얼로그 닫은 후 원래 행이 화면에 그대로 있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)