### PR TITLE
Replace dot markers with scooter + battery icons

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -18,15 +18,16 @@ const NCP_STYLE_ID_DARK = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK;
 const SEOUL_DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 const DEFAULT_ZOOM = 13;
 
-// NCP `visualization.DotMap` 스펙을 옮긴 dot 마커. 기본 radius 5(=직경 10)
-// 보다 약간 키운 15px 로 두어서 한국 지도 시점에서 점이 잘 보이되, 너무
-// 부풀어 보이지 않도록 균형을 잡았다. opacity 0.5 + 흰색 1px stroke 는 그대로
-// — 점이 겹치면 alpha 합성으로 색이 짙어져 자연스러운 밀도 시각화가
-// 유지된다. 색만 우리 테마 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔
-// 적용. 줌 ≥ LABEL_VISIBLE_ZOOM 이면 dot 위에 pill 형태의 라벨(번호판 /
-// 스테이션 이름) 이 같이 노출되어 확대 시 식별이 가능하다.
-const DOT_PX = 15;
-const DOT_ANCHOR = DOT_PX / 2;
+// Line-art SVG 아이콘 마커. 운영자가 "이건 차량 / 이건 BSS" 를 즉시 알아볼 수
+// 있도록 dot 대신 인지 가능한 silhouette 로 교체.
+// - 차량: 배달용 스쿠터 (앞·뒤 바퀴 + 핸들 + 후방 배달박스). 색은 `--rm-accent`.
+// - BSS: 배터리 + 가운데 번개 마크. 색은 `--rm-battery-mid` (노랑 톤).
+// stroke 기반(`currentColor`) 이라 light/dark 테마 색 변동도 그대로 따라간다.
+// drop-shadow 1px 로 어떤 지도 배경 위에서도 외곽선이 살아 보이게 보강.
+// 줌 ≥ LABEL_VISIBLE_ZOOM 이면 아이콘 위에 pill 형태 라벨(번호판 / 스테이션
+// 이름)이 함께 노출되어 확대 시 식별 가능.
+const ICON_PX = 28;
+const ICON_ANCHOR = ICON_PX / 2;
 const LABEL_VISIBLE_ZOOM = 12;
 
 // Two-step load: base SDK first, then the GL companion. The official
