### PR TITLE
Float the vehicle detail panel over the map and pan to selection

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -575,6 +575,69 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
+
+/* 차량 floating 상세 패널 — 모달 대신 지도 우측 상단에 떠 있는 비-모달
+   카드. 운영자가 panel 을 띄운 채로도 표/지도와 상호작용할 수 있어야 해서
+   `position: fixed` + 우측 anchor + max-height 로 viewport 안에 고정.
+   `pointer-events: auto` 는 명시 — 부모 wrapper 의 events: none 같은 패턴이
+   상위에 들어와도 패널 자체는 클릭 가능하게 보호. */
+.vehicle-floating-panel {
+  position: fixed;
+  top: 96px;
+  right: 24px;
+  width: 380px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  padding: 20px 24px;
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-panel);
+  color: var(--color-text-primary);
+  z-index: 50;
+  pointer-events: auto;
+}
+.vehicle-floating-panel h3 { margin: 0; font-size: 16px; }
+.vehicle-floating-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.vehicle-floating-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+.vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
+.vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+.vehicle-floating-panel label input,
+.vehicle-floating-panel label select {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--color-bg-soft);
+  color: var(--color-text-primary);
+  box-shadow: 0 0 0 1px var(--color-border);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
 /* 라이더 상세 다이얼로그의 헤딩 줄. 왼쪽 = 제목, 오른쪽 = 활성 매칭 차량의
    시동 상태 + 시동 제어 토글 패널. 활성 매칭이 없는 라이더는 우측이 비고
    제목만 보인다. h3 의 margin-bottom 은 헤딩 줄 자체로 옮겨 처리. */

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -4,14 +4,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import { updateVehicleFromOverviewAction } from "@/app/actions";
-import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 
 /**
- * 차량 상세 + 편집 다이얼로그. 차체 기본 정보(plateNumber / modelName) 와
- * 운영 상태(operationStatus) 가 백엔드에서는 두 endpoint 로 분리되어 있지만
- * UI 에서는 "저장" 한 번으로 묶고, server action 안에서 두 호출을 순차 실행한다.
+ * 차량 상세 + 편집 floating 패널. PR-γ3b 이전엔 native `<dialog>` modal 이었지만,
+ * 운영자가 표 행을 누르면 지도 위에서 그 차량을 따라가며 상세를 보고 싶다고
+ * 요청해 `<div position: fixed>` 로 바꿔 floating presentation 으로 전환.
+ *
+ * 자동으로 지도 열기 + 차량 위치 pan 은 부모 (`VehiclesPanel`) 가 행 클릭 시
+ * `VehicleFilterContext` 의 `setSelectedBikeId` 를 호출해 처리. 이 컴포넌트는
+ * 자체 모달 lifecycle 을 더 이상 갖지 않는다 — open/close 는 부모의 `row` prop
+ * 으로만 제어.
  *
  * IMEI(단말기 deviceUid) 도 같은 form 의 일부 — server action 이 device
  * 생성/조회 + bike-device-installation 생성/해제를 자동으로 처리한다. 운영자
@@ -35,15 +39,22 @@ export function VehicleDetailDialog({
   row: VehicleDetailRow | null;
   onClose: () => void;
 }) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const [mode, setMode] = useState<"view" | "edit">("view");
   // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-  // 모달 open/close + scroll 보존을 공유 훅으로 위임. 상태 리셋은 부모의
-  // key prop 으로 재마운트해 useState 초기값이 새로 잡히도록 한다.
-  useScrollLockedDialog(dialogRef, row !== null);
+  // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
+  // 않지만 키보드 접근성을 위해 listener 등록.
+  useEffect(() => {
+    if (!row) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [row, onClose]);
 
   // 차량이 바뀌면 단말기 정보도 새로 받아온다. 부모(`VehiclesPanel`) 가
   // `key={vehicleId}` 로 다이얼로그를 remount 시키므로 row 가 null → row 로
@@ -72,7 +83,6 @@ export function VehicleDetailDialog({
   }, [vehicleIdForFetch]);
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onClose();
   }, [onClose]);
 
@@ -86,13 +96,25 @@ export function VehicleDetailDialog({
   const currentInstallationId = deviceState?.installationId ?? "";
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="overview-create-dialog"
-      onClose={onClose}
-      onCancel={onClose}
+    <div
+      ref={panelRef}
+      className="vehicle-floating-panel"
+      role="dialog"
+      aria-label="차량 상세"
+      aria-modal="false"
     >
-      <h3>차량 상세</h3>
+      <div className="vehicle-floating-panel-header">
+        <h3>차량 상세</h3>
+        <button
+          type="button"
+          className="vehicle-floating-panel-close"
+          onClick={handleClose}
+          aria-label="닫기"
+          title="닫기"
+        >
+          ×
+        </button>
+      </div>
       {mode === "view" ? (
         <div className="detail-row-grid">
           <DetailField label="차량번호" value={vehicle.plateNumber} />
@@ -162,7 +184,7 @@ export function VehicleDetailDialog({
           </div>
         </form>
       )}
-    </dialog>
+    </div>
   );
 }
 

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -112,7 +112,7 @@ export function VehiclesPanel({
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
-  const { setFilteredBikeIds } = useVehicleFilter();
+  const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
   // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
   const bikePinById = useMemo(() => {
@@ -194,6 +194,20 @@ export function VehiclesPanel({
   useEffect(() => {
     return () => setFilteredBikeIds(null);
   }, [setFilteredBikeIds]);
+
+  // 행 클릭으로 activeRow 가 잡히면 context 의 selectedBikeId 도 같이 publish
+  // 해 지도가 자동으로 켜지고 그 차량으로 pan 한다. 닫힐 때 (activeRow=null)
+  // 는 selection 도 함께 해제. 언마운트(탭 전환) 시에도 잔존 방지.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = activeRow?.vehicle.id ?? null;
+    const handle = window.requestAnimationFrame(() => setSelectedBikeId(id));
+    return () => window.cancelAnimationFrame(handle);
+  }, [activeRow, setSelectedBikeId]);
+
+  useEffect(() => {
+    return () => setSelectedBikeId(null);
+  }, [setSelectedBikeId]);
 
   return (
     <div className="vehicles-panel">

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
@@ -10,21 +10,18 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * 루트 페이지(`/`) 상단에 박히는 글로벌 "지도 보기" 토글 + 지도. 차량 /
- * 라이더 / BSS 탭과 독립적으로 켰다 끌 수 있고, 켜면 차량 마커 + BSS 마커를
- * 한 지도에 띄운다.
- *
- * 탭 전환은 Next.js Link 로 같은 라우트의 query string 만 바꾸므로 이 client
- * 컴포넌트는 mount 가 유지되어 토글 상태도 보존된다. (탭마다 매번 다시
- * 켜야 하는 불편 없음.)
+ * 루트 페이지(`/`) 상단에 박히는 글로벌 "지도 보기" 토글 + 지도.
  *
  * 토글 OFF 상태에선 MapShell 을 mount 하지 않아 NCP 지도 SDK 세션이 생기지
  * 않는다 — 운영자가 지도가 필요 없을 때까지 API 미터를 잡지 않도록.
  *
- * 차량 탭 활성 + 필터 적용 상태에선 `VehicleFilterContext` 가 `filteredBikeIds`
- * 를 넘겨 그 부분 집합만 마커로 노출한다. 다른 탭(라이더/BSS)에 가면
- * VehiclesPanel 이 언마운트되며 context 가 null 로 되돌아가 전체 차량 핀이
- * 다시 보인다.
+ * 차량 탭 활성 + 필터 적용 상태에선 `VehicleFilterContext` 의
+ * `filteredBikeIds` 로 부분 집합만 마커로 노출. 다른 탭에선 VehiclesPanel 이
+ * 언마운트되며 context 가 null 로 되돌아가 전체 핀 복귀.
+ *
+ * 차량 행 클릭 시(VehiclesPanel 이 `selectedBikeId` 를 context 에 publish)
+ * 지도가 자동으로 열리고 그 차량 위치로 pan. 이미 열려 있으면 pan 만. 운영자
+ * 가 토글로 다시 끄기 전까지 자동으로 닫지 않는다.
  */
 export function OverviewMapBanner({
   bikePins,
@@ -34,12 +31,38 @@ export function OverviewMapBanner({
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
 }) {
   const [open, setOpen] = useState(false);
-  const { filteredBikeIds } = useVehicleFilter();
+  const { filteredBikeIds, selectedBikeId } = useVehicleFilter();
 
   const effectiveBikePins = useMemo(() => {
     if (filteredBikeIds === null) return bikePins;
     return bikePins.filter((pin) => filteredBikeIds.has(pin.bikeId));
   }, [bikePins, filteredBikeIds]);
+
+  const bikePinById = useMemo(() => {
+    const map = new Map<string, FrontendDashboardBikePin>();
+    for (const pin of bikePins) map.set(pin.bikeId, pin);
+    return map;
+  }, [bikePins]);
+
+  // 행 클릭 시 자동으로 토글 ON. setState in effect 는 rAF 한 프레임 양보로
+  // 회피 — 같은 commit 안에서 동기 호출하면 lint(`react-hooks/set-state-in-
+  // effect`) 가 잡는다.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (selectedBikeId && !open) {
+      const handle = window.requestAnimationFrame(() => setOpen(true));
+      return () => window.cancelAnimationFrame(handle);
+    }
+  }, [selectedBikeId, open]);
+
+  // 선택 차량의 위치로 pan. 객체 identity 가 매번 새로 생성되어 MapShell 의
+  // targetLocation effect 가 재발화 (같은 차량을 두 번 골라도 다시 panning).
+  const targetLocation = useMemo(() => {
+    if (!selectedBikeId) return null;
+    const pin = bikePinById.get(selectedBikeId);
+    if (!pin) return null;
+    return { lat: pin.latitude, lng: pin.longitude };
+  }, [selectedBikeId, bikePinById]);
 
   const totalLabel =
     filteredBikeIds === null
