### PR TITLE
Stop seeded admin password from resetting on restart; let it be changed in-app

### DIFF
--- a/development/front-admin-web/app/login/actions.ts
+++ b/development/front-admin-web/app/login/actions.ts
@@ -3,7 +3,11 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@supabase/supabase-js";
 import { createServiceOpsApiClient, serviceOpsApiConfigured } from "@/lib/services/service-ops-api";
-import { logoutServiceOpsSession, setServiceOpsSession } from "@/lib/services/service-ops-session";
+import {
+  createAuthenticatedServiceOpsApiClient,
+  logoutServiceOpsSession,
+  setServiceOpsSession
+} from "@/lib/services/service-ops-session";
 
 export async function signInAdmin(formData: FormData) {
   const loginId = String(formData.get("loginId") ?? formData.get("email") ?? "").trim();
@@ -49,4 +53,45 @@ export async function signInAdmin(formData: FormData) {
 export async function signOutAdmin() {
   await logoutServiceOpsSession();
   redirect("/login?status=signed-out");
+}
+
+/**
+ * 로그인된 admin 본인 비밀번호 변경. 우상단 floating bar 의 "비밀번호 변경"
+ * 다이얼로그 form 이 호출. 현재 비밀번호 미일치 / 새 비밀번호 길이 미달 시
+ * status 파라미터로 안내 메시지를 띄운다.
+ *
+ * 성공 시엔 `/?status=password-changed` 로 redirect — 운영자에게 변경 결과를
+ * 보여주고 세션은 그대로 유지 (강제 로그아웃 없음).
+ */
+export async function changeAdminPassword(formData: FormData) {
+  const currentPassword = String(formData.get("currentPassword") ?? "");
+  const newPassword = String(formData.get("newPassword") ?? "");
+  const confirmPassword = String(formData.get("confirmPassword") ?? "");
+
+  if (!currentPassword || !newPassword) {
+    redirect("/?status=password-missing");
+  }
+  if (newPassword.length < 8) {
+    redirect("/?status=password-too-short");
+  }
+  if (newPassword !== confirmPassword) {
+    redirect("/?status=password-mismatch");
+  }
+  if (!serviceOpsApiConfigured()) {
+    redirect("/?status=password-changed");
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.changeAdminPassword({ currentPassword, newPassword });
+  } catch {
+    // 401 / 기타 — 현재 비밀번호 미일치가 가장 빈번한 케이스.
+    redirect("/?status=password-current-mismatch");
+  }
+
+  redirect("/?status=password-changed");
 }

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { LogoutButton } from "@/components/layout/LogoutButton";
+import { PasswordChangeButton } from "@/components/layout/PasswordChangeButton";
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { serviceOpsSessionReady } from "@/lib/services/service-ops-session";
 
 /**
@@ -24,7 +25,10 @@ export async function AppShell({ children }: { children: ReactNode }) {
       <div className="top-actions" aria-label="유틸리티">
         <ThemeToggle />
         {serviceOpsSessionActive ? (
-          <LogoutButton />
+          <>
+            <PasswordChangeButton />
+            <LogoutButton />
+          </>
         ) : (
           <a className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
             <span className="sidebar-icon" aria-hidden="true">↗</span>

--- a/development/front-admin-web/components/layout/PasswordChangeButton.tsx
+++ b/development/front-admin-web/components/layout/PasswordChangeButton.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRef } from "react";
+
+import { changeAdminPassword } from "@/app/login/actions";
+
+/**
+ * 우상단 floating action bar 의 "비밀번호 변경" 버튼 + 다이얼로그. 로그인된
+ * admin 본인 비밀번호만 변경 가능 — 현재 비밀번호 + 새 비밀번호 + 새 비밀번호
+ * 확인 세 필드. server action 이 길이/일치 검증 후 backend 호출, 결과는
+ * status param 으로 query string 에 실려 부모 페이지가 안내 메시지로 노출.
+ *
+ * 다이얼로그는 native modal `<dialog>` + `showModal()` 으로 띄움. 다른 detail
+ * 다이얼로그들과 동일한 modal 패턴이라 일관성 유지.
+ */
+export function PasswordChangeButton() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleOpen = () => {
+    formRef.current?.reset();
+    dialogRef.current?.showModal();
+  };
+
+  return (
+    <>
+      <button
+        className="sidebar-link"
+        type="button"
+        onClick={handleOpen}
+        title="비밀번호 변경"
+        aria-label="비밀번호 변경"
+      >
+        <KeyIcon />
+        <span className="sidebar-label">비밀번호 변경</span>
+      </button>
+      <dialog ref={dialogRef} className="overview-create-dialog">
+        <form
+          ref={formRef}
+          action={changeAdminPassword}
+          onSubmit={() => {
+            // server action submit 직후 페이지 redirect 가 일어나므로 modal 을
+            // 명시적으로 닫지 않아도 unmount 된다. 다만 redirect 가 실패하는
+            // 환경(개발 모드 일부) 대비 dialog 를 미리 닫아둔다.
+            dialogRef.current?.close();
+          }}
+        >
+          <h3>비밀번호 변경</h3>
+          <label>
+            현재 비밀번호
+            <input
+              type="password"
+              name="currentPassword"
+              required
+              autoComplete="current-password"
+              maxLength={100}
+            />
+          </label>
+          <label>
+            새 비밀번호 (8자 이상)
+            <input
+              type="password"
+              name="newPassword"
+              required
+              minLength={8}
+              maxLength={100}
+              autoComplete="new-password"
+            />
+          </label>
+          <label>
+            새 비밀번호 확인
+            <input
+              type="password"
+              name="confirmPassword"
+              required
+              minLength={8}
+              maxLength={100}
+              autoComplete="new-password"
+            />
+          </label>
+          <div className="overview-create-dialog-actions">
+            <button type="button" className="button-neutral" onClick={() => dialogRef.current?.close()}>
+              취소
+            </button>
+            <button type="submit" className="button-primary">
+              변경
+            </button>
+          </div>
+        </form>
+      </dialog>
+    </>
+  );
+}
+
+// 작은 자물쇠/열쇠 outline 아이콘. 로그아웃 / 테마 토글 아이콘과 같은 stroke
+// 기반 line-art 세트.
+function KeyIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="15" r="3.5" />
+      <path d="M10.5 12.5 L20 3" />
+      <path d="M16 7 L19 10" />
+      <path d="M14 9 L17 12" />
+    </svg>
+  );
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -847,6 +847,8 @@ export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
   logout: () => Promise<void>;
