### PR TITLE
Release: dialog centering + map loader + icon markers

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -236,6 +236,35 @@ button, input, select, textarea { font: inherit; }
 
 .control-map-page { position: relative; min-height: 100vh; overflow: hidden; background: var(--rm-bg-base); }
 .map-shell { position: absolute; inset: 0; z-index: 0; background: var(--rm-map-block); }
+/* fit-to-layer 가 결정될 때까지 NCP 캔버스 위를 덮는 로딩 오버레이.
+   캔버스와 같은 배경 톤이라 운영자에게는 "지도가 아직 안 떠 있는 상태" 로
+   읽힌다 — 첫 fit 이 끝난 뒤 React 가 이 노드를 제거하면 그제서야 GL
+   캔버스가 노출된다. */
+.map-shell-loading {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: var(--rm-map-block);
+  color: var(--color-text-muted);
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+.map-shell-spinner {
+  width: 26px;
+  height: 26px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--rm-accent);
+  border-radius: 50%;
+  animation: map-shell-spin 0.85s linear infinite;
+}
+@keyframes map-shell-spin {
+  to { transform: rotate(360deg); }
+}
 .map-shell[data-map-theme="dark"] { background: var(--rm-map-road-minor); }
 /* NCP overrides position: relative inline on the element it
    manages, so we size with width/height (which OL leaves alone) rather than

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -489,7 +489,38 @@ textarea { padding-top: 10px; min-height: 96px; }
 .overview-tab-action { padding-bottom: 6px; }
 .overview-tabs { display: flex; gap: 4px; overflow-x: auto; }
 .overview-tabs-row .overview-tabs { margin-bottom: 0; border-bottom: 0; }
-.overview-create-dialog { position: relative; padding: 24px 28px; border: 0; border-radius: 12px; max-width: 520px; width: calc(100% - 32px); background: var(--color-surface); box-shadow: var(--shadow-panel); color: var(--color-text-primary); }
+/* Viewport 중앙 고정. native <dialog> UA 스타일은 `showModal()` 시 top-
+   layer 에서 `position: fixed; inset: 0; margin: auto` 로 자동 가운데
+   정렬되지만, 예전엔 `position: relative` 로 그 기본 동작을 덮어써서
+   다이얼로그가 document 좌표 기준 in-flow 위치 (= body 상단) 에 박혀 있었다.
+   #236 에서 page scroll 이 유지되도록 바꾼 뒤에는 그 부작용이 그대로 노출
+   되어 운영자가 표 중간을 보고 있을 때 다이얼로그가 viewport 위쪽 밖으로
+   잘려 안 보이는 자리에 떴다.
+
+   `position: fixed` + `top/left 50%` + `translate(-50%, -50%)` 로 viewport
+   정중앙에 잠근다. `inset 0 + margin auto` 보다 dialog 내용이 viewport
+   보다 클 때 부드럽게 잘리고 (max-height 와 자체 overflow 로 보호),
+   `.overview-create-dialog-reset` 등 자식의 `position: absolute` 기준점도
+   그대로 유지된다 (fixed 도 자식 absolute 의 containing block).
+
+   max-height + overflow:auto 로 긴 폼이 viewport 보다 커도 다이얼로그 내부
+   스크롤로 처리 — 페이지 전체 스크롤은 #236 정책대로 그대로 두고. */
+.overview-create-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 24px 28px;
+  border: 0;
+  border-radius: 12px;
+  max-width: 520px;
+  width: calc(100% - 32px);
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-panel);
+  color: var(--color-text-primary);
+}
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
 /* 라이더 상세 다이얼로그의 헤딩 줄. 왼쪽 = 제목, 오른쪽 = 활성 매칭 차량의

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -18,15 +18,16 @@ const NCP_STYLE_ID_DARK = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK;
 const SEOUL_DEFAULT_CENTER = { lat: 37.5666103, lng: 126.9783882 };
 const DEFAULT_ZOOM = 13;
 
-// NCP `visualization.DotMap` 스펙을 옮긴 dot 마커. 기본 radius 5(=직경 10)
-// 보다 약간 키운 15px 로 두어서 한국 지도 시점에서 점이 잘 보이되, 너무
-// 부풀어 보이지 않도록 균형을 잡았다. opacity 0.5 + 흰색 1px stroke 는 그대로
-// — 점이 겹치면 alpha 합성으로 색이 짙어져 자연스러운 밀도 시각화가
-// 유지된다. 색만 우리 테마 토큰 (`--rm-accent`, `--rm-battery-mid`) 으로 바꿔
-// 적용. 줌 ≥ LABEL_VISIBLE_ZOOM 이면 dot 위에 pill 형태의 라벨(번호판 /
-// 스테이션 이름) 이 같이 노출되어 확대 시 식별이 가능하다.
-const DOT_PX = 15;
-const DOT_ANCHOR = DOT_PX / 2;
+// Line-art SVG 아이콘 마커. 운영자가 "이건 차량 / 이건 BSS" 를 즉시 알아볼 수
+// 있도록 dot 대신 인지 가능한 silhouette 로 교체.
+// - 차량: 배달용 스쿠터 (앞·뒤 바퀴 + 핸들 + 후방 배달박스). 색은 `--rm-accent`.
+// - BSS: 배터리 + 가운데 번개 마크. 색은 `--rm-battery-mid` (노랑 톤).
+// stroke 기반(`currentColor`) 이라 light/dark 테마 색 변동도 그대로 따라간다.
+// drop-shadow 1px 로 어떤 지도 배경 위에서도 외곽선이 살아 보이게 보강.
+// 줌 ≥ LABEL_VISIBLE_ZOOM 이면 아이콘 위에 pill 형태 라벨(번호판 / 스테이션
+// 이름)이 함께 노출되어 확대 시 식별 가능.
+const ICON_PX = 28;
+const ICON_ANCHOR = ICON_PX / 2;
 const LABEL_VISIBLE_ZOOM = 12;
 
 // Two-step load: base SDK first, then the GL companion. The official
@@ -347,8 +348,8 @@ export function MapShell({
       const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
       const icon = {
         content: html,
-        anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
-        size: new naver.maps.Size(DOT_PX, DOT_PX)
+        anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
+        size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.bikeId);
       if (existing) {
@@ -397,8 +398,8 @@ export function MapShell({
       const html = stationMarkerHtml(pin.name, showLabel);
       const icon = {
         content: html,
-        anchor: new naver.maps.Point(DOT_ANCHOR, DOT_ANCHOR),
-        size: new naver.maps.Size(DOT_PX, DOT_PX)
+        anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
+        size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.stationId);
       if (existing) {
@@ -471,19 +472,9 @@ export function MapShell({
   );
 }
 
-// NCP `visualization.DotMap` 기본 스타일을 그대로 옮긴 dot 본체:
-// - 10×10 px (radius 5 * 2)
-// - 1px 흰색 stroke (`box-sizing: border-box` 로 외곽 안쪽에 그려서 클릭 박스
-//   를 안정적으로 10px 로 유지)
-// - opacity 0.5 → 점이 겹치면 alpha 합성으로 색 짙어짐 (DotMap 의 핵심 효과)
-// fill 색만 우리 테마 토큰으로 받아서 light/dark 자동 전환.
-function dotMarkup(fillVar: string): string {
-  return `<div style="width:${DOT_PX}px;height:${DOT_PX}px;border-radius:50%;background:var(${fillVar});border:1px solid #ffffff;box-sizing:border-box;opacity:0.5;"></div>`;
-}
-
 /**
  * 마커 위에 띄우는 pill 형태 라벨. CSS 는 globals.css 의 `.map-marker-label`
- * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. dot 의
+ * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. 마커의
  * `pointer-events: auto` 와 충돌하지 않게 라벨 자체는 `pointer-events: none`.
  */
 function labelMarkup(text: string): string {
@@ -495,16 +486,52 @@ function labelMarkup(text: string): string {
   return `<span class="map-marker-label">${safe}</span>`;
 }
 
-/** BSS 마커 — DotMap 스타일 노란 dot + (옵션) 라벨. */
-function stationMarkerHtml(name: string, showLabel: boolean): string {
-  const dot = dotMarkup("--rm-battery-mid");
-  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
-  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(name)}${dot}</div>`;
+// 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
+const ICON_SVG_PROPS = `width="${ICON_PX}" height="${ICON_PX}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
+
+/** 배달 스쿠터 silhouette — 앞·뒤 바퀴 + 핸들 + 좌석 + 후방 배달박스. */
+function bikeIconSvg(): string {
+  return `<svg ${ICON_SVG_PROPS}>
+    <circle cx="6" cy="18" r="2"/>
+    <circle cx="18" cy="18" r="2"/>
+    <path d="M6 16 L7 10"/>
+    <path d="M7 10 L10 8"/>
+    <path d="M7 10 H13 L16 14"/>
+    <path d="M8 16 H16"/>
+    <rect x="13" y="4" width="7" height="6" rx="0.75"/>
+    <path d="M13 6.5 H20"/>
+  </svg>`;
 }
 
-/** 차량 마커 — DotMap 스타일 dot (`--rm-accent` 색) + (옵션) 번호판 라벨. */
+/** 충전 배터리 silhouette — 위쪽 단자 + 본체 + 가운데 번개 마크. */
+function stationIconSvg(): string {
+  return `<svg ${ICON_SVG_PROPS}>
+    <path d="M10 4 H14"/>
+    <rect x="6" y="6" width="12" height="15" rx="1.5"/>
+    <path d="M12.5 9 L9.5 14 H12 L10.8 18 L14 12.5 H11.5 Z"/>
+  </svg>`;
+}
+
+/**
+ * 마커 래퍼. `color: var(...)` 가 SVG `stroke="currentColor"` 로 전파되어
+ * 색을 가르고, drop-shadow 로 지도 배경 위 가시성을 확보한다. `line-height: 0`
+ * 은 SVG 가 inline-element 라 기본적으로 baseline 여백을 만드는 걸 잘라 — 그
+ * 여백이 anchor 계산과 어긋나면 마커가 lat/lng 점 위에서 미세하게 떠 보임.
+ */
+function markerWrapper(iconSvg: string, colorVar: string): string {
+  return `<div style="pointer-events:auto;color:var(${colorVar});width:${ICON_PX}px;height:${ICON_PX}px;line-height:0;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.35));">${iconSvg}</div>`;
+}
+
+/** BSS 마커 — 충전 배터리 아이콘 + (옵션) 스테이션 이름 라벨. */
+function stationMarkerHtml(name: string, showLabel: boolean): string {
+  const wrapped = markerWrapper(stationIconSvg(), "--rm-battery-mid");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(name)}${wrapped}</div>`;
+}
+
+/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨. */
 function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
-  const dot = dotMarkup("--rm-accent");
-  if (!showLabel) return `<div style="pointer-events:auto;">${dot}</div>`;
-  return `<div style="position:relative;pointer-events:auto;">${labelMarkup(plateNumber)}${dot}</div>`;
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
 }

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -263,7 +263,17 @@ export function MapShell({
   // `hasFittedRef` 로 1회만 발화 — 폴링으로 핀이 추가/제거되어도 운영자의
   // 현재 시점을 잡아챘다가 다시 fit 하지 않는다. 테마 토글로 NCP map 이
   // 재생성되면(mapVersion 증가) 그땐 새 인스턴스에 다시 한 번 fit.
+  //
+  // `firstFitReady` 는 "fit 결정 완료" 신호 — 렌더러가 그 시점까지 캔버스
+  // 위에 로딩 오버레이를 띄워서 운영자가 "서울 기본 중심 → 휙 이동" 의 잠깐
+  // 잘못된 위치 단계를 안 보게 한다.
   const hasFittedRef = useRef(false);
+  const [firstFitReady, setFirstFitReady] = useState(false);
+  // 테마 토글로 새 NCP map 인스턴스가 만들어지면 그 인스턴스에 대해 다시
+  // fit 을 돌려야 하니 ref 만 리셋한다. `firstFitReady` 자체는 리셋하지
+  // 않는다 — 운영자가 이미 지도를 보고 있는 상태라 짧은 깜빡임이 로딩
+  // 오버레이가 다시 깔리는 것보다 거슬리지 않고, 첫 mount 가 아닌 swap 의
+  // 한 프레임 차이는 GL canvas 가 자연스럽게 메꿔준다.
   useEffect(() => {
     hasFittedRef.current = false;
   }, [mapVersion]);
@@ -276,7 +286,24 @@ export function MapShell({
     const all: { lat: number; lng: number }[] = [];
     for (const pin of bikePins) all.push({ lat: pin.latitude, lng: pin.longitude });
     for (const pin of stationPins) all.push({ lat: pin.latitude, lng: pin.longitude });
-    if (all.length === 0) return;
+    // fit 완료 신호는 항상 다음 frame 으로 미뤄서 GL 캔버스가 새 시점을
+    // 실제로 그린 다음에 오버레이를 걷어내도록 한다. 또한 effect 안에서의
+    // sync setState (`react-hooks/set-state-in-effect`) 도 피한다.
+    const markReady = () => {
+      if (typeof window !== "undefined") {
+        window.requestAnimationFrame(() => setFirstFitReady(true));
+      } else {
+        setFirstFitReady(true);
+      }
+    };
+
+    if (all.length === 0) {
+      // 핀이 아예 없으면 fit 할 게 없으니 기본 중심 그대로 노출. 운영자가
+      // 빈 상태도 봐야 데이터 없음을 인지할 수 있어서 무한 로딩으로 두지 않음.
+      hasFittedRef.current = true;
+      markReady();
+      return;
+    }
 
     if (all.length === 1) {
       // 핀 한 개면 fitBounds 가 max-zoom 까지 끌어버려 너무 가까워진다 —
@@ -284,6 +311,7 @@ export function MapShell({
       const only = all[0];
       map.setCenter?.(new naver.maps.LatLng(only.lat, only.lng));
       hasFittedRef.current = true;
+      markReady();
       return;
     }
 
@@ -298,6 +326,7 @@ export function MapShell({
     // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
     map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
     hasFittedRef.current = true;
+    markReady();
   }, [sdkReady, bikePins, stationPins, mapVersion]);
 
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
@@ -427,6 +456,15 @@ export function MapShell({
           ref={containerRef}
           className="map-shell-canvas"
         />
+        {/* fit-to-layer 가 끝날 때까지 캔버스를 가리는 로딩 오버레이. NCP 가
+            map 인스턴스를 막 만든 직후의 "서울 기본 중심" 첫 프레임이 운영자
+            눈에 들어가지 않도록 함. */}
+        {!firstFitReady ? (
+          <div className="map-shell-loading" role="status" aria-live="polite">
+            <span className="map-shell-spinner" aria-hidden="true" />
+            <span>지도 불러오는 중…</span>
+          </div>
+        ) : null}
       </div>
       {children}
     </>


### PR DESCRIPTION
## Summary
- 상세 다이얼로그를 viewport 정중앙에 고정 (\`position: fixed\` + \`transform: translate(-50%, -50%)\`). \`position: relative\` 잔재 제거 (#238)
- 지도 보기 ON 후 첫 fit-to-layer 가 결정될 때까지 캔버스 위에 로딩 오버레이 (스피너 + "지도 불러오는 중…"). "서울 → 휙 이동" 깜빡임 제거 (#239)
- 차량/BSS 마커를 dot → 스쿠터 / 배터리 line-art SVG 로 교체 (#240)

## Test plan
- [ ] 표 스크롤한 뒤 행 클릭 시 다이얼로그가 viewport 중앙에 뜨고 페이지 스크롤은 그대로 유지
- [ ] 긴 폼은 다이얼로그 내부 스크롤로 동작
- [ ] 지도 보기 OFF → ON 시 스피너가 잠깐 뜨고, 사라지자마자 fit-to-layer 된 시점에서 마커가 처음 보임
- [ ] 차량 마커가 스쿠터, BSS 마커가 배터리+번개 모양으로 표시
- [ ] light / dark 테마 토글 시 마커 색이 액센트/배터리 톤으로 정확히 바뀜
- [ ] 줌 ≥ 12 일 때 마커 위에 라벨이 정상 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)