@@ -63,7 +86,11 @@ export function OverviewMapBanner({
       </div>
       {open ? (
         <div className="overview-map-canvas">
-          <MapShell bikePins={[...effectiveBikePins]} stationPins={[...stationPins]} />
+          <MapShell
+            bikePins={[...effectiveBikePins]}
+            stationPins={[...stationPins]}
+            targetLocation={targetLocation}
+          />
         </div>
       ) : null}
     </section>

--- a/development/front-admin-web/components/overview/VehicleFilterContext.tsx
+++ b/development/front-admin-web/components/overview/VehicleFilterContext.tsx
@@ -3,33 +3,40 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 /**
- * 차량 탭 필터가 적용되었을 때 지도가 그 부분 집합만 마커로 띄울 수 있도록
- * 두 client 컴포넌트(VehiclesPanel ↔ OverviewMapBanner) 사이의 공유 채널.
+ * 차량 탭과 지도가 공유하는 두 가지 채널:
  *
- * `filteredBikeIds === null` 은 "필터 미적용 / 차량 탭 외 다른 탭 활성"을
- * 의미 — 지도는 전체 차량 핀을 그대로 노출한다. Set 이면 그 집합에 속한
- * 차량 핀만 노출.
+ * 1. **필터 동기화** — `filteredBikeIds === null` 이면 필터 미적용(전체 핀
+ *    노출), Set 이면 그 부분 집합만 마커로. VehiclesPanel 이 publish, Map
+ *    Banner 가 consume.
  *
- * Provider 는 page 의 최상단 (`OverviewClientShell`) 에서 한 번만 마운트되어
- * 모든 탭 컨텐츠가 같은 인스턴스를 본다. VehiclesPanel 이 마운트되었을 때만
- * 값을 쓰고, 언마운트 시(탭 전환) cleanup 으로 null 로 되돌려 다른 탭에서
- * 의도치 않은 필터가 살아 있는 사태를 막는다.
+ * 2. **선택 차량 동기화** — `selectedBikeId` 가 있으면 지도가 자동으로 켜지고
+ *    그 차량의 위치로 pan. 행 클릭이 modal 모달 대신 지도 위 floating panel
+ *    을 띄우는 채널이기도 하다.
+ *
+ * Provider 는 page 의 client subtree 를 한 번만 감싸는 `OverviewClientShell`
+ * 에서 마운트되어 모든 탭 컨텐츠가 같은 인스턴스를 본다.
  */
 type FilterContextValue = {
   filteredBikeIds: ReadonlySet<string> | null;
   setFilteredBikeIds: (ids: ReadonlySet<string> | null) => void;
+  selectedBikeId: string | null;
+  setSelectedBikeId: (id: string | null) => void;
 };
 
 const VehicleFilterContext = createContext<FilterContextValue | null>(null);
 
 export function VehicleFilterProvider({ children }: { children: ReactNode }) {
-  const [filteredBikeIds, setRaw] = useState<ReadonlySet<string> | null>(null);
+  const [filteredBikeIds, setFilteredRaw] = useState<ReadonlySet<string> | null>(null);
+  const [selectedBikeId, setSelectedRaw] = useState<string | null>(null);
   const setFilteredBikeIds = useCallback((ids: ReadonlySet<string> | null) => {
-    setRaw(ids);
+    setFilteredRaw(ids);
+  }, []);
+  const setSelectedBikeId = useCallback((id: string | null) => {
+    setSelectedRaw(id);
   }, []);
   const value = useMemo<FilterContextValue>(
-    () => ({ filteredBikeIds, setFilteredBikeIds }),
-    [filteredBikeIds, setFilteredBikeIds]
+    () => ({ filteredBikeIds, setFilteredBikeIds, selectedBikeId, setSelectedBikeId }),
+    [filteredBikeIds, setFilteredBikeIds, selectedBikeId, setSelectedBikeId]
   );
   return <VehicleFilterContext.Provider value={value}>{children}</VehicleFilterContext.Provider>;
 }
@@ -41,7 +48,12 @@ export function VehicleFilterProvider({ children }: { children: ReactNode }) {
 export function useVehicleFilter(): FilterContextValue {
   const ctx = useContext(VehicleFilterContext);
   if (!ctx) {
-    return { filteredBikeIds: null, setFilteredBikeIds: () => {} };
+    return {
+      filteredBikeIds: null,
+      setFilteredBikeIds: () => {},
+      selectedBikeId: null,
+      setSelectedBikeId: () => {}
+    };
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary
PR-γ3b — 차량 상세를 모달 → 지도 위 floating panel 로 교체 + 선택 시 지도 자동 ON + 차량 위치 pan.

- \`VehicleFilterContext\` 에 \`selectedBikeId\` + setter 추가
- VehiclesPanel: 행 클릭 시 \`setSelectedBikeId(vehicle.id)\` 도 같이 publish, 언마운트 시 cleanup
- OverviewMapBanner: selectedBikeId 가 잡히면
  - 지도가 닫혀 있으면 자동 ON (rAF 1프레임 양보로 lint 회피)
  - 그 차량 pin 위치로 \`targetLocation\` 전달 → MapShell pan
- VehicleDetailDialog: \`<dialog>\` modal → \`<div role="dialog" aria-modal="false">\` floating
  - position: fixed, top 96px, right 24px, width 380px
  - ESC 로 닫기 listener (native dialog 의 escape 핸들링 잃어버린 대체)
  - useScrollLockedDialog 의존 제거
- 라이더 / BSS / Create 다이얼로그는 그대로 모달 유지 (`.overview-create-dialog` 클래스)

## Test plan
- [ ] 차량 탭에서 차량 행 클릭 → 우측 상단에 floating panel 노출
- [ ] 동시에 지도 보기가 OFF였다면 자동 ON
- [ ] 지도가 선택 차량의 위치로 panning
- [ ] 같은 행을 한 번 더 클릭해도 pan 재발화
- [ ] panel 우측 × 버튼 클릭 / ESC 키 → 닫힘, selectedBikeId 해제, 지도는 그대로 유지
- [ ] panel 띄운 채로도 표/지도 클릭 가능 (모달 아님)
- [ ] 라이더 탭 / BSS 탭 진입 시 floating panel 비활성, 라이더/BSS 상세는 여전히 모달로 동작
- [ ] panel 내부 "수정" 버튼 → edit 폼 노출, 저장 시 server action 발사 후 panel 닫힘 (revalidate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)