### PR TITLE
Activate the maintenance-status filter on the vehicles tab

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -28,6 +28,8 @@ import {
 import { loadStationList } from "@/lib/services/station-data";
 import { loadVehicleList } from "@/lib/services/vehicle-data";
 import { loadVehicleDeviceMap } from "@/lib/services/vehicle-device-data";
+import { loadMaintenanceDataset } from "@/lib/services/vehicle-maintenance-data";
+import { summarizeMaintenanceByBike } from "@/components/management/vehicle-maintenance-derive";
 
 // Authenticated, per-admin loader. At build time the env-less mock fallback
 // returns synchronously without touching cookies, which lets Next.js
@@ -93,7 +95,8 @@ export default async function RootPage({
     vehicleData,
     matching,
     opsExtra,
-    deviceMap
+    deviceMap,
+    maintenanceData
   ] = await Promise.all([
     searchParams,
     loadDashboardMapState(),
@@ -101,7 +104,8 @@ export default async function RootPage({
     loadVehicleList(),
     loadRiderMatchingSnapshot(),
     loadContractsAndInsurances(),
-    loadVehicleDeviceMap()
+    loadVehicleDeviceMap(),
+    loadMaintenanceDataset()
   ]);
 
   const activeTab: TabKey = isValidTabKey(tabParam) ? tabParam : "vehicles";
@@ -175,6 +179,19 @@ export default async function RootPage({
     if (vehicle.id) ignitionBlockedByBikeId.set(vehicle.id, vehicle.ignitionBlocked ?? false);
   }
 
+  // 차량 탭 "정비 상태" 필터가 임박/지연 차량을 골라낼 때 참조. bikeId →
+  // {hasOverdue, hasDueSoon, overallStatus}. 차량별 engineType 으로 적용
+  // catalog 를 분기해 catalog × records 의 매트릭스를 한 번에 derive.
+  const bikeEngineTypeById = new Map<string, "ELECTRIC" | "ICE">();
+  for (const vehicle of vehicleData.vehicles) {
+    if (vehicle.id) bikeEngineTypeById.set(vehicle.id, vehicle.engineType ?? "ELECTRIC");
+  }
+  const maintenanceSummaryByBike = summarizeMaintenanceByBike(
+    maintenanceData.items,
+    maintenanceData.records,
+    bikeEngineTypeById
+  );
+
   // 시동 차량 = telemetry ignition_status === "ON". The dashboard summary
   // does not aggregate this yet, so we count it from the bike pin list
   // (which carries `ignitionStatus` per pin). UNKNOWN / OFF are excluded.
@@ -237,6 +254,7 @@ export default async function RootPage({
                 riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId}
                 insuranceOptions={insuranceOptions}
                 ignitionBlockedByBikeId={ignitionBlockedByBikeId}
+                maintenanceSummaryByBike={maintenanceSummaryByBike}
               />
             ),
             notice: vehicleData.notice

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -9,6 +9,7 @@ import { OperationStatusToggle } from "@/components/management/OperationStatusTo
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
+import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
@@ -60,8 +61,8 @@ type FilterState = {
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
   connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
   ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
-  // 정비 상태 필터는 PR-ζ 에서 활성. 자리만 잡아둠.
-  maintenance: "ALL";
+  // 정비 상태 — DUE_SOON 은 임박, OVERDUE 는 지연, ANY 는 둘 다.
+  maintenance: "ALL" | "DUE_SOON" | "OVERDUE" | "ANY";
 };
 
 const DEFAULT_FILTERS: FilterState = {
@@ -90,7 +91,8 @@ export function VehiclesPanel({
   riderActiveContractById,
   riderActiveInsuranceByRiderId,
   insuranceOptions,
-  ignitionBlockedByBikeId
+  ignitionBlockedByBikeId,
+  maintenanceSummaryByBike
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
@@ -109,6 +111,8 @@ export function VehiclesPanel({
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
   /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
   ignitionBlockedByBikeId?: Map<string, boolean>;
+  /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
+  maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
@@ -171,9 +175,16 @@ export function VehiclesPanel({
         if (filters.ignition === "OFF" && status !== "OFF") return false;
         if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
       }
+      if (filters.maintenance !== "ALL") {
+        const summary = maintenanceSummaryByBike?.get(vehicleKey);
+        if (!summary) return false;
+        if (filters.maintenance === "OVERDUE" && !summary.hasOverdue) return false;
+        if (filters.maintenance === "DUE_SOON" && !summary.hasDueSoon) return false;
+        if (filters.maintenance === "ANY" && !summary.hasOverdue && !summary.hasDueSoon) return false;
+      }
       return true;
     });
-  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById]);
+  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById, maintenanceSummaryByBike]);
 
   // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
   // OverviewMapBanner 가 이 부분 집합만 핀으로 노출한다. rAF 한 프레임 양보로
@@ -277,11 +288,14 @@ export function VehiclesPanel({
         <select
           className="vehicles-filter-select"
           value={filters.maintenance}
-          disabled
-          title="정비 이력 UI 후속 PR 에서 활성화"
-          onChange={() => {}}
+          onChange={(event) =>
+            setFilters({ ...filters, maintenance: event.target.value as FilterState["maintenance"] })
+          }
         >
-          <option value="ALL">정비 상태 (준비중)</option>
+          <option value="ALL">정비 상태: 전체</option>
+          <option value="ANY">임박 + 지연</option>
+          <option value="DUE_SOON">임박만</option>
+          <option value="OVERDUE">지연만</option>
         </select>
       </div>
 

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -96,6 +96,79 @@ export function deriveMaintenanceRows(
   });
 }
 
+/**
+ * 차량 한 대의 정비 상태 요약. 차량 탭 필터가 임박/지연 차량을 빠르게
+ * 골라내기 위해 각 차량에 대해 한 번씩만 계산하고 캐싱.
+ *
+ * `hasOverdue` / `hasDueSoon` — 해당 차량의 어떤 품목이라도 그 상태면 true.
+ * `overallStatus` — 우선순위 OVERDUE > DUE_SOON > HEALTHY > NEVER > UNKNOWN.
+ */
+export type VehicleMaintenanceSummary = {
+  hasOverdue: boolean;
+  hasDueSoon: boolean;
+  overallStatus: MaintenanceStatus;
+};
+
+const STATUS_PRIORITY: Record<MaintenanceStatus, number> = {
+  OVERDUE: 4,
+  DUE_SOON: 3,
+  HEALTHY: 2,
+  NEVER: 1,
+  UNKNOWN: 0
+};
+
+/**
+ * bikeId → 그 차량의 정비 상태 요약 map. 전체 데이터셋(items + records) 와
+ * engineType-별 catalog 매핑을 받아 한 번에 계산.
+ *
+ * `bikeEngineTypeById` — 차량 ID 가 ICE/ELECTRIC 중 어느 catalog 를 봐야 하는지.
+ *   엔트리 없으면 ELECTRIC 으로 fallback (V21 default 정책과 일치).
+ */
+export function summarizeMaintenanceByBike(
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>,
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  bikeEngineTypeById: Map<string, "ELECTRIC" | "ICE">,
+  now: Date = new Date()
+): Map<string, VehicleMaintenanceSummary> {
+  // engineType 별 적용 catalog 두 묶음 미리 분리.
+  const electricItems = items.filter(
+    (item) => item.appliesTo === "ELECTRIC" || item.appliesTo === "BOTH"
+  );
+  const iceItems = items.filter(
+    (item) => item.appliesTo === "ICE" || item.appliesTo === "BOTH"
+  );
+
+  // bikeId → records 그룹핑.
+  const recordsByBike = new Map<string, ServiceOpsVehicleMaintenanceRecord[]>();
+  for (const record of records) {
+    const list = recordsByBike.get(record.bikeId);
+    if (list) list.push(record);
+    else recordsByBike.set(record.bikeId, [record]);
+  }
+
+  // bikeEngineTypeById 에 등장한 모든 차량에 대해 요약 계산.
+  const result = new Map<string, VehicleMaintenanceSummary>();
+  for (const [bikeId, engineType] of bikeEngineTypeById) {
+    const applicableItems = engineType === "ICE" ? iceItems : electricItems;
+    const bikeRecords = recordsByBike.get(bikeId) ?? [];
+    // 다음 단계에선 servicedAt desc 정렬 가정 — recordsByBike push 순서가
+    // 백엔드 응답(이미 정렬됨) 그대로라 별도 정렬 안 함.
+    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, now);
+    let overall: MaintenanceStatus = "UNKNOWN";
+    let hasOverdue = false;
+    let hasDueSoon = false;
+    for (const row of rows) {
+      if (row.status === "OVERDUE") hasOverdue = true;
+      if (row.status === "DUE_SOON") hasDueSoon = true;
+      if (STATUS_PRIORITY[row.status] > STATUS_PRIORITY[overall]) {
+        overall = row.status;
+      }
+    }
+    result.set(bikeId, { hasOverdue, hasDueSoon, overallStatus: overall });
+  }
+  return result;
+}
+
 function nextDueAtFromCycle(lastServicedAt: string | null, cycleMonths: number | null): string | null {
   if (cycleMonths === null) return null;
   const base = lastServicedAt ? new Date(lastServicedAt) : null;

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -886,8 +886,12 @@ export type ServiceOpsApiClient = {
   removeBikeDeviceInstallation: (id: string, request: BikeDeviceInstallationRemoveInput) => Promise<ServiceOpsBikeDeviceInstallation>;
   /** 차량 단위 적용 가능 정비 항목 — backend 가 engineType + BOTH 매칭으로 필터링. */
   listMaintenanceItemsForBike: (bikeId: string) => Promise<ServiceOpsMaintenanceItem[]>;
+  /** 전체 카탈로그 (페이지) — 차량 탭 정비 상태 필터가 모든 품목을 한 번에 받기 위해. */
+  listMaintenanceItems: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsMaintenanceItem>>;
   /** 한 차량의 정비 이벤트 로그 (최신순). */
   listMaintenanceRecordsForBike: (bikeId: string) => Promise<ServiceOpsVehicleMaintenanceRecord[]>;
+  /** 전체 차량의 정비 이력 (페이지) — 차량 탭 정비 상태 필터 용. */
+  listMaintenanceRecords: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>;
   /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
   createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
@@ -1278,10 +1282,22 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-items`,
         { method: "GET" }
       ),
+    listMaintenanceItems: ({ page = 0, size = 200, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsMaintenanceItem>>(
+        "/maintenance-items",
+        { method: "GET" },
+        { page, size, sort }
+      ),
     listMaintenanceRecordsForBike: (bikeId) =>
       request<ServiceOpsVehicleMaintenanceRecord[]>(
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
         { method: "GET" }
+      ),
+    listMaintenanceRecords: ({ page = 0, size = 500, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>(
+        "/maintenance-records",
+        { method: "GET" },
+        { page, size, sort }
       ),
     createMaintenanceRecord: (bikeId, createRequest) =>
       request<ServiceOpsVehicleMaintenanceRecord>(

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -21,6 +21,37 @@ export type VehicleMaintenanceBundle = {
 
 const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
 
+/**
+ * 차량 탭의 "정비 상태" 필터가 차량 별로 임박/지연 여부를 derive 할 때 쓰는
+ * 전체 dataset. catalog 전체 + 모든 차량의 정비 이력을 한 번에 받아오는 두
+ * 페이지 요청.
+ *
+ * MVP 규모(< 200 차량 × ~10 품목)에서 페이지 size 200/500 한 번이면 충분.
+ * 데이터가 더 커지면 size 늘리거나 서버 쪽에 차량 별 latest-record-per-item
+ * 집계 endpoint 를 추가.
+ */
+export type MaintenanceDatasetResult = {
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+};
+
+const EMPTY_DATASET: MaintenanceDatasetResult = { items: [], records: [] };
+
+export async function loadMaintenanceDataset(): Promise<MaintenanceDatasetResult> {
+  if (!serviceOpsApiConfigured()) return EMPTY_DATASET;
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) return EMPTY_DATASET;
+  try {
+    const [itemsPage, recordsPage] = await Promise.all([
+      client.listMaintenanceItems({ page: 0, size: 200 }),
+      client.listMaintenanceRecords({ page: 0, size: 500 })
+    ]);
+    return { items: itemsPage.items, records: recordsPage.items };
+  } catch {
+    return EMPTY_DATASET;
+  }
+}
+
 export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<VehicleMaintenanceBundle> {
   if (!serviceOpsApiConfigured()) return EMPTY_BUNDLE;
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
@@ -46,4 +46,12 @@ public class MaintenanceReadController {
     List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(@PathVariable UUID bikeId) {
         return maintenanceReadService.listRecordsForBike(bikeId);
     }
+
+    /** 전체 차량의 정비 이력 — 차량 탭 정비 상태 필터 용 (대량 페이지). */
+    @GetMapping("/api/v1/maintenance-records")
+    PageResponse<VehicleMaintenanceRecordReadResponse> listRecords(
+            @PageableDefault(size = 500, sort = "idx", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return maintenanceReadService.listRecords(pageable);
+    }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
 public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMaintenanceRecord, UUID> {
@@ -17,4 +19,11 @@ public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMa
      * 할 때 시간 역순으로 한 번 훑는다.
      */
     List<VehicleMaintenanceRecord> findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(UUID bikeId);
+
+    /**
+     * 전체 차량의 정비 이력 (페이징). 차량 탭의 "정비 상태" 필터가 모든 차량의
+     * 마지막 교환 시점을 한 번에 받기 위해 사용. MVP 규모(< 200 차량 × ~10 품목)
+     * 에서 한 페이지 (size=500) 면 1회 호출로 충분.
+     */
+    Page<VehicleMaintenanceRecord> findByDeletedAtIsNull(Pageable pageable);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -68,6 +68,16 @@ public class MaintenanceReadService {
                 .toList();
     }
 
+    /**
+     * 전체 차량의 정비 이력 (페이징). 차량 탭 필터가 차량별 최신 record 를 한 번에
+     * 받아 임박/지연 상태를 client-side 에서 derive 할 때 사용.
+     */
+    public PageResponse<VehicleMaintenanceRecordReadResponse> listRecords(Pageable pageable) {
+        return PageResponse.of(
+                recordRepository.findByDeletedAtIsNull(pageable).map(VehicleMaintenanceRecordReadResponse::from)
+        );
+    }
+
     public List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(UUID bikeId) {
         // bike 존재 여부 보장 — 삭제된 차량 ID 로 잘못 조회되면 404.
         bikeRepository.findByIdAndDeletedAtIsNull(bikeId)


### PR DESCRIPTION
## Summary
PR-ζ — 차량 탭 "정비 상태" 필터 활성. PR-γ1 의 placeholder select 가 실제 동작.

**Backend (1 endpoint)**
- \`GET /api/v1/maintenance-records?page&size&sort\` — 전체 차량 정비 이력 페이징 (default size=500)
- Repository, Service, Controller 각각에 list-all 메서드 1개씩 추가

**Frontend client + loader**
- 새 client method 2개: \`listMaintenanceItems\` (paged) / \`listMaintenanceRecords\` (paged)
- \`loadMaintenanceDataset\` — catalog 전체 + 모든 차량 record 페이지 한 round-trip

**차량별 정비 요약 derivation**
- 새 \`summarizeMaintenanceByBike(items, records, bikeEngineTypeById)\` — bikeId → \`{ hasOverdue, hasDueSoon, overallStatus }\`
- ELECTRIC vs ICE catalog 자동 분기 (BOTH 는 양쪽 합쳐서)
- 기존 \`deriveMaintenanceRows\` 재사용

**필터 활성**
- \`VehiclesPanel.FilterState.maintenance\` 가 placeholder 에서 실제 union (\`ALL | DUE_SOON | OVERDUE | ANY\`) 으로
- placeholder disabled select → 인터랙티브 select (\"임박 + 지연\" / \"임박만\" / \"지연만\")
- 필터 적용 시 마커도 함께 거름 (PR-γ3a 의 context publish 인프라 그대로 작동)

## Test plan
- [ ] 차량 탭에서 정비 상태 select 가 disabled 가 아닌 활성 상태로 노출
- [ ] cycle_months 보유 차량에서 ≥ 90% 경과 record 있으면 \"임박\" 필터로 노출
- [ ] cycle_months 100% 초과 record 있으면 \"지연\" 필터로 노출
- [ ] cycle_km 전용 품목은 필터 적용 시 자동 derivation 안 함 (UNKNOWN 처리, 임박/지연 false)
- [ ] 필터 적용 → 표 + 지도 마커 모두 거름
- [ ] 라이더/BSS 탭 이동 후 차량 탭 복귀 시 필터 상태 유지 안 됨 (정상, 탭 unmount 시 reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)