### PR TITLE
Inline operation-status toggle + trash-icon delete column

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -361,6 +361,40 @@ export async function createContractFromOverviewAction(formData: FormData): Prom
   redirect("/");
 }
 
+export async function setVehicleOperationStatusFromOverviewAction(
+  vehicleId: string,
+  formData: FormData
+): Promise<void> {
+  // 차량 탭 행의 "운영 상태" 인라인 토글이 호출. hidden field `operationStatus`
+  // 가 "IN_SERVICE" / "READY" 둘 중 하나. 별도 detail 다이얼로그 저장 흐름은
+  // 그대로 두되, 한 컬럼 즉시 변경용으로 가벼운 endpoint 하나 분리.
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=vehicles");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const next = String(formData.get("operationStatus") ?? "") as ServiceOpsBikeOperationStatus;
+  if (next !== "IN_SERVICE" && next !== "READY") {
+    redirect("/?tab=vehicles&status=operation-status-error");
+  }
+
+  try {
+    await client.changeVehicleOperationStatus(vehicleId, {
+      operationStatus: next,
+      reason: "OPERATOR_EDIT"
+    });
+  } catch {
+    redirect("/?tab=vehicles&status=operation-status-error");
+  }
+
+  revalidatePath("/");
+  redirect("/?tab=vehicles");
+}
+
 export async function setVehicleIgnitionBlockFromOverviewAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -467,6 +467,26 @@ textarea { padding-top: 10px; min-height: 96px; }
 .toggle-switch--compact { padding: 2px 10px 2px 2px; font-size: 11px; }
 .toggle-switch--compact .toggle-switch-thumb { width: 14px; height: 14px; }
 .toggle-switch--compact .toggle-switch-text { min-width: 20px; }
