### PR TITLE
Anchor detail dialogs to viewport center

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -489,7 +489,38 @@ textarea { padding-top: 10px; min-height: 96px; }
 .overview-tab-action { padding-bottom: 6px; }
 .overview-tabs { display: flex; gap: 4px; overflow-x: auto; }
 .overview-tabs-row .overview-tabs { margin-bottom: 0; border-bottom: 0; }
-.overview-create-dialog { position: relative; padding: 24px 28px; border: 0; border-radius: 12px; max-width: 520px; width: calc(100% - 32px); background: var(--color-surface); box-shadow: var(--shadow-panel); color: var(--color-text-primary); }
+/* Viewport 중앙 고정. native <dialog> UA 스타일은 `showModal()` 시 top-
+   layer 에서 `position: fixed; inset: 0; margin: auto` 로 자동 가운데
+   정렬되지만, 예전엔 `position: relative` 로 그 기본 동작을 덮어써서
+   다이얼로그가 document 좌표 기준 in-flow 위치 (= body 상단) 에 박혀 있었다.
+   #236 에서 page scroll 이 유지되도록 바꾼 뒤에는 그 부작용이 그대로 노출
+   되어 운영자가 표 중간을 보고 있을 때 다이얼로그가 viewport 위쪽 밖으로
+   잘려 안 보이는 자리에 떴다.
+
+   `position: fixed` + `top/left 50%` + `translate(-50%, -50%)` 로 viewport
+   정중앙에 잠근다. `inset 0 + margin auto` 보다 dialog 내용이 viewport
+   보다 클 때 부드럽게 잘리고 (max-height 와 자체 overflow 로 보호),
+   `.overview-create-dialog-reset` 등 자식의 `position: absolute` 기준점도
+   그대로 유지된다 (fixed 도 자식 absolute 의 containing block).
+
+   max-height + overflow:auto 로 긴 폼이 viewport 보다 커도 다이얼로그 내부
+   스크롤로 처리 — 페이지 전체 스크롤은 #236 정책대로 그대로 두고. */
+.overview-create-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 24px 28px;
+  border: 0;
+  border-radius: 12px;
+  max-width: 520px;
+  width: calc(100% - 32px);
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-panel);
+  color: var(--color-text-primary);
+}
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
 /* 라이더 상세 다이얼로그의 헤딩 줄. 왼쪽 = 제목, 오른쪽 = 활성 매칭 차량의


### PR DESCRIPTION
## Summary
- 상세 다이얼로그가 운영자가 보고 있는 화면 중앙이 아니라 페이지 상단(스크롤 안 한 위치)에 떠 있던 문제 해결
- 원인: \`.overview-create-dialog\` 의 \`position: relative\` 가 native \`<dialog>\` UA 스타일의 \`position: fixed; inset 0; margin auto\` viewport-centering 을 덮어쓰고 있었음. #236 이전엔 브라우저 자동 스크롤로 view 안으로 끌려왔지만 #236 이후엔 페이지 스크롤이 잠겨 그 자리에 그대로 머물러서 운영자에게는 화면 밖으로 잘려 보였다
- \`position: fixed\` + \`top/left 50%\` + \`translate(-50%, -50%)\` 로 viewport 정중앙에 잠금
- \`max-height: calc(100vh - 32px)\` + \`overflow: auto\` 로 긴 폼은 다이얼로그 내부 스크롤로 처리, 페이지 전체 스크롤은 #236 정책대로 유지

## Test plan
- [ ] 차량 / 라이더 / BSS 표를 한참 스크롤한 뒤 행 클릭 → 다이얼로그가 viewport 정중앙에 뜨는지 확인
- [ ] 페이지 최상단에서도 다이얼로그가 viewport 중앙에 뜨는지 확인 (기존 동작 회귀 없음)
- [ ] 다이얼로그 닫은 뒤 페이지 스크롤이 원래 자리 유지되는지 확인
- [ ] 긴 폼(예: 라이더 수정 모드)에서 다이얼로그 내부 스크롤이 동작하는지 확인
- [ ] 다이얼로그 우상단 ↻ 리셋 버튼 위치가 그대로인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)