### PR TITLE
Seed maintenance catalog + per-bike service-record schema

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceCommandController.java
@@ -1,0 +1,68 @@
+package com.thundercrew.opsapi.maintenance.controller;
+
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemUpdateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.service.MaintenanceCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MaintenanceCommandController {
+
+    private final MaintenanceCommandService maintenanceCommandService;
+
+    public MaintenanceCommandController(MaintenanceCommandService maintenanceCommandService) {
+        this.maintenanceCommandService = maintenanceCommandService;
+    }
+
+    @PostMapping("/api/v1/maintenance-items")
+    ResponseEntity<MaintenanceItemReadResponse> createItem(
+            @Valid @RequestBody MaintenanceItemCreateRequest request
+    ) {
+        MaintenanceItemReadResponse response = maintenanceCommandService.createItem(request);
+        return ResponseEntity.created(URI.create("/api/v1/maintenance-items/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/api/v1/maintenance-items/{id}")
+    MaintenanceItemReadResponse updateItem(
+            @PathVariable UUID id,
+            @Valid @RequestBody MaintenanceItemUpdateRequest request
+    ) {
+        return maintenanceCommandService.updateItem(id, request);
+    }
+
+    @DeleteMapping("/api/v1/maintenance-items/{id}")
+    ResponseEntity<Void> deleteItem(@PathVariable UUID id) {
+        maintenanceCommandService.softDeleteItem(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/api/v1/bikes/{bikeId}/maintenance-records")
+    ResponseEntity<VehicleMaintenanceRecordReadResponse> createRecord(
+            @PathVariable UUID bikeId,
+            @Valid @RequestBody VehicleMaintenanceRecordCreateRequest request
+    ) {
+        VehicleMaintenanceRecordReadResponse response = maintenanceCommandService.createRecord(bikeId, request);
+        return ResponseEntity.created(URI.create(
+                "/api/v1/bikes/" + bikeId + "/maintenance-records/" + response.id()
+        )).body(response);
+    }
+
+    @DeleteMapping("/api/v1/maintenance-records/{id}")
+    ResponseEntity<Void> deleteRecord(@PathVariable UUID id) {
+        maintenanceCommandService.softDeleteRecord(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
@@ -1,0 +1,49 @@
+package com.thundercrew.opsapi.maintenance.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.service.MaintenanceReadService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MaintenanceReadController {
+
+    private final MaintenanceReadService maintenanceReadService;
+
+    public MaintenanceReadController(MaintenanceReadService maintenanceReadService) {
+        this.maintenanceReadService = maintenanceReadService;
+    }
+
+    /** 전체 카탈로그 — 카탈로그 편집 화면이 두 표(전기/내연)를 모두 받아 그룹핑. */
+    @GetMapping("/api/v1/maintenance-items")
+    PageResponse<MaintenanceItemReadResponse> listItems(
+            @PageableDefault(size = 100, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        return maintenanceReadService.listItems(pageable);
+    }
+
+    @GetMapping("/api/v1/maintenance-items/{id}")
+    MaintenanceItemReadResponse getItem(@PathVariable UUID id) {
+        return maintenanceReadService.getItem(id);
+    }
+
+    /** 특정 차량에 적용 가능한 카탈로그 — engineType 필터링이 서비스 측에 위치. */
+    @GetMapping("/api/v1/bikes/{bikeId}/maintenance-items")
+    List<MaintenanceItemReadResponse> listItemsForBike(@PathVariable UUID bikeId) {
+        return maintenanceReadService.listItemsForBike(bikeId);
+    }
+
+    /** 차량 정비 이력 (최신순). 차량 상세 다이얼로그가 품목별 마지막 교환을 derive. */
+    @GetMapping("/api/v1/bikes/{bikeId}/maintenance-records")
+    List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(@PathVariable UUID bikeId) {
+        return maintenanceReadService.listRecordsForBike(bikeId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceAppliesTo.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceAppliesTo.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+/**
+ * 정비 품목이 어떤 차종에 적용되는지. `BikeEngineType` 과 평행하지만 "둘 다"
+ * 를 표현해야 해서 별도 enum.
+ *
+ * 차량별 카탈로그 조회 시: ELECTRIC 차량은 `ELECTRIC` + `BOTH` 를 합쳐서,
+ * ICE 차량은 `ICE` + `BOTH` 를 합쳐서 노출한다.
+ */
+public enum MaintenanceAppliesTo {
+    ELECTRIC,
+    ICE,
+    BOTH
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
@@ -1,0 +1,150 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+/**
+ * 정비 품목 카탈로그 row. "엔진오일", "브레이크 패드(앞)" 같은 한 줄에 해당한다.
+ *
+ * 그룹(예: 구동계3종) 표현은 `parentItemId` 셀프-FK 로. 부모 자체는 cycle 이
+ * 없고, 자식들이 각각 cycle 을 보유한다. UI 는 부모를 카드 헤더로 묶고 자식
+ * 세 개를 그 안에 펼친다.
+ *
+ * 단위 혼재: km / 개월 / 자유 텍스트 셋이 동시 보유 가능. UI 우선순위는
+ * 자유 텍스트(cycle_label) → km → 개월 순으로 표시.
+ */
+@Entity
+@Table(name = "maintenance_items")
+public class MaintenanceItem extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "applies_to", nullable = false, length = 20)
+    private MaintenanceAppliesTo appliesTo;
+
+    @Column(name = "parent_item_id")
+    private UUID parentItemId;
+
+    @Column(name = "cycle_km")
+    private Integer cycleKm;
+
+    @Column(name = "cycle_months")
+    private Integer cycleMonths;
+
+    @Column(name = "cycle_label", length = 50)
+    private String cycleLabel;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column
+    private String memo;
+
+    public static MaintenanceItem create(
+            String name,
+            MaintenanceAppliesTo appliesTo,
+            UUID parentItemId,
+            Integer cycleKm,
+            Integer cycleMonths,
+            String cycleLabel,
+            int displayOrder,
+            String memo
+    ) {
+        MaintenanceItem item = new MaintenanceItem();
+        item.name = name;
+        item.appliesTo = appliesTo;
+        item.parentItemId = parentItemId;
+        item.cycleKm = cycleKm;
+        item.cycleMonths = cycleMonths;
+        item.cycleLabel = cycleLabel;
+        item.displayOrder = displayOrder;
+        item.enabled = true;
+        item.memo = memo;
+        return item;
+    }
+
+    public void updateCatalog(
+            String name,
+            MaintenanceAppliesTo appliesTo,
+            UUID parentItemId,
+            Integer cycleKm,
+            Integer cycleMonths,
+            String cycleLabel,
+            Integer displayOrder,
+            Boolean enabled,
+            String memo
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (appliesTo != null) {
+            this.appliesTo = appliesTo;
+        }
+        // parentItemId / cycle 들은 명시적으로 null 로 보내는 케이스(그룹 분리,
+        // cycle 변경 등) 가 있으므로 null 도 그대로 수용. 호출 측이 partial
+        // update 를 원하면 wrapper(Optional) 패턴이 필요하나 운영자 편집 화면이
+        // 항상 전체 필드를 보내는 가정 하에 단순화.
+        this.parentItemId = parentItemId;
+        this.cycleKm = cycleKm;
+        this.cycleMonths = cycleMonths;
+        this.cycleLabel = cycleLabel;
+        if (displayOrder != null) {
+            this.displayOrder = displayOrder;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MaintenanceAppliesTo getAppliesTo() {
+        return appliesTo;
+    }
+
+    public UUID getParentItemId() {
+        return parentItemId;
+    }
+
+    public Integer getCycleKm() {
+        return cycleKm;
+    }
+
+    public Integer getCycleMonths() {
+        return cycleMonths;
+    }
+
+    public String getCycleLabel() {
+        return cycleLabel;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    protected MaintenanceItem() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/VehicleMaintenanceRecord.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/VehicleMaintenanceRecord.java
@@ -1,0 +1,78 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 차량별 정비 이벤트 한 건. 운영자가 차량 상세에서 "[엔진오일] 교환 완료" 를
+ * 누를 때마다 row 가 추가된다.
+ *
+ * "다음 교환 예정 / 임박 / 지연" 은 서비스 코드가 이 record + 해당 item.cycle_*
+ * 를 합쳐 derive — DB 컬럼으로는 안 두어 cycle 이 사후에 바뀌어도 자동 반영.
+ *
+ * `servicedAtOdometerKm` 는 운영자가 교환 시점에 알고 있다면 입력. odometer
+ * 텔레메트리가 없는 현 상태에서 km 기준 품목의 정확한 카운팅을 위해 선택적
+ * 입력 채널 제공.
+ */
+@Entity
+@Table(name = "vehicle_maintenance_records")
+public class VehicleMaintenanceRecord extends DisplaySequencedEntity {
+
+    @Column(name = "bike_id", nullable = false)
+    private UUID bikeId;
+
+    @Column(name = "item_id", nullable = false)
+    private UUID itemId;
+
+    @Column(name = "serviced_at", nullable = false)
+    private Instant servicedAt;
+
+    @Column(name = "serviced_at_odometer_km")
+    private Integer servicedAtOdometerKm;
+
+    @Column
+    private String memo;
+
+    public static VehicleMaintenanceRecord create(
+            UUID bikeId,
+            UUID itemId,
+            Instant servicedAt,
+            Integer servicedAtOdometerKm,
+            String memo
+    ) {
+        VehicleMaintenanceRecord record = new VehicleMaintenanceRecord();
+        record.bikeId = bikeId;
+        record.itemId = itemId;
+        record.servicedAt = servicedAt;
+        record.servicedAtOdometerKm = servicedAtOdometerKm;
+        record.memo = memo;
+        return record;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public UUID getItemId() {
+        return itemId;
+    }
+
+    public Instant getServicedAt() {
+        return servicedAt;
+    }
+
+    public Integer getServicedAtOdometerKm() {
+        return servicedAtOdometerKm;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    protected VehicleMaintenanceRecord() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MaintenanceItemCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotNull MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        @PositiveOrZero Integer cycleKm,
+        @PositiveOrZero Integer cycleMonths,
+        @Size(max = 50) String cycleLabel,
+        @PositiveOrZero Integer displayOrder,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
@@ -1,0 +1,40 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import java.time.Instant;
+import java.util.UUID;
+
+public record MaintenanceItemReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        Integer cycleKm,
+        Integer cycleMonths,
+        String cycleLabel,
+        int displayOrder,
+        boolean enabled,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static MaintenanceItemReadResponse from(MaintenanceItem item) {
+        return new MaintenanceItemReadResponse(
+                item.getId(),
+                item.getIdx(),
+                item.getName(),
+                item.getAppliesTo(),
+                item.getParentItemId(),
+                item.getCycleKm(),
+                item.getCycleMonths(),
+                item.getCycleLabel(),
+                item.getDisplayOrder(),
+                item.isEnabled(),
+                item.getMemo(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+/**
+ * 카탈로그 편집용 partial update. 모든 필드 optional — null 이면 변경 안 함.
+ * 단, `parentItemId` / `cycleKm` / `cycleMonths` / `cycleLabel` 은 명시적
+ * null 도 "값 비움" 의미로 그대로 반영. 다른 필드와 구분을 두는 이유는
+ * 카탈로그 편집 화면이 항상 전체 cycle 필드를 채워서 보내고, "그룹 해제" /
+ * "cycle 값 제거" 같은 케이스를 자연스럽게 표현해야 하기 때문.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MaintenanceItemUpdateRequest(
+        @Size(max = 100) String name,
+        MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        @PositiveOrZero Integer cycleKm,
+        @PositiveOrZero Integer cycleMonths,
+        @Size(max = 50) String cycleLabel,
+        @PositiveOrZero Integer displayOrder,
+        Boolean enabled,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordCreateRequest.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VehicleMaintenanceRecordCreateRequest(
+        @NotNull UUID itemId,
+        /** 미지정 시 서비스가 현재 시각으로 채움. */
+        Instant servicedAt,
+        @PositiveOrZero Integer servicedAtOdometerKm,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordReadResponse.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import java.time.Instant;
+import java.util.UUID;
+
+public record VehicleMaintenanceRecordReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        UUID itemId,
+        Instant servicedAt,
+        Integer servicedAtOdometerKm,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static VehicleMaintenanceRecordReadResponse from(VehicleMaintenanceRecord record) {
+        return new VehicleMaintenanceRecordReadResponse(
+                record.getId(),
+                record.getIdx(),
+                record.getBikeId(),
+                record.getItemId(),
+                record.getServicedAt(),
+                record.getServicedAtOdometerKm(),
+                record.getMemo(),
+                record.getCreatedAt(),
+                record.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
@@ -1,0 +1,28 @@
+package com.thundercrew.opsapi.maintenance.repository;
+
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface MaintenanceItemRepository extends Repository<MaintenanceItem, UUID> {
+
+    MaintenanceItem save(MaintenanceItem item);
+
+    Optional<MaintenanceItem> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<MaintenanceItem> findByDeletedAtIsNull(Pageable pageable);
+
+    /**
+     * 차량 단위 catalog 조회 — bike.engineType 이 ELECTRIC 이면
+     * `appliesTo IN (ELECTRIC, BOTH)`, ICE 면 `(ICE, BOTH)`.
+     * 서비스 측에서 호출 전에 in-list 를 만들어 넘긴다.
+     */
+    List<MaintenanceItem> findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(
+            List<MaintenanceAppliesTo> appliesTo
+    );
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
@@ -1,0 +1,20 @@
+package com.thundercrew.opsapi.maintenance.repository;
+
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMaintenanceRecord, UUID> {
+
+    VehicleMaintenanceRecord save(VehicleMaintenanceRecord record);
+
+    Optional<VehicleMaintenanceRecord> findByIdAndDeletedAtIsNull(UUID id);
+
+    /**
+     * 한 차량의 모든 정비 이력 (최신순). UI 가 품목별로 마지막 교환을 derive
+     * 할 때 시간 역순으로 한 번 훑는다.
+     */
+    List<VehicleMaintenanceRecord> findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(UUID bikeId);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
@@ -1,0 +1,119 @@
+package com.thundercrew.opsapi.maintenance.service;
+
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemUpdateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
+import com.thundercrew.opsapi.maintenance.repository.VehicleMaintenanceRecordRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MaintenanceCommandService {
+
+    private final MaintenanceItemRepository itemRepository;
+    private final VehicleMaintenanceRecordRepository recordRepository;
+    private final BikeRepository bikeRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public MaintenanceCommandService(
+            MaintenanceItemRepository itemRepository,
+            VehicleMaintenanceRecordRepository recordRepository,
+            BikeRepository bikeRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.itemRepository = itemRepository;
+        this.recordRepository = recordRepository;
+        this.bikeRepository = bikeRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public MaintenanceItemReadResponse createItem(MaintenanceItemCreateRequest request) {
+        MaintenanceItem item = MaintenanceItem.create(
+                request.name(),
+                request.appliesTo(),
+                request.parentItemId(),
+                request.cycleKm(),
+                request.cycleMonths(),
+                request.cycleLabel(),
+                request.displayOrder() != null ? request.displayOrder() : 0,
+                request.memo()
+        );
+        MaintenanceItem saved = itemRepository.save(item);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return MaintenanceItemReadResponse.from(saved);
+    }
+
+    @Transactional
+    public MaintenanceItemReadResponse updateItem(UUID id, MaintenanceItemUpdateRequest request) {
+        MaintenanceItem item = itemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+        item.updateCatalog(
+                request.name(),
+                request.appliesTo(),
+                request.parentItemId(),
+                request.cycleKm(),
+                request.cycleMonths(),
+                request.cycleLabel(),
+                request.displayOrder(),
+                request.enabled(),
+                request.memo()
+        );
+        entityManager.flush();
+        return MaintenanceItemReadResponse.from(item);
+    }
+
+    @Transactional
+    public void softDeleteItem(UUID id) {
+        MaintenanceItem item = itemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+        item.markDeleted(null, clock.instant());
+    }
+
+    @Transactional
+    public VehicleMaintenanceRecordReadResponse createRecord(
+            UUID bikeId,
+            VehicleMaintenanceRecordCreateRequest request
+    ) {
+        // bike + item 모두 존재 확인. 삭제된 행 참조 차단.
+        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        itemRepository.findByIdAndDeletedAtIsNull(request.itemId())
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", request.itemId()));
+
+        Instant servicedAt = request.servicedAt() != null ? request.servicedAt() : Instant.now(clock);
+        VehicleMaintenanceRecord record = VehicleMaintenanceRecord.create(
+                bikeId,
+                request.itemId(),
+                servicedAt,
+                request.servicedAtOdometerKm(),
+                request.memo()
+        );
+        VehicleMaintenanceRecord saved = recordRepository.save(record);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return VehicleMaintenanceRecordReadResponse.from(saved);
+    }
+
+    @Transactional
+    public void softDeleteRecord(UUID id) {
+        VehicleMaintenanceRecord record = recordRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("VehicleMaintenanceRecord", id));
+        record.markDeleted(null, clock.instant());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -1,0 +1,81 @@
+package com.thundercrew.opsapi.maintenance.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
+import com.thundercrew.opsapi.maintenance.repository.VehicleMaintenanceRecordRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MaintenanceReadService {
+
+    private final MaintenanceItemRepository itemRepository;
+    private final VehicleMaintenanceRecordRepository recordRepository;
+    private final BikeRepository bikeRepository;
+
+    public MaintenanceReadService(
+            MaintenanceItemRepository itemRepository,
+            VehicleMaintenanceRecordRepository recordRepository,
+            BikeRepository bikeRepository
+    ) {
+        this.itemRepository = itemRepository;
+        this.recordRepository = recordRepository;
+        this.bikeRepository = bikeRepository;
+    }
+
+    /**
+     * 전체 카탈로그(페이지). 카탈로그 편집 화면이 두 표(전기/내연)를 한 번에
+     * 노출하기 위해 호출. UI 가 클라이언트 측에서 appliesTo 별로 그룹핑.
+     */
+    public PageResponse<MaintenanceItemReadResponse> listItems(Pageable pageable) {
+        return PageResponse.of(
+                itemRepository.findByDeletedAtIsNull(pageable).map(MaintenanceItemReadResponse::from)
+        );
+    }
+
+    public MaintenanceItemReadResponse getItem(UUID id) {
+        return itemRepository.findByIdAndDeletedAtIsNull(id)
+                .map(MaintenanceItemReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+    }
+
+    /**
+     * 한 차량의 정비 catalog — 그 차량의 engineType 에 적용 가능한 품목만.
+     * ELECTRIC 차량은 (ELECTRIC + BOTH), ICE 는 (ICE + BOTH). 정렬은
+     * displayOrder 오름차순으로 사진 표 순서 유지.
+     */
+    public List<MaintenanceItemReadResponse> listItemsForBike(UUID bikeId) {
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        List<MaintenanceAppliesTo> appliesTo = bike.getEngineType() == BikeEngineType.ELECTRIC
+                ? List.of(MaintenanceAppliesTo.ELECTRIC, MaintenanceAppliesTo.BOTH)
+                : List.of(MaintenanceAppliesTo.ICE, MaintenanceAppliesTo.BOTH);
+        return itemRepository
+                .findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo)
+                .stream()
+                .map(MaintenanceItemReadResponse::from)
+                .toList();
+    }
+
+    public List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(UUID bikeId) {
+        // bike 존재 여부 보장 — 삭제된 차량 ID 로 잘못 조회되면 404.
+        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        return recordRepository
+                .findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(bikeId)
+                .stream()
+                .map(VehicleMaintenanceRecordReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V22__init_maintenance_catalog.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V22__init_maintenance_catalog.sql
@@ -1,0 +1,122 @@
+-- 정비 스케줄 도메인: 차량 단위 정비 catalog + 이벤트 이력. 두 테이블만 추가.
+--
+-- `maintenance_items` 가 카탈로그(품목 + 교환 주기 default) 를 보유하고,
+-- `vehicle_maintenance_records` 가 운영자가 "이 차량 이 품목을 교환했다"
+-- 마킹할 때마다 row 를 추가한다. "다음 교환 예정 / 임박 / 지연" 같은 derived
+-- 표시는 서비스 코드에서 record.serviced_at + item.cycle_* 로 계산.
+--
+-- engine type 분리: `applies_to` 가 `ELECTRIC` / `ICE` / `BOTH` 셋. 차량 단위
+-- 카탈로그 조회 시 (bike.engine_type 가 ELECTRIC 이면) `ELECTRIC` + `BOTH` 를
+-- 합쳐서 노출. ICE 차량도 같은 패턴.
+--
+-- 단위 혼재: km 기반(엔진오일 1,500km), 시간 기반(체인 장력조절 1개월), 그리고
+-- "12개월 이상", "6~7개월" 같은 비정형. `cycle_km` 와 `cycle_months` 가 둘 다
+-- nullable 이고, `cycle_label` 이 자유 텍스트로 비정형 표현을 잡는다.
+--
+-- 그룹(구동계3종) 표현: 자식 품목이 `parent_item_id` 로 부모를 참조. 부모 자체
+-- 의 cycle 은 NULL (그룹은 자체 cycle 없음, 자식이 각각 보유).
+
+create table maintenance_items (
+    id uuid primary key,
+    idx bigserial not null,
+    name varchar(100) not null,
+    -- ELECTRIC = 전기 차량에만 적용, ICE = 내연기관에만, BOTH = 둘 다.
+    applies_to varchar(20) not null,
+    -- 그룹용 부모 참조. null 이면 단독 품목.
+    parent_item_id uuid references maintenance_items(id) on delete restrict,
+    -- 둘 다 nullable. 둘 중 하나만 채워질 수도, 둘 다 채워질 수도 있다.
+    -- 둘 다 null 이지만 cycle_label 만 채워지는 경우(예: "운영자 판단") 도 허용.
+    cycle_km integer,
+    cycle_months integer,
+    -- "6~7개월", "12개월 이상" 같이 cycle_km/months 로 표현 안 되는 비정형 텍스트.
+    -- 채워져 있으면 UI 가 우선 표시. cycle_km/months 와 동시 보유 가능 (텍스트는
+    -- 보조 설명).
+    cycle_label varchar(50),
+    -- 같은 applies_to 안에서 정렬 순서. 사진 표 순서 그대로 0,1,2,... 로 seed.
+    display_order integer not null default 0,
+    enabled boolean not null default true,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    deleted_by uuid,
+    constraint ck_maintenance_items_applies_to
+        check (applies_to in ('ELECTRIC', 'ICE', 'BOTH')),
+    constraint ck_maintenance_items_cycle_present
+        check (cycle_km is not null or cycle_months is not null or cycle_label is not null)
+);
+
+create unique index ux_maintenance_items_idx on maintenance_items(idx);
+create index ix_maintenance_items_applies_to_active
+    on maintenance_items(applies_to)
+    where deleted_at is null;
+create index ix_maintenance_items_parent_active
+    on maintenance_items(parent_item_id)
+    where deleted_at is null;
+
+create table vehicle_maintenance_records (
+    id uuid primary key,
+    idx bigserial not null,
+    bike_id uuid not null references bikes(id) on delete restrict,
+    item_id uuid not null references maintenance_items(id) on delete restrict,
+    serviced_at timestamptz not null,
+    -- 운영자가 교환 시점에 알고 있다면 같이 입력. 우리에게 odometer 텔레메트리가
+    -- 없어 km 기준 품목은 운영자 보정 입력으로 보완한다 (계획서 옵션 (c)).
+    serviced_at_odometer_km integer,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    deleted_by uuid
+);
+
+create unique index ux_vehicle_maintenance_records_idx on vehicle_maintenance_records(idx);
+create index ix_vehicle_maintenance_records_bike_active
+    on vehicle_maintenance_records(bike_id, serviced_at desc)
+    where deleted_at is null;
+create index ix_vehicle_maintenance_records_item_active
+    on vehicle_maintenance_records(item_id)
+    where deleted_at is null;
+
+-- ============================================================================
+-- Seed: 사진 두 표 그대로
+-- ============================================================================
+--
+-- 공통 품목(브레이크 패드, 타이어) 은 applies_to = BOTH 로 한 행만 박는다 —
+-- ELECTRIC 차량 catalog 조회 시 `applies_to in ('ELECTRIC', 'BOTH')` 로 합쳐서
+-- 노출하면 사진과 동일한 목록이 된다.
+--
+-- 구동계3종 은 그룹 부모 + 자식 3개. 부모 UUID 는 self-FK 참조 위해 literal 로
+-- 고정.
+
+-- ICE 단독 품목
+insert into maintenance_items (id, name, applies_to, cycle_km, display_order) values
+    ('aaaa1111-0001-4001-8001-000000000001'::uuid, '엔진오일', 'ICE', 1500, 10),
+    ('aaaa1111-0001-4001-8001-000000000002'::uuid, '에어필터', 'ICE', 12000, 20),
+    ('aaaa1111-0001-4001-8001-000000000003'::uuid, '점화플러그', 'ICE', 20000, 30),
+    ('aaaa1111-0001-4001-8001-000000000006'::uuid, '브레이크오일 점검 및 보충', 'ICE', 30000, 60),
+    ('aaaa1111-0001-4001-8001-000000000007'::uuid, '냉각수 점검 및 보충', 'ICE', 20000, 70);
+
+-- 구동계3종 그룹 (부모) — cycle 없음.
+insert into maintenance_items (id, name, applies_to, cycle_label, display_order, cycle_km) values
+    ('aaaa1111-0001-4001-8001-000000000080'::uuid, '구동계3종', 'ICE', '그룹', 80, null);
+
+-- 구동계3종 자식 세 품목 — 같은 부모 참조.
+insert into maintenance_items (id, name, applies_to, parent_item_id, cycle_km, display_order) values
+    ('aaaa1111-0001-4001-8001-000000000081'::uuid, '슬라이드피스',         'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 81),
+    ('aaaa1111-0001-4001-8001-000000000082'::uuid, '드라이브벨트',         'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 82),
+    ('aaaa1111-0001-4001-8001-000000000083'::uuid, '무브볼(웨이트롤러)',   'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 83);
+
+-- ELECTRIC 단독 품목
+insert into maintenance_items (id, name, applies_to, cycle_months, cycle_label, cycle_km, display_order) values
+    ('bbbb2222-0002-4002-8002-000000000001'::uuid, '대소기어',         'ELECTRIC', 12,   '12개월 이상', null, 110),
+    ('bbbb2222-0002-4002-8002-000000000002'::uuid, '체인 장력조절',     'ELECTRIC', 1,    null,           null, 120),
+    ('bbbb2222-0002-4002-8002-000000000003'::uuid, '체인 교체',         'ELECTRIC', 6,    '6~7개월',     null, 130),
+    ('bbbb2222-0002-4002-8002-000000000004'::uuid, '모터오일',           'ELECTRIC', null, null,           30000, 140);
+
+-- 공통 (BOTH) 품목 — 두 표 모두에 등장
+insert into maintenance_items (id, name, applies_to, cycle_km, display_order) values
+    ('cccc3333-0003-4003-8003-000000000001'::uuid, '브레이크 패드(앞)', 'BOTH', 4000,  210),
+    ('cccc3333-0003-4003-8003-000000000002'::uuid, '브레이크 패드(뒤)', 'BOTH', 5000,  220),
+    ('cccc3333-0003-4003-8003-000000000003'::uuid, '타이어(앞)',         'BOTH', 15000, 230),
+    ('cccc3333-0003-4003-8003-000000000004'::uuid, '타이어(뒤)',         'BOTH', 12000, 240);


### PR DESCRIPTION
## Summary
정비 backend 슬라이스 — UI 변경 없음. PR-α(#247) 의 \`engine_type\` 컬럼을 base 로 정비 카탈로그 + 차량별 정비 이력 영속화 + REST 표면을 깐다.

**V22 migration:**
- \`maintenance_items\`: catalog row per replaceable part. \`applies_to\` enum (ELECTRIC / ICE / BOTH) — 공통 품목(브레이크 패드, 타이어)은 BOTH 한 row 로 표현. \`parent_item_id\` self-FK 로 구동계3종 같은 그룹 표현. cycle 은 \`cycle_km\` / \`cycle_months\` / \`cycle_label\` 셋 중 최소 하나 (check constraint)
- \`vehicle_maintenance_records\`: 운영자가 "교환 완료" 마킹할 때마다 append. \`serviced_at_odometer_km\` 는 odometer 텔레메트리 없는 현 상태에서 운영자 보정 입력용 (옵션 (c))
- Seed: 사진 두 표 그대로

**Java surface:**
- \`MaintenanceAppliesTo\` enum + \`MaintenanceItem\` / \`VehicleMaintenanceRecord\` entity
- Spring Data repository (list-by-bike, list items by applies_to IN)
- \`MaintenanceReadService\` / \`MaintenanceCommandService\`
- \`MaintenanceReadController\` / \`MaintenanceCommandController\`

**REST endpoints**:
- \`GET /api/v1/maintenance-items\` (페이지) — 카탈로그 편집용
- \`GET /api/v1/maintenance-items/{id}\`
- \`POST /api/v1/maintenance-items\` / \`PATCH /api/v1/maintenance-items/{id}\` / \`DELETE /api/v1/maintenance-items/{id}\` — 카탈로그 편집
- \`GET /api/v1/bikes/{bikeId}/maintenance-items\` — 차량 단위 (engineType 별 ELECTRIC+BOTH 또는 ICE+BOTH 필터링)
- \`GET /api/v1/bikes/{bikeId}/maintenance-records\` — 차량 정비 이력 (최신순)
- \`POST /api/v1/bikes/{bikeId}/maintenance-records\` — "교환 완료" 마킹
- \`DELETE /api/v1/maintenance-records/{id}\` — 잘못 입력 정정

**Frontend**: 변경 없음. UI 통합은 후속 PR-δ (차량 floating panel 안 정비 섹션) 에서.

## Test plan
- [ ] V22 migration 적용 시 \`maintenance_items\` 사진 표 그대로 seed 됨 (전기 4 + 내연 5 + 그룹 1 + 자식 3 + BOTH 4 = 17 row)
- [ ] \`GET /api/v1/maintenance-items\` 응답에 17개 row, applies_to / cycle_km / cycle_months / cycle_label 모두 노출
- [ ] ELECTRIC 차량 ID 로 \`GET /api/v1/bikes/{id}/maintenance-items\` 호출 시 ELECTRIC + BOTH = 8개 노출
- [ ] ICE 차량 ID 로 호출 시 ICE + BOTH = 13개 노출 (그룹 부모 1 + 자식 3 + 단독 5 + 공통 4)
- [ ] \`POST /api/v1/bikes/{id}/maintenance-records\` 로 정비 record 등록 → 응답에 servicedAt + serviced_at_odometer_km 포함, DB 에 row 생성
- [ ] 같은 차량에 record 두 번 등록 후 \`GET .../maintenance-records\` 호출 시 servicedAt desc 순서로 정렬되어 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)