+
+/* 삭제 아이콘 버튼 (vehicles / riders / stations 테이블 가장 왼쪽 컬럼) —
+   행 클릭 영역과 시각적으로 분리되도록 작은 원형 ghost button. hover 시 적색
+   톤으로 액션이 destructive 임을 알리고, 색 외에는 다른 화면 요소를 안 어지럽힌다. */
+.delete-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background .12s ease, color .12s ease;
+}
+.delete-icon-button:hover { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); }
+.delete-icon-button:focus-visible { outline: 2px solid var(--rm-battery-low); outline-offset: 1px; }
 /* Empty-state cell. Sits inside the same table as the data rows so the
    column headers stay visible above it. Height is the card (240px) minus
    the sticky thead row (40px) so the message lands in the visual centre

--- a/development/front-admin-web/components/management/DeleteRiderButton.tsx
+++ b/development/front-admin-web/components/management/DeleteRiderButton.tsx
@@ -3,27 +3,53 @@
 import { deleteRiderFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page riders tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes
- * the rider (sets deleted_at), the loader filters those out, so the
- * row disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page riders tab. See
+ * `DeleteVehicleButton` for the shared design (icon button + confirm +
+ * stopPropagation). Backend soft-deletes the rider.
  */
 export function DeleteRiderButton({ riderId, riderName }: { riderId: string; riderName: string }) {
   const boundAction = deleteRiderFromOverviewAction.bind(null, riderId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
-        if (!window.confirm(`라이더 "${riderName}"을 삭제하시겠습니까?`)) {
+        if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`라이더 "${riderName}" 삭제`}
+        aria-label={`라이더 "${riderName}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/DeleteStationButton.tsx
+++ b/development/front-admin-web/components/management/DeleteStationButton.tsx
@@ -3,27 +3,53 @@
 import { deleteStationFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page stations tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes the
- * battery station (sets deleted_at), the loader filters those out, so the
- * row disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page stations tab. See
+ * `DeleteVehicleButton` for the shared design (icon button + confirm +
+ * stopPropagation). Backend soft-deletes the battery station.
  */
 export function DeleteStationButton({ stationId, stationLabel }: { stationId: string; stationLabel: string }) {
   const boundAction = deleteStationFromOverviewAction.bind(null, stationId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
         if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`스테이션 "${stationLabel}" 삭제`}
+        aria-label={`스테이션 "${stationLabel}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/DeleteVehicleButton.tsx
+++ b/development/front-admin-web/components/management/DeleteVehicleButton.tsx
@@ -3,27 +3,62 @@
 import { deleteVehicleFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page vehicles tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes the
- * bike (sets deleted_at), the loader filters those out, so the row
- * disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page vehicles tab. Renders as a
+ * trash-icon button so the column on the far left stays narrow and visual
+ * weight is similar to other inline-action icons. Wraps the server action
+ * in a small client form so we can intercept submit and confirm before
+ * deletion. Backend soft-deletes the bike (sets deleted_at) and the
+ * loader filters those out, so the row disappears from the next render
+ * after revalidatePath fires.
+ *
+ * The button is wrapped in a stopPropagation handler so clicking it does
+ * not also open the row's detail dialog.
  */
 export function DeleteVehicleButton({ vehicleId, plateNumber }: { vehicleId: string; plateNumber: string }) {
   const boundAction = deleteVehicleFromOverviewAction.bind(null, vehicleId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
         if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`차량 "${plateNumber}" 삭제`}
+        aria-label={`차량 "${plateNumber}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+// Trash can outline icon — light line-art matching the marker/logout
+// glyphs so the table action column reads as one consistent set.
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/OperationStatusToggle.tsx
+++ b/development/front-admin-web/components/management/OperationStatusToggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { setVehicleOperationStatusFromOverviewAction } from "@/app/actions";
+import type { ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 탭 테이블의 "운영 상태" 컬럼에서 한 줄에 박히는 인라인 토글. READY ↔
+ * IN_SERVICE 둘 사이만 오가는 단순한 boolean 같지만 운영 상태는 차량 별로
+ * 별도 endpoint 가 있어 ignition block 토글과 짝을 이루도록 같은 스위치
+ * 시각/동작을 채택했다.
+ *
+ * 켜짐(.is-on) = "운행"(IN_SERVICE), 꺼짐 = "대기"(READY). 라벨은 현재 값을
+ * 그대로 출력해 운영자가 "지금 어느 상태인지" 한눈에 보이도록.
+ *
+ * 행 클릭은 차량 상세 다이얼로그를 띄우므로, 토글 클릭이 행 클릭으로
+ * 전파되지 않도록 stopPropagation. optimistic 으로 즉시 시각 갱신 →
+ * server revalidate 후 props 가 재유입되면 자연스럽게 정정.
+ */
+export function OperationStatusToggle({
+  bikeId,
+  initialStatus
+}: {
+  bikeId: string;
+  initialStatus: ServiceOpsBikeOperationStatus;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [optimistic, setOptimistic] = useState<ServiceOpsBikeOperationStatus | null>(null);
+  const status = optimistic ?? initialStatus;
+  const isOperating = status === "IN_SERVICE";
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    const next: ServiceOpsBikeOperationStatus = isOperating ? "READY" : "IN_SERVICE";
+    setOptimistic(next);
+    const fd = new FormData();
+    fd.append("operationStatus", next);
+    startTransition(() => {
+      void setVehicleOperationStatusFromOverviewAction(bikeId, fd);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`toggle-switch toggle-switch--compact${isOperating ? " is-on" : ""}`}
+      role="switch"
+      aria-checked={isOperating}
+      aria-label="운영 상태 토글"
+      disabled={pending}
+      onClick={handleClick}
+    >
+      <span className="toggle-switch-thumb" aria-hidden="true" />
+      <span className="toggle-switch-text">{isOperating ? "운행" : "대기"}</span>
+    </button>
+  );
+}

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
+import { DeleteRiderButton } from "@/components/management/DeleteRiderButton";
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { RiderDetailDialog, type RiderDetailRow } from "@/components/management/RiderDetailDialog";
 import { RIDER_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
@@ -71,6 +72,7 @@ export function RidersPanel({
     <div className="table-card">
       <table className="table" style={{ tableLayout: "fixed" }}>
         <colgroup>
+          <col style={{ width: "48px" }} />
           <col />
           <col />
           <col />
@@ -84,6 +86,7 @@ export function RidersPanel({
         </colgroup>
         <thead>
           <tr>
+            <th aria-label="삭제" />
             <th>이름</th>
             <th>연락처</th>
             <th>교육</th>
@@ -99,7 +102,7 @@ export function RidersPanel({
         <tbody>
           {data.riders.length === 0 ? (
             <tr>
-              <td colSpan={10} className="table-empty-cell">
+              <td colSpan={11} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
@@ -146,6 +149,9 @@ export function RidersPanel({
                   })
                 }
               >
+                <td onClick={(event) => event.stopPropagation()}>
+                  {rider.id ? <DeleteRiderButton riderId={rider.id} riderName={rider.name} /> : null}
+                </td>
                 <td>{rider.name}</td>
                 <td>{rider.phone}</td>
                 <td>{renderEducationType(educationType)}</td>

--- a/development/front-admin-web/components/management/StationsPanel.tsx
+++ b/development/front-admin-web/components/management/StationsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { DeleteStationButton } from "@/components/management/DeleteStationButton";
 import { StationDetailDialog, type StationDetailRow } from "@/components/management/StationDetailDialog";
 import type { StationDataResult } from "@/lib/services/station-data";
 import type { BatteryStation } from "@/types/domain";
@@ -26,11 +27,13 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
     <div className="table-card">
       <table className="table" style={{ tableLayout: "fixed" }}>
         <colgroup>
+          <col style={{ width: "48px" }} />
           <col />
           <col style={{ width: "120px" }} />
         </colgroup>
         <thead>
           <tr>
+            <th aria-label="삭제" />
             <th>주소</th>
             <th style={{ textAlign: "center" }}>잔여/총</th>
           </tr>
@@ -38,7 +41,7 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
         <tbody>
           {data.stations.length === 0 ? (
             <tr>
-              <td colSpan={2} className="table-empty-cell">
+              <td colSpan={3} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
@@ -52,6 +55,11 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
                 className="table-row-clickable"
                 onClick={() => setActiveRow({ station, available, max })}
               >
+                <td onClick={(event) => event.stopPropagation()}>
+                  {station.id ? (
+                    <DeleteStationButton stationId={station.id} stationLabel={station.address} />
+                  ) : null}
+                </td>
                 <td>{station.address}</td>
                 <td style={{ textAlign: "center" }}>
                   <strong>{available}</strong>

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -3,7 +3,9 @@
 import { useMemo, useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
+import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
+import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
@@ -149,6 +151,7 @@ export function VehiclesPanel({
         <table className="table vehicles-table">
           <thead>
             <tr>
+              <th aria-label="삭제" />
               <th>차량번호</th>
               <th>모델</th>
               <th>운영 상태</th>
@@ -170,7 +173,7 @@ export function VehiclesPanel({
           <tbody>
             {visibleVehicles.length === 0 ? (
               <tr>
-                <td colSpan={16} className="table-empty-cell">
+                <td colSpan={17} className="table-empty-cell">
                   조건에 맞는 차량 없음
                 </td>
               </tr>
@@ -205,9 +208,20 @@ export function VehiclesPanel({
                     })
                   }
                 >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {vehicle.id ? (
+                      <DeleteVehicleButton vehicleId={vehicle.id} plateNumber={vehicle.plateNumber} />
+                    ) : null}
+                  </td>
                   <td>{vehicle.plateNumber}</td>
                   <td>{vehicle.model || <span className="muted">—</span>}</td>
-                  <td>{renderOperationBadge(op)}</td>
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {vehicle.id ? (
+                      <OperationStatusToggle bikeId={vehicle.id} initialStatus={op} />
+                    ) : (
+                      renderOperationBadge(op)
+                    )}
+                  </td>
                   <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
                   <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
                   <td>{renderEducationType(educationType)}</td>


### PR DESCRIPTION
## Summary
- 차량 탭 **운영 상태** 컬럼을 badge → 인라인 토글로 교체 (READY ↔ IN_SERVICE). \`시동 제어\` 와 동일한 \`toggle-switch--compact\` 시각/동작
- 차량/라이더/BSS 표 **가장 왼쪽에 삭제 아이콘 컬럼** 추가. 28px ghost 버튼, hover 시 destructive-red 톤. 기존 \`DeleteVehicleButton\` / \`DeleteRiderButton\` / \`DeleteStationButton\` 의 confirm 흐름 + 트레이시 아이콘으로 재구성
- 새 server action \`setVehicleOperationStatusFromOverviewAction\` — 기존 \`changeVehicleOperationStatus\` endpoint 호출, 한 컬럼 즉시 변경용 가벼운 경로
- 행 클릭으로 인한 상세 다이얼로그 오픈과 충돌 방지 위해 토글/삭제 cell 모두 \`onClick\` stopPropagation

## Test plan
- [ ] 차량 탭 운영 상태 토글 클릭 시 라벨이 운행/대기 사이로 즉시(optimistic) 바뀌고 server revalidate 후에도 유지되는지 확인
- [ ] 운영 상태 토글 클릭이 행 클릭(차량 상세 다이얼로그)을 트리거하지 않는지 확인
- [ ] 차량/라이더/BSS 각 행 가장 왼쪽에 trash 아이콘 버튼이 보이고 hover 시 적색 톤으로 바뀌는지 확인
- [ ] trash 아이콘 클릭 시 confirm 다이얼로그가 뜨고, 취소 시 행 유지, OK 시 행이 사라지는지 확인
- [ ] trash 아이콘 클릭이 행 클릭(상세 다이얼로그)을 트리거하지 않는지 확인
- [ ] 차량 탭의 다른 컬럼(이름, 연락처, 교육, …)이 회귀 없이 그대로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)