### PR TITLE
Wire the maintenance catalog into the vehicle floating panel

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -399,6 +399,44 @@ export async function setVehicleOperationStatusFromOverviewAction(
   redirect("/?tab=vehicles");
 }
 
+export async function markVehicleMaintenanceServicedAction(
+  vehicleId: string,
+  formData: FormData
+): Promise<void> {
+  // 차량 floating panel 의 "교환 완료" 버튼이 호출. 같은 차량 + 같은 품목에
+  // 대해 row 를 한 건 새로 추가하기만 한다 — 다음 교환 예정 / 임박 / 지연
+  // 등은 derived 라 클라이언트가 list 재조회로 갱신.
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=vehicles");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const itemId = String(formData.get("itemId") ?? "").trim();
+  if (!itemId) {
+    redirect("/?tab=vehicles&status=maintenance-missing-item");
+  }
+  const odoRaw = String(formData.get("servicedAtOdometerKm") ?? "").trim();
+  const odo = odoRaw ? Number.parseInt(odoRaw, 10) : null;
+
+  try {
+    await client.createMaintenanceRecord(vehicleId, {
+      itemId,
+      servicedAt: null,
+      servicedAtOdometerKm: odo !== null && Number.isFinite(odo) ? odo : null,
+      memo: null
+    });
+  } catch {
+    redirect("/?tab=vehicles&status=maintenance-record-error");
+  }
+
+  revalidatePath("/");
+  redirect("/?tab=vehicles");
+}
+
 export async function setVehicleIgnitionBlockFromOverviewAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/api/overview/vehicle-maintenance/[bikeId]/route.ts
