### PR TITLE
Surface engine_type as the vehicle's primary classification

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import {
+  type ServiceOpsBikeEngineType,
   type ServiceOpsBikeOperationStatus,
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
@@ -110,6 +111,7 @@ export async function createVehicleFromOverviewAction(formData: FormData): Promi
       // sticker has been read off the vehicle.
       vin: null,
       modelName: optionalText(formData.get("modelName")),
+      engineType: parseEngineType(formData.get("engineType")),
       operationStatus: String(formData.get("operationStatus") ?? "READY") as ServiceOpsBikeOperationStatus
     });
   } catch {
@@ -231,12 +233,14 @@ export async function updateVehicleFromOverviewAction(
   const currentDeviceUid = String(formData.get("currentDeviceUid") ?? "").trim();
 
   try {
-    // 차체 기본 정보 (plateNumber / modelName) 는 일반 update endpoint 로,
-    // operationStatus 는 상태 이력을 남기는 별도 endpoint 로 분리 호출. 둘
-    // 다 같은 트랜잭션은 아니지만 운영자 입장에선 한 번의 "저장" 으로 묶이게 한다.
+    // 차체 기본 정보 (plateNumber / modelName / engineType) 는 일반 update
+    // endpoint 로, operationStatus 는 상태 이력을 남기는 별도 endpoint 로
+    // 분리 호출. 둘 다 같은 트랜잭션은 아니지만 운영자 입장에선 한 번의
+    // "저장" 으로 묶이게 한다.
     await client.updateVehicle(vehicleId, {
       plateNumber: requiredText(formData.get("plateNumber")),
-      modelName: optionalText(formData.get("modelName"))
+      modelName: optionalText(formData.get("modelName")),
+      engineType: parseEngineType(formData.get("engineType"))
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {
@@ -542,6 +546,16 @@ function requiredText(value: FormDataEntryValue | null): string {
 function optionalText(value: FormDataEntryValue | null): string | null {
   const text = requiredText(value);
   return text ? text : null;
+}
+
+// formData("engineType") 가 빈 값이면 undefined 로 (backend 가 ELECTRIC default
+// 처리). 인식 못 하는 값은 잡고 무시 — 운영자 UI 의 select 만 접근하는 경로라
+// 사실상 ELECTRIC / ICE 둘 중 하나만 들어오지만, 외부에서 잘못된 값이 들어와도
+// throw 하지 않고 그냥 backend default 에 위임.
+function parseEngineType(value: FormDataEntryValue | null): ServiceOpsBikeEngineType | undefined {
+  const text = String(value ?? "").trim();
+  if (text === "ELECTRIC" || text === "ICE") return text;
+  return undefined;
 }
 
 function parseNumber(value: FormDataEntryValue | null, fallback: number): number {

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -410,6 +410,8 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-pill--ignition-on { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
 .vehicles-pill--ignition-off { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
 .vehicles-pill--unknown { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); border: 1px solid var(--rm-battery-low-line); }
+.vehicles-pill--engine-electric { background: var(--rm-accent-soft); color: var(--rm-accent); border: 1px solid var(--rm-accent-outline); }
+.vehicles-pill--engine-ice { background: var(--rm-battery-mid-soft); color: var(--rm-battery-mid); border: 1px solid var(--rm-battery-mid-line); }
 
 /* 글로벌 "지도 보기" 토글 + 캔버스. 페이지 KPI/탭 위에 자리한다. */
 .overview-map-section { display: flex; flex-direction: column; gap: 10px; margin: 20px 0 12px; }

--- a/development/front-admin-web/components/management/CreateVehicleDialog.tsx
+++ b/development/front-admin-web/components/management/CreateVehicleDialog.tsx
@@ -8,9 +8,15 @@ import { createVehicleFromOverviewAction } from "@/app/actions";
 /**
  * Floating create dialog for the root page vehicles tab.
  *
+ * 차량의 1차 분류 키는 `engineType` (전기/내연) — backend V21 에서 도입되어
+ * 모든 차량이 이 둘 중 하나에 속한다. 정비 catalog 매칭 / 필터의 기준이라
+ * 등록 시점에 명시적으로 고른다 (기본 ELECTRIC). 자유 텍스트 모델명은
+ * "모델명 (메모)" 보조 필드로 같이 입력 가능.
+ *
  * 상단 우측 ↻ 버튼은 입력 초기화 — `form.reset()` 으로 uncontrolled
- * 입력(`modelName`, `operationStatus` select) 을 비우고, 내부 state 를
- * 가진 `PlateNumberInput` 은 key 증가로 재마운트 시켜 같이 초기화한다.
+ * 입력(`modelName`, `operationStatus` select, `engineType` select) 을 비우고,
+ * 내부 state 를 가진 `PlateNumberInput` 은 key 증가로 재마운트 시켜 같이
+ * 초기화한다.
  */
 export function CreateVehicleDialog() {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -48,7 +54,14 @@ export function CreateVehicleDialog() {
             <PlateNumberInput key={`plate-${resetKey}`} name="plateNumber" required />
           </label>
           <label>
-            모델
+            구분
+            <select name="engineType" defaultValue="ELECTRIC">
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연기관</option>
+            </select>
+          </label>
+          <label>
+            모델명 (메모)
             <input name="modelName" maxLength={100} placeholder="예: NIU NQi GTS" />
           </label>
           <label>

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -96,7 +96,8 @@ export function VehicleDetailDialog({
       {mode === "view" ? (
         <div className="detail-row-grid">
           <DetailField label="차량번호" value={vehicle.plateNumber} />
-          <DetailField label="모델" value={vehicle.model || "—"} />
+          <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
+          <DetailField label="모델명" value={vehicle.model || "—"} />
           <DetailField label="운영 상태" value={vehicle.status} />
           <DetailField label="이름" value={row.riderName ?? "—"} />
           <DetailField label="연락처" value={row.riderPhone ?? "—"} />
@@ -123,7 +124,14 @@ export function VehicleDetailDialog({
             <PlateNumberInput name="plateNumber" defaultValue={vehicle.plateNumber} required />
           </label>
           <label>
-            모델
+            구분
+            <select name="engineType" defaultValue={vehicle.engineType ?? "ELECTRIC"}>
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연기관</option>
+            </select>
+          </label>
+          <label>
+            모델명 (메모)
             <input name="modelName" defaultValue={vehicle.model} maxLength={100} placeholder="예: NIU NQi GTS" />
           </label>
           <label>
@@ -165,4 +173,10 @@ function DetailField({ label, value }: { label: string; value: string }) {
       <span className="detail-field-value">{value}</span>
     </div>
   );
+}
+
+function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
+  if (value === "ELECTRIC") return "전기";
+  if (value === "ICE") return "내연";
+  return "—";
 }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -22,11 +22,11 @@ import type {
  * 훑을 수 있도록 라이더 탭과 동일한 라이더-측 컬럼들을 함께 노출한다.
  *
  * 컬럼 (총 16):
- *   차량번호 / 모델 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
+ *   차량번호 / 구분 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
  *   기간 / 보험 / IMEI / 연결 상태 / 시동 상태 / 시동 제어 / 속도 / 잔량
  *
  * 데이터 매핑:
- * - 차량번호 / 모델 / 운영 상태 ← FrontendVehicle (이 패널 데이터)
+ * - 차량번호 / 구분(engineType) / 운영 상태 ← FrontendVehicle (이 패널 데이터)
  * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
  * - 교육 / 구독·렌탈 / 형태 / 기간 / 보험 ← bikeActiveRiderById 로 riderId 를
  *   먼저 찾고, 라이더 탭과 동일한 4 종 map (educationTypeByRiderId,
@@ -40,7 +40,7 @@ import type {
  * 라이더 탭에서 처리하도록 책임 분리. 시동 제어 토글만 행 안에서 직접 동작.
  *
  * 지도 보기 토글은 페이지 최상단의 글로벌 토글로 이동했으므로 이 패널에서는
- * 다루지 않는다. 필터는 차량번호/모델/IMEI 검색 한 줄만.
+ * 다루지 않는다. 필터는 차량번호/모델명/IMEI 검색 한 줄만.
  */
 
 type FilterState = {
@@ -125,7 +125,7 @@ export function VehiclesPanel({
           <input
             className="vehicles-filter-search"
             type="search"
-            placeholder="차량번호, 모델, IMEI 검색"
+            placeholder="차량번호, 모델명, IMEI 검색"
             value={filters.query}
             onChange={(event) => setFilters({ ...filters, query: event.target.value })}
           />
@@ -153,7 +153,7 @@ export function VehiclesPanel({
             <tr>
               <th aria-label="삭제" />
               <th>차량번호</th>
-              <th>모델</th>
+              <th>구분</th>
               <th>운영 상태</th>
               <th>이름</th>
               <th>연락처</th>
@@ -214,7 +214,7 @@ export function VehiclesPanel({
                     ) : null}
                   </td>
                   <td>{vehicle.plateNumber}</td>
-                  <td>{vehicle.model || <span className="muted">—</span>}</td>
+                  <td>{renderEngineTypeBadge(vehicle.engineType)}</td>
                   <td onClick={(event) => event.stopPropagation()}>
                     {vehicle.id ? (
                       <OperationStatusToggle bikeId={vehicle.id} initialStatus={op} />
@@ -255,6 +255,19 @@ export function VehiclesPanel({
       />
     </div>
   );
+}
+
+// 구분(engineType) 뱃지. ELECTRIC = 액센트 톤 (전기 = 정상 운영의 기본 차종),
+// ICE = battery-mid(노랑) 톤으로 시각 구분. 도메인 가정상 다수가 ELECTRIC 이므로
+// 액센트가 "기본" 컬러 역할.
+function renderEngineTypeBadge(engineType: FrontendVehicle["engineType"]): ReactNode {
+  if (engineType === "ICE") {
+    return <span className="vehicles-pill vehicles-pill--engine-ice">내연</span>;
+  }
+  if (engineType === "ELECTRIC") {
+    return <span className="vehicles-pill vehicles-pill--engine-electric">전기</span>;
+  }
+  return <span className="muted">—</span>;
 }
 
 function statusToOperation(status: FrontendVehicle["status"]): ServiceOpsBikeOperationStatus {


### PR DESCRIPTION
## Summary
PR-β — 프론트엔드 도메인 swap. PR-α(#247) 가 깐 \`engine_type\` 컬럼을 운영자 화면에 노출.

- 차량 표 \"모델\" 컬럼 → **\"구분\"** (전기/내연 뱃지)
- \`CreateVehicleDialog\` / \`VehicleDetailDialog\` 모두 \`engineType\` select 추가 (ELECTRIC default)
- \`modelName\` 입력은 \"모델명 (메모)\" 보조 필드로 demote — 자유 텍스트 메모로 살아 있음
- 차량 상세 view 모드에 "구분" 추가 노출
- \`createVehicleFromOverviewAction\` / \`updateVehicleFromOverviewAction\` 가 \`engineType\` formData 처리 (\`parseEngineType\` 헬퍼)
- 색: 전기 = accent (기본 도메인 톤), 내연 = battery-mid (노랑) — 두 새 pill 클래스

## Test plan
- [ ] 차량 표 컬럼 헤더가 \"구분\" 으로 표시
- [ ] 기존 차량(post V21 default ELECTRIC) 행에 \"전기\" 뱃지 표시
- [ ] CreateVehicleDialog 에서 \"구분\" select 가 ELECTRIC 으로 시작, ICE 로 바꿔 등록 시 DB 에 ICE 로 저장
- [ ] 등록 후 표에서 \"내연\" 뱃지로 노출
- [ ] VehicleDetailDialog view 모드에서 \"구분\" 행이 \"전기\" 또는 \"내연\" 표시
- [ ] edit 모드에서 select 변경 → 저장 → DB engine_type 갱신
- [ ] modelName 입력은 그대로 동작 (보조 메모)
- [ ] 검색 placeholder \"차량번호, 모델명, IMEI 검색\" 으로 변경됐는지 확인, 모델명 substring 검색 여전히 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)