@@ -347,8 +348,8 @@ export function MapShell({
       const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
       const icon = {
         content: html,
-        anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
-        size: new naver.maps.Size(DOT_PX, DOT_PX)
+        anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
+        size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.bikeId);
       if (existing) {
@@ -397,8 +398,8 @@ export function MapShell({
       const html = stationMarkerHtml(pin.name, showLabel);
       const icon = {
         content: html,
-        anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
-        size: new naver.maps.Size(DOT_PX, DOT_PX)
+        anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
+        size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.stationId);
       if (existing) {
@@ -471,19 +472,9 @@ export function MapShell({
   );
 }
 
-// NCP `visualization.DotMap` 기본 스타일을 그대로 옮긴 dot 본체:
-// - 10×10 px (radius 5 * 2)
-// - 1px 흰색 stroke (`box-sizing: border-box` 로 외곽 안쪽에 그려서 클릭 박스
-//   를 안정적으로 10px 로 유지)
-// - opacity 0.5 → 점이 겹치면 alpha 합성으로 색 짙어짐 (DotMap 의 핵심 효과)
-// fill 색만 우리 테마 토큰으로 받아서 light/dark 자동 전환.
-function dotMarkup(fillVar: string): string {
-  return `<div style="width:${DOT_PX}px;height:${DOT_PX}px;border-radius:50%;background:var(${fillVar});border:1px solid #ffffff;box-sizing:border-box;opacity:0.5;"></div>`;
-}
-
 /**
  * 마커 위에 띄우는 pill 형태 라벨. CSS 는 globals.css 의 `.map-marker-label`
- * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. dot 의
+ * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. 마커의
  * `pointer-events: auto` 와 충돌하지 않게 라벨 자체는 `pointer-events: none`.
  */
 function labelMarkup(text: string): string {
@@ -495,16 +486,52 @@ function labelMarkup(text: string): string {
   return `<span class="map-marker-label">${safe}</span>`;
 }
 
-/** BSS 마커 — DotMap 스타일 노란 dot + (옵션) 라벨. */
-function stationMarkerHtml(name: string, showLabel: boolean): string {
-  const dot = dotMarkup("--rm-battery-mid");
-  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
-  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(name)}${dot}</div>`;
+// 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
+const ICON_SVG_PROPS = `width="${ICON_PX}" height="${ICON_PX}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
+
+/** 배달 스쿠터 silhouette — 앞·뒤 바퀴 + 핸들 + 좌석 + 후방 배달박스. */
+function bikeIconSvg(): string {
+  return `<svg ${ICON_SVG_PROPS}>
+    <circle cx="6" cy="18" r="2"/>
+    <circle cx="18" cy="18" r="2"/>
+    <path d="M6 16 L7 10"/>
+    <path d="M7 10 L10 8"/>
+    <path d="M7 10 H13 L16 14"/>
+    <path d="M8 16 H16"/>
+    <rect x="13" y="4" width="7" height="6" rx="0.75"/>
+    <path d="M13 6.5 H20"/>
+  </svg>`;
 }
 
-/** 차량 마커 — DotMap 스타일 dot (`--rm-accent` 색) + (옵션) 번호판 라벨. */
+/** 충전 배터리 silhouette — 위쪽 단자 + 본체 + 가운데 번개 마크. */
+function stationIconSvg(): string {
+  return `<svg ${ICON_SVG_PROPS}>
+    <path d="M10 4 H14"/>
+    <rect x="6" y="6" width="12" height="15" rx="1.5"/>
+    <path d="M12.5 9 L9.5 14 H12 L10.8 18 L14 12.5 H11.5 Z"/>
+  </svg>`;
+}
+
+/**
+ * 마커 래퍼. `color: var(...)` 가 SVG `stroke="currentColor"` 로 전파되어
+ * 색을 가르고, drop-shadow 로 지도 배경 위 가시성을 확보한다. `line-height: 0`
+ * 은 SVG 가 inline-element 라 기본적으로 baseline 여백을 만드는 걸 잘라 — 그
+ * 여백이 anchor 계산과 어긋나면 마커가 lat/lng 점 위에서 미세하게 떠 보임.
+ */
+function markerWrapper(iconSvg: string, colorVar: string): string {
+  return `<div style="pointer-events:auto;color:var(${colorVar});width:${ICON_PX}px;height:${ICON_PX}px;line-height:0;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.35));">${iconSvg}</div>`;
+}
+
+/** BSS 마커 — 충전 배터리 아이콘 + (옵션) 스테이션 이름 라벨. */
+function stationMarkerHtml(name: string, showLabel: boolean): string {
+  const wrapped = markerWrapper(stationIconSvg(), "--rm-battery-mid");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(name)}${wrapped}</div>`;
+}
+
+/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨. */
 function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
-  const dot = dotMarkup("--rm-accent");
-  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
-  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(plateNumber)}${dot}</div>`;
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
 }


### PR DESCRIPTION
## Summary
- 차량 마커: 단색 dot → **배달 스쿠터** line-art SVG (앞·뒤 바퀴 + 핸들 + 좌석 + 후방 배달박스). 색 \`--rm-accent\`
- BSS 마커: 단색 dot → **배터리 + 번개** line-art SVG (위쪽 단자 + 본체 + 가운데 번개). 색 \`--rm-battery-mid\`
- 크기 15px → 28px (\`ICON_PX\`). \`currentColor\` 기반이라 light/dark 테마 색 변동도 그대로 따라감
- \`line-height: 0\` + \`drop-shadow(0 1px 2px rgba(0,0,0,0.35))\` 로 anchor 정렬 + 어떤 지도 배경에서도 외곽선 가시성 확보
- 라벨(번호판 / 스테이션 이름) 위치 로직은 그대로

## Test plan
- [ ] 지도 보기 ON 시 차량 마커가 스쿠터 silhouette 로 보이는지 확인
- [ ] BSS 마커가 배터리+번개 silhouette 로 보이는지 확인
- [ ] light / dark 테마 토글 시 색이 액센트/배터리 톤으로 정확히 바뀌는지 확인
- [ ] 줌 ≥ 12 일 때 라벨이 아이콘 위에 정상 노출되는지 확인
- [ ] 마커가 lat/lng 위치 정확히 위에 떠 있는지 (anchor 어긋남 없음) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)