### PR TITLE
Tag bikes with engine_type (ELECTRIC/ICE)

### DIFF
--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -120,12 +120,20 @@ export type RiderEducationRecordUpdateInput = {
 
 export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE";
 
+/**
+ * 차량 동력 종류. 정비 카탈로그 매칭과 운영자 필터의 1차 분류 키. backend
+ * V21 마이그레이션으로 도입 — 기존 차량은 모두 `ELECTRIC` 으로 default.
+ */
+export type ServiceOpsBikeEngineType = "ELECTRIC" | "ICE";
+
 export type ServiceOpsBike = {
   id: string;
   idx: number | null;
   plateNumber: string;
   vin: string;
   modelName: string | null;
+  /** Backend V21 부터 응답에 포함. 옛 backend 호환 위해 optional. */
+  engineType?: ServiceOpsBikeEngineType;
   operationStatus: ServiceOpsBikeOperationStatus;
   /** "시동 방지" 플래그. 라이더 상세 다이얼로그의 토글이 이 값을 PATCH 한다. */
   ignitionBlocked?: boolean;
@@ -145,6 +153,8 @@ export type FrontendVehicle = {
   plateNumber: string;
   vin?: string | null;
   model: string;
+  /** 정비 카탈로그 매칭에 쓰이는 동력 종류. 옛 backend 호환 위해 optional. */
+  engineType?: ServiceOpsBikeEngineType;
   status: "운행" | "대기";
   operationStatus?: ServiceOpsBikeOperationStatus;
   /** 시동 방지 토글의 현재 상태. 백엔드가 응답에 포함; 없으면 false 로 간주. */
@@ -164,6 +174,8 @@ export type VehicleCreateInput = {
   plateNumber: string;
   vin?: string | null;
   modelName?: string | null;
+  /** 미지정 시 backend 가 ELECTRIC 으로 기본값 (V21). */
+  engineType?: ServiceOpsBikeEngineType;
   operationStatus: ServiceOpsBikeOperationStatus;
   memo?: string | null;
 };
@@ -1314,6 +1326,7 @@ export function toFrontendVehicle(bike: ServiceOpsBike): FrontendVehicle {
     plateNumber: bike.plateNumber,
     vin: bike.vin,
     model: normalizeDisplayText(bike.modelName, "모델 미지정"),
+    engineType: bike.engineType,
     status: toFrontendVehicleStatus(bike.operationStatus),
     operationStatus: bike.operationStatus,
     ignitionBlocked: bike.ignitionBlocked ?? false,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -20,6 +20,15 @@ public class Bike extends DisplaySequencedEntity {
     @Column(length = 100)
     private String modelName;
 
+    /**
+     * 동력 종류 — 정비 catalog 매칭과 운영자 필터의 1차 분류 키. 자유
+     * 텍스트인 modelName 과 별도로 enum 으로 박아 분기 비용을 줄인다. 기존
+     * 행은 V21 마이그레이션에서 ELECTRIC 으로 기본값 잡힘.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "engine_type", nullable = false, length = 20)
+    private BikeEngineType engineType;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 40)
     private BikeOperationStatus operationStatus;
@@ -38,6 +47,7 @@ public class Bike extends DisplaySequencedEntity {
             String plateNumber,
             String vin,
             String modelName,
+            BikeEngineType engineType,
             BikeOperationStatus operationStatus,
             String memo
     ) {
@@ -45,6 +55,7 @@ public class Bike extends DisplaySequencedEntity {
         bike.plateNumber = plateNumber;
         bike.vin = vin;
         bike.modelName = modelName;
+        bike.engineType = engineType;
         bike.operationStatus = operationStatus;
         bike.memo = memo;
         return bike;
@@ -54,6 +65,7 @@ public class Bike extends DisplaySequencedEntity {
             String plateNumber,
             String vin,
             String modelName,
+            BikeEngineType engineType,
             String memo
     ) {
         if (plateNumber != null) {
@@ -64,6 +76,9 @@ public class Bike extends DisplaySequencedEntity {
         }
         if (modelName != null) {
             this.modelName = modelName;
+        }
+        if (engineType != null) {
+            this.engineType = engineType;
         }
         if (memo != null) {
             this.memo = memo;
@@ -89,6 +104,10 @@ public class Bike extends DisplaySequencedEntity {
 
     public String getModelName() {
         return modelName;
+    }
+
+    public BikeEngineType getEngineType() {
+        return engineType;
     }
 
     public BikeOperationStatus getOperationStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeEngineType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeEngineType.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.bike.domain;
+
+/**
+ * 차량의 동력 종류. 정비 스케줄 catalog 매칭, 필터, KPI 분류의 기준 축이 되는
+ * 차량 단위의 단순 분류. 모델명(`Bike.modelName`)은 자유 텍스트 메모로 유지하고
+ * 이 enum 이 도메인 분기의 1차 키 역할.
+ */
+public enum BikeEngineType {
+    /** 전기 이륜차. */
+    ELECTRIC,
+    /** 내연기관 이륜차. */
+    ICE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,12 @@ public record BikeCreateRequest(
         /** Optional at register time — operator updates later via the bike edit flow. */
         @Size(max = 100) String vin,
         @Size(max = 100) String modelName,
+        /**
+         * 동력 종류. null 이면 서비스 측에서 ELECTRIC 으로 기본값 잡음 — 현재
+         * 운영 차량이 모두 전기 이륜차라는 도메인 가정과 일치. ICE 차량은
+         * 운영자가 명시적으로 ICE 를 골라야 등록된다.
+         */
+        BikeEngineType engineType,
         @NotNull BikeOperationStatus operationStatus,
         String memo
 ) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,6 +12,7 @@ public record BikeReadResponse(
         String plateNumber,
         String vin,
         String modelName,
+        BikeEngineType engineType,
         BikeOperationStatus operationStatus,
         boolean ignitionBlocked,
         String memo,
@@ -24,6 +26,7 @@ public record BikeReadResponse(
                 bike.getPlateNumber(),
                 bike.getVin(),
                 bike.getModelName(),
+                bike.getEngineType(),
                 bike.getOperationStatus(),
                 bike.isIgnitionBlocked(),
                 bike.getMemo(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +10,8 @@ public record BikeUpdateRequest(
         @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String plateNumber,
         @Size(max = 100) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String vin,
         @Size(max = 100) String modelName,
+        /** null 이면 변경 안 함 (다른 필드와 동일한 partial-update 규약). */
+        BikeEngineType engineType,
         String memo
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
 import com.thundercrew.opsapi.bike.dto.BikeCreateRequest;
 import com.thundercrew.opsapi.bike.dto.BikeOperationStatusChangeRequest;
@@ -47,10 +48,16 @@ public class BikeCommandService {
         if (vin != null) {
             assertVinIsNotDuplicated(vin);
         }
+        // engineType 미지정 시 ELECTRIC 으로 기본값 — 현재 운영 차종이 모두
+        // 전기 이륜차라는 도메인 가정과 일치. ICE 는 명시적으로 골라야 등록.
+        BikeEngineType engineType = request.engineType() != null
+                ? request.engineType()
+                : BikeEngineType.ELECTRIC;
         Bike bike = Bike.create(
                 request.plateNumber(),
                 vin,
                 request.modelName(),
+                engineType,
                 request.operationStatus(),
                 request.memo()
         );
@@ -89,6 +96,7 @@ public class BikeCommandService {
                     request.plateNumber(),
                     request.vin(),
                     request.modelName(),
+                    request.engineType(),
                     request.memo()
             );
             entityManager.flush();

--- a/development/service-ops-api/src/main/resources/db/migration/V21__add_bikes_engine_type.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V21__add_bikes_engine_type.sql
@@ -1,0 +1,19 @@
+-- Tag each bike with the engine family it belongs to so downstream features
+-- (정비 스케줄 catalog 매칭, 필터) can branch on ICE vs ELECTRIC without
+-- relying on the free-form model_name string. Default is ELECTRIC because
+-- the current operating fleet is all electric two-wheelers; ICE rows can be
+-- created/edited explicitly by the operator.
+alter table bikes
+    add column engine_type varchar(20) not null default 'ELECTRIC';
+
+-- Existing rows are all electric by domain assumption — pinning the column
+-- value explicitly so future schema dumps don't depend on the default.
+update bikes set engine_type = 'ELECTRIC' where engine_type is null;
+
+alter table bikes
+    add constraint ck_bikes_engine_type
+        check (engine_type in ('ELECTRIC', 'ICE'));
+
+create index ix_bikes_engine_type_active
+    on bikes(engine_type)
+    where deleted_at is null;


### PR DESCRIPTION
## Summary
정비 + 필터 + 도메인 변경의 첫 슬라이스 — \`engine_type\` 컬럼만 백엔드에 깔고 끝남. 후속 PR 에서 정비 카탈로그, UI swap, 필터 확장이 차례로 들어옴.

- V21 migration: \`bikes.engine_type\` non-null 추가, check 제약 + 활성 행 인덱스, 기존 행 모두 \`ELECTRIC\` default
- 새 enum \`BikeEngineType\` (\`ELECTRIC\`, \`ICE\`)
- \`Bike\` entity / \`BikeCreate · Update · Read\` DTO + \`BikeCommandService\` 전부 새 필드 처리. Create 에서 null → ELECTRIC fallback (옛 client 무중단 보장)
- Frontend type 만 \`ServiceOpsBikeEngineType\` + \`engineType?\` 추가 — UI 변경 없음, 후속 PR-β 에서 "모델" 컬럼이 "구분" 으로 바뀌면서 실제 사용

이 PR 만 머지해도 운영에 visible change 는 없지만, 후속 PR 들의 base 가 됨.

## Test plan
- [ ] CI typecheck / lint / 백엔드 빌드 통과
- [ ] V21 migration 적용 후 기존 차량 행 모두 \`engine_type = 'ELECTRIC'\`
- [ ] BikeCreate POST 시 \`engineType\` 생략하면 자동으로 ELECTRIC 으로 저장
- [ ] \`engineType: "ICE"\` 명시 시 ICE 로 저장
- [ ] BikeRead 응답에 \`engineType\` 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)