### PR TITLE
Release: engine type + maintenance catalog + vehicle floating panel + tab filters

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -399,6 +399,127 @@ export async function setVehicleOperationStatusFromOverviewAction(
   redirect("/?tab=vehicles");
 }
 
+// ============================================================================
+// 정비 카탈로그 편집 — "정비" 탭에서 운영자가 default cycle / 품목 / 그룹을
+// 추가/수정/삭제. backend V22 의 maintenance-items endpoint 를 그대로 호출.
+// ============================================================================
+
+import type { ServiceOpsMaintenanceAppliesTo } from "@/lib/services/service-ops-api";
+
+export async function createMaintenanceItemAction(formData: FormData): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const name = requiredText(formData.get("name"));
+  if (!name) {
+    redirect("/?tab=maintenance&status=maintenance-item-missing-name");
+  }
+  const appliesTo = parseAppliesTo(formData.get("appliesTo"));
+  if (!appliesTo) {
+    redirect("/?tab=maintenance&status=maintenance-item-invalid-applies-to");
+  }
+  const cycleKm = optionalInteger(formData.get("cycleKm"));
+  const cycleMonths = optionalInteger(formData.get("cycleMonths"));
+  const cycleLabel = optionalText(formData.get("cycleLabel"));
+  if (cycleKm === null && cycleMonths === null && !cycleLabel) {
+    // 백엔드 check 제약과 동일 정책 — 최소 한 종류의 cycle 표현은 있어야 한다.
+    redirect("/?tab=maintenance&status=maintenance-item-cycle-required");
+  }
+  const parentItemId = optionalText(formData.get("parentItemId"));
+  const displayOrder = optionalInteger(formData.get("displayOrder"));
+  try {
+    await client.createMaintenanceItem({
+      name,
+      appliesTo,
+      parentItemId,
+      cycleKm,
+      cycleMonths,
+      cycleLabel,
+      displayOrder: displayOrder ?? null,
+      memo: optionalText(formData.get("memo"))
+    });
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-create-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+export async function updateMaintenanceItemAction(
+  itemId: string,
+  formData: FormData
+): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+  const name = optionalText(formData.get("name"));
+  const appliesTo = parseAppliesTo(formData.get("appliesTo"));
+  // 모든 필드 optional; cycle 들은 명시적 null (빈 입력) 도 그대로 반영.
+  try {
+    await client.updateMaintenanceItem(itemId, {
+      name,
+      appliesTo: appliesTo ?? null,
+      parentItemId: optionalText(formData.get("parentItemId")),
+      cycleKm: optionalInteger(formData.get("cycleKm")),
+      cycleMonths: optionalInteger(formData.get("cycleMonths")),
+      cycleLabel: optionalText(formData.get("cycleLabel")),
+      displayOrder: optionalInteger(formData.get("displayOrder")),
+      enabled: parseOptionalBoolean(formData.get("enabled")),
+      memo: optionalText(formData.get("memo"))
+    });
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-update-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+export async function deleteMaintenanceItemAction(itemId: string): Promise<void> {
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=maintenance");
+  }
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+  try {
+    await client.deleteMaintenanceItem(itemId);
+  } catch {
+    redirect("/?tab=maintenance&status=maintenance-item-delete-error");
+  }
+  revalidatePath("/");
+  redirect("/?tab=maintenance");
+}
+
+function parseAppliesTo(value: FormDataEntryValue | null): ServiceOpsMaintenanceAppliesTo | null {
+  const text = String(value ?? "").trim();
+  if (text === "ELECTRIC" || text === "ICE" || text === "BOTH") return text;
+  return null;
+}
+
+function parseOptionalBoolean(value: FormDataEntryValue | null): boolean | null {
+  const text = String(value ?? "").trim().toLowerCase();
+  if (text === "true") return true;
+  if (text === "false") return false;
+  return null;
+}
+
+function optionalInteger(value: FormDataEntryValue | null): number | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const parsed = Number.parseInt(text, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export async function markVehicleMaintenanceServicedAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import {
+  type ServiceOpsBikeEngineType,
   type ServiceOpsBikeOperationStatus,
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
@@ -110,6 +111,7 @@ export async function createVehicleFromOverviewAction(formData: FormData): Promi
       // sticker has been read off the vehicle.
       vin: null,
       modelName: optionalText(formData.get("modelName")),
+      engineType: parseEngineType(formData.get("engineType")),
       operationStatus: String(formData.get("operationStatus") ?? "READY") as ServiceOpsBikeOperationStatus
     });
   } catch {
@@ -231,12 +233,14 @@ export async function updateVehicleFromOverviewAction(
   const currentDeviceUid = String(formData.get("currentDeviceUid") ?? "").trim();
 
   try {
-    // 차체 기본 정보 (plateNumber / modelName) 는 일반 update endpoint 로,
-    // operationStatus 는 상태 이력을 남기는 별도 endpoint 로 분리 호출. 둘
-    // 다 같은 트랜잭션은 아니지만 운영자 입장에선 한 번의 "저장" 으로 묶이게 한다.
+    // 차체 기본 정보 (plateNumber / modelName / engineType) 는 일반 update
+    // endpoint 로, operationStatus 는 상태 이력을 남기는 별도 endpoint 로
+    // 분리 호출. 둘 다 같은 트랜잭션은 아니지만 운영자 입장에선 한 번의
+    // "저장" 으로 묶이게 한다.
     await client.updateVehicle(vehicleId, {
       plateNumber: requiredText(formData.get("plateNumber")),
-      modelName: optionalText(formData.get("modelName"))
+      modelName: optionalText(formData.get("modelName")),
+      engineType: parseEngineType(formData.get("engineType"))
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {
@@ -542,6 +546,16 @@ function requiredText(value: FormDataEntryValue | null): string {
 function optionalText(value: FormDataEntryValue | null): string | null {
   const text = requiredText(value);
   return text ? text : null;
+}
+
+// formData("engineType") 가 빈 값이면 undefined 로 (backend 가 ELECTRIC default
+// 처리). 인식 못 하는 값은 잡고 무시 — 운영자 UI 의 select 만 접근하는 경로라
+// 사실상 ELECTRIC / ICE 둘 중 하나만 들어오지만, 외부에서 잘못된 값이 들어와도
+// throw 하지 않고 그냥 backend default 에 위임.
+function parseEngineType(value: FormDataEntryValue | null): ServiceOpsBikeEngineType | undefined {
+  const text = String(value ?? "").trim();
+  if (text === "ELECTRIC" || text === "ICE") return text;
+  return undefined;
 }
 
 function parseNumber(value: FormDataEntryValue | null, fallback: number): number {

--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -399,6 +399,44 @@ export async function setVehicleOperationStatusFromOverviewAction(
   redirect("/?tab=vehicles");
 }
 
+export async function markVehicleMaintenanceServicedAction(
+  vehicleId: string,
+  formData: FormData
+): Promise<void> {
+  // 차량 floating panel 의 "교환 완료" 버튼이 호출. 같은 차량 + 같은 품목에
+  // 대해 row 를 한 건 새로 추가하기만 한다 — 다음 교환 예정 / 임박 / 지연
+  // 등은 derived 라 클라이언트가 list 재조회로 갱신.
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=vehicles");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const itemId = String(formData.get("itemId") ?? "").trim();
+  if (!itemId) {
+    redirect("/?tab=vehicles&status=maintenance-missing-item");
+  }
+  const odoRaw = String(formData.get("servicedAtOdometerKm") ?? "").trim();
+  const odo = odoRaw ? Number.parseInt(odoRaw, 10) : null;
+
+  try {
+    await client.createMaintenanceRecord(vehicleId, {
+      itemId,
+      servicedAt: null,
+      servicedAtOdometerKm: odo !== null && Number.isFinite(odo) ? odo : null,
+      memo: null
+    });
+  } catch {
+    redirect("/?tab=vehicles&status=maintenance-record-error");
+  }
+
+  revalidatePath("/");
+  redirect("/?tab=vehicles");
+}
+
 export async function setVehicleIgnitionBlockFromOverviewAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -361,6 +361,40 @@ export async function createContractFromOverviewAction(formData: FormData): Prom
   redirect("/");
 }
 
+export async function setVehicleOperationStatusFromOverviewAction(
+  vehicleId: string,
+  formData: FormData
+): Promise<void> {
+  // 차량 탭 행의 "운영 상태" 인라인 토글이 호출. hidden field `operationStatus`
+  // 가 "IN_SERVICE" / "READY" 둘 중 하나. 별도 detail 다이얼로그 저장 흐름은
+  // 그대로 두되, 한 컬럼 즉시 변경용으로 가벼운 endpoint 하나 분리.
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?tab=vehicles");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  const next = String(formData.get("operationStatus") ?? "") as ServiceOpsBikeOperationStatus;
+  if (next !== "IN_SERVICE" && next !== "READY") {
+    redirect("/?tab=vehicles&status=operation-status-error");
+  }
+
+  try {
+    await client.changeVehicleOperationStatus(vehicleId, {
+      operationStatus: next,
+      reason: "OPERATOR_EDIT"
+    });
+  } catch {
+    redirect("/?tab=vehicles&status=operation-status-error");
+  }
+
+  revalidatePath("/");
+  redirect("/?tab=vehicles");
+}
+
 export async function setVehicleIgnitionBlockFromOverviewAction(
   vehicleId: string,
   formData: FormData

--- a/development/front-admin-web/app/api/overview/vehicle-maintenance/[bikeId]/route.ts
+++ b/development/front-admin-web/app/api/overview/vehicle-maintenance/[bikeId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { loadVehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
+
+/**
+ * 차량 floating 상세 패널이 open 시 호출하는 lazy fetch. 한 차량의 정비 카탈로그
+ * (engineType 매칭) + 정비 이력을 한 번에 묶어서 반환. cookie-bound session 은
+ * 서버 측에 머무르고 응답만 JSON 으로 내려준다.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ bikeId: string }> }
+) {
+  const { bikeId } = await context.params;
+  const bundle = await loadVehicleMaintenanceBundle(bikeId);
+  return NextResponse.json(bundle, {
+    headers: { "Cache-Control": "no-store" }
+  });
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -393,6 +393,7 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-filter-search:focus { outline: 2px solid var(--rm-accent); outline-offset: -1px; border-color: transparent; }
 .vehicles-filter-search-icon { position: absolute; right: 10px; top: 50%; transform: translateY(-50%); font-size: 14px; opacity: 0.55; pointer-events: none; }
 .vehicles-filter-select { flex: 0 1 160px; min-width: 130px; height: 38px; padding: 0 10px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; cursor: pointer; }
+.vehicles-filter-select:disabled { opacity: 0.55; cursor: not-allowed; }
 .vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
 /* 16컬럼 테이블 (차량 자체 + 매칭 라이더 라이프 사이클) — 좁은 화면에선 가로 스크롤. */
 .vehicles-table-scroll { max-height: 560px; overflow: auto; }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -410,6 +410,8 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-pill--ignition-on { background: var(--rm-battery-high-soft); color: var(--rm-battery-high); border: 1px solid var(--rm-battery-high-line); }
 .vehicles-pill--ignition-off { background: var(--color-bg-muted); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
 .vehicles-pill--unknown { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); border: 1px solid var(--rm-battery-low-line); }
+.vehicles-pill--engine-electric { background: var(--rm-accent-soft); color: var(--rm-accent); border: 1px solid var(--rm-accent-outline); }
+.vehicles-pill--engine-ice { background: var(--rm-battery-mid-soft); color: var(--rm-battery-mid); border: 1px solid var(--rm-battery-mid-line); }
 
 /* 글로벌 "지도 보기" 토글 + 캔버스. 페이지 KPI/탭 위에 자리한다. */
 .overview-map-section { display: flex; flex-direction: column; gap: 10px; margin: 20px 0 12px; }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -467,6 +467,26 @@ textarea { padding-top: 10px; min-height: 96px; }
 .toggle-switch--compact { padding: 2px 10px 2px 2px; font-size: 11px; }
 .toggle-switch--compact .toggle-switch-thumb { width: 14px; height: 14px; }
 .toggle-switch--compact .toggle-switch-text { min-width: 20px; }
+
+/* 삭제 아이콘 버튼 (vehicles / riders / stations 테이블 가장 왼쪽 컬럼) —
+   행 클릭 영역과 시각적으로 분리되도록 작은 원형 ghost button. hover 시 적색
+   톤으로 액션이 destructive 임을 알리고, 색 외에는 다른 화면 요소를 안 어지럽힌다. */
+.delete-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background .12s ease, color .12s ease;
+}
+.delete-icon-button:hover { background: var(--rm-battery-low-soft); color: var(--rm-battery-low); }
+.delete-icon-button:focus-visible { outline: 2px solid var(--rm-battery-low); outline-offset: 1px; }
 /* Empty-state cell. Sits inside the same table as the data rows so the
    column headers stay visible above it. Height is the card (240px) minus
    the sticky thead row (40px) so the message lands in the visual centre

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -394,9 +394,9 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicles-filter-search-icon { position: absolute; right: 10px; top: 50%; transform: translateY(-50%); font-size: 14px; opacity: 0.55; pointer-events: none; }
 .vehicles-filter-select { flex: 0 1 160px; min-width: 130px; height: 38px; padding: 0 10px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; cursor: pointer; }
 .vehicles-filter-count { margin-left: auto; font-size: 12px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
-/* 10컬럼 테이블은 좁은 화면에선 가로 스크롤. */
+/* 16컬럼 테이블 (차량 자체 + 매칭 라이더 라이프 사이클) — 좁은 화면에선 가로 스크롤. */
 .vehicles-table-scroll { max-height: 560px; overflow: auto; }
-.vehicles-table { min-width: 1080px; table-layout: auto; }
+.vehicles-table { min-width: 1640px; table-layout: auto; }
 .vehicles-cell-mono { font-family: var(--font-sans); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .vehicles-soc { font-variant-numeric: tabular-nums; font-weight: 700; }
 .vehicles-soc--high { color: var(--rm-battery-high); }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -575,6 +575,69 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
+
+/* 차량 floating 상세 패널 — 모달 대신 지도 우측 상단에 떠 있는 비-모달
+   카드. 운영자가 panel 을 띄운 채로도 표/지도와 상호작용할 수 있어야 해서
+   `position: fixed` + 우측 anchor + max-height 로 viewport 안에 고정.
+   `pointer-events: auto` 는 명시 — 부모 wrapper 의 events: none 같은 패턴이
+   상위에 들어와도 패널 자체는 클릭 가능하게 보호. */
+.vehicle-floating-panel {
+  position: fixed;
+  top: 96px;
+  right: 24px;
+  width: 380px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  padding: 20px 24px;
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-panel);
+  color: var(--color-text-primary);
+  z-index: 50;
+  pointer-events: auto;
+}
+.vehicle-floating-panel h3 { margin: 0; font-size: 16px; }
+.vehicle-floating-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.vehicle-floating-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+.vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
+.vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+.vehicle-floating-panel label input,
+.vehicle-floating-panel label select {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--color-bg-soft);
+  color: var(--color-text-primary);
+  box-shadow: 0 0 0 1px var(--color-border);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
 /* 라이더 상세 다이얼로그의 헤딩 줄. 왼쪽 = 제목, 오른쪽 = 활성 매칭 차량의
    시동 상태 + 시동 제어 토글 패널. 활성 매칭이 없는 라이더는 우측이 비고
    제목만 보인다. h3 의 margin-bottom 은 헤딩 줄 자체로 옮겨 처리. */

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -622,6 +622,13 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+/* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
+   각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
+.maintenance-panel { display: flex; flex-direction: column; gap: 24px; }
+.maintenance-panel-section { display: flex; flex-direction: column; gap: 8px; }
+.maintenance-panel-section-title { margin: 0; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
+.maintenance-panel-indent { color: var(--color-text-muted); margin-right: 4px; }
+
 /* 차량 floating panel 안의 "정비 상태" 섹션 — 한 줄에 5컬럼 grid
    (품목 / 주기 / 마지막 교환 / 상태 / 액션). 자식(그룹 멤버) 행은 좌측에
    살짝 들여쓰기 해서 그룹 헤더와 묶음 시각화. */

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -622,6 +622,37 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+/* 차량 floating panel 안의 "정비 상태" 섹션 — 한 줄에 5컬럼 grid
+   (품목 / 주기 / 마지막 교환 / 상태 / 액션). 자식(그룹 멤버) 행은 좌측에
+   살짝 들여쓰기 해서 그룹 헤더와 묶음 시각화. */
+.maintenance-section { margin-top: 8px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
+.maintenance-section h4 { margin: 0 0 8px; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .02em; }
+.maintenance-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.maintenance-row { padding: 6px 8px; border-radius: 8px; background: var(--color-bg-soft); }
+.maintenance-row--child { margin-left: 12px; background: transparent; }
+.maintenance-row-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1.2fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.maintenance-row-name { font-weight: 700; color: var(--color-text-primary); }
+.maintenance-row-cycle, .maintenance-row-last { color: var(--color-text-secondary); font-variant-numeric: tabular-nums; }
+.maintenance-row-action {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--rm-accent-outline);
+  border-radius: 6px;
+  background: var(--rm-accent-soft);
+  color: var(--rm-accent);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+.maintenance-row-action:hover:not(:disabled) { background: var(--rm-accent-halo-strong); }
+.maintenance-row-action:disabled { opacity: 0.5; cursor: not-allowed; }
 .vehicle-floating-panel label input,
 .vehicle-floating-panel label select {
   display: block;

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -28,6 +28,8 @@ import {
 import { loadStationList } from "@/lib/services/station-data";
 import { loadVehicleList } from "@/lib/services/vehicle-data";
 import { loadVehicleDeviceMap } from "@/lib/services/vehicle-device-data";
+import { loadMaintenanceDataset } from "@/lib/services/vehicle-maintenance-data";
+import { summarizeMaintenanceByBike } from "@/components/management/vehicle-maintenance-derive";
 
 // Authenticated, per-admin loader. At build time the env-less mock fallback
 // returns synchronously without touching cookies, which lets Next.js
@@ -93,7 +95,8 @@ export default async function RootPage({
     vehicleData,
     matching,
     opsExtra,
-    deviceMap
+    deviceMap,
+    maintenanceData
   ] = await Promise.all([
     searchParams,
     loadDashboardMapState(),
@@ -101,7 +104,8 @@ export default async function RootPage({
     loadVehicleList(),
     loadRiderMatchingSnapshot(),
     loadContractsAndInsurances(),
-    loadVehicleDeviceMap()
+    loadVehicleDeviceMap(),
+    loadMaintenanceDataset()
   ]);
 
   const activeTab: TabKey = isValidTabKey(tabParam) ? tabParam : "vehicles";
@@ -175,6 +179,19 @@ export default async function RootPage({
     if (vehicle.id) ignitionBlockedByBikeId.set(vehicle.id, vehicle.ignitionBlocked ?? false);
   }
 
+  // 차량 탭 "정비 상태" 필터가 임박/지연 차량을 골라낼 때 참조. bikeId →
+  // {hasOverdue, hasDueSoon, overallStatus}. 차량별 engineType 으로 적용
+  // catalog 를 분기해 catalog × records 의 매트릭스를 한 번에 derive.
+  const bikeEngineTypeById = new Map<string, "ELECTRIC" | "ICE">();
+  for (const vehicle of vehicleData.vehicles) {
+    if (vehicle.id) bikeEngineTypeById.set(vehicle.id, vehicle.engineType ?? "ELECTRIC");
+  }
+  const maintenanceSummaryByBike = summarizeMaintenanceByBike(
+    maintenanceData.items,
+    maintenanceData.records,
+    bikeEngineTypeById
+  );
+
   // 시동 차량 = telemetry ignition_status === "ON". The dashboard summary
   // does not aggregate this yet, so we count it from the bike pin list
   // (which carries `ignitionStatus` per pin). UNKNOWN / OFF are excluded.
@@ -237,6 +254,7 @@ export default async function RootPage({
                 riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId}
                 insuranceOptions={insuranceOptions}
                 ignitionBlockedByBikeId={ignitionBlockedByBikeId}
+                maintenanceSummaryByBike={maintenanceSummaryByBike}
               />
             ),
             notice: vehicleData.notice

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -9,6 +9,7 @@ import { CreateVehicleDialog } from "@/components/management/CreateVehicleDialog
 import { RidersPanel, type InsuranceOption } from "@/components/management/RidersPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
+import { OverviewClientShell } from "@/components/overview/OverviewClientShell";
 import { OverviewMapBanner } from "@/components/overview/OverviewMapBanner";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 import { loadRiderList } from "@/lib/services/rider-data";
@@ -250,6 +251,7 @@ export default async function RootPage({
         </p>
       ) : null}
 
+      <OverviewClientShell>
       {/* 페이지 상단 KPI 두 카드(차량 현황 / 라이더 현황). */}
       <div className="overview-kpi-groups">
         <article className="kpi-group">
@@ -347,6 +349,7 @@ export default async function RootPage({
         templateOptions={templateOptions}
         statusParam={statusParam ?? null}
       />
+      </OverviewClientShell>
     </div>
   );
 }

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -231,9 +231,10 @@ export default async function RootPage({
                 riderInfoById={riderInfoById}
                 bikePins={mapState.data.bikePins}
                 deviceUidByBikeId={deviceMap.deviceUidByBikeId}
-                insuredRiderIds={matching.insuredRiderIds}
                 educationTypeByRiderId={matching.educationTypeByRiderId}
                 riderActiveContractById={matching.riderActiveContractById}
+                riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId}
+                insuranceOptions={insuranceOptions}
                 ignitionBlockedByBikeId={ignitionBlockedByBikeId}
               />
             ),

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -3,9 +3,11 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { ContractMatchingForm, type ContractMatchingOption } from "@/components/management/ContractMatchingForm";
+import { CreateMaintenanceItemDialog } from "@/components/management/CreateMaintenanceItemDialog";
 import { CreateRiderDialog } from "@/components/management/CreateRiderDialog";
 import { CreateStationDialog } from "@/components/management/CreateStationDialog";
 import { CreateVehicleDialog } from "@/components/management/CreateVehicleDialog";
+import { MaintenancePanel } from "@/components/management/MaintenancePanel";
 import { RidersPanel, type InsuranceOption } from "@/components/management/RidersPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
@@ -37,7 +39,7 @@ import { summarizeMaintenanceByBike } from "@/components/management/vehicle-main
 // output across all admins, so we opt in to dynamic rendering explicitly.
 export const dynamic = "force-dynamic";
 
-type TabKey = "vehicles" | "riders" | "stations";
+type TabKey = "vehicles" | "riders" | "stations" | "maintenance";
 
 type TabConfig = {
   key: TabKey;
@@ -46,10 +48,13 @@ type TabConfig = {
 
 // 운영팀 요청 — 1순위 화면이 차량 관리이므로 차량 탭이 첫 번째이자 기본.
 // stations 키는 유지하되 라벨만 "BSS"(Battery Swap Station)로 노출한다.
+// maintenance 는 정비 카탈로그 편집 전용 — 평소엔 거의 안 열리지만 운영자가
+// default cycle / 신규 품목을 추가할 때 사용.
 const TABS: ReadonlyArray<TabConfig> = [
   { key: "vehicles", label: "차량" },
   { key: "riders", label: "라이더" },
-  { key: "stations", label: "BSS" }
+  { key: "stations", label: "BSS" },
+  { key: "maintenance", label: "정비" }
 ];
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
@@ -259,7 +264,12 @@ export default async function RootPage({
             ),
             notice: vehicleData.notice
           }
-        : await loadOtherTabContent(activeTab);
+        : activeTab === "maintenance"
+          ? {
+              panel: <MaintenancePanel items={maintenanceData.items} />,
+              notice: undefined
+            }
+          : await loadOtherTabContent(activeTab);
 
   return (
     <div className="page-container">
@@ -343,6 +353,7 @@ export default async function RootPage({
           {activeTab === "riders" ? <CreateRiderDialog /> : null}
           {activeTab === "vehicles" ? <CreateVehicleDialog /> : null}
           {activeTab === "stations" ? <CreateStationDialog /> : null}
+          {activeTab === "maintenance" ? <CreateMaintenanceItemDialog parentOptions={maintenanceData.items} /> : null}
         </div>
       </div>
 

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -231,6 +231,10 @@ export default async function RootPage({
                 riderInfoById={riderInfoById}
                 bikePins={mapState.data.bikePins}
                 deviceUidByBikeId={deviceMap.deviceUidByBikeId}
+                insuredRiderIds={matching.insuredRiderIds}
+                educationTypeByRiderId={matching.educationTypeByRiderId}
+                riderActiveContractById={matching.riderActiveContractById}
+                ignitionBlockedByBikeId={ignitionBlockedByBikeId}
               />
             ),
             notice: vehicleData.notice

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -6,6 +6,7 @@ import type {
   FrontendDashboardStationPin
 } from "@/lib/services/service-ops-api";
 import type {
+  NaverEventListener,
   NaverMapInstance,
   NaverMapOptions,
   NaverMarkerInstance
@@ -287,47 +288,97 @@ export function MapShell({
     const all: { lat: number; lng: number }[] = [];
     for (const pin of bikePins) all.push({ lat: pin.latitude, lng: pin.longitude });
     for (const pin of stationPins) all.push({ lat: pin.latitude, lng: pin.longitude });
-    // fit 완료 신호는 항상 다음 frame 으로 미뤄서 GL 캔버스가 새 시점을
-    // 실제로 그린 다음에 오버레이를 걷어내도록 한다. 또한 effect 안에서의
-    // sync setState (`react-hooks/set-state-in-effect`) 도 피한다.
-    const markReady = () => {
-      if (typeof window !== "undefined") {
-        window.requestAnimationFrame(() => setFirstFitReady(true));
-      } else {
-        setFirstFitReady(true);
+
+    // 오버레이를 걷어내는 시점은 항상 비동기로 미뤄서 GL canvas 가 최종 시점을
+    // paint 한 다음에 노출되게 한다. 또한 effect body 안에서의 sync setState
+    // (`react-hooks/set-state-in-effect`) 도 피한다. 정리 함수를 끼워서
+    // unmount / 재실행 시에는 보류된 ready 신호가 새 인스턴스를 건드리지
+    // 않도록 한다.
+    let scheduledRaf: number | null = null;
+    let pendingIdleListener: NaverEventListener | null = null;
+    let fallbackTimer: number | null = null;
+    let cancelled = false;
+
+    const finalize = () => {
+      if (cancelled) return;
+      cancelled = true;
+      if (pendingIdleListener && naver?.maps?.Event) {
+        naver.maps.Event.removeListener(pendingIdleListener);
+        pendingIdleListener = null;
       }
+      if (fallbackTimer !== null && typeof window !== "undefined") {
+        window.clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+      setFirstFitReady(true);
+    };
+
+    const markReadyNextFrame = () => {
+      if (typeof window === "undefined") {
+        finalize();
+        return;
+      }
+      scheduledRaf = window.requestAnimationFrame(finalize);
+    };
+
+    // fitBounds 는 NCP 가 짧은 pan/zoom 애니메이션을 깔아주는 비동기 동작이라,
+    // 호출 직후 한 프레임만 양보해서 오버레이를 걷으면 운영자에겐 마커가 절반
+    // 정도 이동한 상태가 노출돼 "갑자기 위치가 바뀌는" 느낌이 남는다. 그래서
+    // 첫 `idle` 이벤트 (pan/zoom 완료 + 타일 로드 완료) 를 기다린 뒤 오버레이
+    // 를 제거한다. 1초 fallback 으로 idle 이 어떤 이유로 발화 안 될 때도 무한
+    // 로딩에 빠지지 않게 보호.
+    const waitForIdle = () => {
+      if (!naver?.maps?.Event || typeof window === "undefined") {
+        markReadyNextFrame();
+        return;
+      }
+      pendingIdleListener = naver.maps.Event.addListener(map, "idle", finalize);
+      fallbackTimer = window.setTimeout(finalize, 1000);
     };
 
     if (all.length === 0) {
       // 핀이 아예 없으면 fit 할 게 없으니 기본 중심 그대로 노출. 운영자가
       // 빈 상태도 봐야 데이터 없음을 인지할 수 있어서 무한 로딩으로 두지 않음.
       hasFittedRef.current = true;
-      markReady();
-      return;
-    }
-
-    if (all.length === 1) {
+      markReadyNextFrame();
+    } else if (all.length === 1) {
       // 핀 한 개면 fitBounds 가 max-zoom 까지 끌어버려 너무 가까워진다 —
-      // 그냥 중심만 옮기고 기본 줌을 유지.
+      // 그냥 중심만 옮기고 기본 줌을 유지. setCenter 는 즉시 반영되므로
+      // idle 이벤트가 발화 안 할 수 있어 다음 프레임에 바로 표시.
       const only = all[0];
       map.setCenter?.(new naver.maps.LatLng(only.lat, only.lng));
       hasFittedRef.current = true;
-      markReady();
-      return;
+      markReadyNextFrame();
+    } else {
+      const first = all[0];
+      const bounds = new naver.maps.LatLngBounds(
+        new naver.maps.LatLng(first.lat, first.lng),
+        new naver.maps.LatLng(first.lat, first.lng)
+      );
+      for (let i = 1; i < all.length; i++) {
+        bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
+      }
+      // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
+      map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
+      hasFittedRef.current = true;
+      waitForIdle();
     }
 
-    const first = all[0];
-    const bounds = new naver.maps.LatLngBounds(
-      new naver.maps.LatLng(first.lat, first.lng),
-      new naver.maps.LatLng(first.lat, first.lng)
-    );
-    for (let i = 1; i < all.length; i++) {
-      bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
-    }
-    // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
-    map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
-    hasFittedRef.current = true;
-    markReady();
+    return () => {
+      cancelled = true;
+      if (scheduledRaf !== null && typeof window !== "undefined") {
+        window.cancelAnimationFrame(scheduledRaf);
+        scheduledRaf = null;
+      }
+      if (pendingIdleListener && naver?.maps?.Event) {
+        naver.maps.Event.removeListener(pendingIdleListener);
+        pendingIdleListener = null;
+      }
+      if (fallbackTimer !== null && typeof window !== "undefined") {
+        window.clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+    };
   }, [sdkReady, bikePins, stationPins, mapVersion]);
 
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).

--- a/development/front-admin-web/components/management/CreateMaintenanceItemDialog.tsx
+++ b/development/front-admin-web/components/management/CreateMaintenanceItemDialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { createMaintenanceItemAction } from "@/app/actions";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * 정비 카탈로그 신규 품목 추가 다이얼로그. "정비" 탭 우측 상단 버튼이 열고,
+ * appliesTo 기본값은 ELECTRIC. 운영자가 새 ICE / BOTH 품목을 만들 땐 select
+ * 에서 직접 골라야 한다.
+ *
+ * cycle 세 필드(km / months / label) 중 최소 한 값이 필요 — backend check
+ * 제약과 일치. 폼은 그 검증을 client-side 에서 하지 않고 server action 에서
+ * 처리(silent redirect with status param). 운영자가 비워 보내면 안내 메시지.
+ */
+export function CreateMaintenanceItemDialog({
+  parentOptions
+}: {
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [resetKey, setResetKey] = useState(0);
+
+  const handleReset = useCallback(() => {
+    formRef.current?.reset();
+    setResetKey((k) => k + 1);
+  }, []);
+
+  // 그룹 부모로 쓸 수 있는 후보 — 부모 자체가 다시 부모인 케이스(2단 계층)
+  // 는 backend 제약은 없지만 UI 상 1-depth 그룹만 노출해 단순화.
+  const eligibleParents = parentOptions.filter((option) => option.parentItemId === null);
+
+  return (
+    <>
+      <button
+        className="button-primary"
+        type="button"
+        onClick={() => dialogRef.current?.showModal()}
+      >
+        정비 품목 추가
+      </button>
+      <dialog ref={dialogRef} className="overview-create-dialog">
+        <button
+          type="button"
+          className="overview-create-dialog-reset"
+          onClick={handleReset}
+          aria-label="입력 초기화"
+          title="입력 초기화"
+        >
+          ↻
+        </button>
+        <form ref={formRef} action={createMaintenanceItemAction} key={`create-form-${resetKey}`}>
+          <h3>정비 품목 추가</h3>
+          <label>
+            품목
+            <input name="name" required maxLength={100} placeholder="예: 엔진오일" />
+          </label>
+          <label>
+            적용
+            <select name="appliesTo" defaultValue="ELECTRIC">
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연</option>
+              <option value="BOTH">공통</option>
+            </select>
+          </label>
+          <label>
+            교환주기 (km)
+            <input name="cycleKm" type="number" min={0} placeholder="비우면 km 기준 없음" />
+          </label>
+          <label>
+            교환주기 (개월)
+            <input name="cycleMonths" type="number" min={0} placeholder="비우면 개월 기준 없음" />
+          </label>
+          <label>
+            라벨 (자유 텍스트)
+            <input name="cycleLabel" maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
+          </label>
+          <label>
+            그룹 부모
+            <select name="parentItemId" defaultValue="">
+              <option value="">없음</option>
+              {eligibleParents.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            정렬
+            <input name="displayOrder" type="number" min={0} defaultValue={0} />
+          </label>
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={() => dialogRef.current?.close()}>
+              취소
+            </button>
+            <button className="button-primary" type="submit">
+              추가
+            </button>
+          </div>
+        </form>
+      </dialog>
+    </>
+  );
+}

--- a/development/front-admin-web/components/management/CreateVehicleDialog.tsx
+++ b/development/front-admin-web/components/management/CreateVehicleDialog.tsx
@@ -8,9 +8,15 @@ import { createVehicleFromOverviewAction } from "@/app/actions";
 /**
  * Floating create dialog for the root page vehicles tab.
  *
+ * 차량의 1차 분류 키는 `engineType` (전기/내연) — backend V21 에서 도입되어
+ * 모든 차량이 이 둘 중 하나에 속한다. 정비 catalog 매칭 / 필터의 기준이라
+ * 등록 시점에 명시적으로 고른다 (기본 ELECTRIC). 자유 텍스트 모델명은
+ * "모델명 (메모)" 보조 필드로 같이 입력 가능.
+ *
  * 상단 우측 ↻ 버튼은 입력 초기화 — `form.reset()` 으로 uncontrolled
- * 입력(`modelName`, `operationStatus` select) 을 비우고, 내부 state 를
- * 가진 `PlateNumberInput` 은 key 증가로 재마운트 시켜 같이 초기화한다.
+ * 입력(`modelName`, `operationStatus` select, `engineType` select) 을 비우고,
+ * 내부 state 를 가진 `PlateNumberInput` 은 key 증가로 재마운트 시켜 같이
+ * 초기화한다.
  */
 export function CreateVehicleDialog() {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -48,7 +54,14 @@ export function CreateVehicleDialog() {
             <PlateNumberInput key={`plate-${resetKey}`} name="plateNumber" required />
           </label>
           <label>
-            모델
+            구분
+            <select name="engineType" defaultValue="ELECTRIC">
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연기관</option>
+            </select>
+          </label>
+          <label>
+            모델명 (메모)
             <input name="modelName" maxLength={100} placeholder="예: NIU NQi GTS" />
           </label>
           <label>

--- a/development/front-admin-web/components/management/DeleteMaintenanceItemButton.tsx
+++ b/development/front-admin-web/components/management/DeleteMaintenanceItemButton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { deleteMaintenanceItemAction } from "@/app/actions";
+
+/**
+ * 정비 카탈로그 행의 trash icon 삭제 버튼. 다른 도메인(Delete{Vehicle,Rider,
+ * Station}Button) 와 같은 onClick + confirm + manual server action 패턴.
+ */
+export function DeleteMaintenanceItemButton({
+  itemId,
+  itemName
+}: {
+  itemId: string;
+  itemName: string;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`정비 품목 "${itemName}" 을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteMaintenanceItemAction(itemId);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`정비 품목 "${itemName}" 삭제`}
+      aria-label={`정비 품목 "${itemName}" 삭제`}
+    >
+      <TrashIcon />
+    </button>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}

--- a/development/front-admin-web/components/management/DeleteRiderButton.tsx
+++ b/development/front-admin-web/components/management/DeleteRiderButton.tsx
@@ -3,27 +3,53 @@
 import { deleteRiderFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page riders tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes
- * the rider (sets deleted_at), the loader filters those out, so the
- * row disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page riders tab. See
+ * `DeleteVehicleButton` for the shared design (icon button + confirm +
+ * stopPropagation). Backend soft-deletes the rider.
  */
 export function DeleteRiderButton({ riderId, riderName }: { riderId: string; riderName: string }) {
   const boundAction = deleteRiderFromOverviewAction.bind(null, riderId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
-        if (!window.confirm(`라이더 "${riderName}"을 삭제하시겠습니까?`)) {
+        if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`라이더 "${riderName}" 삭제`}
+        aria-label={`라이더 "${riderName}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/DeleteRiderButton.tsx
+++ b/development/front-admin-web/components/management/DeleteRiderButton.tsx
@@ -1,34 +1,37 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteRiderFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page riders tab. See
- * `DeleteVehicleButton` for the shared design (icon button + confirm +
- * stopPropagation). Backend soft-deletes the rider.
+ * `DeleteVehicleButton` for the shared design (icon button + onClick
+ * confirm + manual server action call). Backend soft-deletes the rider.
  */
 export function DeleteRiderButton({ riderId, riderName }: { riderId: string; riderName: string }) {
-  const boundAction = deleteRiderFromOverviewAction.bind(null, riderId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteRiderFromOverviewAction(riderId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`라이더 "${riderName}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`라이더 "${riderName}" 삭제`}
+      aria-label={`라이더 "${riderName}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`라이더 "${riderName}" 삭제`}
-        aria-label={`라이더 "${riderName}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 

--- a/development/front-admin-web/components/management/DeleteStationButton.tsx
+++ b/development/front-admin-web/components/management/DeleteStationButton.tsx
@@ -1,34 +1,38 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteStationFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page stations tab. See
- * `DeleteVehicleButton` for the shared design (icon button + confirm +
- * stopPropagation). Backend soft-deletes the battery station.
+ * `DeleteVehicleButton` for the shared design (icon button + onClick
+ * confirm + manual server action call). Backend soft-deletes the
+ * battery station.
  */
 export function DeleteStationButton({ stationId, stationLabel }: { stationId: string; stationLabel: string }) {
-  const boundAction = deleteStationFromOverviewAction.bind(null, stationId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteStationFromOverviewAction(stationId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`스테이션 "${stationLabel}" 삭제`}
+      aria-label={`스테이션 "${stationLabel}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`스테이션 "${stationLabel}" 삭제`}
-        aria-label={`스테이션 "${stationLabel}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 

--- a/development/front-admin-web/components/management/DeleteStationButton.tsx
+++ b/development/front-admin-web/components/management/DeleteStationButton.tsx
@@ -3,27 +3,53 @@
 import { deleteStationFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page stations tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes the
- * battery station (sets deleted_at), the loader filters those out, so the
- * row disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page stations tab. See
+ * `DeleteVehicleButton` for the shared design (icon button + confirm +
+ * stopPropagation). Backend soft-deletes the battery station.
  */
 export function DeleteStationButton({ stationId, stationLabel }: { stationId: string; stationLabel: string }) {
   const boundAction = deleteStationFromOverviewAction.bind(null, stationId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
         if (!window.confirm(`스테이션 "${stationLabel}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`스테이션 "${stationLabel}" 삭제`}
+        aria-label={`스테이션 "${stationLabel}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/DeleteVehicleButton.tsx
+++ b/development/front-admin-web/components/management/DeleteVehicleButton.tsx
@@ -1,41 +1,45 @@
 "use client";
 
+import { useTransition } from "react";
+
 import { deleteVehicleFromOverviewAction } from "@/app/actions";
 
 /**
  * Per-row delete control for the root page vehicles tab. Renders as a
- * trash-icon button so the column on the far left stays narrow and visual
- * weight is similar to other inline-action icons. Wraps the server action
- * in a small client form so we can intercept submit and confirm before
- * deletion. Backend soft-deletes the bike (sets deleted_at) and the
- * loader filters those out, so the row disappears from the next render
- * after revalidatePath fires.
+ * trash-icon button; backend soft-deletes the bike (sets deleted_at) and
+ * the loader filters those out so the row disappears next render.
  *
- * The button is wrapped in a stopPropagation handler so clicking it does
- * not also open the row's detail dialog.
+ * 이전엔 `<form action={action} onSubmit={confirm}>` 패턴이었는데, React 19
+ * server action 의 form 제출 경로가 native submit 이벤트를 우회하는 케이스가
+ * 있어 `preventDefault()` 가 확실히 동작 안 할 때가 있었다. form 을 걷어내고
+ * button onClick 안에서 직접 confirm → 통과 시 server action 호출. 이렇게
+ * 하면 LogoutButton 의 confirm 과 동일하게 항상 발화한다. `useTransition`
+ * 으로 pending 표시 + 중복 클릭 방지.
  */
 export function DeleteVehicleButton({ vehicleId, plateNumber }: { vehicleId: string; plateNumber: string }) {
-  const boundAction = deleteVehicleFromOverviewAction.bind(null, vehicleId);
+  const [pending, startTransition] = useTransition();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // 행 클릭으로 인한 상세 다이얼로그 오픈과 충돌 방지.
+    event.stopPropagation();
+    if (pending) return;
+    if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) return;
+    startTransition(() => {
+      void deleteVehicleFromOverviewAction(vehicleId);
+    });
+  };
+
   return (
-    <form
-      action={boundAction}
-      onClick={(event) => event.stopPropagation()}
-      onSubmit={(event) => {
-        if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) {
-          event.preventDefault();
-        }
-      }}
-      style={{ display: "inline-flex" }}
+    <button
+      type="button"
+      className="delete-icon-button"
+      onClick={handleClick}
+      disabled={pending}
+      title={`차량 "${plateNumber}" 삭제`}
+      aria-label={`차량 "${plateNumber}" 삭제`}
     >
-      <button
-        className="delete-icon-button"
-        type="submit"
-        title={`차량 "${plateNumber}" 삭제`}
-        aria-label={`차량 "${plateNumber}" 삭제`}
-      >
-        <TrashIcon />
-      </button>
-    </form>
+      <TrashIcon />
+    </button>
   );
 }
 

--- a/development/front-admin-web/components/management/DeleteVehicleButton.tsx
+++ b/development/front-admin-web/components/management/DeleteVehicleButton.tsx
@@ -3,27 +3,62 @@
 import { deleteVehicleFromOverviewAction } from "@/app/actions";
 
 /**
- * Per-row delete button for the root page vehicles tab. Wraps the server
- * action in a small client form so we can intercept submit and ask the
- * operator to confirm before the row goes away. Backend soft-deletes the
- * bike (sets deleted_at), the loader filters those out, so the row
- * disappears from the next render after revalidatePath fires.
+ * Per-row delete control for the root page vehicles tab. Renders as a
+ * trash-icon button so the column on the far left stays narrow and visual
+ * weight is similar to other inline-action icons. Wraps the server action
+ * in a small client form so we can intercept submit and confirm before
+ * deletion. Backend soft-deletes the bike (sets deleted_at) and the
+ * loader filters those out, so the row disappears from the next render
+ * after revalidatePath fires.
+ *
+ * The button is wrapped in a stopPropagation handler so clicking it does
+ * not also open the row's detail dialog.
  */
 export function DeleteVehicleButton({ vehicleId, plateNumber }: { vehicleId: string; plateNumber: string }) {
   const boundAction = deleteVehicleFromOverviewAction.bind(null, vehicleId);
   return (
     <form
       action={boundAction}
+      onClick={(event) => event.stopPropagation()}
       onSubmit={(event) => {
         if (!window.confirm(`차량 "${plateNumber}"을(를) 삭제하시겠습니까?`)) {
           event.preventDefault();
         }
       }}
-      style={{ display: "inline" }}
+      style={{ display: "inline-flex" }}
     >
-      <button className="button-link" type="submit">
-        삭제
+      <button
+        className="delete-icon-button"
+        type="submit"
+        title={`차량 "${plateNumber}" 삭제`}
+        aria-label={`차량 "${plateNumber}" 삭제`}
+      >
+        <TrashIcon />
       </button>
     </form>
+  );
+}
+
+// Trash can outline icon — light line-art matching the marker/logout
+// glyphs so the table action column reads as one consistent set.
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { updateMaintenanceItemAction } from "@/app/actions";
+import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * 정비 카탈로그 행의 상세 + 수정 다이얼로그. 다른 detail dialog 들과 같은
+ * modal 패턴 (centered, scroll-locked).
+ *
+ * 그룹 부모 (`구동계3종`) 도 같은 폼으로 편집 — cycle 세 필드를 모두 비우면
+ * 헤더-only 행이 된다. parent_item_id select 는 같은 applies_to 내의 다른 행
+ * 들을 옵션으로 노출 (자기 자신은 제외).
+ */
+export function MaintenanceItemDetailDialog({
+  row,
+  parentOptions,
+  onClose
+}: {
+  row: ServiceOpsMaintenanceItem | null;
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  useScrollLockedDialog(dialogRef, row !== null);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  if (!row) return null;
+
+  const boundUpdate = updateMaintenanceItemAction.bind(null, row.id);
+  const eligibleParents = parentOptions.filter(
+    (option) => option.id !== row.id && option.parentItemId === null
+  );
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="overview-create-dialog"
+      onClose={onClose}
+      onCancel={onClose}
+    >
+      <h3>정비 품목 상세</h3>
+      {mode === "view" ? (
+        <div className="detail-row-grid">
+          <DetailField label="품목" value={row.name} />
+          <DetailField label="적용" value={appliesToLabel(row.appliesTo)} />
+          <DetailField label="교환주기 (km)" value={row.cycleKm !== null ? `${row.cycleKm.toLocaleString()} km` : "—"} />
+          <DetailField label="교환주기 (개월)" value={row.cycleMonths !== null ? `${row.cycleMonths}개월` : "—"} />
+          <DetailField label="라벨" value={row.cycleLabel ?? "—"} />
+          <DetailField label="그룹 부모" value={parentLabel(row, parentOptions)} />
+          <DetailField label="활성" value={row.enabled ? "ON" : "OFF"} />
+          <DetailField label="정렬" value={String(row.displayOrder)} />
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={handleClose}>닫기</button>
+            <button type="button" className="button-primary" onClick={() => setMode("edit")}>수정</button>
+          </div>
+        </div>
+      ) : (
+        <form action={boundUpdate}>
+          <label>
+            품목
+            <input name="name" defaultValue={row.name} maxLength={100} required />
+          </label>
+          <label>
+            적용
+            <select name="appliesTo" defaultValue={row.appliesTo}>
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연</option>
+              <option value="BOTH">공통</option>
+            </select>
+          </label>
+          <label>
+            교환주기 (km)
+            <input name="cycleKm" type="number" min={0} defaultValue={row.cycleKm ?? ""} placeholder="비우면 km 기준 없음" />
+          </label>
+          <label>
+            교환주기 (개월)
+            <input name="cycleMonths" type="number" min={0} defaultValue={row.cycleMonths ?? ""} placeholder="비우면 개월 기준 없음" />
+          </label>
+          <label>
+            라벨 (자유 텍스트)
+            <input name="cycleLabel" defaultValue={row.cycleLabel ?? ""} maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
+          </label>
+          <label>
+            그룹 부모
+            <select name="parentItemId" defaultValue={row.parentItemId ?? ""}>
+              <option value="">없음</option>
+              {eligibleParents.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name} ({appliesToLabel(option.appliesTo)})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            정렬
+            <input name="displayOrder" type="number" min={0} defaultValue={row.displayOrder} />
+          </label>
+          <label>
+            활성
+            <select name="enabled" defaultValue={row.enabled ? "true" : "false"}>
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+          </label>
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={() => setMode("view")}>취소</button>
+            <button type="submit" className="button-primary">저장</button>
+          </div>
+        </form>
+      )}
+    </dialog>
+  );
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="detail-field">
+      <span className="detail-field-label">{label}</span>
+      <span className="detail-field-value">{value}</span>
+    </div>
+  );
+}
+
+function appliesToLabel(value: ServiceOpsMaintenanceItem["appliesTo"]): string {
+  if (value === "ELECTRIC") return "전기";
+  if (value === "ICE") return "내연";
+  return "공통";
+}
+
+function parentLabel(
+  row: ServiceOpsMaintenanceItem,
+  options: ReadonlyArray<ServiceOpsMaintenanceItem>
+): string {
+  if (!row.parentItemId) return "—";
+  const parent = options.find((option) => option.id === row.parentItemId);
+  return parent?.name ?? "—";
+}

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+
+import { DeleteMaintenanceItemButton } from "@/components/management/DeleteMaintenanceItemButton";
+import { MaintenanceItemDetailDialog } from "@/components/management/MaintenanceItemDetailDialog";
+import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+
+/**
+ * `/?tab=maintenance` 의 정비 카탈로그 편집 패널. 세 섹션(전기 전용 / 내연
+ * 전용 / 공통) 으로 나눠서 사진의 두 표 + 공통 항목 묶음을 그대로 보여준다.
+ *
+ * 각 행: 품목 / 적용 / 교환주기 / 그룹 부모 / 활성 / 삭제. 행 클릭 시 상세
+ * 다이얼로그가 열리고 거기서 수정 모드로 전환 — 다른 도메인 detail dialog
+ * 와 같은 패턴.
+ *
+ * 그룹 부모(예: 구동계3종) 는 자식 위에 들여쓰기 없이, 자식은 한 단계 들여
+ * 써서 시각적으로 묶음. 표시 정렬은 displayOrder 오름차순. 그룹 자체는
+ * cycle 세 필드가 모두 비어 있는 행으로 표현 (display order 가 자식 바로
+ * 앞으로 박혀 있어서 단순 정렬이 그대로 작동).
+ */
+export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMaintenanceItem> }) {
+  const [activeRow, setActiveRow] = useState<ServiceOpsMaintenanceItem | null>(null);
+
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => a.displayOrder - b.displayOrder),
+    [items]
+  );
+
+  const electric = sorted.filter((item) => item.appliesTo === "ELECTRIC");
+  const ice = sorted.filter((item) => item.appliesTo === "ICE");
+  const both = sorted.filter((item) => item.appliesTo === "BOTH");
+
+  return (
+    <div className="maintenance-panel">
+      <Section title="전기 전용" items={electric} parentOptions={sorted} onActivate={setActiveRow} />
+      <Section title="내연 전용" items={ice} parentOptions={sorted} onActivate={setActiveRow} />
+      <Section title="공통 (양쪽 적용)" items={both} parentOptions={sorted} onActivate={setActiveRow} />
+
+      <MaintenanceItemDetailDialog
+        key={activeRow?.id ?? "none"}
+        row={activeRow}
+        parentOptions={sorted}
+        onClose={() => setActiveRow(null)}
+      />
+    </div>
+  );
+}
+
+function Section({
+  title,
+  items,
+  parentOptions,
+  onActivate
+}: {
+  title: string;
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  onActivate: (item: ServiceOpsMaintenanceItem) => void;
+}) {
+  return (
+    <section className="maintenance-panel-section">
+      <h3 className="maintenance-panel-section-title">{title}</h3>
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <colgroup>
+            <col style={{ width: "48px" }} />
+            <col />
+            <col style={{ width: "140px" }} />
+            <col style={{ width: "120px" }} />
+            <col style={{ width: "72px" }} />
+          </colgroup>
+          <thead>
+            <tr>
+              <th aria-label="삭제" />
+              <th>품목</th>
+              <th>교환주기</th>
+              <th>그룹 부모</th>
+              <th>활성</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="table-empty-cell">
+                  데이터 없음
+                </td>
+              </tr>
+            ) : null}
+            {items.map((item) => {
+              const parent = item.parentItemId
+                ? parentOptions.find((option) => option.id === item.parentItemId) ?? null
+                : null;
+              return (
+                <tr
+                  key={item.id}
+                  className="table-row-clickable"
+                  onClick={() => onActivate(item)}
+                >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    <DeleteMaintenanceItemButton itemId={item.id} itemName={item.name} />
+                  </td>
+                  <td>
+                    {item.parentItemId ? <span className="maintenance-panel-indent">└ </span> : null}
+                    {item.name}
+                  </td>
+                  <td>{renderCycle(item)}</td>
+                  <td>{parent ? parent.name : <span className="muted">—</span>}</td>
+                  <td>{item.enabled ? "ON" : <span className="muted">OFF</span>}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function renderCycle(item: ServiceOpsMaintenanceItem): ReactNode {
+  if (item.cycleLabel) return item.cycleLabel;
+  if (item.cycleKm !== null && item.cycleKm > 0) return `${item.cycleKm.toLocaleString()} km`;
+  if (item.cycleMonths !== null && item.cycleMonths > 0) return `${item.cycleMonths}개월`;
+  // 그룹 부모: cycle 세 값 모두 비어 있는 헤더 행.
+  return <span className="muted">— (그룹)</span>;
+}

--- a/development/front-admin-web/components/management/OperationStatusToggle.tsx
+++ b/development/front-admin-web/components/management/OperationStatusToggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { setVehicleOperationStatusFromOverviewAction } from "@/app/actions";
+import type { ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 탭 테이블의 "운영 상태" 컬럼에서 한 줄에 박히는 인라인 토글. READY ↔
+ * IN_SERVICE 둘 사이만 오가는 단순한 boolean 같지만 운영 상태는 차량 별로
+ * 별도 endpoint 가 있어 ignition block 토글과 짝을 이루도록 같은 스위치
+ * 시각/동작을 채택했다.
+ *
+ * 켜짐(.is-on) = "운행"(IN_SERVICE), 꺼짐 = "대기"(READY). 라벨은 현재 값을
+ * 그대로 출력해 운영자가 "지금 어느 상태인지" 한눈에 보이도록.
+ *
+ * 행 클릭은 차량 상세 다이얼로그를 띄우므로, 토글 클릭이 행 클릭으로
+ * 전파되지 않도록 stopPropagation. optimistic 으로 즉시 시각 갱신 →
+ * server revalidate 후 props 가 재유입되면 자연스럽게 정정.
+ */
+export function OperationStatusToggle({
+  bikeId,
+  initialStatus
+}: {
+  bikeId: string;
+  initialStatus: ServiceOpsBikeOperationStatus;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [optimistic, setOptimistic] = useState<ServiceOpsBikeOperationStatus | null>(null);
+  const status = optimistic ?? initialStatus;
+  const isOperating = status === "IN_SERVICE";
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (pending) return;
+    const next: ServiceOpsBikeOperationStatus = isOperating ? "READY" : "IN_SERVICE";
+    setOptimistic(next);
+    const fd = new FormData();
+    fd.append("operationStatus", next);
+    startTransition(() => {
+      void setVehicleOperationStatusFromOverviewAction(bikeId, fd);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`toggle-switch toggle-switch--compact${isOperating ? " is-on" : ""}`}
+      role="switch"
+      aria-checked={isOperating}
+      aria-label="운영 상태 토글"
+      disabled={pending}
+      onClick={handleClick}
+    >
+      <span className="toggle-switch-thumb" aria-hidden="true" />
+      <span className="toggle-switch-text">{isOperating ? "운행" : "대기"}</span>
+    </button>
+  );
+}

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
+import { DeleteRiderButton } from "@/components/management/DeleteRiderButton";
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { RiderDetailDialog, type RiderDetailRow } from "@/components/management/RiderDetailDialog";
 import { RIDER_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
@@ -71,6 +72,7 @@ export function RidersPanel({
     <div className="table-card">
       <table className="table" style={{ tableLayout: "fixed" }}>
         <colgroup>
+          <col style={{ width: "48px" }} />
           <col />
           <col />
           <col />
@@ -84,6 +86,7 @@ export function RidersPanel({
         </colgroup>
         <thead>
           <tr>
+            <th aria-label="삭제" />
             <th>이름</th>
             <th>연락처</th>
             <th>교육</th>
@@ -99,7 +102,7 @@ export function RidersPanel({
         <tbody>
           {data.riders.length === 0 ? (
             <tr>
-              <td colSpan={10} className="table-empty-cell">
+              <td colSpan={11} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
@@ -146,6 +149,9 @@ export function RidersPanel({
                   })
                 }
               >
+                <td onClick={(event) => event.stopPropagation()}>
+                  {rider.id ? <DeleteRiderButton riderId={rider.id} riderName={rider.name} /> : null}
+                </td>
                 <td>{rider.name}</td>
                 <td>{rider.phone}</td>
                 <td>{renderEducationType(educationType)}</td>

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { DeleteRiderButton } from "@/components/management/DeleteRiderButton";
@@ -25,19 +25,31 @@ export interface InsuranceOption {
  * Columns: 이름 / 연락처 / 교육 / 차량 번호 / 구독·렌탈 / 형태 / 기간 / 보험 /
  * 시동 상태 / 시동 제어.
  *
- * The contract-shape columns (차량 번호 + 구독·렌탈 + 형태 + 기간) all
- * come from the rider's most recent active contract. 차량 번호 needs a
- * separate map (`riderActiveBikePlate`) because the contract row only
- * carries the bikeId.
+ * 보험 컬럼은 단순 "있음/없음" 이 아니라 가입된 insurance_item 의 이름 (예:
+ * "KB손해보험 기본형") 을 그대로 표시. 차량 탭 보험 컬럼과 시각 통일.
  *
- * 시동 상태 / 시동 제어 두 컬럼은 매칭된 차량의 telemetry + 운영자 의도
- * (ignition_blocked) 를 행 안에서 보여주기 위한 컬럼. 매칭이 없는 라이더는
- * 둘 다 "—" 로 폴백. 시동 제어 토글은 행 클릭(상세 다이얼로그) 와 충돌
- * 안 하도록 자체적으로 `event.stopPropagation` 처리.
- *
- * 삭제 버튼은 상세 다이얼로그(view 모드) 안에서만 노출하도록 정리해 행
- * 마지막 "작업" 컬럼은 더 이상 두지 않는다.
+ * 필터 바는 2-row — 검색 한 줄 + select 다섯 개. 검색은 이름/연락처/차량번호
+ * substring 매칭, 나머지 select 들은 그대로 매칭. 모든 필터 AND 조합.
  */
+
+type FilterState = {
+  query: string;
+  education: "ALL" | "ONLINE" | "OFFLINE" | "NONE";
+  assignment: "ALL" | "ASSIGNED" | "UNASSIGNED";
+  contractCategory: "ALL" | "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
+  insurance: "ALL" | "HAS" | "NONE";
+  ignition: "ALL" | "ON" | "OFF" | "UNASSIGNED";
+};
+
+const DEFAULT_FILTERS: FilterState = {
+  query: "",
+  education: "ALL",
+  assignment: "ALL",
+  contractCategory: "ALL",
+  insurance: "ALL",
+  ignition: "ALL"
+};
+
 export function RidersPanel({
   data,
   insuredRiderIds,
@@ -57,7 +69,7 @@ export function RidersPanel({
   riderActiveBikePlate?: Map<string, string>;
   /** riderId → 현재 활성 rider_insurance. 다이얼로그 보험 select 의 기본값/삭제 대상. */
   riderActiveInsuranceByRiderId?: Map<string, ServiceOpsRiderInsurance>;
-  /** 보험 select 의 선택 가능 항목 (insurance_items). 없으면 다이얼로그에서 비활성. */
+  /** 보험 select 의 선택 가능 항목 (insurance_items). 보험 컬럼에서 id → 이름 lookup 에도 같이 쓴다. */
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
   /** bikeId → telemetry ignition_status (ON/OFF/UNKNOWN). 매칭된 차량의 현재 시동 상태 표시. */
   ignitionStatusByBikeId?: Map<string, string>;
@@ -67,112 +79,258 @@ export function RidersPanel({
   riderActiveBikeId?: Map<string, string>;
 }) {
   const [activeRow, setActiveRow] = useState<RiderDetailRow | null>(null);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+
+  // insurance_item id → 이름 사전. 보험 컬럼이 매 행마다 lookup 1회.
+  const insuranceLabelById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const option of insuranceOptions ?? []) {
+      map.set(option.id, option.label);
+    }
+    return map;
+  }, [insuranceOptions]);
+
+  const visibleRiders = useMemo(() => {
+    const q = filters.query.trim().toLowerCase();
+    return data.riders.filter((rider) => {
+      const riderKey = rider.id ?? rider.slug;
+      if (q) {
+        const nameMatch = rider.name.toLowerCase().includes(q);
+        const phoneMatch = rider.phone.toLowerCase().includes(q);
+        const plate = riderActiveBikePlate?.get(riderKey) ?? "";
+        const plateMatch = plate.toLowerCase().includes(q);
+        if (!nameMatch && !phoneMatch && !plateMatch) return false;
+      }
+      if (filters.education !== "ALL") {
+        const eduType = educationTypeByRiderId?.get(riderKey) ?? null;
+        if (filters.education === "NONE" && eduType !== null) return false;
+        if ((filters.education === "ONLINE" || filters.education === "OFFLINE") && eduType !== filters.education) return false;
+      }
+      if (filters.assignment !== "ALL") {
+        const hasBike = Boolean(riderActiveBikeId?.get(riderKey));
+        if (filters.assignment === "ASSIGNED" && !hasBike) return false;
+        if (filters.assignment === "UNASSIGNED" && hasBike) return false;
+      }
+      if (filters.contractCategory !== "ALL") {
+        const category = riderActiveContractById?.get(riderKey)?.category ?? null;
+        if (category !== filters.contractCategory) return false;
+      }
+      if (filters.insurance !== "ALL") {
+        const has = insuredRiderIds?.has(riderKey) ?? false;
+        if (filters.insurance === "HAS" && !has) return false;
+        if (filters.insurance === "NONE" && has) return false;
+      }
+      if (filters.ignition !== "ALL") {
+        const activeBikeId = riderActiveBikeId?.get(riderKey) ?? null;
+        if (filters.ignition === "UNASSIGNED") {
+          if (activeBikeId) return false;
+        } else {
+          if (!activeBikeId) return false;
+          const status = ignitionStatusByBikeId?.get(activeBikeId);
+          if (status !== filters.ignition) return false;
+        }
+      }
+      return true;
+    });
+  }, [
+    data.riders,
+    filters,
+    educationTypeByRiderId,
+    riderActiveBikeId,
+    riderActiveBikePlate,
+    riderActiveContractById,
+    insuredRiderIds,
+    ignitionStatusByBikeId
+  ]);
 
   return (
-    <div className="table-card">
-      <table className="table" style={{ tableLayout: "fixed" }}>
-        <colgroup>
-          <col style={{ width: "48px" }} />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col style={{ width: "92px" }} />
-          <col style={{ width: "104px" }} />
-        </colgroup>
-        <thead>
-          <tr>
-            <th aria-label="삭제" />
-            <th>이름</th>
-            <th>연락처</th>
-            <th>교육</th>
-            <th>차량 번호</th>
-            <th>구독/렌탈</th>
-            <th>형태</th>
-            <th>기간</th>
-            <th>보험</th>
-            <th>시동 상태</th>
-            <th>시동 제어</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.riders.length === 0 ? (
+    <div className="vehicles-panel">
+      {/* Row 1: 검색 · 교육 · 차량 배정 · 카운트 */}
+      <div className="vehicles-filter-row">
+        <div className="vehicles-filter-search-wrap">
+          <input
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="이름, 연락처, 차량번호 검색"
+            value={filters.query}
+            onChange={(event) => setFilters({ ...filters, query: event.target.value })}
+          />
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+        <select
+          className="vehicles-filter-select"
+          value={filters.education}
+          onChange={(event) =>
+            setFilters({ ...filters, education: event.target.value as FilterState["education"] })
+          }
+        >
+          <option value="ALL">교육: 전체</option>
+          <option value="ONLINE">온라인</option>
+          <option value="OFFLINE">오프라인</option>
+          <option value="NONE">미수료</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.assignment}
+          onChange={(event) =>
+            setFilters({ ...filters, assignment: event.target.value as FilterState["assignment"] })
+          }
+        >
+          <option value="ALL">차량 배정: 전체</option>
+          <option value="ASSIGNED">배정됨</option>
+          <option value="UNASSIGNED">미배정</option>
+        </select>
+        <span className="vehicles-filter-count">
+          {visibleRiders.length} / {data.riders.length}
+        </span>
+      </div>
+      {/* Row 2: 구독·렌탈 · 보험 · 시동 상태 */}
+      <div className="vehicles-filter-row">
+        <select
+          className="vehicles-filter-select"
+          value={filters.contractCategory}
+          onChange={(event) =>
+            setFilters({ ...filters, contractCategory: event.target.value as FilterState["contractCategory"] })
+          }
+        >
+          <option value="ALL">구독/렌탈: 전체</option>
+          <option value="SUBSCRIPTION">구독</option>
+          <option value="RENTAL">렌탈</option>
+          <option value="CUSTOM">커스텀</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.insurance}
+          onChange={(event) =>
+            setFilters({ ...filters, insurance: event.target.value as FilterState["insurance"] })
+          }
+        >
+          <option value="ALL">보험: 전체</option>
+          <option value="HAS">가입</option>
+          <option value="NONE">미가입</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.ignition}
+          onChange={(event) =>
+            setFilters({ ...filters, ignition: event.target.value as FilterState["ignition"] })
+          }
+        >
+          <option value="ALL">시동 상태: 전체</option>
+          <option value="ON">ON</option>
+          <option value="OFF">OFF</option>
+          <option value="UNASSIGNED">차량 미배정</option>
+        </select>
+      </div>
+
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <colgroup>
+            <col style={{ width: "48px" }} />
+            <col />
+            <col />
+            <col />
+            <col />
+            <col />
+            <col />
+            <col />
+            <col />
+            <col style={{ width: "92px" }} />
+            <col style={{ width: "104px" }} />
+          </colgroup>
+          <thead>
             <tr>
-              <td colSpan={11} className="table-empty-cell">
-                데이터 없음
-              </td>
+              <th aria-label="삭제" />
+              <th>이름</th>
+              <th>연락처</th>
+              <th>교육</th>
+              <th>차량 번호</th>
+              <th>구독/렌탈</th>
+              <th>형태</th>
+              <th>기간</th>
+              <th>보험</th>
+              <th>시동 상태</th>
+              <th>시동 제어</th>
             </tr>
-          ) : null}
-          {data.riders.map((rider) => {
-            const riderKey = rider.id ?? rider.slug;
-            const hasInsurance = insuredRiderIds ? insuredRiderIds.has(riderKey) : null;
-            const educationType = educationTypeByRiderId?.get(riderKey) ?? null;
-            const contract = riderActiveContractById?.get(riderKey) ?? null;
-            const plate = riderActiveBikePlate?.get(riderKey) ?? null;
-            const activeInsurance = riderActiveInsuranceByRiderId?.get(riderKey) ?? null;
-            // 매칭된 차량의 bikeId 와 그 차량의 시동 정보 (telemetry / 방지 토글).
-            const activeBikeId = riderActiveBikeId?.get(riderKey) ?? null;
-            const ignitionStatus = activeBikeId ? ignitionStatusByBikeId?.get(activeBikeId) ?? null : null;
-            const ignitionBlocked = activeBikeId ? ignitionBlockedByBikeId?.get(activeBikeId) ?? false : false;
-            return (
-              <tr
-                key={rider.slug}
-                className="table-row-clickable"
-                draggable={Boolean(rider.id)}
-                onDragStart={(event) => {
-                  if (!rider.id) return;
-                  // ContractMatchingForm 의 라이더 슬롯이 dataTransfer.types
-                  // 에 이 식별자가 있을 때만 drop 을 허용한다. effectAllowed=copy
-                  // 로 두면 패널 표시는 그대로 유지된다.
-                  event.dataTransfer.setData(RIDER_DRAG_TYPE, rider.id);
-                  event.dataTransfer.effectAllowed = "copy";
-                }}
-                onClick={() =>
-                  setActiveRow({
-                    rider,
-                    educationLabel: educationLabelOf(educationType),
-                    plate,
-                    category: categoryLabelOf(contract?.category ?? null),
-                    returnType: returnTypeLabelOf(contract?.returnType ?? null),
-                    durationLabel: contract?.durationLabel ?? null,
-                    hasInsurance,
-                    activeContractId: contract?.contractId ?? null,
-                    currentInsuranceId: activeInsurance?.id ?? null,
-                    currentInsuranceItemId: activeInsurance?.insuranceItemId ?? null,
-                    activeBikeId,
-                    ignitionStatus,
-                    ignitionBlocked
-                  })
-                }
-              >
-                <td onClick={(event) => event.stopPropagation()}>
-                  {rider.id ? <DeleteRiderButton riderId={rider.id} riderName={rider.name} /> : null}
-                </td>
-                <td>{rider.name}</td>
-                <td>{rider.phone}</td>
-                <td>{renderEducationType(educationType)}</td>
-                <td>{renderPlate(plate)}</td>
-                <td>{renderCategory(contract?.category ?? null)}</td>
-                <td>{renderReturnType(contract?.returnType ?? null)}</td>
-                <td>{renderDuration(contract?.durationLabel ?? null)}</td>
-                <td>{renderPresence(hasInsurance)}</td>
-                <td>{renderIgnitionStatus(ignitionStatus)}</td>
-                <td onClick={(event) => event.stopPropagation()}>
-                  {activeBikeId ? (
-                    <IgnitionControlButton bikeId={activeBikeId} initialBlocked={ignitionBlocked} />
-                  ) : (
-                    <span className="muted">—</span>
-                  )}
+          </thead>
+          <tbody>
+            {visibleRiders.length === 0 ? (
+              <tr>
+                <td colSpan={11} className="table-empty-cell">
+                  조건에 맞는 라이더 없음
                 </td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ) : null}
+            {visibleRiders.map((rider) => {
+              const riderKey = rider.id ?? rider.slug;
+              const hasInsurance = insuredRiderIds ? insuredRiderIds.has(riderKey) : null;
+              const educationType = educationTypeByRiderId?.get(riderKey) ?? null;
+              const contract = riderActiveContractById?.get(riderKey) ?? null;
+              const plate = riderActiveBikePlate?.get(riderKey) ?? null;
+              const activeInsurance = riderActiveInsuranceByRiderId?.get(riderKey) ?? null;
+              const insuranceLabel = activeInsurance
+                ? insuranceLabelById.get(activeInsurance.insuranceItemId) ?? null
+                : null;
+              // 매칭된 차량의 bikeId 와 그 차량의 시동 정보 (telemetry / 방지 토글).
+              const activeBikeId = riderActiveBikeId?.get(riderKey) ?? null;
+              const ignitionStatus = activeBikeId ? ignitionStatusByBikeId?.get(activeBikeId) ?? null : null;
+              const ignitionBlocked = activeBikeId ? ignitionBlockedByBikeId?.get(activeBikeId) ?? false : false;
+              return (
+                <tr
+                  key={rider.slug}
+                  className="table-row-clickable"
+                  draggable={Boolean(rider.id)}
+                  onDragStart={(event) => {
+                    if (!rider.id) return;
+                    // ContractMatchingForm 의 라이더 슬롯이 dataTransfer.types
+                    // 에 이 식별자가 있을 때만 drop 을 허용한다. effectAllowed=copy
+                    // 로 두면 패널 표시는 그대로 유지된다.
+                    event.dataTransfer.setData(RIDER_DRAG_TYPE, rider.id);
+                    event.dataTransfer.effectAllowed = "copy";
+                  }}
+                  onClick={() =>
+                    setActiveRow({
+                      rider,
+                      educationLabel: educationLabelOf(educationType),
+                      plate,
+                      category: categoryLabelOf(contract?.category ?? null),
+                      returnType: returnTypeLabelOf(contract?.returnType ?? null),
+                      durationLabel: contract?.durationLabel ?? null,
+                      hasInsurance,
+                      activeContractId: contract?.contractId ?? null,
+                      currentInsuranceId: activeInsurance?.id ?? null,
+                      currentInsuranceItemId: activeInsurance?.insuranceItemId ?? null,
+                      activeBikeId,
+                      ignitionStatus,
+                      ignitionBlocked
+                    })
+                  }
+                >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {rider.id ? <DeleteRiderButton riderId={rider.id} riderName={rider.name} /> : null}
+                  </td>
+                  <td>{rider.name}</td>
+                  <td>{rider.phone}</td>
+                  <td>{renderEducationType(educationType)}</td>
+                  <td>{renderPlate(plate)}</td>
+                  <td>{renderCategory(contract?.category ?? null)}</td>
+                  <td>{renderReturnType(contract?.returnType ?? null)}</td>
+                  <td>{renderDuration(contract?.durationLabel ?? null)}</td>
+                  <td>{renderInsuranceProduct(insuranceLabel)}</td>
+                  <td>{renderIgnitionStatus(ignitionStatus)}</td>
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {activeBikeId ? (
+                      <IgnitionControlButton bikeId={activeBikeId} initialBlocked={ignitionBlocked} />
+                    ) : (
+                      <span className="muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
       <RiderDetailDialog
         key={activeRow ? (activeRow.rider.id ?? activeRow.rider.slug) : "none"}
         row={activeRow}
@@ -183,9 +341,11 @@ export function RidersPanel({
   );
 }
 
-function renderPresence(hasIt: boolean | null): ReactNode {
-  if (hasIt) return <Badge tone="active">있음</Badge>;
-  return <span className="muted">—</span>;
+// 보험 가입 여부 대신 가입한 상품명을 그대로 노출. 운영자가 "어떤 상품에 가입한
+// 라이더" 인지 한눈에 볼 수 있도록. 미가입 / lookup 실패 시 모두 "—".
+function renderInsuranceProduct(label: string | null): ReactNode {
+  if (!label) return <span className="muted">—</span>;
+  return <Badge tone="active">{label}</Badge>;
 }
 
 function renderIgnitionStatus(status: string | null): ReactNode {

--- a/development/front-admin-web/components/management/StationsPanel.tsx
+++ b/development/front-admin-web/components/management/StationsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { DeleteStationButton } from "@/components/management/DeleteStationButton";
 import { StationDetailDialog, type StationDetailRow } from "@/components/management/StationDetailDialog";
 import type { StationDataResult } from "@/lib/services/station-data";
 import type { BatteryStation } from "@/types/domain";
@@ -26,11 +27,13 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
     <div className="table-card">
       <table className="table" style={{ tableLayout: "fixed" }}>
         <colgroup>
+          <col style={{ width: "48px" }} />
           <col />
           <col style={{ width: "120px" }} />
         </colgroup>
         <thead>
           <tr>
+            <th aria-label="삭제" />
             <th>주소</th>
             <th style={{ textAlign: "center" }}>잔여/총</th>
           </tr>
@@ -38,7 +41,7 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
         <tbody>
           {data.stations.length === 0 ? (
             <tr>
-              <td colSpan={2} className="table-empty-cell">
+              <td colSpan={3} className="table-empty-cell">
                 데이터 없음
               </td>
             </tr>
@@ -52,6 +55,11 @@ export function StationsPanel({ data }: { data: StationDataResult }) {
                 className="table-row-clickable"
                 onClick={() => setActiveRow({ station, available, max })}
               >
+                <td onClick={(event) => event.stopPropagation()}>
+                  {station.id ? (
+                    <DeleteStationButton stationId={station.id} stationLabel={station.address} />
+                  ) : null}
+                </td>
                 <td>{station.address}</td>
                 <td style={{ textAlign: "center" }}>
                   <strong>{available}</strong>

--- a/development/front-admin-web/components/management/StationsPanel.tsx
+++ b/development/front-admin-web/components/management/StationsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { DeleteStationButton } from "@/components/management/DeleteStationButton";
 import { StationDetailDialog, type StationDetailRow } from "@/components/management/StationDetailDialog";
@@ -19,58 +19,124 @@ import type { BatteryStation } from "@/types/domain";
  * effect; the default `auto` layout sizes columns by content and
  * ignores width hints, which let 잔여/총 drift toward the middle of
  * the table when address text was short.
+ *
+ * 필터 바: 주소 substring 검색 + 재고 상태 select 한 줄. 재고 부족 기준은
+ * `LOW_STOCK_RATIO` (default 30%) — `available / max` 비율로 판정해서
+ * 운영자가 충전이 시급한 스테이션만 골라낼 수 있게.
  */
+
+const LOW_STOCK_RATIO = 0.3;
+
+type FilterState = {
+  query: string;
+  stock: "ALL" | "OK" | "LOW";
+};
+
+const DEFAULT_FILTERS: FilterState = {
+  query: "",
+  stock: "ALL"
+};
+
 export function StationsPanel({ data }: { data: StationDataResult }) {
   const [activeRow, setActiveRow] = useState<StationDetailRow | null>(null);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+
+  const visibleStations = useMemo(() => {
+    const q = filters.query.trim().toLowerCase();
+    return data.stations.filter((station) => {
+      if (q) {
+        if (!station.address.toLowerCase().includes(q)) return false;
+      }
+      if (filters.stock !== "ALL") {
+        const max = maxCount(station);
+        const available = availableCount(station);
+        // max 가 0 이면 비율 계산 불가 — 운영자 입장에선 "재고 부족" 으로
+        // 분류해서 손볼 수 있게 노출. 정상으로 빠지지 않도록 명시적 분기.
+        const low = max === 0 || available / max <= LOW_STOCK_RATIO;
+        if (filters.stock === "LOW" && !low) return false;
+        if (filters.stock === "OK" && low) return false;
+      }
+      return true;
+    });
+  }, [data.stations, filters]);
 
   return (
-    <div className="table-card">
-      <table className="table" style={{ tableLayout: "fixed" }}>
-        <colgroup>
-          <col style={{ width: "48px" }} />
-          <col />
-          <col style={{ width: "120px" }} />
-        </colgroup>
-        <thead>
-          <tr>
-            <th aria-label="삭제" />
-            <th>주소</th>
-            <th style={{ textAlign: "center" }}>잔여/총</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.stations.length === 0 ? (
+    <div className="vehicles-panel">
+      <div className="vehicles-filter-row">
+        <div className="vehicles-filter-search-wrap">
+          <input
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="주소 검색"
+            value={filters.query}
+            onChange={(event) => setFilters({ ...filters, query: event.target.value })}
+          />
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+        <select
+          className="vehicles-filter-select"
+          value={filters.stock}
+          onChange={(event) =>
+            setFilters({ ...filters, stock: event.target.value as FilterState["stock"] })
+          }
+        >
+          <option value="ALL">잔여 상태: 전체</option>
+          <option value="OK">정상</option>
+          <option value="LOW">재고 부족 (≤ {Math.round(LOW_STOCK_RATIO * 100)}%)</option>
+        </select>
+        <span className="vehicles-filter-count">
+          {visibleStations.length} / {data.stations.length}
+        </span>
+      </div>
+
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <colgroup>
+            <col style={{ width: "48px" }} />
+            <col />
+            <col style={{ width: "120px" }} />
+          </colgroup>
+          <thead>
             <tr>
-              <td colSpan={3} className="table-empty-cell">
-                데이터 없음
-              </td>
+              <th aria-label="삭제" />
+              <th>주소</th>
+              <th style={{ textAlign: "center" }}>잔여/총</th>
             </tr>
-          ) : null}
-          {data.stations.map((station) => {
-            const available = availableCount(station);
-            const max = maxCount(station);
-            return (
-              <tr
-                key={station.slug}
-                className="table-row-clickable"
-                onClick={() => setActiveRow({ station, available, max })}
-              >
-                <td onClick={(event) => event.stopPropagation()}>
-                  {station.id ? (
-                    <DeleteStationButton stationId={station.id} stationLabel={station.address} />
-                  ) : null}
-                </td>
-                <td>{station.address}</td>
-                <td style={{ textAlign: "center" }}>
-                  <strong>{available}</strong>
-                  <span aria-hidden="true">/</span>
-                  {max}
+          </thead>
+          <tbody>
+            {visibleStations.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="table-empty-cell">
+                  조건에 맞는 스테이션 없음
                 </td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ) : null}
+            {visibleStations.map((station) => {
+              const available = availableCount(station);
+              const max = maxCount(station);
+              return (
+                <tr
+                  key={station.slug}
+                  className="table-row-clickable"
+                  onClick={() => setActiveRow({ station, available, max })}
+                >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {station.id ? (
+                      <DeleteStationButton stationId={station.id} stationLabel={station.address} />
+                    ) : null}
+                  </td>
+                  <td>{station.address}</td>
+                  <td style={{ textAlign: "center" }}>
+                    <strong>{available}</strong>
+                    <span aria-hidden="true">/</span>
+                    {max}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
       <StationDetailDialog
         key={activeRow ? (activeRow.station.id ?? activeRow.station.slug) : "none"}
         row={activeRow}

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
-import { updateVehicleFromOverviewAction } from "@/app/actions";
+import {
+  deriveMaintenanceRows,
+  type DerivedMaintenanceRow,
+  type MaintenanceStatus
+} from "@/components/management/vehicle-maintenance-derive";
+import {
+  markVehicleMaintenanceServicedAction,
+  updateVehicleFromOverviewAction
+} from "@/app/actions";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
+import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
 
 /**
  * 차량 상세 + 편집 floating 패널. PR-γ3b 이전엔 native `<dialog>` modal 이었지만,
@@ -43,6 +52,8 @@ export function VehicleDetailDialog({
   // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
+  // 정비 catalog + 이력. 차량별 두 list 를 한 round-trip 으로 받아 캐싱.
+  const [maintenance, setMaintenance] = useState<VehicleMaintenanceBundle | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
@@ -76,6 +87,28 @@ export function VehicleDetailDialog({
       .catch(() => {
         if (cancelled) return;
         setDeviceState({ bikeId: vehicleIdForFetch, deviceUid: null, installationId: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vehicleIdForFetch]);
+
+  // 정비 catalog + 이력 lazy fetch. 같은 차량에 대해 한 번만 호출.
+  useEffect(() => {
+    if (!vehicleIdForFetch) return;
+    let cancelled = false;
+    fetch(`/api/overview/vehicle-maintenance/${encodeURIComponent(vehicleIdForFetch)}`, {
+      cache: "no-store",
+      credentials: "same-origin"
+    })
+      .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
+      .then((next) => {
+        if (cancelled) return;
+        setMaintenance(next ?? { items: [], records: [] });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMaintenance({ items: [], records: [] });
       });
     return () => {
       cancelled = true;
@@ -124,6 +157,7 @@ export function VehicleDetailDialog({
           <DetailField label="이름" value={row.riderName ?? "—"} />
           <DetailField label="연락처" value={row.riderPhone ?? "—"} />
           <DetailField label="IMEI" value={currentDeviceUid || "—"} />
+          <MaintenanceSection vehicleId={vehicleId} bundle={maintenance} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>
               닫기
@@ -201,4 +235,136 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
   return "—";
+}
+
+// ============================================================================
+// 정비 상태 섹션
+// ============================================================================
+
+function MaintenanceSection({
+  vehicleId,
+  bundle
+}: {
+  vehicleId: string;
+  bundle: VehicleMaintenanceBundle | null;
+}) {
+  const rows = useMemo(() => {
+    if (!bundle) return null;
+    return deriveMaintenanceRows(bundle.items, bundle.records);
+  }, [bundle]);
+
+  if (!bundle) {
+    return (
+      <section className="maintenance-section">
+        <h4>정비 상태</h4>
+        <p className="muted">불러오는 중…</p>
+      </section>
+    );
+  }
+
+  if (!rows || rows.length === 0) {
+    return (
+      <section className="maintenance-section">
+        <h4>정비 상태</h4>
+        <p className="muted">이 차량 구분에 적용되는 정비 품목이 없습니다.</p>
+      </section>
+    );
+  }
+
+  // 그룹 부모(예: 구동계3종) 가 있으면 자식들 위에 헤더로 노출되도록 정렬.
+  // displayOrder 가 catalog seed 에서 부모(80) 다음에 자식(81~83) 순서로 박혀
+  // 있어 단순 displayOrder 정렬로도 자연스러운 그루핑이 나온다. backend 정렬을
+  // 신뢰하되 안전망 차원에서 다시 정렬.
+  const ordered = [...rows].sort((a, b) => a.item.displayOrder - b.item.displayOrder);
+
+  return (
+    <section className="maintenance-section">
+      <h4>정비 상태</h4>
+      <ul className="maintenance-list">
+        {ordered.map((row) => (
+          <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>
+            <MaintenanceRowView vehicleId={vehicleId} row={row} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function MaintenanceRowView({
+  vehicleId,
+  row
+}: {
+  vehicleId: string;
+  row: DerivedMaintenanceRow;
+}) {
+  const [pending, startTransition] = useTransition();
+  const cycleLabel = renderCycleLabel(row);
+  const isGroupHeader = row.item.cycleKm === null && row.item.cycleMonths === null && !row.item.cycleLabel;
+
+  const handleServiced = () => {
+    if (pending) return;
+    if (!window.confirm(`"${row.item.name}" 교환 완료 처리하시겠습니까?`)) return;
+    const fd = new FormData();
+    fd.append("itemId", row.item.id);
+    startTransition(() => {
+      void markVehicleMaintenanceServicedAction(vehicleId, fd);
+    });
+  };
+
+  return (
+    <div className="maintenance-row-grid">
+      <span className="maintenance-row-name">{row.item.name}</span>
+      <span className="maintenance-row-cycle">{cycleLabel}</span>
+      <span className="maintenance-row-last">{renderLastServiced(row)}</span>
+      <span className="maintenance-row-status">{renderStatusBadge(row.status)}</span>
+      {isGroupHeader ? null : (
+        <button
+          type="button"
+          className="maintenance-row-action"
+          onClick={handleServiced}
+          disabled={pending}
+          title={`${row.item.name} 교환 완료 마킹`}
+        >
+          교환 완료
+        </button>
+      )}
+    </div>
+  );
+}
+
+function renderCycleLabel(row: DerivedMaintenanceRow): string {
+  const { item } = row;
+  if (item.cycleLabel) return item.cycleLabel;
+  if (item.cycleKm !== null) return `${item.cycleKm.toLocaleString()} km`;
+  if (item.cycleMonths !== null) return `${item.cycleMonths}개월`;
+  return "—";
+}
+
+function renderLastServiced(row: DerivedMaintenanceRow): ReactNode {
+  if (!row.lastServicedAt) return <span className="muted">기록 없음</span>;
+  const date = new Date(row.lastServicedAt);
+  const dateLabel = Number.isNaN(date.valueOf())
+    ? row.lastServicedAt
+    : date.toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" });
+  if (row.lastServicedAtOdometerKm !== null) {
+    return `${dateLabel} · ${row.lastServicedAtOdometerKm.toLocaleString()} km`;
+  }
+  return dateLabel;
+}
+
+function renderStatusBadge(status: MaintenanceStatus): ReactNode {
+  switch (status) {
+    case "HEALTHY":
+      return <span className="vehicles-pill vehicles-pill--operating">정상</span>;
+    case "DUE_SOON":
+      return <span className="vehicles-pill vehicles-pill--engine-ice">임박</span>;
+    case "OVERDUE":
+      return <span className="vehicles-pill vehicles-pill--unknown">지연</span>;
+    case "NEVER":
+      return <span className="vehicles-pill vehicles-pill--idle">기록 없음</span>;
+    case "UNKNOWN":
+    default:
+      return <span className="muted">—</span>;
+  }
 }

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -96,7 +96,8 @@ export function VehicleDetailDialog({
       {mode === "view" ? (
         <div className="detail-row-grid">
           <DetailField label="차량번호" value={vehicle.plateNumber} />
-          <DetailField label="모델" value={vehicle.model || "—"} />
+          <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
+          <DetailField label="모델명" value={vehicle.model || "—"} />
           <DetailField label="운영 상태" value={vehicle.status} />
           <DetailField label="이름" value={row.riderName ?? "—"} />
           <DetailField label="연락처" value={row.riderPhone ?? "—"} />
@@ -123,7 +124,14 @@ export function VehicleDetailDialog({
             <PlateNumberInput name="plateNumber" defaultValue={vehicle.plateNumber} required />
           </label>
           <label>
-            모델
+            구분
+            <select name="engineType" defaultValue={vehicle.engineType ?? "ELECTRIC"}>
+              <option value="ELECTRIC">전기</option>
+              <option value="ICE">내연기관</option>
+            </select>
+          </label>
+          <label>
+            모델명 (메모)
             <input name="modelName" defaultValue={vehicle.model} maxLength={100} placeholder="예: NIU NQi GTS" />
           </label>
           <label>
@@ -165,4 +173,10 @@ function DetailField({ label, value }: { label: string; value: string }) {
       <span className="detail-field-value">{value}</span>
     </div>
   );
+}
+
+function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
+  if (value === "ELECTRIC") return "전기";
+  if (value === "ICE") return "내연";
+  return "—";
 }

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -4,14 +4,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import { updateVehicleFromOverviewAction } from "@/app/actions";
-import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 
 /**
- * 차량 상세 + 편집 다이얼로그. 차체 기본 정보(plateNumber / modelName) 와
- * 운영 상태(operationStatus) 가 백엔드에서는 두 endpoint 로 분리되어 있지만
- * UI 에서는 "저장" 한 번으로 묶고, server action 안에서 두 호출을 순차 실행한다.
+ * 차량 상세 + 편집 floating 패널. PR-γ3b 이전엔 native `<dialog>` modal 이었지만,
+ * 운영자가 표 행을 누르면 지도 위에서 그 차량을 따라가며 상세를 보고 싶다고
+ * 요청해 `<div position: fixed>` 로 바꿔 floating presentation 으로 전환.
+ *
+ * 자동으로 지도 열기 + 차량 위치 pan 은 부모 (`VehiclesPanel`) 가 행 클릭 시
+ * `VehicleFilterContext` 의 `setSelectedBikeId` 를 호출해 처리. 이 컴포넌트는
+ * 자체 모달 lifecycle 을 더 이상 갖지 않는다 — open/close 는 부모의 `row` prop
+ * 으로만 제어.
  *
  * IMEI(단말기 deviceUid) 도 같은 form 의 일부 — server action 이 device
  * 생성/조회 + bike-device-installation 생성/해제를 자동으로 처리한다. 운영자
@@ -35,15 +39,22 @@ export function VehicleDetailDialog({
   row: VehicleDetailRow | null;
   onClose: () => void;
 }) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const [mode, setMode] = useState<"view" | "edit">("view");
   // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
   // 조회 실패 / 부착됨 세 상태가 같은 모양 (deviceUid: null 또는 string).
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-  // 모달 open/close + scroll 보존을 공유 훅으로 위임. 상태 리셋은 부모의
-  // key prop 으로 재마운트해 useState 초기값이 새로 잡히도록 한다.
-  useScrollLockedDialog(dialogRef, row !== null);
+  // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
+  // 않지만 키보드 접근성을 위해 listener 등록.
+  useEffect(() => {
+    if (!row) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [row, onClose]);
 
   // 차량이 바뀌면 단말기 정보도 새로 받아온다. 부모(`VehiclesPanel`) 가
   // `key={vehicleId}` 로 다이얼로그를 remount 시키므로 row 가 null → row 로
@@ -72,7 +83,6 @@ export function VehicleDetailDialog({
   }, [vehicleIdForFetch]);
 
   const handleClose = useCallback(() => {
-    dialogRef.current?.close();
     onClose();
   }, [onClose]);
 
@@ -86,13 +96,25 @@ export function VehicleDetailDialog({
   const currentInstallationId = deviceState?.installationId ?? "";
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="overview-create-dialog"
-      onClose={onClose}
-      onCancel={onClose}
+    <div
+      ref={panelRef}
+      className="vehicle-floating-panel"
+      role="dialog"
+      aria-label="차량 상세"
+      aria-modal="false"
     >
-      <h3>차량 상세</h3>
+      <div className="vehicle-floating-panel-header">
+        <h3>차량 상세</h3>
+        <button
+          type="button"
+          className="vehicle-floating-panel-close"
+          onClick={handleClose}
+          aria-label="닫기"
+          title="닫기"
+        >
+          ×
+        </button>
+      </div>
       {mode === "view" ? (
         <div className="detail-row-grid">
           <DetailField label="차량번호" value={vehicle.plateNumber} />
@@ -162,7 +184,7 @@ export function VehicleDetailDialog({
           </div>
         </form>
       )}
-    </dialog>
+    </div>
   );
 }
 

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -43,14 +43,31 @@ import type {
  * 다루지 않는다. 필터는 차량번호/모델명/IMEI 검색 한 줄만.
  */
 
+/**
+ * 차량 탭 필터 상태. 모든 필드가 union 이라 select option 의 raw value 를
+ * 그대로 저장해 컨버전 비용을 없앤다. `connection` 의 ANY_OFFLINE 은
+ * telemetry connection_status 가 ONLINE 이 아닌 모든 케이스(OFFLINE,
+ * SIGNAL_LOST, PARKED_OFFLINE 등) 를 한 번에 잡는다. `ignition` 은 핀이 없는
+ * 차량(텔레메트리 미수신)도 "UNKNOWN" 으로 분류해 운영자가 "단말기 없는 차량"
+ * 을 골라낼 수 있도록.
+ */
 type FilterState = {
   query: string;
+  engineType: "ALL" | "ELECTRIC" | "ICE";
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
+  connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
+  ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
+  // 정비 상태 필터는 PR-ζ 에서 활성. 자리만 잡아둠.
+  maintenance: "ALL";
 };
 
 const DEFAULT_FILTERS: FilterState = {
   query: "",
-  operationStatus: "ALL"
+  engineType: "ALL",
+  operationStatus: "ALL",
+  connection: "ALL",
+  ignition: "ALL",
+  maintenance: "ALL"
 };
 
 const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
@@ -110,16 +127,41 @@ export function VehiclesPanel({
         const imeiMatch = imei.toLowerCase().includes(q);
         if (!plateMatch && !modelMatch && !imeiMatch) return false;
       }
+      if (filters.engineType !== "ALL") {
+        // 옛 backend 응답엔 engineType 이 없을 수 있어 ELECTRIC 으로 폴백 —
+        // V21 마이그레이션 이후 모든 행이 ELECTRIC default 라는 가정과 일치.
+        const et = vehicle.engineType ?? "ELECTRIC";
+        if (et !== filters.engineType) return false;
+      }
       if (filters.operationStatus !== "ALL") {
         const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
         if (op !== filters.operationStatus) return false;
       }
+      if (filters.connection !== "ALL") {
+        const pin = bikePinById.get(vehicleKey);
+        const status = pin?.connectionStatus;
+        if (filters.connection === "ONLINE") {
+          if (status !== "ONLINE") return false;
+        } else {
+          // ANY_OFFLINE — ONLINE 이 아닌 모든 케이스. 핀이 아예 없는 차량도
+          // 운영자 관점에선 "통신 없음" 이므로 여기 포함.
+          if (status === "ONLINE") return false;
+        }
+      }
+      if (filters.ignition !== "ALL") {
+        const pin = bikePinById.get(vehicleKey);
+        const status = pin?.ignitionStatus;
+        if (filters.ignition === "ON" && status !== "ON") return false;
+        if (filters.ignition === "OFF" && status !== "OFF") return false;
+        if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
+      }
       return true;
     });
-  }, [data.vehicles, filters, deviceUidByBikeId]);
+  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById]);
 
   return (
     <div className="vehicles-panel">
+      {/* Row 1: 검색 · 구분 · 운영 상태 · 카운트 */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -131,6 +173,17 @@ export function VehiclesPanel({
           />
           <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
         </div>
+        <select
+          className="vehicles-filter-select"
+          value={filters.engineType}
+          onChange={(event) =>
+            setFilters({ ...filters, engineType: event.target.value as FilterState["engineType"] })
+          }
+        >
+          <option value="ALL">구분: 전체</option>
+          <option value="ELECTRIC">전기</option>
+          <option value="ICE">내연</option>
+        </select>
         <select
           className="vehicles-filter-select"
           value={filters.operationStatus}
@@ -145,6 +198,41 @@ export function VehiclesPanel({
         <span className="vehicles-filter-count">
           {visibleVehicles.length} / {data.vehicles.length}
         </span>
+      </div>
+      {/* Row 2: 연결 상태 · 시동 · 정비 상태(준비중) */}
+      <div className="vehicles-filter-row">
+        <select
+          className="vehicles-filter-select"
+          value={filters.connection}
+          onChange={(event) =>
+            setFilters({ ...filters, connection: event.target.value as FilterState["connection"] })
+          }
+        >
+          <option value="ALL">연결 상태: 전체</option>
+          <option value="ONLINE">온라인</option>
+          <option value="ANY_OFFLINE">오프라인/신호끊김</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.ignition}
+          onChange={(event) =>
+            setFilters({ ...filters, ignition: event.target.value as FilterState["ignition"] })
+          }
+        >
+          <option value="ALL">시동: 전체</option>
+          <option value="ON">ON</option>
+          <option value="OFF">OFF</option>
+          <option value="UNKNOWN">상태없음</option>
+        </select>
+        <select
+          className="vehicles-filter-select"
+          value={filters.maintenance}
+          disabled
+          title="정비 이력 UI 후속 PR 에서 활성화"
+          onChange={() => {}}
+        >
+          <option value="ALL">정비 상태 (준비중)</option>
+        </select>
       </div>
 
       <div className="table-card vehicles-table-scroll">

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
@@ -9,6 +9,7 @@ import { OperationStatusToggle } from "@/components/management/OperationStatusTo
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
+import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 import type {
@@ -111,6 +112,7 @@ export function VehiclesPanel({
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const { setFilteredBikeIds } = useVehicleFilter();
 
   // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
   const bikePinById = useMemo(() => {
@@ -172,6 +174,26 @@ export function VehiclesPanel({
       return true;
     });
   }, [data.vehicles, filters, deviceUidByBikeId, bikePinById]);
+
+  // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
+  // OverviewMapBanner 가 이 부분 집합만 핀으로 노출한다. rAF 한 프레임 양보로
+  // `react-hooks/set-state-in-effect` 규칙도 자연스럽게 피한다 (지도 마커
+  // 갱신이 한 프레임 늦는 건 시각적으로 거의 안 보임). 언마운트 시 cleanup
+  // 에서 null 로 되돌려 다른 탭 활성 시 필터가 잔존하지 않게 한다.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const ids = new Set<string>();
+    for (const vehicle of visibleVehicles) {
+      const key = vehicle.id ?? vehicle.slug;
+      if (key) ids.add(key);
+    }
+    const handle = window.requestAnimationFrame(() => setFilteredBikeIds(ids));
+    return () => window.cancelAnimationFrame(handle);
+  }, [visibleVehicles, setFilteredBikeIds]);
+
+  useEffect(() => {
+    return () => setFilteredBikeIds(null);
+  }, [setFilteredBikeIds]);
 
   return (
     <div className="vehicles-panel">

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -2,9 +2,12 @@
 
 import { useMemo, useState, type ReactNode } from "react";
 
+import { Badge } from "@/components/ui/Badge";
+import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
+import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 import type {
   FrontendDashboardBikePin,
   FrontendVehicle,
@@ -12,18 +15,27 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * `/?tab=vehicles` 의 차량 현황 패널. 운영자가 한 화면에서 차량 +
- * 라이더 + 텔레메트리 + 단말기 정보를 한꺼번에 훑을 수 있도록 10개 컬럼만
- * 남긴 단순 구조.
+ * `/?tab=vehicles` 의 차량 현황 패널. 한 행에서 차량 자체 + 매칭된 라이더 +
+ * 라이더의 계약·보험·교육 + 텔레메트리 + 단말기 + 시동 제어까지 한 번에
+ * 훑을 수 있도록 라이더 탭과 동일한 라이더-측 컬럼들을 함께 노출한다.
  *
- * 컬럼:
- *   차량번호 / 모델 / 운영 상태 / 이름 / 연락처 / IMEI / 연결 상태 / 시동 / 속도 / 잔량
+ * 컬럼 (총 16):
+ *   차량번호 / 모델 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
+ *   기간 / 보험 / IMEI / 연결 상태 / 시동 상태 / 시동 제어 / 속도 / 잔량
  *
  * 데이터 매핑:
  * - 차량번호 / 모델 / 운영 상태 ← FrontendVehicle (이 패널 데이터)
  * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
+ * - 교육 / 구독·렌탈 / 형태 / 기간 / 보험 ← bikeActiveRiderById 로 riderId 를
+ *   먼저 찾고, 라이더 탭과 동일한 4 종 map (educationTypeByRiderId,
+ *   riderActiveContractById, insuredRiderIds) 으로 lookup
  * - IMEI ← deviceUidByBikeId (페이지 진입 시 batch-load)
- * - 연결 상태 / 시동 / 속도 / 잔량 ← bikePinById (텔레메트리 핀)
+ * - 연결 상태 / 시동 상태 / 속도 / 잔량 ← bikePinById (텔레메트리 핀)
+ * - 시동 제어 ← ignitionBlockedByBikeId + IgnitionControlButton (라이더 탭과
+ *   같은 컴포넌트 재사용)
+ *
+ * 행 클릭은 차량 상세 다이얼로그 — 라이더 정보는 단순 조회용이고 편집은
+ * 라이더 탭에서 처리하도록 책임 분리. 시동 제어 토글만 행 안에서 직접 동작.
  *
  * 지도 보기 토글은 페이지 최상단의 글로벌 토글로 이동했으므로 이 패널에서는
  * 다루지 않는다. 필터는 차량번호/모델/IMEI 검색 한 줄만.
@@ -51,7 +63,11 @@ export function VehiclesPanel({
   bikeActiveRiderById,
   riderInfoById,
   bikePins,
-  deviceUidByBikeId
+  deviceUidByBikeId,
+  insuredRiderIds,
+  educationTypeByRiderId,
+  riderActiveContractById,
+  ignitionBlockedByBikeId
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
@@ -60,6 +76,14 @@ export function VehiclesPanel({
   bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
   /** 차량 → 부착된 단말기 IMEI 사전. 루트 페이지가 batch loader 로 받아서 내려준다. */
   deviceUidByBikeId?: Map<string, string>;
+  /** 활성 보험 보유 라이더 id set — 매칭된 라이더가 보험에 가입돼 있는지 판단. */
+  insuredRiderIds?: Set<string>;
+  /** riderId → ONLINE/OFFLINE 교육 type. */
+  educationTypeByRiderId?: Map<string, "ONLINE" | "OFFLINE">;
+  /** riderId → 활성 매칭의 계약 요약(category / returnType / durationLabel). */
+  riderActiveContractById?: Map<string, RiderActiveContractSummary>;
+  /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
+  ignitionBlockedByBikeId?: Map<string, boolean>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
@@ -130,9 +154,15 @@ export function VehiclesPanel({
               <th>운영 상태</th>
               <th>이름</th>
               <th>연락처</th>
+              <th>교육</th>
+              <th>구독/렌탈</th>
+              <th>형태</th>
+              <th>기간</th>
+              <th>보험</th>
               <th>IMEI</th>
               <th>연결 상태</th>
-              <th>시동</th>
+              <th>시동 상태</th>
+              <th>시동 제어</th>
               <th>속도</th>
               <th>잔량</th>
             </tr>
@@ -140,7 +170,7 @@ export function VehiclesPanel({
           <tbody>
             {visibleVehicles.length === 0 ? (
               <tr>
-                <td colSpan={10} className="table-empty-cell">
+                <td colSpan={16} className="table-empty-cell">
                   조건에 맞는 차량 없음
                 </td>
               </tr>
@@ -152,6 +182,11 @@ export function VehiclesPanel({
               const pin = bikePinById.get(vehicleKey);
               const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
               const imei = deviceUidByBikeId?.get(vehicleKey) ?? null;
+              // 라이더-측 lookup. 매칭이 없으면 모두 null → "—" 폴백.
+              const educationType = activeRiderId ? educationTypeByRiderId?.get(activeRiderId) ?? null : null;
+              const contract = activeRiderId ? riderActiveContractById?.get(activeRiderId) ?? null : null;
+              const hasInsurance = activeRiderId && insuredRiderIds ? insuredRiderIds.has(activeRiderId) : null;
+              const ignitionBlocked = ignitionBlockedByBikeId?.get(vehicleKey) ?? false;
               return (
                 <tr
                   key={vehicle.slug}
@@ -175,9 +210,21 @@ export function VehiclesPanel({
                   <td>{renderOperationBadge(op)}</td>
                   <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
                   <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
+                  <td>{renderEducationType(educationType)}</td>
+                  <td>{renderCategory(contract?.category ?? null)}</td>
+                  <td>{renderReturnType(contract?.returnType ?? null)}</td>
+                  <td>{renderDuration(contract?.durationLabel ?? null)}</td>
+                  <td>{renderPresence(hasInsurance)}</td>
                   <td className="vehicles-cell-mono">{imei || <span className="muted">—</span>}</td>
                   <td>{renderConnection(pin?.connectionStatus)}</td>
                   <td>{renderIgnition(pin?.ignitionStatus)}</td>
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {vehicle.id ? (
+                      <IgnitionControlButton bikeId={vehicle.id} initialBlocked={ignitionBlocked} />
+                    ) : (
+                      <span className="muted">—</span>
+                    )}
+                  </td>
                   <td>{renderSpeed(pin?.speedKph)}</td>
                   <td>{renderBattery(pin?.batteryPercent)}</td>
                 </tr>
@@ -243,4 +290,34 @@ function renderBattery(percent: number | null | undefined): ReactNode {
       {percent.toFixed(0)}%
     </span>
   );
+}
+
+// 라이더-측 컬럼 렌더러. 라이더 탭 (`RidersPanel`) 과 라벨/톤 통일.
+function renderEducationType(type: "ONLINE" | "OFFLINE" | null): ReactNode {
+  if (type === "ONLINE") return "온라인";
+  if (type === "OFFLINE") return "오프라인";
+  return <span className="muted">—</span>;
+}
+
+function renderCategory(category: RiderActiveContractSummary["category"] | null | undefined): ReactNode {
+  if (category === "SUBSCRIPTION") return "구독";
+  if (category === "RENTAL") return "렌탈";
+  if (category === "CUSTOM") return "커스텀";
+  return <span className="muted">—</span>;
+}
+
+function renderReturnType(returnType: RiderActiveContractSummary["returnType"] | null | undefined): ReactNode {
+  if (returnType === "TAKEOVER") return "인수형";
+  if (returnType === "RETURN") return "반납형";
+  return <span className="muted">—</span>;
+}
+
+function renderDuration(durationLabel: string | null | undefined): ReactNode {
+  if (!durationLabel) return <span className="muted">—</span>;
+  return durationLabel;
+}
+
+function renderPresence(hasIt: boolean | null): ReactNode {
+  if (hasIt) return <Badge tone="active">있음</Badge>;
+  return <span className="muted">—</span>;
 }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -3,7 +3,9 @@
 import { useMemo, useState, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
+import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
+import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
@@ -149,6 +151,7 @@ export function VehiclesPanel({
         <table className="table vehicles-table">
           <thead>
             <tr>
+              <th aria-label="삭제" />
               <th>차량번호</th>
               <th>모델</th>
               <th>운영 상태</th>
@@ -170,7 +173,7 @@ export function VehiclesPanel({
           <tbody>
             {visibleVehicles.length === 0 ? (
               <tr>
-                <td colSpan={16} className="table-empty-cell">
+                <td colSpan={17} className="table-empty-cell">
                   조건에 맞는 차량 없음
                 </td>
               </tr>
@@ -205,9 +208,20 @@ export function VehiclesPanel({
                     })
                   }
                 >
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {vehicle.id ? (
+                      <DeleteVehicleButton vehicleId={vehicle.id} plateNumber={vehicle.plateNumber} />
+                    ) : null}
+                  </td>
                   <td>{vehicle.plateNumber}</td>
                   <td>{vehicle.model || <span className="muted">—</span>}</td>
-                  <td>{renderOperationBadge(op)}</td>
+                  <td onClick={(event) => event.stopPropagation()}>
+                    {vehicle.id ? (
+                      <OperationStatusToggle bikeId={vehicle.id} initialStatus={op} />
+                    ) : (
+                      renderOperationBadge(op)
+                    )}
+                  </td>
                   <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
                   <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
                   <td>{renderEducationType(educationType)}</td>

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -8,12 +8,14 @@ import { IgnitionControlButton } from "@/components/management/IgnitionControlBu
 import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
+import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 import type {
   FrontendDashboardBikePin,
   FrontendVehicle,
-  ServiceOpsBikeOperationStatus
+  ServiceOpsBikeOperationStatus,
+  ServiceOpsRiderInsurance
 } from "@/lib/services/service-ops-api";
 
 /**
@@ -83,9 +85,10 @@ export function VehiclesPanel({
   riderInfoById,
   bikePins,
   deviceUidByBikeId,
-  insuredRiderIds,
   educationTypeByRiderId,
   riderActiveContractById,
+  riderActiveInsuranceByRiderId,
+  insuranceOptions,
   ignitionBlockedByBikeId
 }: {
   data: VehicleDataResult;
@@ -95,12 +98,14 @@ export function VehiclesPanel({
   bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
   /** 차량 → 부착된 단말기 IMEI 사전. 루트 페이지가 batch loader 로 받아서 내려준다. */
   deviceUidByBikeId?: Map<string, string>;
-  /** 활성 보험 보유 라이더 id set — 매칭된 라이더가 보험에 가입돼 있는지 판단. */
-  insuredRiderIds?: Set<string>;
   /** riderId → ONLINE/OFFLINE 교육 type. */
   educationTypeByRiderId?: Map<string, "ONLINE" | "OFFLINE">;
   /** riderId → 활성 매칭의 계약 요약(category / returnType / durationLabel). */
   riderActiveContractById?: Map<string, RiderActiveContractSummary>;
+  /** riderId → 현재 활성 rider_insurance. 보험 컬럼이 상품 id 를 derive 할 때 참조. */
+  riderActiveInsuranceByRiderId?: Map<string, ServiceOpsRiderInsurance>;
+  /** insurance_item id → 표시 라벨 사전. 라이더 탭과 동일. */
+  insuranceOptions?: ReadonlyArray<InsuranceOption>;
   /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
   ignitionBlockedByBikeId?: Map<string, boolean>;
 }) {
@@ -115,6 +120,15 @@ export function VehiclesPanel({
     }
     return map;
   }, [bikePins]);
+
+  // insurance_item id → 표시 라벨 사전. 보험 컬럼이 매 행마다 lookup 1회.
+  const insuranceLabelById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const option of insuranceOptions ?? []) {
+      map.set(option.id, option.label);
+    }
+    return map;
+  }, [insuranceOptions]);
 
   const visibleVehicles = useMemo(() => {
     const q = filters.query.trim().toLowerCase();
@@ -276,7 +290,10 @@ export function VehiclesPanel({
               // 라이더-측 lookup. 매칭이 없으면 모두 null → "—" 폴백.
               const educationType = activeRiderId ? educationTypeByRiderId?.get(activeRiderId) ?? null : null;
               const contract = activeRiderId ? riderActiveContractById?.get(activeRiderId) ?? null : null;
-              const hasInsurance = activeRiderId && insuredRiderIds ? insuredRiderIds.has(activeRiderId) : null;
+              const activeInsurance = activeRiderId ? riderActiveInsuranceByRiderId?.get(activeRiderId) ?? null : null;
+              const insuranceLabel = activeInsurance
+                ? insuranceLabelById.get(activeInsurance.insuranceItemId) ?? null
+                : null;
               const ignitionBlocked = ignitionBlockedByBikeId?.get(vehicleKey) ?? false;
               return (
                 <tr
@@ -316,7 +333,7 @@ export function VehiclesPanel({
                   <td>{renderCategory(contract?.category ?? null)}</td>
                   <td>{renderReturnType(contract?.returnType ?? null)}</td>
                   <td>{renderDuration(contract?.durationLabel ?? null)}</td>
-                  <td>{renderPresence(hasInsurance)}</td>
+                  <td>{renderInsuranceProduct(insuranceLabel)}</td>
                   <td className="vehicles-cell-mono">{imei || <span className="muted">—</span>}</td>
                   <td>{renderConnection(pin?.connectionStatus)}</td>
                   <td>{renderIgnition(pin?.ignitionStatus)}</td>
@@ -432,7 +449,8 @@ function renderDuration(durationLabel: string | null | undefined): ReactNode {
   return durationLabel;
 }
 
-function renderPresence(hasIt: boolean | null): ReactNode {
-  if (hasIt) return <Badge tone="active">있음</Badge>;
-  return <span className="muted">—</span>;
+// 보험 컬럼은 가입 여부 대신 상품명 표시. 라이더 탭과 동일한 형태.
+function renderInsuranceProduct(label: string | null): ReactNode {
+  if (!label) return <span className="muted">—</span>;
+  return <Badge tone="active">{label}</Badge>;
 }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -112,7 +112,7 @@ export function VehiclesPanel({
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
-  const { setFilteredBikeIds } = useVehicleFilter();
+  const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
   // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
   const bikePinById = useMemo(() => {
@@ -194,6 +194,20 @@ export function VehiclesPanel({
   useEffect(() => {
     return () => setFilteredBikeIds(null);
   }, [setFilteredBikeIds]);
+
+  // 행 클릭으로 activeRow 가 잡히면 context 의 selectedBikeId 도 같이 publish
+  // 해 지도가 자동으로 켜지고 그 차량으로 pan 한다. 닫힐 때 (activeRow=null)
+  // 는 selection 도 함께 해제. 언마운트(탭 전환) 시에도 잔존 방지.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = activeRow?.vehicle.id ?? null;
+    const handle = window.requestAnimationFrame(() => setSelectedBikeId(id));
+    return () => window.cancelAnimationFrame(handle);
+  }, [activeRow, setSelectedBikeId]);
+
+  useEffect(() => {
+    return () => setSelectedBikeId(null);
+  }, [setSelectedBikeId]);
 
   return (
     <div className="vehicles-panel">

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -9,6 +9,7 @@ import { OperationStatusToggle } from "@/components/management/OperationStatusTo
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
+import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
@@ -60,8 +61,8 @@ type FilterState = {
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
   connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
   ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
-  // 정비 상태 필터는 PR-ζ 에서 활성. 자리만 잡아둠.
-  maintenance: "ALL";
+  // 정비 상태 — DUE_SOON 은 임박, OVERDUE 는 지연, ANY 는 둘 다.
+  maintenance: "ALL" | "DUE_SOON" | "OVERDUE" | "ANY";
 };
 
 const DEFAULT_FILTERS: FilterState = {
@@ -90,7 +91,8 @@ export function VehiclesPanel({
   riderActiveContractById,
   riderActiveInsuranceByRiderId,
   insuranceOptions,
-  ignitionBlockedByBikeId
+  ignitionBlockedByBikeId,
+  maintenanceSummaryByBike
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
@@ -109,6 +111,8 @@ export function VehiclesPanel({
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
   /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
   ignitionBlockedByBikeId?: Map<string, boolean>;
+  /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
+  maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
 }) {
   const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
@@ -171,9 +175,16 @@ export function VehiclesPanel({
         if (filters.ignition === "OFF" && status !== "OFF") return false;
         if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
       }
+      if (filters.maintenance !== "ALL") {
+        const summary = maintenanceSummaryByBike?.get(vehicleKey);
+        if (!summary) return false;
+        if (filters.maintenance === "OVERDUE" && !summary.hasOverdue) return false;
+        if (filters.maintenance === "DUE_SOON" && !summary.hasDueSoon) return false;
+        if (filters.maintenance === "ANY" && !summary.hasOverdue && !summary.hasDueSoon) return false;
+      }
       return true;
     });
-  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById]);
+  }, [data.vehicles, filters, deviceUidByBikeId, bikePinById, maintenanceSummaryByBike]);
 
   // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
   // OverviewMapBanner 가 이 부분 집합만 핀으로 노출한다. rAF 한 프레임 양보로
@@ -277,11 +288,14 @@ export function VehiclesPanel({
         <select
           className="vehicles-filter-select"
           value={filters.maintenance}
-          disabled
-          title="정비 이력 UI 후속 PR 에서 활성화"
-          onChange={() => {}}
+          onChange={(event) =>
+            setFilters({ ...filters, maintenance: event.target.value as FilterState["maintenance"] })
+          }
         >
-          <option value="ALL">정비 상태 (준비중)</option>
+          <option value="ALL">정비 상태: 전체</option>
+          <option value="ANY">임박 + 지연</option>
+          <option value="DUE_SOON">임박만</option>
+          <option value="OVERDUE">지연만</option>
         </select>
       </div>
 

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -22,11 +22,11 @@ import type {
  * 훑을 수 있도록 라이더 탭과 동일한 라이더-측 컬럼들을 함께 노출한다.
  *
  * 컬럼 (총 16):
- *   차량번호 / 모델 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
+ *   차량번호 / 구분 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
  *   기간 / 보험 / IMEI / 연결 상태 / 시동 상태 / 시동 제어 / 속도 / 잔량
  *
  * 데이터 매핑:
- * - 차량번호 / 모델 / 운영 상태 ← FrontendVehicle (이 패널 데이터)
+ * - 차량번호 / 구분(engineType) / 운영 상태 ← FrontendVehicle (이 패널 데이터)
  * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
  * - 교육 / 구독·렌탈 / 형태 / 기간 / 보험 ← bikeActiveRiderById 로 riderId 를
  *   먼저 찾고, 라이더 탭과 동일한 4 종 map (educationTypeByRiderId,
@@ -40,7 +40,7 @@ import type {
  * 라이더 탭에서 처리하도록 책임 분리. 시동 제어 토글만 행 안에서 직접 동작.
  *
  * 지도 보기 토글은 페이지 최상단의 글로벌 토글로 이동했으므로 이 패널에서는
- * 다루지 않는다. 필터는 차량번호/모델/IMEI 검색 한 줄만.
+ * 다루지 않는다. 필터는 차량번호/모델명/IMEI 검색 한 줄만.
  */
 
 type FilterState = {
@@ -125,7 +125,7 @@ export function VehiclesPanel({
           <input
             className="vehicles-filter-search"
             type="search"
-            placeholder="차량번호, 모델, IMEI 검색"
+            placeholder="차량번호, 모델명, IMEI 검색"
             value={filters.query}
             onChange={(event) => setFilters({ ...filters, query: event.target.value })}
           />
@@ -153,7 +153,7 @@ export function VehiclesPanel({
             <tr>
               <th aria-label="삭제" />
               <th>차량번호</th>
-              <th>모델</th>
+              <th>구분</th>
               <th>운영 상태</th>
               <th>이름</th>
               <th>연락처</th>
@@ -214,7 +214,7 @@ export function VehiclesPanel({
                     ) : null}
                   </td>
                   <td>{vehicle.plateNumber}</td>
-                  <td>{vehicle.model || <span className="muted">—</span>}</td>
+                  <td>{renderEngineTypeBadge(vehicle.engineType)}</td>
                   <td onClick={(event) => event.stopPropagation()}>
                     {vehicle.id ? (
                       <OperationStatusToggle bikeId={vehicle.id} initialStatus={op} />
@@ -255,6 +255,19 @@ export function VehiclesPanel({
       />
     </div>
   );
+}
+
+// 구분(engineType) 뱃지. ELECTRIC = 액센트 톤 (전기 = 정상 운영의 기본 차종),
+// ICE = battery-mid(노랑) 톤으로 시각 구분. 도메인 가정상 다수가 ELECTRIC 이므로
+// 액센트가 "기본" 컬러 역할.
+function renderEngineTypeBadge(engineType: FrontendVehicle["engineType"]): ReactNode {
+  if (engineType === "ICE") {
+    return <span className="vehicles-pill vehicles-pill--engine-ice">내연</span>;
+  }
+  if (engineType === "ELECTRIC") {
+    return <span className="vehicles-pill vehicles-pill--engine-electric">전기</span>;
+  }
+  return <span className="muted">—</span>;
 }
 
 function statusToOperation(status: FrontendVehicle["status"]): ServiceOpsBikeOperationStatus {

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -1,0 +1,116 @@
+import type {
+  ServiceOpsMaintenanceItem,
+  ServiceOpsVehicleMaintenanceRecord
+} from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 floating panel "정비 상태" 섹션의 한 줄에 필요한 derived 정보. catalog
+ * 의 cycle 과 이력의 servicedAt 을 합쳐 다음 예정 / 임박 / 지연 같은 표시 단위
+ * 를 한 곳에서 계산한다.
+ *
+ * **카운팅 정책**:
+ * - cycle_months 가 잡힌 품목은 servicedAt + months 로 다음 예정 일자 계산.
+ *   (운영 시간 누적 추적은 V22 시점에 백엔드 인프라가 없어 운영 일수 기준 단순화)
+ * - cycle_km 만 잡힌 품목은 odometer 텔레메트리가 없어 자동 상태 계산을 안 함 —
+ *   "교환 완료" 시 운영자가 입력한 odometer 가 있으면 그걸 마지막 km 로 노출.
+ * - cycle_label (자유 텍스트, 예: "12개월 이상") 만 있는 품목은 안내 텍스트 그대로
+ *   노출하고 상태는 NONE.
+ *
+ * **상태 등급**:
+ * - NEVER — 한 번도 교환된 적 없음 (등록 직후). UI: 회색 "기록 없음"
+ * - HEALTHY — 다음 예정의 90% 이전
+ * - DUE_SOON — 다음 예정의 90% ~ 100% 사이 (임박)
+ * - OVERDUE — 다음 예정 지남 (지연)
+ * - UNKNOWN — cycle 정보가 너무 비정형해서 derived 계산 불가
+ */
+export type MaintenanceStatus = "NEVER" | "HEALTHY" | "DUE_SOON" | "OVERDUE" | "UNKNOWN";
+
+export type DerivedMaintenanceRow = {
+  item: ServiceOpsMaintenanceItem;
+  lastServicedAt: string | null;
+  lastServicedAtOdometerKm: number | null;
+  /** cycle_months 기반 다음 예정 (ISO). cycle 정보 부족 시 null. */
+  nextDueAt: string | null;
+  status: MaintenanceStatus;
+};
+
+const APPROACH_RATIO = 0.9;
+
+export function deriveMaintenanceRows(
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>,
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  now: Date = new Date()
+): DerivedMaintenanceRow[] {
+  // itemId → 가장 최근 기록 (records 가 이미 servicedAt desc 정렬이라 first hit).
+  const latestByItem = new Map<string, ServiceOpsVehicleMaintenanceRecord>();
+  for (const record of records) {
+    if (!latestByItem.has(record.itemId)) {
+      latestByItem.set(record.itemId, record);
+    }
+  }
+
+  return items.map((item) => {
+    const latest = latestByItem.get(item.id) ?? null;
+    const lastServicedAt = latest?.servicedAt ?? null;
+    const lastServicedAtOdometerKm = latest?.servicedAtOdometerKm ?? null;
+
+    // 그룹 부모 (cycle 없음) — 항상 UNKNOWN, 자식이 실제 상태를 캐리.
+    if (item.cycleKm === null && item.cycleMonths === null) {
+      return {
+        item,
+        lastServicedAt,
+        lastServicedAtOdometerKm,
+        nextDueAt: null,
+        status: "UNKNOWN"
+      };
+    }
+
+    if (!lastServicedAt) {
+      return {
+        item,
+        lastServicedAt: null,
+        lastServicedAtOdometerKm,
+        nextDueAt: nextDueAtFromCycle(null, item.cycleMonths),
+        status: "NEVER"
+      };
+    }
+
+    // cycle_months 기반 자동 계산 — 가장 confident 한 시간 단위.
+    if (item.cycleMonths !== null) {
+      const nextDueAt = nextDueAtFromCycle(lastServicedAt, item.cycleMonths);
+      if (nextDueAt) {
+        const status = classifyByDate(new Date(lastServicedAt), new Date(nextDueAt), now);
+        return { item, lastServicedAt, lastServicedAtOdometerKm, nextDueAt, status };
+      }
+    }
+
+    // cycle_km 만 있는 케이스 — odometer 텔레메트리 없어 자동 상태 derive 안 함.
+    // 운영자가 lastServicedAtOdometerKm + cycle_km 을 보고 직접 판단.
+    return {
+      item,
+      lastServicedAt,
+      lastServicedAtOdometerKm,
+      nextDueAt: null,
+      status: "UNKNOWN"
+    };
+  });
+}
+
+function nextDueAtFromCycle(lastServicedAt: string | null, cycleMonths: number | null): string | null {
+  if (cycleMonths === null) return null;
+  const base = lastServicedAt ? new Date(lastServicedAt) : null;
+  if (!base || Number.isNaN(base.valueOf())) return null;
+  const next = new Date(base);
+  next.setMonth(next.getMonth() + cycleMonths);
+  return next.toISOString();
+}
+
+function classifyByDate(servicedAt: Date, nextDueAt: Date, now: Date): MaintenanceStatus {
+  const totalSpan = nextDueAt.valueOf() - servicedAt.valueOf();
+  if (totalSpan <= 0) return "UNKNOWN";
+  const elapsed = now.valueOf() - servicedAt.valueOf();
+  const ratio = elapsed / totalSpan;
+  if (ratio < APPROACH_RATIO) return "HEALTHY";
+  if (ratio < 1) return "DUE_SOON";
+  return "OVERDUE";
+}

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -96,6 +96,79 @@ export function deriveMaintenanceRows(
   });
 }
 
+/**
+ * 차량 한 대의 정비 상태 요약. 차량 탭 필터가 임박/지연 차량을 빠르게
+ * 골라내기 위해 각 차량에 대해 한 번씩만 계산하고 캐싱.
+ *
+ * `hasOverdue` / `hasDueSoon` — 해당 차량의 어떤 품목이라도 그 상태면 true.
+ * `overallStatus` — 우선순위 OVERDUE > DUE_SOON > HEALTHY > NEVER > UNKNOWN.
+ */
+export type VehicleMaintenanceSummary = {
+  hasOverdue: boolean;
+  hasDueSoon: boolean;
+  overallStatus: MaintenanceStatus;
+};
+
+const STATUS_PRIORITY: Record<MaintenanceStatus, number> = {
+  OVERDUE: 4,
+  DUE_SOON: 3,
+  HEALTHY: 2,
+  NEVER: 1,
+  UNKNOWN: 0
+};
+
+/**
+ * bikeId → 그 차량의 정비 상태 요약 map. 전체 데이터셋(items + records) 와
+ * engineType-별 catalog 매핑을 받아 한 번에 계산.
+ *
+ * `bikeEngineTypeById` — 차량 ID 가 ICE/ELECTRIC 중 어느 catalog 를 봐야 하는지.
+ *   엔트리 없으면 ELECTRIC 으로 fallback (V21 default 정책과 일치).
+ */
+export function summarizeMaintenanceByBike(
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>,
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  bikeEngineTypeById: Map<string, "ELECTRIC" | "ICE">,
+  now: Date = new Date()
+): Map<string, VehicleMaintenanceSummary> {
+  // engineType 별 적용 catalog 두 묶음 미리 분리.
+  const electricItems = items.filter(
+    (item) => item.appliesTo === "ELECTRIC" || item.appliesTo === "BOTH"
+  );
+  const iceItems = items.filter(
+    (item) => item.appliesTo === "ICE" || item.appliesTo === "BOTH"
+  );
+
+  // bikeId → records 그룹핑.
+  const recordsByBike = new Map<string, ServiceOpsVehicleMaintenanceRecord[]>();
+  for (const record of records) {
+    const list = recordsByBike.get(record.bikeId);
+    if (list) list.push(record);
+    else recordsByBike.set(record.bikeId, [record]);
+  }
+
+  // bikeEngineTypeById 에 등장한 모든 차량에 대해 요약 계산.
+  const result = new Map<string, VehicleMaintenanceSummary>();
+  for (const [bikeId, engineType] of bikeEngineTypeById) {
+    const applicableItems = engineType === "ICE" ? iceItems : electricItems;
+    const bikeRecords = recordsByBike.get(bikeId) ?? [];
+    // 다음 단계에선 servicedAt desc 정렬 가정 — recordsByBike push 순서가
+    // 백엔드 응답(이미 정렬됨) 그대로라 별도 정렬 안 함.
+    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, now);
+    let overall: MaintenanceStatus = "UNKNOWN";
+    let hasOverdue = false;
+    let hasDueSoon = false;
+    for (const row of rows) {
+      if (row.status === "OVERDUE") hasOverdue = true;
+      if (row.status === "DUE_SOON") hasDueSoon = true;
+      if (STATUS_PRIORITY[row.status] > STATUS_PRIORITY[overall]) {
+        overall = row.status;
+      }
+    }
+    result.set(bikeId, { hasOverdue, hasDueSoon, overallStatus: overall });
+  }
+  return result;
+}
+
 function nextDueAtFromCycle(lastServicedAt: string | null, cycleMonths: number | null): string | null {
   if (cycleMonths === null) return null;
   const base = lastServicedAt ? new Date(lastServicedAt) : null;

--- a/development/front-admin-web/components/overview/OverviewClientShell.tsx
+++ b/development/front-admin-web/components/overview/OverviewClientShell.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { VehicleFilterProvider } from "@/components/overview/VehicleFilterContext";
+
+/**
+ * 루트 페이지의 client-state 외각. server-render 된 children (KPI / 지도 /
+ * 탭 / 패널들) 을 그대로 받되 그 안의 client 컴포넌트들 (`OverviewMapBanner`,
+ * `VehiclesPanel`) 이 공유해야 할 state (`VehicleFilterContext`) 를 한 번만
+ * 마운트해 둔다.
+ *
+ * 이 컴포넌트 자체는 UI 를 그리지 않음 — 순수 provider 래퍼. 다른 page-level
+ * client state(예: 향후 floating 상세 패널 활성 차량 id) 가 추가되면 여기에
+ * 같이 마운트.
+ */
+export function OverviewClientShell({ children }: { children: ReactNode }) {
+  return <VehicleFilterProvider>{children}</VehicleFilterProvider>;
+}

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
+import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type {
   FrontendDashboardBikePin,
   FrontendDashboardStationPin
@@ -19,6 +20,11 @@ import type {
  *
  * 토글 OFF 상태에선 MapShell 을 mount 하지 않아 NCP 지도 SDK 세션이 생기지
  * 않는다 — 운영자가 지도가 필요 없을 때까지 API 미터를 잡지 않도록.
+ *
+ * 차량 탭 활성 + 필터 적용 상태에선 `VehicleFilterContext` 가 `filteredBikeIds`
+ * 를 넘겨 그 부분 집합만 마커로 노출한다. 다른 탭(라이더/BSS)에 가면
+ * VehiclesPanel 이 언마운트되며 context 가 null 로 되돌아가 전체 차량 핀이
+ * 다시 보인다.
  */
 export function OverviewMapBanner({
   bikePins,
@@ -28,6 +34,17 @@ export function OverviewMapBanner({
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
 }) {
   const [open, setOpen] = useState(false);
+  const { filteredBikeIds } = useVehicleFilter();
+
+  const effectiveBikePins = useMemo(() => {
+    if (filteredBikeIds === null) return bikePins;
+    return bikePins.filter((pin) => filteredBikeIds.has(pin.bikeId));
+  }, [bikePins, filteredBikeIds]);
+
+  const totalLabel =
+    filteredBikeIds === null
+      ? `${bikePins.length}대 차량`
+      : `${effectiveBikePins.length} / ${bikePins.length}대 차량 (필터)`;
 
   return (
     <section className="overview-map-section" aria-label="지도 보기">
@@ -41,12 +58,12 @@ export function OverviewMapBanner({
           <span>지도 보기</span>
         </label>
         <span className="overview-map-toggle-hint">
-          {bikePins.length}대 차량 · {stationPins.length}개 BSS
+          {totalLabel} · {stationPins.length}개 BSS
         </span>
       </div>
       {open ? (
         <div className="overview-map-canvas">
-          <MapShell bikePins={[...bikePins]} stationPins={[...stationPins]} />
+          <MapShell bikePins={[...effectiveBikePins]} stationPins={[...stationPins]} />
         </div>
       ) : null}
     </section>

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
@@ -10,21 +10,18 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * 루트 페이지(`/`) 상단에 박히는 글로벌 "지도 보기" 토글 + 지도. 차량 /
- * 라이더 / BSS 탭과 독립적으로 켰다 끌 수 있고, 켜면 차량 마커 + BSS 마커를
- * 한 지도에 띄운다.
- *
- * 탭 전환은 Next.js Link 로 같은 라우트의 query string 만 바꾸므로 이 client
- * 컴포넌트는 mount 가 유지되어 토글 상태도 보존된다. (탭마다 매번 다시
- * 켜야 하는 불편 없음.)
+ * 루트 페이지(`/`) 상단에 박히는 글로벌 "지도 보기" 토글 + 지도.
  *
  * 토글 OFF 상태에선 MapShell 을 mount 하지 않아 NCP 지도 SDK 세션이 생기지
  * 않는다 — 운영자가 지도가 필요 없을 때까지 API 미터를 잡지 않도록.
  *
- * 차량 탭 활성 + 필터 적용 상태에선 `VehicleFilterContext` 가 `filteredBikeIds`
- * 를 넘겨 그 부분 집합만 마커로 노출한다. 다른 탭(라이더/BSS)에 가면
- * VehiclesPanel 이 언마운트되며 context 가 null 로 되돌아가 전체 차량 핀이
- * 다시 보인다.
+ * 차량 탭 활성 + 필터 적용 상태에선 `VehicleFilterContext` 의
+ * `filteredBikeIds` 로 부분 집합만 마커로 노출. 다른 탭에선 VehiclesPanel 이
+ * 언마운트되며 context 가 null 로 되돌아가 전체 핀 복귀.
+ *
+ * 차량 행 클릭 시(VehiclesPanel 이 `selectedBikeId` 를 context 에 publish)
+ * 지도가 자동으로 열리고 그 차량 위치로 pan. 이미 열려 있으면 pan 만. 운영자
+ * 가 토글로 다시 끄기 전까지 자동으로 닫지 않는다.
  */
 export function OverviewMapBanner({
   bikePins,
@@ -34,12 +31,38 @@ export function OverviewMapBanner({
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
 }) {
   const [open, setOpen] = useState(false);
-  const { filteredBikeIds } = useVehicleFilter();
+  const { filteredBikeIds, selectedBikeId } = useVehicleFilter();
 
   const effectiveBikePins = useMemo(() => {
     if (filteredBikeIds === null) return bikePins;
     return bikePins.filter((pin) => filteredBikeIds.has(pin.bikeId));
   }, [bikePins, filteredBikeIds]);
+
+  const bikePinById = useMemo(() => {
+    const map = new Map<string, FrontendDashboardBikePin>();
+    for (const pin of bikePins) map.set(pin.bikeId, pin);
+    return map;
+  }, [bikePins]);
+
+  // 행 클릭 시 자동으로 토글 ON. setState in effect 는 rAF 한 프레임 양보로
+  // 회피 — 같은 commit 안에서 동기 호출하면 lint(`react-hooks/set-state-in-
+  // effect`) 가 잡는다.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (selectedBikeId && !open) {
+      const handle = window.requestAnimationFrame(() => setOpen(true));
+      return () => window.cancelAnimationFrame(handle);
+    }
+  }, [selectedBikeId, open]);
+
+  // 선택 차량의 위치로 pan. 객체 identity 가 매번 새로 생성되어 MapShell 의
+  // targetLocation effect 가 재발화 (같은 차량을 두 번 골라도 다시 panning).
+  const targetLocation = useMemo(() => {
+    if (!selectedBikeId) return null;
+    const pin = bikePinById.get(selectedBikeId);
+    if (!pin) return null;
+    return { lat: pin.latitude, lng: pin.longitude };
+  }, [selectedBikeId, bikePinById]);
 
   const totalLabel =
     filteredBikeIds === null
@@ -63,7 +86,11 @@ export function OverviewMapBanner({
       </div>
       {open ? (
         <div className="overview-map-canvas">
-          <MapShell bikePins={[...effectiveBikePins]} stationPins={[...stationPins]} />
+          <MapShell
+            bikePins={[...effectiveBikePins]}
+            stationPins={[...stationPins]}
+            targetLocation={targetLocation}
+          />
         </div>
       ) : null}
     </section>

--- a/development/front-admin-web/components/overview/VehicleFilterContext.tsx
+++ b/development/front-admin-web/components/overview/VehicleFilterContext.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+/**
+ * 차량 탭 필터가 적용되었을 때 지도가 그 부분 집합만 마커로 띄울 수 있도록
+ * 두 client 컴포넌트(VehiclesPanel ↔ OverviewMapBanner) 사이의 공유 채널.
+ *
+ * `filteredBikeIds === null` 은 "필터 미적용 / 차량 탭 외 다른 탭 활성"을
+ * 의미 — 지도는 전체 차량 핀을 그대로 노출한다. Set 이면 그 집합에 속한
+ * 차량 핀만 노출.
+ *
+ * Provider 는 page 의 최상단 (`OverviewClientShell`) 에서 한 번만 마운트되어
+ * 모든 탭 컨텐츠가 같은 인스턴스를 본다. VehiclesPanel 이 마운트되었을 때만
+ * 값을 쓰고, 언마운트 시(탭 전환) cleanup 으로 null 로 되돌려 다른 탭에서
+ * 의도치 않은 필터가 살아 있는 사태를 막는다.
+ */
+type FilterContextValue = {
+  filteredBikeIds: ReadonlySet<string> | null;
+  setFilteredBikeIds: (ids: ReadonlySet<string> | null) => void;
+};
+
+const VehicleFilterContext = createContext<FilterContextValue | null>(null);
+
+export function VehicleFilterProvider({ children }: { children: ReactNode }) {
+  const [filteredBikeIds, setRaw] = useState<ReadonlySet<string> | null>(null);
+  const setFilteredBikeIds = useCallback((ids: ReadonlySet<string> | null) => {
+    setRaw(ids);
+  }, []);
+  const value = useMemo<FilterContextValue>(
+    () => ({ filteredBikeIds, setFilteredBikeIds }),
+    [filteredBikeIds, setFilteredBikeIds]
+  );
+  return <VehicleFilterContext.Provider value={value}>{children}</VehicleFilterContext.Provider>;
+}
+
+/**
+ * Context 가 없는 환경(테스트, Storybook 등) 에서도 안전하게 호출되도록 noop
+ * fallback 을 반환. 실제 page 트리에선 항상 provider 가 위에 있다.
+ */
+export function useVehicleFilter(): FilterContextValue {
+  const ctx = useContext(VehicleFilterContext);
+  if (!ctx) {
+    return { filteredBikeIds: null, setFilteredBikeIds: () => {} };
+  }
+  return ctx;
+}

--- a/development/front-admin-web/components/overview/VehicleFilterContext.tsx
+++ b/development/front-admin-web/components/overview/VehicleFilterContext.tsx
@@ -3,33 +3,40 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 /**
- * 차량 탭 필터가 적용되었을 때 지도가 그 부분 집합만 마커로 띄울 수 있도록
- * 두 client 컴포넌트(VehiclesPanel ↔ OverviewMapBanner) 사이의 공유 채널.
+ * 차량 탭과 지도가 공유하는 두 가지 채널:
  *
- * `filteredBikeIds === null` 은 "필터 미적용 / 차량 탭 외 다른 탭 활성"을
- * 의미 — 지도는 전체 차량 핀을 그대로 노출한다. Set 이면 그 집합에 속한
- * 차량 핀만 노출.
+ * 1. **필터 동기화** — `filteredBikeIds === null` 이면 필터 미적용(전체 핀
+ *    노출), Set 이면 그 부분 집합만 마커로. VehiclesPanel 이 publish, Map
+ *    Banner 가 consume.
  *
- * Provider 는 page 의 최상단 (`OverviewClientShell`) 에서 한 번만 마운트되어
- * 모든 탭 컨텐츠가 같은 인스턴스를 본다. VehiclesPanel 이 마운트되었을 때만
- * 값을 쓰고, 언마운트 시(탭 전환) cleanup 으로 null 로 되돌려 다른 탭에서
- * 의도치 않은 필터가 살아 있는 사태를 막는다.
+ * 2. **선택 차량 동기화** — `selectedBikeId` 가 있으면 지도가 자동으로 켜지고
+ *    그 차량의 위치로 pan. 행 클릭이 modal 모달 대신 지도 위 floating panel
+ *    을 띄우는 채널이기도 하다.
+ *
+ * Provider 는 page 의 client subtree 를 한 번만 감싸는 `OverviewClientShell`
+ * 에서 마운트되어 모든 탭 컨텐츠가 같은 인스턴스를 본다.
  */
 type FilterContextValue = {
   filteredBikeIds: ReadonlySet<string> | null;
   setFilteredBikeIds: (ids: ReadonlySet<string> | null) => void;
+  selectedBikeId: string | null;
+  setSelectedBikeId: (id: string | null) => void;
 };
 
 const VehicleFilterContext = createContext<FilterContextValue | null>(null);
 
 export function VehicleFilterProvider({ children }: { children: ReactNode }) {
-  const [filteredBikeIds, setRaw] = useState<ReadonlySet<string> | null>(null);
+  const [filteredBikeIds, setFilteredRaw] = useState<ReadonlySet<string> | null>(null);
+  const [selectedBikeId, setSelectedRaw] = useState<string | null>(null);
   const setFilteredBikeIds = useCallback((ids: ReadonlySet<string> | null) => {
-    setRaw(ids);
+    setFilteredRaw(ids);
+  }, []);
+  const setSelectedBikeId = useCallback((id: string | null) => {
+    setSelectedRaw(id);
   }, []);
   const value = useMemo<FilterContextValue>(
-    () => ({ filteredBikeIds, setFilteredBikeIds }),
-    [filteredBikeIds, setFilteredBikeIds]
+    () => ({ filteredBikeIds, setFilteredBikeIds, selectedBikeId, setSelectedBikeId }),
+    [filteredBikeIds, setFilteredBikeIds, selectedBikeId, setSelectedBikeId]
   );
   return <VehicleFilterContext.Provider value={value}>{children}</VehicleFilterContext.Provider>;
 }
@@ -41,7 +48,12 @@ export function VehicleFilterProvider({ children }: { children: ReactNode }) {
 export function useVehicleFilter(): FilterContextValue {
   const ctx = useContext(VehicleFilterContext);
   if (!ctx) {
-    return { filteredBikeIds: null, setFilteredBikeIds: () => {} };
+    return {
+      filteredBikeIds: null,
+      setFilteredBikeIds: () => {},
+      selectedBikeId: null,
+      setSelectedBikeId: () => {}
+    };
   }
   return ctx;
 }

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -120,12 +120,20 @@ export type RiderEducationRecordUpdateInput = {
 
 export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE";
 
+/**
+ * 차량 동력 종류. 정비 카탈로그 매칭과 운영자 필터의 1차 분류 키. backend
+ * V21 마이그레이션으로 도입 — 기존 차량은 모두 `ELECTRIC` 으로 default.
+ */
+export type ServiceOpsBikeEngineType = "ELECTRIC" | "ICE";
+
 export type ServiceOpsBike = {
   id: string;
   idx: number | null;
   plateNumber: string;
   vin: string;
   modelName: string | null;
+  /** Backend V21 부터 응답에 포함. 옛 backend 호환 위해 optional. */
+  engineType?: ServiceOpsBikeEngineType;
   operationStatus: ServiceOpsBikeOperationStatus;
   /** "시동 방지" 플래그. 라이더 상세 다이얼로그의 토글이 이 값을 PATCH 한다. */
   ignitionBlocked?: boolean;
@@ -145,6 +153,8 @@ export type FrontendVehicle = {
   plateNumber: string;
   vin?: string | null;
   model: string;
+  /** 정비 카탈로그 매칭에 쓰이는 동력 종류. 옛 backend 호환 위해 optional. */
+  engineType?: ServiceOpsBikeEngineType;
   status: "운행" | "대기";
   operationStatus?: ServiceOpsBikeOperationStatus;
   /** 시동 방지 토글의 현재 상태. 백엔드가 응답에 포함; 없으면 false 로 간주. */
@@ -164,6 +174,8 @@ export type VehicleCreateInput = {
   plateNumber: string;
   vin?: string | null;
   modelName?: string | null;
+  /** 미지정 시 backend 가 ELECTRIC 으로 기본값 (V21). */
+  engineType?: ServiceOpsBikeEngineType;
   operationStatus: ServiceOpsBikeOperationStatus;
   memo?: string | null;
 };
@@ -1314,6 +1326,7 @@ export function toFrontendVehicle(bike: ServiceOpsBike): FrontendVehicle {
     plateNumber: bike.plateNumber,
     vin: bike.vin,
     model: normalizeDisplayText(bike.modelName, "모델 미지정"),
+    engineType: bike.engineType,
     status: toFrontendVehicleStatus(bike.operationStatus),
     operationStatus: bike.operationStatus,
     ignitionBlocked: bike.ignitionBlocked ?? false,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -202,6 +202,45 @@ export type ServiceOpsBikeOperationStatusHistory = {
   updatedAt: string;
 };
 
+// === 정비 도메인 (V22 backend 슬라이스) ===
+
+export type ServiceOpsMaintenanceAppliesTo = "ELECTRIC" | "ICE" | "BOTH";
+
+export type ServiceOpsMaintenanceItem = {
+  id: string;
+  idx: number | null;
+  name: string;
+  appliesTo: ServiceOpsMaintenanceAppliesTo;
+  parentItemId: string | null;
+  cycleKm: number | null;
+  cycleMonths: number | null;
+  cycleLabel: string | null;
+  displayOrder: number;
+  enabled: boolean;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ServiceOpsVehicleMaintenanceRecord = {
+  id: string;
+  idx: number | null;
+  bikeId: string;
+  itemId: string;
+  servicedAt: string;
+  servicedAtOdometerKm: number | null;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MaintenanceRecordCreateInput = {
+  itemId: string;
+  servicedAt?: string | null;
+  servicedAtOdometerKm?: number | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsContractCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
 export type ServiceOpsContractReturnType = "TAKEOVER" | "RETURN";
 export type ServiceOpsContractDurationUnit =
@@ -845,6 +884,12 @@ export type ServiceOpsApiClient = {
   getBikeDeviceInstallation: (id: string) => Promise<ServiceOpsBikeDeviceInstallation>;
   createBikeDeviceInstallation: (request: BikeDeviceInstallationCreateInput) => Promise<ServiceOpsBikeDeviceInstallation>;
   removeBikeDeviceInstallation: (id: string, request: BikeDeviceInstallationRemoveInput) => Promise<ServiceOpsBikeDeviceInstallation>;
+  /** 차량 단위 적용 가능 정비 항목 — backend 가 engineType + BOTH 매칭으로 필터링. */
+  listMaintenanceItemsForBike: (bikeId: string) => Promise<ServiceOpsMaintenanceItem[]>;
+  /** 한 차량의 정비 이벤트 로그 (최신순). */
+  listMaintenanceRecordsForBike: (bikeId: string) => Promise<ServiceOpsVehicleMaintenanceRecord[]>;
+  /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
+  createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -1226,6 +1271,23 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify(removeRequest),
         method: "PATCH"
       }),
+    // 정비 카탈로그 / 이력 — backend V22 슬라이스. 페이지 단위가 아니라 차량
+    // 단위 list endpoint 라 그대로 array 응답.
+    listMaintenanceItemsForBike: (bikeId) =>
+      request<ServiceOpsMaintenanceItem[]>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-items`,
+        { method: "GET" }
+      ),
+    listMaintenanceRecordsForBike: (bikeId) =>
+      request<ServiceOpsVehicleMaintenanceRecord[]>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
+        { method: "GET" }
+      ),
+    createMaintenanceRecord: (bikeId, createRequest) =>
+      request<ServiceOpsVehicleMaintenanceRecord>(
+        `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
+        { body: JSON.stringify(createRequest), method: "POST" }
+      ),
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -886,8 +886,12 @@ export type ServiceOpsApiClient = {
   removeBikeDeviceInstallation: (id: string, request: BikeDeviceInstallationRemoveInput) => Promise<ServiceOpsBikeDeviceInstallation>;
   /** 차량 단위 적용 가능 정비 항목 — backend 가 engineType + BOTH 매칭으로 필터링. */
   listMaintenanceItemsForBike: (bikeId: string) => Promise<ServiceOpsMaintenanceItem[]>;
+  /** 전체 카탈로그 (페이지) — 차량 탭 정비 상태 필터가 모든 품목을 한 번에 받기 위해. */
+  listMaintenanceItems: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsMaintenanceItem>>;
   /** 한 차량의 정비 이벤트 로그 (최신순). */
   listMaintenanceRecordsForBike: (bikeId: string) => Promise<ServiceOpsVehicleMaintenanceRecord[]>;
+  /** 전체 차량의 정비 이력 (페이지) — 차량 탭 정비 상태 필터 용. */
+  listMaintenanceRecords: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>;
   /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
   createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
@@ -1278,10 +1282,22 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-items`,
         { method: "GET" }
       ),
+    listMaintenanceItems: ({ page = 0, size = 200, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsMaintenanceItem>>(
+        "/maintenance-items",
+        { method: "GET" },
+        { page, size, sort }
+      ),
     listMaintenanceRecordsForBike: (bikeId) =>
       request<ServiceOpsVehicleMaintenanceRecord[]>(
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
         { method: "GET" }
+      ),
+    listMaintenanceRecords: ({ page = 0, size = 500, sort } = {}) =>
+      request<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>(
+        "/maintenance-records",
+        { method: "GET" },
+        { page, size, sort }
       ),
     createMaintenanceRecord: (bikeId, createRequest) =>
       request<ServiceOpsVehicleMaintenanceRecord>(

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -241,6 +241,29 @@ export type MaintenanceRecordCreateInput = {
   memo?: string | null;
 };
 
+export type MaintenanceItemCreateInput = {
+  name: string;
+  appliesTo: ServiceOpsMaintenanceAppliesTo;
+  parentItemId?: string | null;
+  cycleKm?: number | null;
+  cycleMonths?: number | null;
+  cycleLabel?: string | null;
+  displayOrder?: number | null;
+  memo?: string | null;
+};
+
+export type MaintenanceItemUpdateInput = {
+  name?: string | null;
+  appliesTo?: ServiceOpsMaintenanceAppliesTo | null;
+  parentItemId?: string | null;
+  cycleKm?: number | null;
+  cycleMonths?: number | null;
+  cycleLabel?: string | null;
+  displayOrder?: number | null;
+  enabled?: boolean | null;
+  memo?: string | null;
+};
+
 export type ServiceOpsContractCategory = "SUBSCRIPTION" | "RENTAL" | "CUSTOM";
 export type ServiceOpsContractReturnType = "TAKEOVER" | "RETURN";
 export type ServiceOpsContractDurationUnit =
@@ -894,6 +917,12 @@ export type ServiceOpsApiClient = {
   listMaintenanceRecords: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<ServiceOpsVehicleMaintenanceRecord>>;
   /** "교환 완료" 마킹 — bike 별 정비 이력에 한 건 추가. */
   createMaintenanceRecord: (bikeId: string, request: MaintenanceRecordCreateInput) => Promise<ServiceOpsVehicleMaintenanceRecord>;
+  /** 정비 카탈로그 편집 — 신규 품목 추가. */
+  createMaintenanceItem: (request: MaintenanceItemCreateInput) => Promise<ServiceOpsMaintenanceItem>;
+  /** 정비 카탈로그 편집 — 품목 partial update. */
+  updateMaintenanceItem: (id: string, request: MaintenanceItemUpdateInput) => Promise<ServiceOpsMaintenanceItem>;
+  /** 정비 카탈로그 편집 — soft delete. */
+  deleteMaintenanceItem: (id: string) => Promise<void>;
   listRiders: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendRider>>;
   getRider: (id: string) => Promise<FrontendRider>;
   createRider: (request: RiderCreateInput) => Promise<FrontendRider>;
@@ -1304,6 +1333,19 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/bikes/${encodeURIComponent(bikeId)}/maintenance-records`,
         { body: JSON.stringify(createRequest), method: "POST" }
       ),
+    createMaintenanceItem: (createRequest) =>
+      request<ServiceOpsMaintenanceItem>(
+        "/maintenance-items",
+        { body: JSON.stringify(createRequest), method: "POST" }
+      ),
+    updateMaintenanceItem: (id, updateRequest) =>
+      request<ServiceOpsMaintenanceItem>(
+        `/maintenance-items/${encodeURIComponent(id)}`,
+        { body: JSON.stringify(updateRequest), method: "PATCH" }
+      ),
+    deleteMaintenanceItem: async (id) => {
+      await request<void>(`/maintenance-items/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
     listRiders: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsRider>>("/riders", { method: "GET" }, { page, size, sort });
       return {

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -21,6 +21,37 @@ export type VehicleMaintenanceBundle = {
 
 const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
 
+/**
+ * 차량 탭의 "정비 상태" 필터가 차량 별로 임박/지연 여부를 derive 할 때 쓰는
+ * 전체 dataset. catalog 전체 + 모든 차량의 정비 이력을 한 번에 받아오는 두
+ * 페이지 요청.
+ *
+ * MVP 규모(< 200 차량 × ~10 품목)에서 페이지 size 200/500 한 번이면 충분.
+ * 데이터가 더 커지면 size 늘리거나 서버 쪽에 차량 별 latest-record-per-item
+ * 집계 endpoint 를 추가.
+ */
+export type MaintenanceDatasetResult = {
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+};
+
+const EMPTY_DATASET: MaintenanceDatasetResult = { items: [], records: [] };
+
+export async function loadMaintenanceDataset(): Promise<MaintenanceDatasetResult> {
+  if (!serviceOpsApiConfigured()) return EMPTY_DATASET;
+  const client = await createAuthenticatedServiceOpsApiClient();
+  if (!client) return EMPTY_DATASET;
+  try {
+    const [itemsPage, recordsPage] = await Promise.all([
+      client.listMaintenanceItems({ page: 0, size: 200 }),
+      client.listMaintenanceRecords({ page: 0, size: 500 })
+    ]);
+    return { items: itemsPage.items, records: recordsPage.items };
+  } catch {
+    return EMPTY_DATASET;
+  }
+}
+
 export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<VehicleMaintenanceBundle> {
   if (!serviceOpsApiConfigured()) return EMPTY_BUNDLE;
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -1,0 +1,40 @@
+import {
+  createAuthenticatedServiceOpsApiClient
+} from "@/lib/services/service-ops-session";
+import {
+  serviceOpsApiConfigured,
+  type ServiceOpsMaintenanceItem,
+  type ServiceOpsVehicleMaintenanceRecord
+} from "@/lib/services/service-ops-api";
+
+/**
+ * 차량 상세 floating panel 의 "정비 상태" 섹션이 lazy-fetch 하는 두 list 의
+ * 결합 응답. 한 round-trip 으로 catalog + history 를 같이 받아 클라이언트가
+ * 두 번 fetch 하지 않게 한다.
+ *
+ * 미설정 / 미인증 환경에선 둘 다 빈 배열로 — UI 는 "데이터 없음" 으로 fallback.
+ */
+export type VehicleMaintenanceBundle = {
+  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
+  records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+};
+
+const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
+
+export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<VehicleMaintenanceBundle> {
+  if (!serviceOpsApiConfigured()) return EMPTY_BUNDLE;
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return EMPTY_BUNDLE;
+
+  try {
+    const [items, records] = await Promise.all([
+      client.listMaintenanceItemsForBike(bikeId),
+      client.listMaintenanceRecordsForBike(bikeId)
+    ]);
+    return { items, records };
+  } catch {
+    // 조회 실패는 운영자 화면을 깨뜨리지 않게 빈 bundle. console.error 는 backend
+    // log 가 잡고, 클라이언트엔 "정비 데이터 불러오기 실패" UI 가 추후 필요.
+    return EMPTY_BUNDLE;
+  }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -20,6 +20,15 @@ public class Bike extends DisplaySequencedEntity {
     @Column(length = 100)
     private String modelName;
 
+    /**
+     * 동력 종류 — 정비 catalog 매칭과 운영자 필터의 1차 분류 키. 자유
+     * 텍스트인 modelName 과 별도로 enum 으로 박아 분기 비용을 줄인다. 기존
+     * 행은 V21 마이그레이션에서 ELECTRIC 으로 기본값 잡힘.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "engine_type", nullable = false, length = 20)
+    private BikeEngineType engineType;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 40)
     private BikeOperationStatus operationStatus;
@@ -38,6 +47,7 @@ public class Bike extends DisplaySequencedEntity {
             String plateNumber,
             String vin,
             String modelName,
+            BikeEngineType engineType,
             BikeOperationStatus operationStatus,
             String memo
     ) {
@@ -45,6 +55,7 @@ public class Bike extends DisplaySequencedEntity {
         bike.plateNumber = plateNumber;
         bike.vin = vin;
         bike.modelName = modelName;
+        bike.engineType = engineType;
         bike.operationStatus = operationStatus;
         bike.memo = memo;
         return bike;
@@ -54,6 +65,7 @@ public class Bike extends DisplaySequencedEntity {
             String plateNumber,
             String vin,
             String modelName,
+            BikeEngineType engineType,
             String memo
     ) {
         if (plateNumber != null) {
@@ -64,6 +76,9 @@ public class Bike extends DisplaySequencedEntity {
         }
         if (modelName != null) {
             this.modelName = modelName;
+        }
+        if (engineType != null) {
+            this.engineType = engineType;
         }
         if (memo != null) {
             this.memo = memo;
@@ -89,6 +104,10 @@ public class Bike extends DisplaySequencedEntity {
 
     public String getModelName() {
         return modelName;
+    }
+
+    public BikeEngineType getEngineType() {
+        return engineType;
     }
 
     public BikeOperationStatus getOperationStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeEngineType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeEngineType.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.bike.domain;
+
+/**
+ * 차량의 동력 종류. 정비 스케줄 catalog 매칭, 필터, KPI 분류의 기준 축이 되는
+ * 차량 단위의 단순 분류. 모델명(`Bike.modelName`)은 자유 텍스트 메모로 유지하고
+ * 이 enum 이 도메인 분기의 1차 키 역할.
+ */
+public enum BikeEngineType {
+    /** 전기 이륜차. */
+    ELECTRIC,
+    /** 내연기관 이륜차. */
+    ICE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,12 @@ public record BikeCreateRequest(
         /** Optional at register time — operator updates later via the bike edit flow. */
         @Size(max = 100) String vin,
         @Size(max = 100) String modelName,
+        /**
+         * 동력 종류. null 이면 서비스 측에서 ELECTRIC 으로 기본값 잡음 — 현재
+         * 운영 차량이 모두 전기 이륜차라는 도메인 가정과 일치. ICE 차량은
+         * 운영자가 명시적으로 ICE 를 골라야 등록된다.
+         */
+        BikeEngineType engineType,
         @NotNull BikeOperationStatus operationStatus,
         String memo
 ) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,6 +12,7 @@ public record BikeReadResponse(
         String plateNumber,
         String vin,
         String modelName,
+        BikeEngineType engineType,
         BikeOperationStatus operationStatus,
         boolean ignitionBlocked,
         String memo,
@@ -24,6 +26,7 @@ public record BikeReadResponse(
                 bike.getPlateNumber(),
                 bike.getVin(),
                 bike.getModelName(),
+                bike.getEngineType(),
                 bike.getOperationStatus(),
                 bike.isIgnitionBlocked(),
                 bike.getMemo(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +10,8 @@ public record BikeUpdateRequest(
         @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String plateNumber,
         @Size(max = 100) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String vin,
         @Size(max = 100) String modelName,
+        /** null 이면 변경 안 함 (다른 필드와 동일한 partial-update 규약). */
+        BikeEngineType engineType,
         String memo
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.bike.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
 import com.thundercrew.opsapi.bike.dto.BikeCreateRequest;
 import com.thundercrew.opsapi.bike.dto.BikeOperationStatusChangeRequest;
@@ -47,10 +48,16 @@ public class BikeCommandService {
         if (vin != null) {
             assertVinIsNotDuplicated(vin);
         }
+        // engineType 미지정 시 ELECTRIC 으로 기본값 — 현재 운영 차종이 모두
+        // 전기 이륜차라는 도메인 가정과 일치. ICE 는 명시적으로 골라야 등록.
+        BikeEngineType engineType = request.engineType() != null
+                ? request.engineType()
+                : BikeEngineType.ELECTRIC;
         Bike bike = Bike.create(
                 request.plateNumber(),
                 vin,
                 request.modelName(),
+                engineType,
                 request.operationStatus(),
                 request.memo()
         );
@@ -89,6 +96,7 @@ public class BikeCommandService {
                     request.plateNumber(),
                     request.vin(),
                     request.modelName(),
+                    request.engineType(),
                     request.memo()
             );
             entityManager.flush();

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceCommandController.java
@@ -1,0 +1,68 @@
+package com.thundercrew.opsapi.maintenance.controller;
+
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemUpdateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.service.MaintenanceCommandService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MaintenanceCommandController {
+
+    private final MaintenanceCommandService maintenanceCommandService;
+
+    public MaintenanceCommandController(MaintenanceCommandService maintenanceCommandService) {
+        this.maintenanceCommandService = maintenanceCommandService;
+    }
+
+    @PostMapping("/api/v1/maintenance-items")
+    ResponseEntity<MaintenanceItemReadResponse> createItem(
+            @Valid @RequestBody MaintenanceItemCreateRequest request
+    ) {
+        MaintenanceItemReadResponse response = maintenanceCommandService.createItem(request);
+        return ResponseEntity.created(URI.create("/api/v1/maintenance-items/" + response.id()))
+                .body(response);
+    }
+
+    @PatchMapping("/api/v1/maintenance-items/{id}")
+    MaintenanceItemReadResponse updateItem(
+            @PathVariable UUID id,
+            @Valid @RequestBody MaintenanceItemUpdateRequest request
+    ) {
+        return maintenanceCommandService.updateItem(id, request);
+    }
+
+    @DeleteMapping("/api/v1/maintenance-items/{id}")
+    ResponseEntity<Void> deleteItem(@PathVariable UUID id) {
+        maintenanceCommandService.softDeleteItem(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/api/v1/bikes/{bikeId}/maintenance-records")
+    ResponseEntity<VehicleMaintenanceRecordReadResponse> createRecord(
+            @PathVariable UUID bikeId,
+            @Valid @RequestBody VehicleMaintenanceRecordCreateRequest request
+    ) {
+        VehicleMaintenanceRecordReadResponse response = maintenanceCommandService.createRecord(bikeId, request);
+        return ResponseEntity.created(URI.create(
+                "/api/v1/bikes/" + bikeId + "/maintenance-records/" + response.id()
+        )).body(response);
+    }
+
+    @DeleteMapping("/api/v1/maintenance-records/{id}")
+    ResponseEntity<Void> deleteRecord(@PathVariable UUID id) {
+        maintenanceCommandService.softDeleteRecord(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
@@ -1,0 +1,49 @@
+package com.thundercrew.opsapi.maintenance.controller;
+
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.service.MaintenanceReadService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MaintenanceReadController {
+
+    private final MaintenanceReadService maintenanceReadService;
+
+    public MaintenanceReadController(MaintenanceReadService maintenanceReadService) {
+        this.maintenanceReadService = maintenanceReadService;
+    }
+
+    /** 전체 카탈로그 — 카탈로그 편집 화면이 두 표(전기/내연)를 모두 받아 그룹핑. */
+    @GetMapping("/api/v1/maintenance-items")
+    PageResponse<MaintenanceItemReadResponse> listItems(
+            @PageableDefault(size = 100, sort = "idx", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        return maintenanceReadService.listItems(pageable);
+    }
+
+    @GetMapping("/api/v1/maintenance-items/{id}")
+    MaintenanceItemReadResponse getItem(@PathVariable UUID id) {
+        return maintenanceReadService.getItem(id);
+    }
+
+    /** 특정 차량에 적용 가능한 카탈로그 — engineType 필터링이 서비스 측에 위치. */
+    @GetMapping("/api/v1/bikes/{bikeId}/maintenance-items")
+    List<MaintenanceItemReadResponse> listItemsForBike(@PathVariable UUID bikeId) {
+        return maintenanceReadService.listItemsForBike(bikeId);
+    }
+
+    /** 차량 정비 이력 (최신순). 차량 상세 다이얼로그가 품목별 마지막 교환을 derive. */
+    @GetMapping("/api/v1/bikes/{bikeId}/maintenance-records")
+    List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(@PathVariable UUID bikeId) {
+        return maintenanceReadService.listRecordsForBike(bikeId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/controller/MaintenanceReadController.java
@@ -46,4 +46,12 @@ public class MaintenanceReadController {
     List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(@PathVariable UUID bikeId) {
         return maintenanceReadService.listRecordsForBike(bikeId);
     }
+
+    /** 전체 차량의 정비 이력 — 차량 탭 정비 상태 필터 용 (대량 페이지). */
+    @GetMapping("/api/v1/maintenance-records")
+    PageResponse<VehicleMaintenanceRecordReadResponse> listRecords(
+            @PageableDefault(size = 500, sort = "idx", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return maintenanceReadService.listRecords(pageable);
+    }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceAppliesTo.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceAppliesTo.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+/**
+ * 정비 품목이 어떤 차종에 적용되는지. `BikeEngineType` 과 평행하지만 "둘 다"
+ * 를 표현해야 해서 별도 enum.
+ *
+ * 차량별 카탈로그 조회 시: ELECTRIC 차량은 `ELECTRIC` + `BOTH` 를 합쳐서,
+ * ICE 차량은 `ICE` + `BOTH` 를 합쳐서 노출한다.
+ */
+public enum MaintenanceAppliesTo {
+    ELECTRIC,
+    ICE,
+    BOTH
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
@@ -1,0 +1,150 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+/**
+ * 정비 품목 카탈로그 row. "엔진오일", "브레이크 패드(앞)" 같은 한 줄에 해당한다.
+ *
+ * 그룹(예: 구동계3종) 표현은 `parentItemId` 셀프-FK 로. 부모 자체는 cycle 이
+ * 없고, 자식들이 각각 cycle 을 보유한다. UI 는 부모를 카드 헤더로 묶고 자식
+ * 세 개를 그 안에 펼친다.
+ *
+ * 단위 혼재: km / 개월 / 자유 텍스트 셋이 동시 보유 가능. UI 우선순위는
+ * 자유 텍스트(cycle_label) → km → 개월 순으로 표시.
+ */
+@Entity
+@Table(name = "maintenance_items")
+public class MaintenanceItem extends DisplaySequencedEntity {
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "applies_to", nullable = false, length = 20)
+    private MaintenanceAppliesTo appliesTo;
+
+    @Column(name = "parent_item_id")
+    private UUID parentItemId;
+
+    @Column(name = "cycle_km")
+    private Integer cycleKm;
+
+    @Column(name = "cycle_months")
+    private Integer cycleMonths;
+
+    @Column(name = "cycle_label", length = 50)
+    private String cycleLabel;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column
+    private String memo;
+
+    public static MaintenanceItem create(
+            String name,
+            MaintenanceAppliesTo appliesTo,
+            UUID parentItemId,
+            Integer cycleKm,
+            Integer cycleMonths,
+            String cycleLabel,
+            int displayOrder,
+            String memo
+    ) {
+        MaintenanceItem item = new MaintenanceItem();
+        item.name = name;
+        item.appliesTo = appliesTo;
+        item.parentItemId = parentItemId;
+        item.cycleKm = cycleKm;
+        item.cycleMonths = cycleMonths;
+        item.cycleLabel = cycleLabel;
+        item.displayOrder = displayOrder;
+        item.enabled = true;
+        item.memo = memo;
+        return item;
+    }
+
+    public void updateCatalog(
+            String name,
+            MaintenanceAppliesTo appliesTo,
+            UUID parentItemId,
+            Integer cycleKm,
+            Integer cycleMonths,
+            String cycleLabel,
+            Integer displayOrder,
+            Boolean enabled,
+            String memo
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (appliesTo != null) {
+            this.appliesTo = appliesTo;
+        }
+        // parentItemId / cycle 들은 명시적으로 null 로 보내는 케이스(그룹 분리,
+        // cycle 변경 등) 가 있으므로 null 도 그대로 수용. 호출 측이 partial
+        // update 를 원하면 wrapper(Optional) 패턴이 필요하나 운영자 편집 화면이
+        // 항상 전체 필드를 보내는 가정 하에 단순화.
+        this.parentItemId = parentItemId;
+        this.cycleKm = cycleKm;
+        this.cycleMonths = cycleMonths;
+        this.cycleLabel = cycleLabel;
+        if (displayOrder != null) {
+            this.displayOrder = displayOrder;
+        }
+        if (enabled != null) {
+            this.enabled = enabled;
+        }
+        if (memo != null) {
+            this.memo = memo;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MaintenanceAppliesTo getAppliesTo() {
+        return appliesTo;
+    }
+
+    public UUID getParentItemId() {
+        return parentItemId;
+    }
+
+    public Integer getCycleKm() {
+        return cycleKm;
+    }
+
+    public Integer getCycleMonths() {
+        return cycleMonths;
+    }
+
+    public String getCycleLabel() {
+        return cycleLabel;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    protected MaintenanceItem() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/VehicleMaintenanceRecord.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/VehicleMaintenanceRecord.java
@@ -1,0 +1,78 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 차량별 정비 이벤트 한 건. 운영자가 차량 상세에서 "[엔진오일] 교환 완료" 를
+ * 누를 때마다 row 가 추가된다.
+ *
+ * "다음 교환 예정 / 임박 / 지연" 은 서비스 코드가 이 record + 해당 item.cycle_*
+ * 를 합쳐 derive — DB 컬럼으로는 안 두어 cycle 이 사후에 바뀌어도 자동 반영.
+ *
+ * `servicedAtOdometerKm` 는 운영자가 교환 시점에 알고 있다면 입력. odometer
+ * 텔레메트리가 없는 현 상태에서 km 기준 품목의 정확한 카운팅을 위해 선택적
+ * 입력 채널 제공.
+ */
+@Entity
+@Table(name = "vehicle_maintenance_records")
+public class VehicleMaintenanceRecord extends DisplaySequencedEntity {
+
+    @Column(name = "bike_id", nullable = false)
+    private UUID bikeId;
+
+    @Column(name = "item_id", nullable = false)
+    private UUID itemId;
+
+    @Column(name = "serviced_at", nullable = false)
+    private Instant servicedAt;
+
+    @Column(name = "serviced_at_odometer_km")
+    private Integer servicedAtOdometerKm;
+
+    @Column
+    private String memo;
+
+    public static VehicleMaintenanceRecord create(
+            UUID bikeId,
+            UUID itemId,
+            Instant servicedAt,
+            Integer servicedAtOdometerKm,
+            String memo
+    ) {
+        VehicleMaintenanceRecord record = new VehicleMaintenanceRecord();
+        record.bikeId = bikeId;
+        record.itemId = itemId;
+        record.servicedAt = servicedAt;
+        record.servicedAtOdometerKm = servicedAtOdometerKm;
+        record.memo = memo;
+        return record;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public UUID getItemId() {
+        return itemId;
+    }
+
+    public Instant getServicedAt() {
+        return servicedAt;
+    }
+
+    public Integer getServicedAtOdometerKm() {
+        return servicedAtOdometerKm;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    protected VehicleMaintenanceRecord() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MaintenanceItemCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotNull MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        @PositiveOrZero Integer cycleKm,
+        @PositiveOrZero Integer cycleMonths,
+        @Size(max = 50) String cycleLabel,
+        @PositiveOrZero Integer displayOrder,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
@@ -1,0 +1,40 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import java.time.Instant;
+import java.util.UUID;
+
+public record MaintenanceItemReadResponse(
+        UUID id,
+        Long idx,
+        String name,
+        MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        Integer cycleKm,
+        Integer cycleMonths,
+        String cycleLabel,
+        int displayOrder,
+        boolean enabled,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static MaintenanceItemReadResponse from(MaintenanceItem item) {
+        return new MaintenanceItemReadResponse(
+                item.getId(),
+                item.getIdx(),
+                item.getName(),
+                item.getAppliesTo(),
+                item.getParentItemId(),
+                item.getCycleKm(),
+                item.getCycleMonths(),
+                item.getCycleLabel(),
+                item.getDisplayOrder(),
+                item.isEnabled(),
+                item.getMemo(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+/**
+ * 카탈로그 편집용 partial update. 모든 필드 optional — null 이면 변경 안 함.
+ * 단, `parentItemId` / `cycleKm` / `cycleMonths` / `cycleLabel` 은 명시적
+ * null 도 "값 비움" 의미로 그대로 반영. 다른 필드와 구분을 두는 이유는
+ * 카탈로그 편집 화면이 항상 전체 cycle 필드를 채워서 보내고, "그룹 해제" /
+ * "cycle 값 제거" 같은 케이스를 자연스럽게 표현해야 하기 때문.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MaintenanceItemUpdateRequest(
+        @Size(max = 100) String name,
+        MaintenanceAppliesTo appliesTo,
+        UUID parentItemId,
+        @PositiveOrZero Integer cycleKm,
+        @PositiveOrZero Integer cycleMonths,
+        @Size(max = 50) String cycleLabel,
+        @PositiveOrZero Integer displayOrder,
+        Boolean enabled,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordCreateRequest.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VehicleMaintenanceRecordCreateRequest(
+        @NotNull UUID itemId,
+        /** 미지정 시 서비스가 현재 시각으로 채움. */
+        Instant servicedAt,
+        @PositiveOrZero Integer servicedAtOdometerKm,
+        String memo
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/VehicleMaintenanceRecordReadResponse.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.maintenance.dto;
+
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import java.time.Instant;
+import java.util.UUID;
+
+public record VehicleMaintenanceRecordReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        UUID itemId,
+        Instant servicedAt,
+        Integer servicedAtOdometerKm,
+        String memo,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static VehicleMaintenanceRecordReadResponse from(VehicleMaintenanceRecord record) {
+        return new VehicleMaintenanceRecordReadResponse(
+                record.getId(),
+                record.getIdx(),
+                record.getBikeId(),
+                record.getItemId(),
+                record.getServicedAt(),
+                record.getServicedAtOdometerKm(),
+                record.getMemo(),
+                record.getCreatedAt(),
+                record.getUpdatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
@@ -1,0 +1,28 @@
+package com.thundercrew.opsapi.maintenance.repository;
+
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+public interface MaintenanceItemRepository extends Repository<MaintenanceItem, UUID> {
+
+    MaintenanceItem save(MaintenanceItem item);
+
+    Optional<MaintenanceItem> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<MaintenanceItem> findByDeletedAtIsNull(Pageable pageable);
+
+    /**
+     * 차량 단위 catalog 조회 — bike.engineType 이 ELECTRIC 이면
+     * `appliesTo IN (ELECTRIC, BOTH)`, ICE 면 `(ICE, BOTH)`.
+     * 서비스 측에서 호출 전에 in-list 를 만들어 넘긴다.
+     */
+    List<MaintenanceItem> findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(
+            List<MaintenanceAppliesTo> appliesTo
+    );
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
@@ -4,6 +4,8 @@ import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
 public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMaintenanceRecord, UUID> {
@@ -17,4 +19,11 @@ public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMa
      * 할 때 시간 역순으로 한 번 훑는다.
      */
     List<VehicleMaintenanceRecord> findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(UUID bikeId);
+
+    /**
+     * 전체 차량의 정비 이력 (페이징). 차량 탭의 "정비 상태" 필터가 모든 차량의
+     * 마지막 교환 시점을 한 번에 받기 위해 사용. MVP 규모(< 200 차량 × ~10 품목)
+     * 에서 한 페이지 (size=500) 면 1회 호출로 충분.
+     */
+    Page<VehicleMaintenanceRecord> findByDeletedAtIsNull(Pageable pageable);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/VehicleMaintenanceRecordRepository.java
@@ -1,0 +1,20 @@
+package com.thundercrew.opsapi.maintenance.repository;
+
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface VehicleMaintenanceRecordRepository extends Repository<VehicleMaintenanceRecord, UUID> {
+
+    VehicleMaintenanceRecord save(VehicleMaintenanceRecord record);
+
+    Optional<VehicleMaintenanceRecord> findByIdAndDeletedAtIsNull(UUID id);
+
+    /**
+     * 한 차량의 모든 정비 이력 (최신순). UI 가 품목별로 마지막 교환을 derive
+     * 할 때 시간 역순으로 한 번 훑는다.
+     */
+    List<VehicleMaintenanceRecord> findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(UUID bikeId);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
@@ -1,0 +1,119 @@
+package com.thundercrew.opsapi.maintenance.service;
+
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import com.thundercrew.opsapi.maintenance.domain.VehicleMaintenanceRecord;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemUpdateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordCreateRequest;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
+import com.thundercrew.opsapi.maintenance.repository.VehicleMaintenanceRecordRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MaintenanceCommandService {
+
+    private final MaintenanceItemRepository itemRepository;
+    private final VehicleMaintenanceRecordRepository recordRepository;
+    private final BikeRepository bikeRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public MaintenanceCommandService(
+            MaintenanceItemRepository itemRepository,
+            VehicleMaintenanceRecordRepository recordRepository,
+            BikeRepository bikeRepository,
+            EntityManager entityManager,
+            Clock clock
+    ) {
+        this.itemRepository = itemRepository;
+        this.recordRepository = recordRepository;
+        this.bikeRepository = bikeRepository;
+        this.entityManager = entityManager;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public MaintenanceItemReadResponse createItem(MaintenanceItemCreateRequest request) {
+        MaintenanceItem item = MaintenanceItem.create(
+                request.name(),
+                request.appliesTo(),
+                request.parentItemId(),
+                request.cycleKm(),
+                request.cycleMonths(),
+                request.cycleLabel(),
+                request.displayOrder() != null ? request.displayOrder() : 0,
+                request.memo()
+        );
+        MaintenanceItem saved = itemRepository.save(item);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return MaintenanceItemReadResponse.from(saved);
+    }
+
+    @Transactional
+    public MaintenanceItemReadResponse updateItem(UUID id, MaintenanceItemUpdateRequest request) {
+        MaintenanceItem item = itemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+        item.updateCatalog(
+                request.name(),
+                request.appliesTo(),
+                request.parentItemId(),
+                request.cycleKm(),
+                request.cycleMonths(),
+                request.cycleLabel(),
+                request.displayOrder(),
+                request.enabled(),
+                request.memo()
+        );
+        entityManager.flush();
+        return MaintenanceItemReadResponse.from(item);
+    }
+
+    @Transactional
+    public void softDeleteItem(UUID id) {
+        MaintenanceItem item = itemRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+        item.markDeleted(null, clock.instant());
+    }
+
+    @Transactional
+    public VehicleMaintenanceRecordReadResponse createRecord(
+            UUID bikeId,
+            VehicleMaintenanceRecordCreateRequest request
+    ) {
+        // bike + item 모두 존재 확인. 삭제된 행 참조 차단.
+        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        itemRepository.findByIdAndDeletedAtIsNull(request.itemId())
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", request.itemId()));
+
+        Instant servicedAt = request.servicedAt() != null ? request.servicedAt() : Instant.now(clock);
+        VehicleMaintenanceRecord record = VehicleMaintenanceRecord.create(
+                bikeId,
+                request.itemId(),
+                servicedAt,
+                request.servicedAtOdometerKm(),
+                request.memo()
+        );
+        VehicleMaintenanceRecord saved = recordRepository.save(record);
+        entityManager.flush();
+        entityManager.refresh(saved);
+        return VehicleMaintenanceRecordReadResponse.from(saved);
+    }
+
+    @Transactional
+    public void softDeleteRecord(UUID id) {
+        VehicleMaintenanceRecord record = recordRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("VehicleMaintenanceRecord", id));
+        record.markDeleted(null, clock.instant());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -68,6 +68,16 @@ public class MaintenanceReadService {
                 .toList();
     }
 
+    /**
+     * 전체 차량의 정비 이력 (페이징). 차량 탭 필터가 차량별 최신 record 를 한 번에
+     * 받아 임박/지연 상태를 client-side 에서 derive 할 때 사용.
+     */
+    public PageResponse<VehicleMaintenanceRecordReadResponse> listRecords(Pageable pageable) {
+        return PageResponse.of(
+                recordRepository.findByDeletedAtIsNull(pageable).map(VehicleMaintenanceRecordReadResponse::from)
+        );
+    }
+
     public List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(UUID bikeId) {
         // bike 존재 여부 보장 — 삭제된 차량 ID 로 잘못 조회되면 404.
         bikeRepository.findByIdAndDeletedAtIsNull(bikeId)

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -1,0 +1,81 @@
+package com.thundercrew.opsapi.maintenance.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeEngineType;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.PageResponse;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
+import com.thundercrew.opsapi.maintenance.repository.VehicleMaintenanceRecordRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MaintenanceReadService {
+
+    private final MaintenanceItemRepository itemRepository;
+    private final VehicleMaintenanceRecordRepository recordRepository;
+    private final BikeRepository bikeRepository;
+
+    public MaintenanceReadService(
+            MaintenanceItemRepository itemRepository,
+            VehicleMaintenanceRecordRepository recordRepository,
+            BikeRepository bikeRepository
+    ) {
+        this.itemRepository = itemRepository;
+        this.recordRepository = recordRepository;
+        this.bikeRepository = bikeRepository;
+    }
+
+    /**
+     * 전체 카탈로그(페이지). 카탈로그 편집 화면이 두 표(전기/내연)를 한 번에
+     * 노출하기 위해 호출. UI 가 클라이언트 측에서 appliesTo 별로 그룹핑.
+     */
+    public PageResponse<MaintenanceItemReadResponse> listItems(Pageable pageable) {
+        return PageResponse.of(
+                itemRepository.findByDeletedAtIsNull(pageable).map(MaintenanceItemReadResponse::from)
+        );
+    }
+
+    public MaintenanceItemReadResponse getItem(UUID id) {
+        return itemRepository.findByIdAndDeletedAtIsNull(id)
+                .map(MaintenanceItemReadResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException("MaintenanceItem", id));
+    }
+
+    /**
+     * 한 차량의 정비 catalog — 그 차량의 engineType 에 적용 가능한 품목만.
+     * ELECTRIC 차량은 (ELECTRIC + BOTH), ICE 는 (ICE + BOTH). 정렬은
+     * displayOrder 오름차순으로 사진 표 순서 유지.
+     */
+    public List<MaintenanceItemReadResponse> listItemsForBike(UUID bikeId) {
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        List<MaintenanceAppliesTo> appliesTo = bike.getEngineType() == BikeEngineType.ELECTRIC
+                ? List.of(MaintenanceAppliesTo.ELECTRIC, MaintenanceAppliesTo.BOTH)
+                : List.of(MaintenanceAppliesTo.ICE, MaintenanceAppliesTo.BOTH);
+        return itemRepository
+                .findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo)
+                .stream()
+                .map(MaintenanceItemReadResponse::from)
+                .toList();
+    }
+
+    public List<VehicleMaintenanceRecordReadResponse> listRecordsForBike(UUID bikeId) {
+        // bike 존재 여부 보장 — 삭제된 차량 ID 로 잘못 조회되면 404.
+        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        return recordRepository
+                .findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(bikeId)
+                .stream()
+                .map(VehicleMaintenanceRecordReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V21__add_bikes_engine_type.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V21__add_bikes_engine_type.sql
@@ -1,0 +1,19 @@
+-- Tag each bike with the engine family it belongs to so downstream features
+-- (정비 스케줄 catalog 매칭, 필터) can branch on ICE vs ELECTRIC without
+-- relying on the free-form model_name string. Default is ELECTRIC because
+-- the current operating fleet is all electric two-wheelers; ICE rows can be
+-- created/edited explicitly by the operator.
+alter table bikes
+    add column engine_type varchar(20) not null default 'ELECTRIC';
+
+-- Existing rows are all electric by domain assumption — pinning the column
+-- value explicitly so future schema dumps don't depend on the default.
+update bikes set engine_type = 'ELECTRIC' where engine_type is null;
+
+alter table bikes
+    add constraint ck_bikes_engine_type
+        check (engine_type in ('ELECTRIC', 'ICE'));
+
+create index ix_bikes_engine_type_active
+    on bikes(engine_type)
+    where deleted_at is null;

--- a/development/service-ops-api/src/main/resources/db/migration/V22__init_maintenance_catalog.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V22__init_maintenance_catalog.sql
@@ -1,0 +1,122 @@
+-- 정비 스케줄 도메인: 차량 단위 정비 catalog + 이벤트 이력. 두 테이블만 추가.
+--
+-- `maintenance_items` 가 카탈로그(품목 + 교환 주기 default) 를 보유하고,
+-- `vehicle_maintenance_records` 가 운영자가 "이 차량 이 품목을 교환했다"
+-- 마킹할 때마다 row 를 추가한다. "다음 교환 예정 / 임박 / 지연" 같은 derived
+-- 표시는 서비스 코드에서 record.serviced_at + item.cycle_* 로 계산.
+--
+-- engine type 분리: `applies_to` 가 `ELECTRIC` / `ICE` / `BOTH` 셋. 차량 단위
+-- 카탈로그 조회 시 (bike.engine_type 가 ELECTRIC 이면) `ELECTRIC` + `BOTH` 를
+-- 합쳐서 노출. ICE 차량도 같은 패턴.
+--
+-- 단위 혼재: km 기반(엔진오일 1,500km), 시간 기반(체인 장력조절 1개월), 그리고
+-- "12개월 이상", "6~7개월" 같은 비정형. `cycle_km` 와 `cycle_months` 가 둘 다
+-- nullable 이고, `cycle_label` 이 자유 텍스트로 비정형 표현을 잡는다.
+--
+-- 그룹(구동계3종) 표현: 자식 품목이 `parent_item_id` 로 부모를 참조. 부모 자체
+-- 의 cycle 은 NULL (그룹은 자체 cycle 없음, 자식이 각각 보유).
+
+create table maintenance_items (
+    id uuid primary key,
+    idx bigserial not null,
+    name varchar(100) not null,
+    -- ELECTRIC = 전기 차량에만 적용, ICE = 내연기관에만, BOTH = 둘 다.
+    applies_to varchar(20) not null,
+    -- 그룹용 부모 참조. null 이면 단독 품목.
+    parent_item_id uuid references maintenance_items(id) on delete restrict,
+    -- 둘 다 nullable. 둘 중 하나만 채워질 수도, 둘 다 채워질 수도 있다.
+    -- 둘 다 null 이지만 cycle_label 만 채워지는 경우(예: "운영자 판단") 도 허용.
+    cycle_km integer,
+    cycle_months integer,
+    -- "6~7개월", "12개월 이상" 같이 cycle_km/months 로 표현 안 되는 비정형 텍스트.
+    -- 채워져 있으면 UI 가 우선 표시. cycle_km/months 와 동시 보유 가능 (텍스트는
+    -- 보조 설명).
+    cycle_label varchar(50),
+    -- 같은 applies_to 안에서 정렬 순서. 사진 표 순서 그대로 0,1,2,... 로 seed.
+    display_order integer not null default 0,
+    enabled boolean not null default true,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    deleted_by uuid,
+    constraint ck_maintenance_items_applies_to
+        check (applies_to in ('ELECTRIC', 'ICE', 'BOTH')),
+    constraint ck_maintenance_items_cycle_present
+        check (cycle_km is not null or cycle_months is not null or cycle_label is not null)
+);
+
+create unique index ux_maintenance_items_idx on maintenance_items(idx);
+create index ix_maintenance_items_applies_to_active
+    on maintenance_items(applies_to)
+    where deleted_at is null;
+create index ix_maintenance_items_parent_active
+    on maintenance_items(parent_item_id)
+    where deleted_at is null;
+
+create table vehicle_maintenance_records (
+    id uuid primary key,
+    idx bigserial not null,
+    bike_id uuid not null references bikes(id) on delete restrict,
+    item_id uuid not null references maintenance_items(id) on delete restrict,
+    serviced_at timestamptz not null,
+    -- 운영자가 교환 시점에 알고 있다면 같이 입력. 우리에게 odometer 텔레메트리가
+    -- 없어 km 기준 품목은 운영자 보정 입력으로 보완한다 (계획서 옵션 (c)).
+    serviced_at_odometer_km integer,
+    memo text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    deleted_by uuid
+);
+
+create unique index ux_vehicle_maintenance_records_idx on vehicle_maintenance_records(idx);
+create index ix_vehicle_maintenance_records_bike_active
+    on vehicle_maintenance_records(bike_id, serviced_at desc)
+    where deleted_at is null;
+create index ix_vehicle_maintenance_records_item_active
+    on vehicle_maintenance_records(item_id)
+    where deleted_at is null;
+
+-- ============================================================================
+-- Seed: 사진 두 표 그대로
+-- ============================================================================
+--
+-- 공통 품목(브레이크 패드, 타이어) 은 applies_to = BOTH 로 한 행만 박는다 —
+-- ELECTRIC 차량 catalog 조회 시 `applies_to in ('ELECTRIC', 'BOTH')` 로 합쳐서
+-- 노출하면 사진과 동일한 목록이 된다.
+--
+-- 구동계3종 은 그룹 부모 + 자식 3개. 부모 UUID 는 self-FK 참조 위해 literal 로
+-- 고정.
+
+-- ICE 단독 품목
+insert into maintenance_items (id, name, applies_to, cycle_km, display_order) values
+    ('aaaa1111-0001-4001-8001-000000000001'::uuid, '엔진오일', 'ICE', 1500, 10),
+    ('aaaa1111-0001-4001-8001-000000000002'::uuid, '에어필터', 'ICE', 12000, 20),
+    ('aaaa1111-0001-4001-8001-000000000003'::uuid, '점화플러그', 'ICE', 20000, 30),
+    ('aaaa1111-0001-4001-8001-000000000006'::uuid, '브레이크오일 점검 및 보충', 'ICE', 30000, 60),
+    ('aaaa1111-0001-4001-8001-000000000007'::uuid, '냉각수 점검 및 보충', 'ICE', 20000, 70);
+
+-- 구동계3종 그룹 (부모) — cycle 없음.
+insert into maintenance_items (id, name, applies_to, cycle_label, display_order, cycle_km) values
+    ('aaaa1111-0001-4001-8001-000000000080'::uuid, '구동계3종', 'ICE', '그룹', 80, null);
+
+-- 구동계3종 자식 세 품목 — 같은 부모 참조.
+insert into maintenance_items (id, name, applies_to, parent_item_id, cycle_km, display_order) values
+    ('aaaa1111-0001-4001-8001-000000000081'::uuid, '슬라이드피스',         'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 81),
+    ('aaaa1111-0001-4001-8001-000000000082'::uuid, '드라이브벨트',         'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 82),
+    ('aaaa1111-0001-4001-8001-000000000083'::uuid, '무브볼(웨이트롤러)',   'ICE', 'aaaa1111-0001-4001-8001-000000000080'::uuid, 15000, 83);
+
+-- ELECTRIC 단독 품목
+insert into maintenance_items (id, name, applies_to, cycle_months, cycle_label, cycle_km, display_order) values
+    ('bbbb2222-0002-4002-8002-000000000001'::uuid, '대소기어',         'ELECTRIC', 12,   '12개월 이상', null, 110),
+    ('bbbb2222-0002-4002-8002-000000000002'::uuid, '체인 장력조절',     'ELECTRIC', 1,    null,           null, 120),
+    ('bbbb2222-0002-4002-8002-000000000003'::uuid, '체인 교체',         'ELECTRIC', 6,    '6~7개월',     null, 130),
+    ('bbbb2222-0002-4002-8002-000000000004'::uuid, '모터오일',           'ELECTRIC', null, null,           30000, 140);
+
+-- 공통 (BOTH) 품목 — 두 표 모두에 등장
+insert into maintenance_items (id, name, applies_to, cycle_km, display_order) values
+    ('cccc3333-0003-4003-8003-000000000001'::uuid, '브레이크 패드(앞)', 'BOTH', 4000,  210),
+    ('cccc3333-0003-4003-8003-000000000002'::uuid, '브레이크 패드(뒤)', 'BOTH', 5000,  220),
+    ('cccc3333-0003-4003-8003-000000000003'::uuid, '타이어(앞)',         'BOTH', 15000, 230),
+    ('cccc3333-0003-4003-8003-000000000004'::uuid, '타이어(뒤)',         'BOTH', 12000, 240);


### PR DESCRIPTION
## Summary
대규모 기능 묶음 — backend 정비 도메인 신설 + engine_type 기반 차량 분류 + 차량 탭/라이더 탭/BSS 탭 필터 확장 + 차량 상세 floating panel + 정비 카탈로그 편집 UI.

**Backend (V21 + V22 migration)**
- \`bikes.engine_type\` 컬럼 (ELECTRIC / ICE), 기존 행 ELECTRIC default (#247)
- \`maintenance_items\` + \`vehicle_maintenance_records\` 테이블 + 사진 두 표 seed (#248)
- maintenance CRUD endpoints + 전체 records list-all endpoint (#248, #255)

**도메인 swap**
- 차량 표 \"모델\" 컬럼 → \"구분\" (전기/내연 뱃지). Create/Detail 다이얼로그에 engineType select 추가. modelName 은 자유 텍스트 메모로 demote (#249)

**차량 탭 필터 확장 (2-row, 6개)**
- 검색 / 구분 / 운영 상태 / 연결 상태 / 시동 / 정비 상태 (#250 + #255 활성화)

**라이더/BSS 검색·필터 + 보험 컬럼 상품명**
- 라이더 탭: 검색 + 교육 + 차량 배정 + 구독·렌탈 + 보험 + 시동 상태 (5 selects)
- BSS 탭: 주소 검색 + 잔여 상태 (재고 부족 ≤30%)
- 보험 컬럼이 \`있음/—\` 에서 가입한 \`insurance_item.name\` 으로 (#251)

**필터 → 지도 sync + floating panel + auto-pan**
- 차량 필터가 지도 마커도 같이 거름 — \`VehicleFilterContext\` 공유 채널 (#252)
- 차량 행 클릭 → 모달 → 지도 위 floating 패널. 지도 자동 ON + 선택 차량 위치 pan (#253)

**차량 상세 정비 섹션**
- floating panel 안에 \"정비 상태\" 표 — engineType 별 카탈로그 + 마지막 교환 / 다음 예정 / 상태(정상·임박·지연) / 교환 완료 버튼 (#254)

**정비 카탈로그 편집 탭**
- 4번째 탭 \"정비\" 신설. 전기/내연/공통 3 섹션. 행 클릭 수정 / trash 삭제 / + 추가 다이얼로그 (#256)

## Test plan
- [ ] 백엔드 V21/V22 마이그레이션 적용 후 기존 차량 모두 engine_type=ELECTRIC
- [ ] 차량 표에 \"구분\" 컬럼이 전기/내연 뱃지로 표시
- [ ] 차량 탭 6개 필터 모두 동작 + 결과가 지도 마커에도 반영
- [ ] 차량 행 클릭 시 floating panel 노출 + 지도 자동 ON + 선택 차량으로 pan
- [ ] floating panel 안 \"정비 상태\" 섹션 (전기 8 / 내연 13 항목) 노출
- [ ] \"교환 완료\" 버튼 → confirm → record 추가, 패널 재오픈 시 마지막 교환 일자 갱신
- [ ] 라이더 탭 필터 5개 + 보험 컬럼 상품명 표시
- [ ] BSS 탭 검색 + 재고 부족 필터
- [ ] \"정비\" 탭 진입 시 3 섹션에 17개 품목 노출, CRUD 모두 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)