+++ b/development/front-admin-web/app/api/overview/vehicle-maintenance/[bikeId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { loadVehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
+
+/**
+ * 차량 floating 상세 패널이 open 시 호출하는 lazy fetch. 한 차량의 정비 카탈로그
+ * (engineType 매칭) + 정비 이력을 한 번에 묶어서 반환. cookie-bound session 은
+ * 서버 측에 머무르고 응답만 JSON 으로 내려준다.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ bikeId: string }> }
+) {
+  const { bikeId } = await context.params;
+  const bundle = await loadVehicleMaintenanceBundle(bikeId);
+  return NextResponse.json(bundle, {
+    headers: { "Cache-Control": "no-store" }
+  });
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -622,6 +622,37 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+/* 차량 floating panel 안의 "정비 상태" 섹션 — 한 줄에 5컬럼 grid
+   (품목 / 주기 / 마지막 교환 / 상태 / 액션). 자식(그룹 멤버) 행은 좌측에
+   살짝 들여쓰기 해서 그룹 헤더와 묶음 시각화. */
+.maintenance-section { margin-top: 8px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
+.maintenance-section h4 { margin: 0 0 8px; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .02em; }
+.maintenance-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.maintenance-row { padding: 6px 8px; border-radius: 8px; background: var(--color-bg-soft); }
+.maintenance-row--child { margin-left: 12px; background: transparent; }
+.maintenance-row-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1.2fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.maintenance-row-name { font-weight: 700; color: var(--color-text-primary); }
+.maintenance-row-cycle, .maintenance-row-last { color: var(--color-text-secondary); font-variant-numeric: tabular-nums; }
+.maintenance-row-action {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--rm-accent-outline);
+  border-radius: 6px;
+  background: var(--rm-accent-soft);
+  color: var(--rm-accent);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+.maintenance-row-action:hover:not(:disabled) { background: var(--rm-accent-halo-strong); }
+.maintenance-row-action:disabled { opacity: 0.5; cursor: not-allowed; }
 .vehicle-floating-panel label input,
 .vehicle-floating-panel label select {
   display: block;

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
-import { updateVehicleFromOverviewAction } from "@/app/actions";
+import {
+  deriveMaintenanceRows,
+  type DerivedMaintenanceRow,
+  type MaintenanceStatus
+} from "@/components/management/vehicle-maintenance-derive";
+import {
+  markVehicleMaintenanceServicedAction,
+  updateVehicleFromOverviewAction
+} from "@/app/actions";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
+import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
 
 /**
  * 차량 상세 + 편집 floating 패널. PR-γ3b 이전엔 native `<dialog>` modal 이었지만,
@@ -43,6 +52,8 @@ export function VehicleDetailDialog({
   // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
+  // 정비 catalog + 이력. 차량별 두 list 를 한 round-trip 으로 받아 캐싱.
+  const [maintenance, setMaintenance] = useState<VehicleMaintenanceBundle | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
@@ -76,6 +87,28 @@ export function VehicleDetailDialog({
       .catch(() => {
         if (cancelled) return;
         setDeviceState({ bikeId: vehicleIdForFetch, deviceUid: null, installationId: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vehicleIdForFetch]);
+
+  // 정비 catalog + 이력 lazy fetch. 같은 차량에 대해 한 번만 호출.
+  useEffect(() => {
+    if (!vehicleIdForFetch) return;
+    let cancelled = false;
+    fetch(`/api/overview/vehicle-maintenance/${encodeURIComponent(vehicleIdForFetch)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
+      .then((next) => {
+        if (cancelled) return;
+        setMaintenance(next ?? { items: [], records: [] });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMaintenance({ items: [], records: [] });
       });
     return () => {
       cancelled = true;
@@ -124,6 +157,7 @@ export function VehicleDetailDialog({
           <DetailField label="이름" value={row.riderName ?? "—"} />
           <DetailField label="연락처" value={row.riderPhone ?? "—"} />
           <DetailField label="IMEI" value={currentDeviceUid || "—"} />
+          <MaintenanceSection vehicleId={vehicleId} bundle={maintenance} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>
               닫기
@@ -201,4 +235,136 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
   return "—";
+}
+
+// ============================================================================
+// 정비 상태 섹션
+// ============================================================================
+
+function MaintenanceSection({
+  vehicleId,
+  bundle
+}: {
+  vehicleId: string;
+  bundle: VehicleMaintenanceBundle | null;
+}) {
+  const rows = useMemo(() => {
+    if (!bundle) return null;
+    return deriveMaintenanceRows(bundle.items, bundle.records);
+  }, [bundle]);
+
+  if (!bundle) {
+    return (
+      <section className="maintenance-section">
+        <h4>정비 상태</h4>
+        <p className="muted">불러오는 중…</p>
+      </section>
+    );
+  }
+
+  if (!rows || rows.length === 0) {
+    return (
+      <section className="maintenance-section">
+        <h4>정비 상태</h4>
+        <p className="muted">이 차량 구분에 적용되는 정비 품목이 없습니다.</p>
+      </section>
+    );
+  }
+
+  // 그룹 부모(예: 구동계3종) 가 있으면 자식들 위에 헤더로 노출되도록 정렬.
+  // displayOrder 가 catalog seed 에서 부모(80) 다음에 자식(81~83) 순서로 박혀
+  // 있어 단순 displayOrder 정렬로도 자연스러운 그루핑이 나온다. backend 정렬을
+  // 신뢰하되 안전망 차원에서 다시 정렬.
+  const ordered = [...rows].sort((a, b) => a.item.displayOrder - b.item.displayOrder);
+
+  return (
+    <section className="maintenance-section">
+      <h4>정비 상태</h4>
+      <ul className="maintenance-list">
+        {ordered.map((row) => (
+          <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>
+            <MaintenanceRowView vehicleId={vehicleId} row={row} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function MaintenanceRowView({
+  vehicleId,
+  row
+}: {
+  vehicleId: string;
+  row: DerivedMaintenanceRow;
+}) {
+  const [pending, startTransition] = useTransition();
+  const cycleLabel = renderCycleLabel(row);
+  const isGroupHeader = row.item.cycleKm === null && row.item.cycleMonths === null && !row.item.cycleLabel;
+
+  const handleServiced = () => {
+    if (pending) return;
+    if (!window.confirm(`"${row.item.name}" 교환 완료 처리하시겠습니까?`)) return;
+    const fd = new FormData();
+    fd.append("itemId", row.item.id);
+    startTransition(() => {
+      void markVehicleMaintenanceServicedAction(vehicleId, fd);
+    });
+  };
+
+  return (
+    <div className="maintenance-row-grid">
+      <span className="maintenance-row-name">{row.item.name}</span>
+      <span className="maintenance-row-cycle">{cycleLabel}</span>
+      <span className="maintenance-row-last">{renderLastServiced(row)}</span>
+      <span className="maintenance-row-status">{renderStatusBadge(row.status)}</span>
+      {isGroupHeader ? null : (
+        <button
+          type="button"
+          className="maintenance-row-action"
+          onClick={handleServiced}
+          disabled={pending}
+          title={`${row.item.name} 교환 완료 마킹`}
+        >
+          교환 완료
+        </button>
+      )}
+    </div>
+  );
+}
+
+function renderCycleLabel(row: DerivedMaintenanceRow): string {
+  const { item } = row;
+  if (item.cycleLabel) return item.cycleLabel;
+  if (item.cycleKm !== null) return `${item.cycleKm.toLocaleString()} km`;
+  if (item.cycleMonths !== null) return `${item.cycleMonths}개월`;
+  return "—";
+}
+
+function renderLastServiced(row: DerivedMaintenanceRow): ReactNode {
+  if (!row.lastServicedAt) return <span className="muted">기록 없음</span>;
+  const date = new Date(row.lastServicedAt);
+  const dateLabel = Number.isNaN(date.valueOf())
+    ? row.lastServicedAt
+    : date.toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" });
+  if (row.lastServicedAtOdometerKm !== null) {
+    return `${dateLabel} · ${row.lastServicedAtOdometerKm.toLocaleString()} km`;
+  }
+  return dateLabel;
+}
+
+function renderStatusBadge(status: MaintenanceStatus): ReactNode {
+  switch (status) {
+    case "HEALTHY":
+      return <span className="vehicles-pill vehicles-pill--operating">정상</span>;
+    case "DUE_SOON":
+      return <span className="vehicles-pill vehicles-pill--engine-ice">임박</span>;
+    case "OVERDUE":
+      return <span className="vehicles-pill vehicles-pill--unknown">지연</span>;
+    case "NEVER":
+      return <span className="vehicles-pill vehicles-pill--idle">기록 없음</span>;
+    case "UNKNOWN":
+    default:
+      return <span className="muted">—</span>;
+  }
 }

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -1,0 +1,116 @@
+import type {
+  ServiceOpsMaintenanceItem,
+  ServiceOpsVehicleMaintenanceRecord
+} from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 floating panel "정비 상태" 섹션의 한 줄에 필요한 derived 정보. catalog
+ * 의 cycle 과 이력의 servicedAt 을 합쳐 다음 예정 / 임박 / 지연 같은 표시 단위
+ * 를 한 곳에서 계산한다.
+ *
+ * **카운팅 정책**:
+ * - cycle_months 가 잡힌 품목은 servicedAt + months 로 다음 예정 일자 계산.
+ *   (운영 시간 누적 추적은 V22 시점에 백엔드 인프라가 없어 운영 일수 기준 단순화)
+ * - cycle_km 만 잡힌 품목은 odometer 텔레메트리가 없어 자동 상태 계산을 안 함 —
+ *   "교환 완료" 시 운영자가 입력한 odometer 가 있으면 그걸 마지막 km 로 노출.
+ * - cycle_label (자유 텍스트, 예: "12개월 이상") 만 있는 품목은 안내 텍스트 그대로
+ *   노출하고 상태는 NONE.
+ *
+ * **상태 등급**:
+ * - NEVER — 한 번도 교환된 적 없음 (등록 직후). UI: 회색 "기록 없음"
+ * - HEALTHY — 다음 예정의 90% 이전
+ * - DUE_SOON — 다음 예정의 90% ~ 100% 사이 (임박)
+ * - OVERDUE — 다음 예정 지남 (지연)
+ * - UNKNOWN — cycle 정보가 너무 비정형해서 derived 계산 불가
+ */
+export type MaintenanceStatus = "NEVER" | "HEALTHY" | "DUE_SOON" | "OVERDUE" | "UNKNOWN";
+
+export type DerivedMaintenanceRow = {
+  item: ServiceOpsMaintenanceItem;
+  lastServicedAt: string | null;
+  lastServicedAtOdometerKm: number | null;
+  /** cycle_months 기반 다음 예정 (ISO). cycle 정보 부족 시 null. */
+  nextDueAt: string | null;
+  status: MaintenanceStatus;
+};
+
+const APPROACH_RATIO = 0.9;
+
+export function deriveMaintenanceRows(
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>,
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  now: Date = new Date()
+): DerivedMaintenanceRow[] {
+  // itemId → 가장 최근 기록 (records 가 이미 servicedAt desc 정렬이라 first hit).
+  const latestByItem = new Map<string, ServiceOpsVehicleMaintenanceRecord>();
+  for (const record of records) {
+    if (!latestByItem.has(record.itemId)) {
+      latestByItem.set(record.itemId, record);
+    }
+  }
+
+  return items.map((item) => {
+    const latest = latestByItem.get(item.id) ?? null;
+    const lastServicedAt = latest?.servicedAt ?? null;
+    const lastServicedAtOdometerKm = latest?.servicedAtOdometerKm ?? null;
+
+    // 그룹 부모 (cycle 없음) — 항상 UNKNOWN, 자식이 실제 상태를 캐리.
+    if (item.cycleKm === null && item.cycleMonths === null) {
+      return {
+        item,
+        lastServicedAt,
+        lastServicedAtOdometerKm,
+        nextDueAt: null,
+        status: "UNKNOWN"
+      };
+    }
+
+    if (!lastServicedAt) {
+      return {
+        item,
+        lastServicedAt: null,
+        lastServicedAtOdometerKm,
+        nextDueAt: nextDueAtFromCycle(null, item.cycleMonths),
+        status: "NEVER"
+      };
+    }
+
+    // cycle_months 기반 자동 계산 — 가장 confident 한 시간 단위.
+    if (item.cycleMonths !== null) {
+      const nextDueAt = nextDueAtFromCycle(lastServicedAt, item.cycleMonths);
+      if (nextDueAt) {
+        const status = classifyByDate(new Date(lastServicedAt), new Date(nextDueAt), now);
+        return { item, lastServicedAt, lastServicedAtOdometerKm, nextDueAt, status };
+      }
+    }
+
+    // cycle_km 만 있는 케이스 — odometer 텔레메트리 없어 자동 상태 derive 안 함.
+    // 운영자가 lastServicedAtOdometerKm + cycle_km 을 보고 직접 판단.
+    return {
+      item,
+      lastServicedAt,
+      lastServicedAtOdometerKm,
+      nextDueAt: null,
+      status: "UNKNOWN"
+    };
+  });
+}
+
+function nextDueAtFromCycle(lastServicedAt: string | null, cycleMonths: number | null): string | null {
+  if (cycleMonths === null) return null;
+  const base = lastServicedAt ? new Date(lastServicedAt) : null;
+  if (!base || Number.isNaN(base.valueOf())) return null;
+  const next = new Date(base);
+  next.setMonth(next.getMonth() + cycleMonths);
+  return next.toISOString();
+}
+
+function classifyByDate(servicedAt: Date, nextDueAt: Date, now: Date): MaintenanceStatus {
+  const totalSpan = nextDueAt.valueOf() - servicedAt.valueOf();
+  if (totalSpan <= 0) return "UNKNOWN";
+  const elapsed = now.valueOf() - servicedAt.valueOf();
+  const ratio = elapsed / totalSpan;
+  if (ratio < APPROACH_RATIO) return "HEALTHY";
+  if (ratio < 1) return "DUE_SOON";
+  return "OVERDUE";
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -202,6 +202,45 @@ export type ServiceOpsBikeOperationStatusHistory = {
   updatedAt: string;
 };
 
+// === 정비 도메인 (V22 backend 슬라이스) ===
+
+export type ServiceOpsMaintenanceAppliesTo = "ELECTRIC" | "ICE" | "BOTH";
+
+export type ServiceOpsMaintenanceItem = {
+  id: string;
+  idx: number | null;
+  name: string;
+  appliesTo: ServiceOpsMaintenanceAppliesTo;
+  parentItemId: string | null;
+  cycleKm: number | null;
+  cycleMonths: number | null;
+  cycleLabel: string | null;
+  displayOrder: number;
+  enabled: boolean;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ServiceOpsVehicleMaintenanceRecord = {
+  id: string;
+  idx: number | null;
+  bikeId: string;
+  itemId: string;
+  servicedAt: string;
+  servicedAtOdometerKm: number | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MaintenanceRecordCreateInput = {
+  itemId: string;
+  servicedAt?: string | null;
+  servicedAtOdometerKm?: number | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsContractCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
 export type ServiceOpsContractReturnType = "TAKEOVER" | "RETURN";
 export type ServiceOpsContractDurationUnit =
@@ -845,6 +884,12 @@ export type ServiceOpsApiClient = {
   getBikeDeviceInstallation: (id: string) => Promise<ServiceOpsBikeDeviceInstallation>;
   createBikeDeviceInstallation: (request: BikeDeviceInstallationCreateInput) => Promise<ServiceOpsBikeDeviceInstallation>;
   removeBikeDeviceInstallation: (id: string, request: BikeDeviceInstallationRemoveInput) => Promise<ServiceOpsBikeDeviceInstallation>;
+  /** 차량 단위 적용 가능 정비 항목 — backend 가 engineType + BOTH 매칭으로 필터링. */
+  listMaintenanceItemsForBike: (bikeId: string) => Promise<ServiceOpsMaintenanceItem[]>;
+  /** 한 차량의 정비 이벤트 로그 (최신순). */
+  listMaintenanceRecordsForBike: (bikeId: string) => Promise<ServiceOpsVehicleMaintenanceRecord[]>;
+  /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
+  createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -1226,6 +1271,23 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify(removeRequest),
         method: "PATCH"
       }),
+    // 정비 카탈로그 / 이력 — backend V22 슬라이스. 페이지 단위가 아니라 차량
+    // 단위 list endpoint 라 그대로 array 응답.
+    listMaintenanceItemsForBike: (bikeId) =>
+      request<ServiceOpsMaintenanceItem[]>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-items`,
+        { method: "GET" }
+      ),
+    listMaintenanceRecordsForBike: (bikeId) =>
+      request<ServiceOpsVehicleMaintenanceRecord[]>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
+        { method: "GET" }
+      ),
+    createMaintenanceRecord: (bikeId, createRequest) =>
+      request<ServiceOpsVehicleMaintenanceRecord>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
+        { body: JSON.stringify(createRequest), method: "POST" }
+      ),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -1,0 +1,40 @@
+import {
+  createAuthenticatedServiceOpsApiClient
+} from "@/lib/services/service-ops-session";
+import {
+  serviceOpsApiConfigured,
+  type ServiceOpsMaintenanceItem,
+  type ServiceOpsVehicleMaintenanceRecord
+} from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 상세 floating panel 의 "정비 상태" 섹션이 lazy-fetch 하는 두 list 의
+ * 결합 응답. 한 round-trip 으로 catalog + history 를 같이 받아 클라이언트가
+ * 두 번 fetch 하지 않게 한다.
+ *
+ * 미설정 / 미인증 환경에선 둘 다 빈 배열로 — UI 는 "데이터 없음" 으로 fallback.
+ */
+export type VehicleMaintenanceBundle = {
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+};
+
+const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
+
+export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<VehicleMaintenanceBundle> {
+  if (!serviceOpsApiConfigured()) return EMPTY_BUNDLE;
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return EMPTY_BUNDLE;
+
+  try {
+    const [items, records] = await Promise.all([
+      client.listMaintenanceItemsForBike(bikeId),
+      client.listMaintenanceRecordsForBike(bikeId)
+    ]);
+    return { items, records };
+  } catch {
+    // 조회 실패는 운영자 화면을 깨뜨리지 않게 빈 bundle. console.error 는 backend
+    // log 가 잡고, 클라이언트엔 "정비 데이터 불러오기 실패" UI 가 추후 필요.
+    return EMPTY_BUNDLE;
+  }
+}


### PR DESCRIPTION
## Summary
PR-δ — 차량 floating panel 안 "정비 상태" 섹션 활성. PR-α2(#248) 의 backend 카탈로그/이력을 운영자 시야에 노출.

**Client → backend 연결**
- \`service-ops-api.ts\`: 정비 도메인 타입 3개 (\`ServiceOpsMaintenanceItem\` / \`ServiceOpsVehicleMaintenanceRecord\` / \`MaintenanceRecordCreateInput\`)
- 새 client method 3개: \`listMaintenanceItemsForBike\` / \`listMaintenanceRecordsForBike\` / \`createMaintenanceRecord\`
- \`loadVehicleMaintenanceBundle\` cookie-bound loader (catalog + history 한 round-trip)
- 새 internal API route \`/api/overview/vehicle-maintenance/[bikeId]\` 가 floating panel 의 lazy fetch 진입점

**Server action**
- \`markVehicleMaintenanceServicedAction(vehicleId, formData)\` — "교환 완료" 버튼이 호출. \`itemId\` + 선택 \`servicedAtOdometerKm\` 입력 받아 record 한 건 추가 후 revalidate

**상태 derivation** (`vehicle-maintenance-derive.ts`)
- \`cycleMonths\` 보유 품목 — servicedAt + N개월 기준 자동 상태 (HEALTHY / DUE_SOON / OVERDUE, 90% 임박 threshold)
- \`cycleKm\` 전용 품목 — odometer 텔레메트리 없어 자동 상태 안 함, 운영자 입력한 마지막 km 만 표시
- 그룹 부모(구동계3종) — cycle 없이 헤더로만, 자식이 들여쓰기 되어 묶음 시각화

**UI**
- 5-컬럼 grid: 품목 · 주기 · 마지막 교환(날짜 · km) · 상태 뱃지 · 교환 완료 버튼
- 상태 뱃지 톤 재사용: operating(녹) / engine-ice(노랑 임박) / unknown(빨강 지연)
- 교환 완료 버튼 confirm 후 server action 발사

## Test plan
- [ ] 전기 차량 floating panel 진입 시 ELECTRIC + BOTH 품목 (8개) 모두 노출
- [ ] 내연 차량 진입 시 ICE + BOTH 품목 (13개) 노출, 구동계3종 부모 + 자식 3개 시각 묶음
- [ ] 한 번도 정비 안 한 품목 → "기록 없음" 회색 뱃지
- [ ] 교환 완료 클릭 → confirm → record 추가, revalidate 후 panel 재오픈 시 \`마지막 교환\` 컬럼이 오늘 날짜로
- [ ] cycle_months 품목에서 마지막 교환 ≥ 90% 경과 시 \`임박\` (노랑), 100% 초과 시 \`지연\` (빨강)
- [ ] cycle_km 품목은 자동 상태 derivation 없이 km 정보만 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)