### PR TITLE
Make row delete actually pop a confirm before firing

### DIFF
--- a/development/front-admin-web/components/management/DeleteRiderButton.tsx
+++ b/development/front-admin-web/components/management/DeleteRiderButton.tsx
@@ -1,34 +1,37 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteRiderFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page riders tab. See
- * `DeleteVehicleButton` for the shared design (icon button + confirm +
- * stopPropagation). Backend soft-deletes the rider.
+ * `DeleteVehicleButton` for the shared design (icon button + onClick
+ * confirm + manual server action call). Backend soft-deletes the rider.
  */
 export function DeleteRiderButton({ riderId, riderName }: { riderId: string; riderName: string }) {
-  const boundAction = deleteRiderFromOverviewAction.bind(null, riderId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteRiderFromOverviewAction(riderId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`라이더 "${riderName}" 삭제`}
+      aria-label={`라이더 "${riderName}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`라이더 "${riderName}" 삭제`}
-        aria-label={`라이더 "${riderName}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 

--- a/development/front-admin-web/components/management/DeleteStationButton.tsx
+++ b/development/front-admin-web/components/management/DeleteStationButton.tsx
@@ -1,34 +1,38 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteStationFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page stations tab. See
- * `DeleteVehicleButton` for the shared design (icon button + confirm +
- * stopPropagation). Backend soft-deletes the battery station.
+ * `DeleteVehicleButton` for the shared design (icon button + onClick
+ * confirm + manual server action call). Backend soft-deletes the
+ * battery station.
  */
 export function DeleteStationButton({ stationId, stationLabel }: { stationId: string; stationLabel: string }) {
-  const boundAction = deleteStationFromOverviewAction.bind(null, stationId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteStationFromOverviewAction(stationId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`스테이션 "${stationLabel}" 삭제`}
+      aria-label={`스테이션 "${stationLabel}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`스테이션 "${stationLabel}" 삭제`}
-        aria-label={`스테이션 "${stationLabel}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 

--- a/development/front-admin-web/components/management/DeleteVehicleButton.tsx
+++ b/development/front-admin-web/components/management/DeleteVehicleButton.tsx
@@ -1,41 +1,45 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteVehicleFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page vehicles tab. Renders as a
- * trash-icon button so the column on the far left stays narrow and visual
- * weight is similar to other inline-action icons. Wraps the server action
- * in a small client form so we can intercept submit and confirm before
- * deletion. Backend soft-deletes the bike (sets deleted_at) and the
- * loader filters those out, so the row disappears from the next render
- * after revalidatePath fires.
+ * trash-icon button; backend soft-deletes the bike (sets deleted_at) and
+ * the loader filters those out so the row disappears next render.
  *
- * The button is wrapped in a stopPropagation handler so clicking it does
- * not also open the row's detail dialog.
+ * 이전엔 `<form action={action} onSubmit={confirm}>` 패턴이었는데, React 19
+ * server action 의 form 제출 경로가 native submit 이벤트를 우회하는 케이스가
+ * 있어 `preventDefault()` 가 확실히 동작 안 할 때가 있었다. form 을 걷어내고
+ * button onClick 안에서 직접 confirm → 통과 시 server action 호출. 이렇게
+ * 하면 LogoutButton 의 confirm 과 동일하게 항상 발화한다. `useTransition`
+ * 으로 pending 표시 + 중복 클릭 방지.
  */
 export function DeleteVehicleButton({ vehicleId, plateNumber }: { vehicleId: string; plateNumber: string }) {
-  const boundAction = deleteVehicleFromOverviewAction.bind(null, vehicleId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // 행 클릭으로 인한 상세 다이얼로그 오픈과 충돌 방지.
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteVehicleFromOverviewAction(vehicleId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`차량 "${plateNumber}" 삭제`}
+      aria-label={`차량 "${plateNumber}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`차량 "${plateNumber}" 삭제`}
-        aria-label={`차량 "${plateNumber}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 


### PR DESCRIPTION
**Stacked on #244** — base 는 \`cc-185-op-toggle-delete-icon\`. #244 머지 후 자동으로 \`dev\` 를 base 로 재타겟됩니다.

## Summary
- 운영자가 trash 아이콘을 눌러도 confirm 안내문이 안 뜨고 바로 삭제되던 문제 해결
- 원인: \`<form action={serverAction} onSubmit={confirm}>\` 패턴에서 React 19 server action 의 form dispatcher 가 synthetic submit 의 \`preventDefault\` 를 우회하는 케이스가 있음 (LogoutButton 은 client action 이라 영향 없었음)
- 수정: \`<form>\` 자체를 걷어내고 \`<button type="button" onClick={confirm + action}>\` 패턴으로. \`window.confirm\` 통과 시에만 server action 을 직접 호출
- \`useTransition\` 으로 pending 표시 + 중복 클릭 시 두 번 발사 방지
- 차량 / 라이더 / BSS 셋 다 동일하게

## Test plan
- [ ] 차량 / 라이더 / BSS trash 아이콘 클릭 시 confirm 다이얼로그가 반드시 뜨는지 확인
- [ ] 취소 누르면 행이 그대로 남아 있는지 확인
- [ ] OK 누르면 행이 삭제되고 표가 즉시 갱신되는지 확인
- [ ] 행 클릭(상세 다이얼로그)이 trash 클릭과 충돌 없이 분리되는지 확인
- [ ] 빠르게 trash 를 두 번 클릭해도 두 번 발사 안 되는지 확인 (pending 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)