### PR TITLE
Force /login redirect when only a stale refresh cookie remains

### DIFF
--- a/development/front-admin-web/lib/services/service-ops-session.ts
+++ b/development/front-admin-web/lib/services/service-ops-session.ts
@@ -57,6 +57,19 @@ export async function getServiceOpsRefreshToken(): Promise<string | null> {
   return readServiceOpsSessionTokens(cookieStore).refreshToken;
 }
 
+/**
+ * 운영자 세션이 살아 있는지 능동적으로 확인. 단순 쿠키 존재 검사로는 access
+ * 만료 + refresh 쿠키 잔존 상태(브라우저는 access 쿠키만 만료시키고 refresh
+ * 쿠키는 14일 까지 유지) 를 분간 못 해서, 세션이 사실상 만료됐는데도 페이지가
+ * 진입한 뒤 데이터 로더가 silent-fail 하는 문제가 있었다.
+ *
+ * 정책:
+ *   1. access / refresh 모두 없으면 → false (로그아웃 상태)
+ *   2. access 가 있으면 → true (들어가서 페이지 로더가 실제 호출로 검증)
+ *   3. access 없고 refresh 만 있으면 → 능동적으로 refresh 시도해서 access 를
+ *      재발급. 성공하면 true, 실패하면 (refresh 도 만료/거부) cookie 정리 후
+ *      false → page.tsx 가 `/login` 으로 redirect.
+ */
 export async function serviceOpsSessionReady(): Promise<boolean> {
   if (!serviceOpsApiConfigured()) {
     return false;
@@ -64,7 +77,15 @@ export async function serviceOpsSessionReady(): Promise<boolean> {
 
   const cookieStore = await cookies();
   const { accessToken, refreshToken } = readServiceOpsSessionTokens(cookieStore);
-  return Boolean(accessToken || refreshToken);
+
+  if (accessToken) return true;
+  if (!refreshToken) return false;
+
+  // access 만료 + refresh 잔존 — 능동 refresh. 실패 시 refresh* 함수가 내부
+  // 적으로 cookie 정리까지 처리.
+  return await refreshServiceOpsSessionCookies(cookieStore, createServiceOpsApiClient(), {
+    secure: serviceOpsCookieSecure()
+  });
 }
 
 export async function refreshServiceOpsSession(): Promise<boolean> {


### PR DESCRIPTION
## Summary
세션이 만료되어도 \`/login\` 으로 안 가던 문제 수정.

**원인**: \`serviceOpsSessionReady()\` 가 access OR refresh 쿠키 존재만 검사. access 토큰 만료 시 브라우저가 access 쿠키만 삭제하고 refresh 쿠키는 14일 까지 유지 → \"refresh 가 살아있으니 세션 OK\" 로 판단해 페이지 진입 → loader 들이 401 silent fail → 빈/깨진 화면, /login 으로 안 감.

**수정**: access 가 없고 refresh 만 남은 경우 능동적으로 refresh 시도 (`refreshServiceOpsSessionCookies`). 성공하면 세션 복구 후 페이지 진입, 실패 시 함수 내부에서 쿠키 정리 + false 반환 → \`app/page.tsx\` 가 깔끔하게 \`/login\` 으로 redirect.

backend 변경 없음, migration 없음, client 컴포넌트 변경 없음. 한 함수만 수정.

## Test plan
- [ ] 정상 세션 진입 → 페이지 정상 노출 (회귀 없음)
- [ ] access 만료 + refresh 살아있음 → 자동 refresh 후 세션 유지 (회귀 없음)
- [ ] access + refresh 둘 다 만료 → \`/login\` 으로 redirect
- [ ] refresh 토큰 backend 가 거부 (admin disabled) → \`/login\` 으로 redirect, 쿠키 정리됨
- [ ] /login 페이지에서 새로고침 시 무한 루프 안 일어남

🤖 Generated with [Claude Code](https://claude.com/claude-code)