### PR TITLE
Expand vehicles tab filter bar (engine/connection/ignition)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -393,6 +393,7 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-filter-search:focus { outline: 2px solid var(--rm-accent); outline-offset: -1px; border-color: transparent; }
 .vehicles-filter-search-icon { position: absolute; right: 10px; top: 50%; transform: translateY(-50%); font-size: 14px; opacity: 0.55; pointer-events: none; }
 .vehicles-filter-select { flex: 0 1 160px; min-width: 130px; height: 38px; padding: 0 10px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; cursor: pointer; }
+.vehicles-filter-select:disabled { opacity: 0.55; cursor: not-allowed; }
 .vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
 /* 16컬럼 테이블 (차량 자체 + 매칭 라이더 라이프 사이클) — 좁은 화면에선 가로 스크롤. */
 .vehicles-table-scroll { max-height: 560px; overflow: auto; }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -43,14 +43,31 @@ import type {
  * 다루지 않는다. 필터는 차량번호/모델명/IMEI 검색 한 줄만.
  */
 
+/**
+ * 차량 탭 필터 상태. 모든 필드가 union 이라 select option 의 raw value 를
+ * 그대로 저장해 컨버전 비용을 없앤다. `connection` 의 ANY_OFFLINE 은
+ * telemetry connection_status 가 ONLINE 이 아닌 모든 케이스(OFFLINE,
+ * SIGNAL_LOST, PARKED_OFFLINE 등) 를 한 번에 잡는다. `ignition` 은 핀이 없는
+ * 차량(텔레메트리 미수신)도 "UNKNOWN" 으로 분류해 운영자가 "단말기 없는 차량"
+ * 을 골라낼 수 있도록.
+ */
 type FilterState = {
   query: string;
+  engineType: "ALL" | "ELECTRIC" | "ICE";
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
+  connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
+  ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
+  // 정비 상태 필터는 PR-ζ 에서 활성. 자리만 잡아둠.
+  maintenance: "ALL";
 };
 
 const DEFAULT_FILTERS: FilterState = {
   query: "",
-  operationStatus: "ALL"
+  engineType: "ALL",
+  operationStatus: "ALL",
+  connection: "ALL",
+  ignition: "ALL",
+  maintenance: "ALL"
 };
 
 const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
@@ -110,16 +127,41 @@ export function VehiclesPanel({
         const imeiMatch = imei.toLowerCase().includes(q);
         if (!plateMatch && !modelMatch && !imeiMatch) return false;
       }
+      if (filters.engineType !== "ALL") {
+        // 옛 backend 응답엔 engineType 이 없을 수 있어 ELECTRIC 으로 폴백 —
+        // V21 마이그레이션 이후 모든 행이 ELECTRIC default 라는 가정과 일치.
+        const et = vehicle.engineType ?? "ELECTRIC";
+        if (et !== filters.engineType) return false;
+      }
       if (filters.operationStatus !== "ALL") {
         const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
         if (op !== filters.operationStatus) return false;
       }
+      if (filters.connection !== "ALL") {
+        const pin = bikePinById.get(vehicleKey);
+        const status = pin?.connectionStatus;
+        if (filters.connection === "ONLINE") {
+          if (status !== "ONLINE") return false;
+        } else {
+          // ANY_OFFLINE — ONLINE 이 아닌 모든 케이스. 핀이 아예 없는 차량도
+          // 운영자 관점에선 "통신 없음" 이므로 여기 포함.
+          if (status === "ONLINE") return false;
+        }
+      }
+      if (filters.ignition !== "ALL") {
+        const pin = bikePinById.get(vehicleKey);
+        const status = pin?.ignitionStatus;
+        if (filters.ignition === "ON" && status !== "ON") return false;
+        if (filters.ignition === "OFF" && status !== "OFF") return false;
+        if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
+      }
       return true;
     });
-  }, [data.vehicles, filters, deviceUidByBikeId]);
+  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById]);
 
   return (
     <div className="vehicles-panel">
+      {/* Row 1: 검색 · 구분 · 운영 상태 · 카운트 */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -131,6 +173,17 @@ export function VehiclesPanel({
           />
           <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
         </div>
+        <select
+          className="vehicles-filter-select"
+          value={filters.engineType}
+          onChange={(event) =>
+            setFilters({ ...filters, engineType: event.target.value as FilterState["engineType"] })
+          }
+        >
+          <option value="ALL">구분: 전체</option>
+          <option value="ELECTRIC">전기</option>
+          <option value="ICE">내연</option>
+        </select>
         <select
           className="vehicles-filter-select"
           value={filters.operationStatus}
@@ -145,6 +198,41 @@ export function VehiclesPanel({
         <span className="vehicles-filter-count">
           {visibleVehicles.length} / {data.vehicles.length}
         </span>
+      </div>
+      {/* Row 2: 연결 상태 · 시동 · 정비 상태(준비중) */}
+      <div className="vehicles-filter-row">
+        <select
+          className="vehicles-filter-select"
+          value={filters.connection}
+          onChange={(event) =>
+            setFilters({ ...filters, connection: event.target.value as FilterState["connection"] })
+          }
+        >
+          <option value="ALL">연결 상태: 전체</option>
+          <option value="ONLINE">온라인</option>
+          <option value="ANY_OFFLINE">오프라인/신호끊김</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.ignition}
+          onChange={(event) =>
+            setFilters({ ...filters, ignition: event.target.value as FilterState["ignition"] })
+          }
+        >
+          <option value="ALL">시동: 전체</option>
+          <option value="ON">ON</option>
+          <option value="OFF">OFF</option>
+          <option value="UNKNOWN">상태없음</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.maintenance}
+          disabled
+          title="정비 이력 UI 후속 PR 에서 활성화"
+          onChange={() => {}}
+        >
+          <option value="ALL">정비 상태 (준비중)</option>
+        </select>
       </div>
 
       <div className="table-card vehicles-table-scroll">


### PR DESCRIPTION
## Summary
PR-γ1 — 차량 탭 필터 확장. 한 줄 → 2-row 로 늘리고 세 개 select 추가, 정비 상태는 placeholder 만.

| Row | 컨트롤 |
|---|---|
| 1 | 검색 (차량번호/모델명/IMEI) · **구분** · 운영 상태 · 카운트 |
| 2 | **연결 상태** · **시동** · 정비 상태 (준비중, disabled) |

옵션:
- 구분: 전체 / 전기 / 내연 (engineType 필드 사용)
- 연결 상태: 전체 / 온라인 / 오프라인·신호끊김 (\`ANY_OFFLINE\` = ONLINE 외 모든 케이스 + 핀 없음)
- 시동: 전체 / ON / OFF / 상태없음 (\`UNKNOWN\` = 핀 없음 또는 ON/OFF 외)
- 정비 상태: placeholder — PR-ζ 에서 활성

필터 상태는 일단 panel local. 필터 → 지도 마커 동기화는 다음 슬라이스 (state lift + 글로벌 마커 갱신).

## Test plan
- [ ] 차량 탭 필터 바가 2줄로 노출
- [ ] 구분 필터 = 전기 → 전기 차량만 표시 (engineType ELECTRIC)
- [ ] 구분 필터 = 내연 → ICE 차량만 표시
- [ ] 연결 상태 = 온라인 → ONLINE 상태 차량만
- [ ] 연결 상태 = 오프라인·신호끊김 → 그 외 (텔레메트리 없는 차량 포함)
- [ ] 시동 = ON / OFF / 상태없음 각각 정확히 필터링
- [ ] 정비 상태 select 는 disabled + "준비중" 라벨
- [ ] 모든 필터 조합 동시 적용 (AND) 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)