+  /** 로그인한 admin 본인 비밀번호 변경. 현재 비밀번호 매칭 실패 시 401. */
+  changeAdminPassword: (request: { currentPassword: string; newPassword: string }) => Promise<void>;
   getDashboardMapState: () => Promise<FrontendDashboardMapState>;
   getBikeCurrentState: (bikeId: string) => Promise<FrontendBikeCurrentState>;
   getBikeSnapshot: (bikeId: string) => Promise<ServiceOpsBikeSnapshot>;
@@ -1058,6 +1060,12 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       }),
     logout: async () => {
       await request<void>("/auth/logout", { method: "POST" });
+    },
+    changeAdminPassword: async (passwordRequest) => {
+      await request<void>("/auth/me/password", {
+        body: JSON.stringify(passwordRequest),
+        method: "PATCH"
+      });
     },
     getDashboardMapState: async () =>
       toFrontendDashboardMapState(await request<ServiceOpsDashboardMapState>("/dashboard/map-state", { method: "GET" })),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.thundercrew.opsapi.auth.controller;
 
 import com.thundercrew.opsapi.auth.dto.AdminLoginRequest;
 import com.thundercrew.opsapi.auth.dto.AdminLoginResponse;
+import com.thundercrew.opsapi.auth.dto.AdminPasswordChangeRequest;
 import com.thundercrew.opsapi.auth.dto.AdminRefreshRequest;
 import com.thundercrew.opsapi.auth.service.AdminAuthService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +39,21 @@ public class AuthController {
     @PostMapping("/logout")
     ResponseEntity<Void> logout(@AuthenticationPrincipal Jwt jwt) {
         adminAuthService.logout(jwt.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 로그인된 admin 본인 비밀번호 변경. JWT subject 가 대상 admin 의 UUID.
+     * 현재 비밀번호 미일치 시 service 가 AdminAuthenticationException 을 던지고
+     * `AuthExceptionHandler` 가 401 로 매핑.
+     */
+    @PatchMapping("/me/password")
+    ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody AdminPasswordChangeRequest request
+    ) {
+        UUID adminUserId = UUID.fromString(jwt.getSubject());
+        adminAuthService.changePassword(adminUserId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPasswordChangeRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/dto/AdminPasswordChangeRequest.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 관리자 비밀번호 변경 요청. UI 의 "비밀번호 변경" 다이얼로그가 호출하는
+ * `PATCH /api/v1/auth/me/password` 의 body. JWT 의 subject 가 대상 admin 을
+ * 식별하므로 body 에는 현재 비밀번호 + 새 비밀번호만 담는다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AdminPasswordChangeRequest(
+        @NotBlank String currentPassword,
+        @NotBlank @Size(min = 8, max = 100) String newPassword
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/repository/AdminUserAccountRepository.java
@@ -42,6 +42,19 @@ public class AdminUserAccountRepository {
         ).stream().findFirst();
     }
 
+    /**
+     * 비밀번호 변경 시 호출. 이미 BCrypt 처리된 hash 를 그대로 받는다 — 평문은
+     * 서비스 레이어에서 BCryptPasswordEncoder 로 인코딩 후 넘긴다.
+     */
+    public int updatePasswordHash(UUID id, String passwordHash) {
+        return jdbcTemplate.update("""
+                update admin_users
+                set password_hash = ?, updated_at = now()
+                where id = ?
+                  and deleted_at is null
+                """, passwordHash, id);
+    }
+
     private AdminUserAccount mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
         return new AdminUserAccount(
                 resultSet.getObject("id", UUID.class),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/seed/AdminSeedRunner.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/seed/AdminSeedRunner.java
@@ -36,6 +36,17 @@ public class AdminSeedRunner implements ApplicationRunner {
         this.email = email;
     }
 
+    /**
+     * Spring startup 시점 admin 계정 보장. 이전엔 매 startup 마다 env 값으로
+     * password / display_name / email 을 모두 덮어써서 운영자가 UI 에서 바꾼
+     * 비밀번호도 다음 배포 때 초기화되는 부작용이 있었다. 이제는 idempotent —
+     * 같은 loginId 의 admin 이 이미 존재하면 아무 것도 하지 않고 return,
+     * 부재 시에만 env 값으로 새 row 를 만든다.
+     *
+     * 운영자가 비밀번호를 바꾸려면 UI 의 "비밀번호 변경" 흐름(`PATCH
+     * /api/v1/auth/me/password`)을 사용. env 의 password 값은 빈 DB 첫 부팅
+     * 시점의 seed 로만 의미가 있다.
+     */
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
@@ -43,7 +54,6 @@ public class AdminSeedRunner implements ApplicationRunner {
             return;
         }
 
-        String passwordHash = passwordEncoder.encode(password);
         Integer existing = jdbcTemplate.queryForObject(
                 "select count(*) from admin_users where login_id = ? and deleted_at is null",
                 Integer.class,
@@ -51,14 +61,10 @@ public class AdminSeedRunner implements ApplicationRunner {
         );
 
         if (existing != null && existing > 0) {
-            jdbcTemplate.update("""
-                    update admin_users
-                    set password_hash = ?, display_name = ?, email = nullif(?, ''), enabled = true, updated_at = now()
-                    where login_id = ? and deleted_at is null
-                    """, passwordHash, displayName, email, loginId);
             return;
         }
 
+        String passwordHash = passwordEncoder.encode(password);
         jdbcTemplate.update("""
                 insert into admin_users (
                     id, login_id, email, password_hash, display_name, enabled, created_at, updated_at

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/AdminAuthService.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.auth.service;
 import com.thundercrew.opsapi.auth.dto.AdminIdentityResponse;
 import com.thundercrew.opsapi.auth.dto.AdminLoginRequest;
 import com.thundercrew.opsapi.auth.dto.AdminLoginResponse;
+import com.thundercrew.opsapi.auth.dto.AdminPasswordChangeRequest;
 import com.thundercrew.opsapi.auth.dto.AdminRefreshRequest;
 import com.thundercrew.opsapi.auth.repository.AdminAuthSession;
 import com.thundercrew.opsapi.auth.repository.AdminAuthSessionRepository;
@@ -77,6 +78,24 @@ public class AdminAuthService {
     @Transactional
     public void logout(String accessTokenJti) {
         adminAuthSessionRepository.revokeByAccessTokenJti(accessTokenJti, Instant.now(clock), "LOGOUT");
+    }
+
+    /**
+     * 운영자가 UI 에서 비밀번호를 변경. JWT subject 로 식별된 admin 의 현재
+     * 비밀번호를 확인 후 새 BCrypt hash 로 교체. 현재 비밀번호 미일치 시 login
+     * 과 동일하게 `AdminAuthenticationException` 던지고 controller 가 401 으로
+     * 매핑. 다른 세션의 토큰은 그대로 살아있다 — "강제 로그아웃" 정책이
+     * 필요하면 후속 작업에서 토큰 revoke 추가.
+     */
+    @Transactional
+    public void changePassword(UUID adminUserId, AdminPasswordChangeRequest request) {
+        AdminUserAccount account = adminUserAccountRepository.findEnabledActiveById(adminUserId)
+                .orElseThrow(AdminAuthenticationException::new);
+        if (!passwordEncoder.matches(request.currentPassword(), account.passwordHash())) {
+            throw new AdminAuthenticationException();
+        }
+        String nextHash = passwordEncoder.encode(request.newPassword());
+        adminUserAccountRepository.updatePasswordHash(adminUserId, nextHash);
     }
 
     private AdminLoginResponse issueTokenPair(AdminUserAccount account) {


### PR DESCRIPTION
## Summary
운영자 비밀번호 관리 두 가지 변경 — 매 Spring 재시작 시 env 값으로 reset 되던 동작 끊고, UI 에서 비번을 바꿀 수 있게.

**A. AdminSeedRunner idempotent**
- 기존: 매 startup 마다 \`UPDATE admin_users SET password_hash, display_name, email\` — env 값으로 덮어씀
- 변경: admin row 가 이미 있으면 그냥 \`return\`. env 의 password 는 **빈 DB 첫 부팅 시점 seed** 로만 의미

**C. \`PATCH /api/v1/auth/me/password\` endpoint**
- 새 DTO \`AdminPasswordChangeRequest { currentPassword, newPassword }\`
- \`AdminAuthService.changePassword(adminUserId, request)\` — 현재 비번 검증 후 BCrypt hash 갱신, 미일치 시 \`AdminAuthenticationException\` (401)
- \`AdminUserAccountRepository.updatePasswordHash(id, hash)\` 추가
- JWT subject 가 대상 admin 식별

**Frontend**
- \`ServiceOpsApiClient.changeAdminPassword\` 메서드
- \`changeAdminPassword\` server action (\`app/login/actions.ts\`) — 길이/일치 검증 + status param redirect
- \`PasswordChangeButton\` — 우상단 floating bar 의 새 버튼. 클릭 시 modal 다이얼로그 (현재 비번 / 새 비번 / 확인). key/lock 아이콘

## Test plan
- [ ] V21+V22 (이미 dev 머지) + 이번 변경 적용 후 systemctl restart 시 기존 admin 비번이 그대로 유지됨
- [ ] 빈 DB 에선 env 의 \`THUNDERCREW_ADMIN_SEED_PASSWORD\` 값으로 admin 한 건 생성
- [ ] 로그인된 상태에서 우상단 새 \"비밀번호 변경\" 버튼 노출
- [ ] 다이얼로그에서 현재 비번 미일치 시 \`/?status=password-current-mismatch\` 로 redirect (운영자 안내 메시지)
- [ ] 새 비번 < 8자 시 \`/?status=password-too-short\` 로 redirect
- [ ] 새 비번 ≠ 확인 비번 시 \`/?status=password-mismatch\`
- [ ] 모두 통과 시 \`/?status=password-changed\` 로 redirect, 다음 로그아웃 후 새 비번으로 로그인 성공
- [ ] systemctl restart 후에도 새 비번이 유지됨

## Deploy note
배포 후 운영자가 환경 변수 \`THUNDERCREW_ADMIN_SEED_PASSWORD\` 값을 더 외우기 쉬운 문자열로 한 번 바꾼 뒤, 한 번은 DB 의 admin row 를 지우고 (or env 값 그대로 두고 UI 에서 바로 변경) 운영자가 원하는 비번으로 정착시키는 흐름.

🤖 Generated with [Claude Code](https://claude.com/claude-code)