### PR TITLE
Add a maintenance catalog editor as the 4th tab

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -399,6 +399,127 @@ export async function setVehicleOperationStatusFromOverviewAction(
   redirect("/?tab=vehicles");
 }
 
+// ============================================================================
+// 정비 카탈로그 편집 — "정비" 탭에서 운영자가 default cycle / 품목 / 그룹을
+// 추가/수정/삭제. backend V22 의 maintenance-items endpoint 를 그대로 호출.
+// ============================================================================
+
+import type { ServiceOpsMaintenanceAppliesTo } from "@/lib/services/service-ops-api";
+
+export async function createMaintenanceItemAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const name = requiredText(formData.get("name"));
+  if (!name) {
+    redirect("/?tab=maintenance&status=maintenance-item-missing-name");
+  }
+  const appliesTo = parseAppliesTo(formData.get("appliesTo"));
+  if (!appliesTo) {
+    redirect("/?tab=maintenance&status=maintenance-item-invalid-applies-to");
+  }
+  const cycleKm = optionalInteger(formData.get("cycleKm"));
+  const cycleMonths = optionalInteger(formData.get("cycleMonths"));
+  const cycleLabel = optionalText(formData.get("cycleLabel"));
+  if (cycleKm === null && cycleMonths === null && !cycleLabel) {
+    // 백엔드 check 제약과 동일 정책 — 최소 한 종류의 cycle 표현은 있어야 한다.
+    redirect("/?tab=maintenance&status=maintenance-item-cycle-required");
+  }
+  const parentItemId = optionalText(formData.get("parentItemId"));
+  const displayOrder = optionalInteger(formData.get("displayOrder"));
+  try {
+    await client.createMaintenanceItem({
+      name,
+      appliesTo,
+      parentItemId,
+      cycleKm,
+      cycleMonths,
+      cycleLabel,
+      displayOrder: displayOrder ?? null,
+      memo: optionalText(formData.get("memo"))
+    });
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-create-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+export async function updateMaintenanceItemAction(
+  itemId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+  const name = optionalText(formData.get("name"));
+  const appliesTo = parseAppliesTo(formData.get("appliesTo"));
+  // 모든 필드 optional; cycle 들은 명시적 null (빈 입력) 도 그대로 반영.
+  try {
+    await client.updateMaintenanceItem(itemId, {
+      name,
+      appliesTo: appliesTo ?? null,
+      parentItemId: optionalText(formData.get("parentItemId")),
+      cycleKm: optionalInteger(formData.get("cycleKm")),
+      cycleMonths: optionalInteger(formData.get("cycleMonths")),
+      cycleLabel: optionalText(formData.get("cycleLabel")),
+      displayOrder: optionalInteger(formData.get("displayOrder")),
+      enabled: parseOptionalBoolean(formData.get("enabled")),
+      memo: optionalText(formData.get("memo"))
+    });
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-update-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+export async function deleteMaintenanceItemAction(itemId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+  try {
+    await client.deleteMaintenanceItem(itemId);
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-delete-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+function parseAppliesTo(value: FormDataEntryValue | null): ServiceOpsMaintenanceAppliesTo | null {
+  const text = String(value ?? "").trim();
+  if (text === "ELECTRIC" || text === "ICE" || text === "BOTH") return text;
+  return null;
+}
+
+function parseOptionalBoolean(value: FormDataEntryValue | null): boolean | null {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (text === "true") return true;
+  if (text === "false") return false;
+  return null;
+}
+
+function optionalInteger(value: FormDataEntryValue | null): number | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const parsed = Number.parseInt(text, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export async function markVehicleMaintenanceServicedAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -622,6 +622,13 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+/* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
+   각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
+.maintenance-panel { display: flex; flex-direction: column; gap: 24px; }
+.maintenance-panel-section { display: flex; flex-direction: column; gap: 8px; }
+.maintenance-panel-section-title { margin: 0; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
+.maintenance-panel-indent { color: var(--color-text-muted); margin-right: 4px; }
+
 /* 차량 floating panel 안의 "정비 상태" 섹션 — 한 줄에 5컬럼 grid
    (품목 / 주기 / 마지막 교환 / 상태 / 액션). 자식(그룹 멤버) 행은 좌측에
    살짝 들여쓰기 해서 그룹 헤더와 묶음 시각화. */

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -3,9 +3,11 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { ContractMatchingForm, type ContractMatchingOption } from "@/components/management/ContractMatchingForm";
+import { CreateMaintenanceItemDialog } from "@/components/management/CreateMaintenanceItemDialog";
 import { CreateRiderDialog } from "@/components/management/CreateRiderDialog";
 import { CreateStationDialog } from "@/components/management/CreateStationDialog";
 import { CreateVehicleDialog } from "@/components/management/CreateVehicleDialog";
+import { MaintenancePanel } from "@/components/management/MaintenancePanel";
 import { RidersPanel, type InsuranceOption } from "@/components/management/RidersPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
@@ -37,7 +39,7 @@ import { summarizeMaintenanceByBike } from "@/components/management/vehicle-main
 // output across all admins, so we opt in to dynamic rendering explicitly.
 export const dynamic = "force-dynamic";
 
-type TabKey = "vehicles" | "riders" | "stations";
+type TabKey = "vehicles" | "riders" | "stations" | "maintenance";
 
 type TabConfig = {
   key: TabKey;
@@ -46,10 +48,13 @@ type TabConfig = {
 
 // 운영팀 요청 — 1순위 화면이 차량 관리이므로 차량 탭이 첫 번째이자 기본.
 // stations 키는 유지하되 라벨만 "BSS"(Battery Swap Station)로 노출한다.
+// maintenance 는 정비 카탈로그 편집 전용 — 평소엔 거의 안 열리지만 운영자가
+// default cycle / 신규 품목을 추가할 때 사용.
 const TABS: ReadonlyArray<TabConfig> = [
   { key: "vehicles", label: "차량" },
   { key: "riders", label: "라이더" },
-  { key: "stations", label: "BSS" }
+  { key: "stations", label: "BSS" },
+  { key: "maintenance", label: "정비" }
 ];
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
@@ -259,7 +264,12 @@ export default async function RootPage({
             ),
             notice: vehicleData.notice
           }
-        : await loadOtherTabContent(activeTab);
+        : activeTab === "maintenance"
+          ? {
+              panel: <MaintenancePanel items={maintenanceData.items} />,
+              notice: undefined
+            }
+          : await loadOtherTabContent(activeTab);
 
   return (
     <div className="page-container">
@@ -343,6 +353,7 @@ export default async function RootPage({
           {activeTab === "riders" ? <CreateRiderDialog /> : null}
           {activeTab === "vehicles" ? <CreateVehicleDialog /> : null}
           {activeTab === "stations" ? <CreateStationDialog /> : null}
+          {activeTab === "maintenance" ? <CreateMaintenanceItemDialog parentOptions={maintenanceData.items} /> : null}
         </div>
       </div>
 

--- a/development/front-admin-web/components/management/CreateMaintenanceItemDialog.tsx
+++ b/development/front-admin-web/components/management/CreateMaintenanceItemDialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { createMaintenanceItemAction } from "@/app/actions";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * 정비 카탈로그 신규 품목 추가 다이얼로그. "정비" 탭 우측 상단 버튼이 열고,
+ * appliesTo 기본값은 ELECTRIC. 운영자가 새 ICE / BOTH 품목을 만들 땐 select
+ * 에서 직접 골라야 한다.
+ *
+ * cycle 세 필드(km / months / label) 중 최소 한 값이 필요 — backend check
+ * 제약과 일치. 폼은 그 검증을 client-side 에서 하지 않고 server action 에서
+ * 처리(silent redirect with status param). 운영자가 비워 보내면 안내 메시지.
+ */
+export function CreateMaintenanceItemDialog({
+  parentOptions
+}: {
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [resetKey, setResetKey] = useState(0);
+
+  const handleReset = useCallback(() => {
+    formRef.current?.reset();
+    setResetKey((k) => k + 1);
+  }, []);
+
+  // 그룹 부모로 쓸 수 있는 후보 — 부모 자체가 다시 부모인 케이스(2단 계층)
+  // 는 backend 제약은 없지만 UI 상 1-depth 그룹만 노출해 단순화.
+  const eligibleParents = parentOptions.filter((option) => option.parentItemId === null);
+
+  return (
+    <>
+      <button
+        className="button-primary"
+        type="button"
+        onClick={() => dialogRef.current?.showModal()}
+      >
+        정비 품목 추가
+      </button>
+      <dialog ref={dialogRef} className="overview-create-dialog">
+        <button
+          type="button"
+          className="overview-create-dialog-reset"
+          onClick={handleReset}
+          aria-label="입력 초기화"
+          title="입력 초기화"
+        >
+          ↻
+        </button>
+        <form ref={formRef} action={createMaintenanceItemAction} key={`create-form-${resetKey}`}>
+          <h3>정비 품목 추가</h3>
+          <label>
+            품목
+            <input name="name" required maxLength={100} placeholder="예: 엔진오일" />
+          </label>
+          <label>
+            적용
+            <select name="appliesTo" defaultValue="ELECTRIC">
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연</option>
+              <option value="BOTH">공통</option>
+            </select>
+          </label>
+          <label>
+            교환주기 (km)
+            <input name="cycleKm" type="number" min={0} placeholder="비우면 km 기준 없음" />
+          </label>
+          <label>
+            교환주기 (개월)
+            <input name="cycleMonths" type="number" min={0} placeholder="비우면 개월 기준 없음" />
+          </label>
+          <label>
+            라벨 (자유 텍스트)
+            <input name="cycleLabel" maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
+          </label>
+          <label>
+            그룹 부모
+            <select name="parentItemId" defaultValue="">
+              <option value="">없음</option>
+              {eligibleParents.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            정렬
+            <input name="displayOrder" type="number" min={0} defaultValue={0} />
+          </label>
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={() => dialogRef.current?.close()}>
+              취소
+            </button>
+            <button className="button-primary" type="submit">
+              추가
+            </button>
+          </div>
+        </form>
+      </dialog>
+    </>
+  );
+}

--- a/development/front-admin-web/components/management/DeleteMaintenanceItemButton.tsx
+++ b/development/front-admin-web/components/management/DeleteMaintenanceItemButton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { deleteMaintenanceItemAction } from "@/app/actions";
+
+/**
+ * 정비 카탈로그 행의 trash icon 삭제 버튼. 다른 도메인(Delete{Vehicle,Rider,
+ * Station}Button) 와 같은 onClick + confirm + manual server action 패턴.
+ */
+export function DeleteMaintenanceItemButton({
+  itemId,
+  itemName
+}: {
+  itemId: string;
+  itemName: string;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`정비 품목 "${itemName}" 을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteMaintenanceItemAction(itemId);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`정비 품목 "${itemName}" 삭제`}
+      aria-label={`정비 품목 "${itemName}" 삭제`}
+    >
+      <TrashIcon />
+    </button>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { updateMaintenanceItemAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * 정비 카탈로그 행의 상세 + 수정 다이얼로그. 다른 detail dialog 들과 같은
+ * modal 패턴 (centered, scroll-locked).
+ *
+ * 그룹 부모 (`구동계3종`) 도 같은 폼으로 편집 — cycle 세 필드를 모두 비우면
+ * 헤더-only 행이 된다. parent_item_id select 는 같은 applies_to 내의 다른 행
+ * 들을 옵션으로 노출 (자기 자신은 제외).
+ */
+export function MaintenanceItemDetailDialog({
+  row,
+  parentOptions,
+  onClose
+}: {
+  row: ServiceOpsMaintenanceItem | null;
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  useScrollLockedDialog(dialogRef, row !== null);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  if (!row) return null;
+
+  const boundUpdate = updateMaintenanceItemAction.bind(null, row.id);
+  const eligibleParents = parentOptions.filter(
+    (option) => option.id !== row.id && option.parentItemId === null
+  );
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="overview-create-dialog"
+      onClose={onClose}
+      onCancel={onClose}
+    >
+      <h3>정비 품목 상세</h3>
+      {mode === "view" ? (
+        <div className="detail-row-grid">
+          <DetailField label="품목" value={row.name} />
+          <DetailField label="적용" value={appliesToLabel(row.appliesTo)} />
+          <DetailField label="교환주기 (km)" value={row.cycleKm !== null ? `${row.cycleKm.toLocaleString()} km` : "—"} />
+          <DetailField label="교환주기 (개월)" value={row.cycleMonths !== null ? `${row.cycleMonths}개월` : "—"} />
+          <DetailField label="라벨" value={row.cycleLabel ?? "—"} />
+          <DetailField label="그룹 부모" value={parentLabel(row, parentOptions)} />
+          <DetailField label="활성" value={row.enabled ? "ON" : "OFF"} />
+          <DetailField label="정렬" value={String(row.displayOrder)} />
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={handleClose}>닫기</button>
+            <button type="button" className="button-primary" onClick={() => setMode("edit")}>수정</button>
+          </div>
+        </div>
+      ) : (
+        <form action={boundUpdate}>
+          <label>
+            품목
+            <input name="name" defaultValue={row.name} maxLength={100} required />
+          </label>
+          <label>
+            적용
+            <select name="appliesTo" defaultValue={row.appliesTo}>
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연</option>
+              <option value="BOTH">공통</option>
+            </select>
+          </label>
+          <label>
+            교환주기 (km)
+            <input name="cycleKm" type="number" min={0} defaultValue={row.cycleKm ?? ""} placeholder="비우면 km 기준 없음" />
+          </label>
+          <label>
+            교환주기 (개월)
+            <input name="cycleMonths" type="number" min={0} defaultValue={row.cycleMonths ?? ""} placeholder="비우면 개월 기준 없음" />
+          </label>
+          <label>
+            라벨 (자유 텍스트)
+            <input name="cycleLabel" defaultValue={row.cycleLabel ?? ""} maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
+          </label>
+          <label>
+            그룹 부모
+            <select name="parentItemId" defaultValue={row.parentItemId ?? ""}>
+              <option value="">없음</option>
+              {eligibleParents.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name} ({appliesToLabel(option.appliesTo)})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            정렬
+            <input name="displayOrder" type="number" min={0} defaultValue={row.displayOrder} />
+          </label>
+          <label>
+            활성
+            <select name="enabled" defaultValue={row.enabled ? "true" : "false"}>
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+          </label>
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={() => setMode("view")}>취소</button>
+            <button type="submit" className="button-primary">저장</button>
+          </div>
+        </form>
+      )}
+    </dialog>
+  );
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="detail-field">
+      <span className="detail-field-label">{label}</span>
+      <span className="detail-field-value">{value}</span>
+    </div>
+  );
+}
+
+function appliesToLabel(value: ServiceOpsMaintenanceItem["appliesTo"]): string {
+  if (value === "ELECTRIC") return "전기";
+  if (value === "ICE") return "내연";
+  return "공통";
+}
+
+function parentLabel(
+  row: ServiceOpsMaintenanceItem,
+  options: ReadonlyArray<ServiceOpsMaintenanceItem>
+): string {
+  if (!row.parentItemId) return "—";
+  const parent = options.find((option) => option.id === row.parentItemId);
+  return parent?.name ?? "—";
+}

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+
+import { DeleteMaintenanceItemButton } from "@/components/management/DeleteMaintenanceItemButton";
+import { MaintenanceItemDetailDialog } from "@/components/management/MaintenanceItemDetailDialog";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * `/?tab=maintenance` 의 정비 카탈로그 편집 패널. 세 섹션(전기 전용 / 내연
+ * 전용 / 공통) 으로 나눠서 사진의 두 표 + 공통 항목 묶음을 그대로 보여준다.
+ *
+ * 각 행: 품목 / 적용 / 교환주기 / 그룹 부모 / 활성 / 삭제. 행 클릭 시 상세
+ * 다이얼로그가 열리고 거기서 수정 모드로 전환 — 다른 도메인 detail dialog
+ * 와 같은 패턴.
+ *
+ * 그룹 부모(예: 구동계3종) 는 자식 위에 들여쓰기 없이, 자식은 한 단계 들여
+ * 써서 시각적으로 묶음. 표시 정렬은 displayOrder 오름차순. 그룹 자체는
+ * cycle 세 필드가 모두 비어 있는 행으로 표현 (display order 가 자식 바로
+ * 앞으로 박혀 있어서 단순 정렬이 그대로 작동).
+ */
+export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMaintenanceItem> }) {
+  const [activeRow, setActiveRow] = useState<ServiceOpsMaintenanceItem | null>(null);
+
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => a.displayOrder - b.displayOrder),
+    [items]
+  );
+
+  const electric = sorted.filter((item) => item.appliesTo === "ELECTRIC");
+  const ice = sorted.filter((item) => item.appliesTo === "ICE");
+  const both = sorted.filter((item) => item.appliesTo === "BOTH");
+
+  return (
+    <div className="maintenance-panel">
+      <Section title="전기 전용" items={electric} parentOptions={sorted} onActivate={setActiveRow} />
+      <Section title="내연 전용" items={ice} parentOptions={sorted} onActivate={setActiveRow} />
+      <Section title="공통 (양쪽 적용)" items={both} parentOptions={sorted} onActivate={setActiveRow} />
+
+      <MaintenanceItemDetailDialog
+        key={activeRow?.id ?? "none"}
+        row={activeRow}
+        parentOptions={sorted}
+        onClose={() => setActiveRow(null)}
+      />
+    </div>
+  );
+}
+
+function Section({
+  title,
+  items,
+  parentOptions,
+  onActivate
+}: {
+  title: string;
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  onActivate: (item: ServiceOpsMaintenanceItem) => void;
+}) {
+  return (
+    <section className="maintenance-panel-section">
+      <h3 className="maintenance-panel-section-title">{title}</h3>
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <colgroup>
+            <col style={{ width: "48px" }} />
+            <col />
+            <col style={{ width: "140px" }} />
+            <col style={{ width: "120px" }} />
+            <col style={{ width: "72px" }} />
+          </colgroup>
+          <thead>
+            <tr>
+              <th aria-label="삭제" />
+              <th>품목</th>
+              <th>교환주기</th>
+              <th>그룹 부모</th>
+              <th>활성</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="table-empty-cell">
+                  데이터 없음
+                </td>
+              </tr>
+            ) : null}
+            {items.map((item) => {
+              const parent = item.parentItemId
+                ? parentOptions.find((option) => option.id === item.parentItemId) ?? null
+                : null;
+              return (
+                <tr
+                  key={item.id}
+                  className="table-row-clickable"
+                  onClick={() => onActivate(item)}
+                >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    <DeleteMaintenanceItemButton itemId={item.id} itemName={item.name} />
+                  </td>
+                  <td>
+                    {item.parentItemId ? <span className="maintenance-panel-indent">└ </span> : null}
+                    {item.name}
+                  </td>
+                  <td>{renderCycle(item)}</td>
+                  <td>{parent ? parent.name : <span className="muted">—</span>}</td>
+                  <td>{item.enabled ? "ON" : <span className="muted">OFF</span>}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function renderCycle(item: ServiceOpsMaintenanceItem): ReactNode {
+  if (item.cycleLabel) return item.cycleLabel;
+  if (item.cycleKm !== null && item.cycleKm > 0) return `${item.cycleKm.toLocaleString()} km`;
+  if (item.cycleMonths !== null && item.cycleMonths > 0) return `${item.cycleMonths}개월`;
+  // 그룹 부모: cycle 세 값 모두 비어 있는 헤더 행.
+  return <span className="muted">— (그룹)</span>;
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -241,6 +241,29 @@ export type MaintenanceRecordCreateInput = {
   memo?: string | null;
 };
 
+export type MaintenanceItemCreateInput = {
+  name: string;
+  appliesTo: ServiceOpsMaintenanceAppliesTo;
+  parentItemId?: string | null;
+  cycleKm?: number | null;
+  cycleMonths?: number | null;
+  cycleLabel?: string | null;
+  displayOrder?: number | null;
+  memo?: string | null;
+};
+
+export type MaintenanceItemUpdateInput = {
+  name?: string | null;
+  appliesTo?: ServiceOpsMaintenanceAppliesTo | null;
+  parentItemId?: string | null;
+  cycleKm?: number | null;
+  cycleMonths?: number | null;
+  cycleLabel?: string | null;
+  displayOrder?: number | null;
+  enabled?: boolean | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsContractCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
 export type ServiceOpsContractReturnType = "TAKEOVER" | "RETURN";
 export type ServiceOpsContractDurationUnit =
@@ -894,6 +917,12 @@ export type ServiceOpsApiClient = {
   listMaintenanceRecords: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>;
   /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
   createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
+  /** 정비 카탈로그 편집 — 신규 품목 추가. */
+  createMaintenanceItem: (request: MaintenanceItemCreateInput) => Promise<ServiceOpsMaintenanceItem>;
+  /** 정비 카탈로그 편집 — 품목 partial update. */
+  updateMaintenanceItem: (id: string, request: MaintenanceItemUpdateInput) => Promise<ServiceOpsMaintenanceItem>;
+  /** 정비 카탈로그 편집 — soft delete. */
+  deleteMaintenanceItem: (id: string) => Promise<void>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -1304,6 +1333,19 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
         { body: JSON.stringify(createRequest), method: "POST" }
       ),
+    createMaintenanceItem: (createRequest) =>
+      request<ServiceOpsMaintenanceItem>(
+        "/maintenance-items",
+        { body: JSON.stringify(createRequest), method: "POST" }
+      ),
+    updateMaintenanceItem: (id, updateRequest) =>
+      request<ServiceOpsMaintenanceItem>(
+        `/maintenance-items/${encodeURIComponent(id)}`,
+        { body: JSON.stringify(updateRequest), method: "PATCH" }
+      ),
+    deleteMaintenanceItem: async (id) => {
+      await request<void>(`/maintenance-items/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {


### PR DESCRIPTION
## Summary
PR-η — 정비 카탈로그 편집 UI. \"정비\" 탭 신설 + CRUD 다이얼로그.

**새 탭 \"정비\"**
- 차량 / 라이더 / BSS / **정비** — TABS 배열에 추가
- 3 섹션 (\`전기 전용\` / \`내연 전용\` / \`공통\`) 으로 \`applies_to\` enum 별 분리. 그룹 자식은 \"└\" 들여쓰기
- 행 클릭 → \`MaintenanceItemDetailDialog\` (view+edit modal)
- 행 좌측 trash 아이콘 → 즉시 confirm + 삭제
- 우상단 \"정비 품목 추가\" 버튼 → \`CreateMaintenanceItemDialog\`

**Server actions** (\`app/actions.ts\`)
- \`createMaintenanceItemAction\` — name + applies_to + cycle 셋 중 하나 검증
- \`updateMaintenanceItemAction\` — partial update, null 명시값도 그대로 반영
- \`deleteMaintenanceItemAction\` — soft delete

**Client API**
- 4 새 method: \`createMaintenanceItem\` / \`updateMaintenanceItem\` / \`deleteMaintenanceItem\` + 입출력 타입
- \`parentItemId\` / cycle 세 필드 모두 nullable — 운영자가 빈 값으로 보내면 "비움" 의미

**Page loader 재사용**
- PR-ζ 에서 이미 prefetch 한 \`maintenanceData.items\` 그대로 사용 — 추가 round-trip 없음

## Test plan
- [ ] 상단 탭에 \"정비\" 4번째로 노출
- [ ] 정비 탭 진입 시 사진 두 표 + 공통 = 총 17개 품목이 3 섹션에 분리되어 표시
- [ ] 구동계3종 부모 + 자식 3개가 \"내연 전용\" 섹션에 묶음 형태로 노출 (자식 \"└\" 들여쓰기)
- [ ] 행 클릭 → 상세 다이얼로그 열림, 수정 모드로 cycle / 그룹 부모 변경 가능
- [ ] \"정비 품목 추가\" 클릭 → 빈 폼, 필수값 (name + applies_to + cycle 중 하나) 미입력 시 silent redirect 안내
- [ ] trash 아이콘 → confirm → 행 사라짐, 다음 페이지 새로고침 후에도 안 보임
- [ ] 모든 동작 후 \`/?tab=maintenance\` 로 redirect 되어 탭 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)