### PR TITLE
Restore audit columns on maintenance tables (V23 hotfix)

### DIFF
--- a/development/service-ops-api/src/main/resources/db/migration/V23__add_maintenance_audit_columns.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V23__add_maintenance_audit_columns.sql
@@ -1,0 +1,16 @@
+-- V22 가 정비 두 테이블을 만들 때 audit 컬럼 중 `created_by` / `updated_by` 두
+-- 개를 빠뜨려서 Hibernate schema-validation 이 startup 시 실패했다 (entity 의
+-- `AuditableEntity` 슈퍼클래스는 두 컬럼을 기대). 핫픽스로 두 테이블에 nullable
+-- UUID 컬럼을 더한다.
+--
+-- 시스템 계정이 record 를 만드는 경로(seed / 자동 작업) 가 있어 nullable 로
+-- 둔다. 기존 행은 null 로 채워지고, 새 row 는 @PrePersist 가 채워주는 것이
+-- 운영자 UUID 일 때만 값이 박힌다.
+
+alter table maintenance_items
+    add column created_by uuid,
+    add column updated_by uuid;
+
+alter table vehicle_maintenance_records
+    add column created_by uuid,
+    add column updated_by uuid;


### PR DESCRIPTION
## Summary
**핫픽스** — service-ops-api 가 부팅 못 하던 schema-validation 실패 복구.

V22 가 정비 두 테이블을 만들 때 \`created_by\` / \`updated_by\` 두 audit 컬럼을 누락. Hibernate 의 \`AuditableEntity\` 슈퍼클래스가 두 컬럼을 기대하므로 매 startup 의 schema-validation 단계에서:

\`\`\`
Schema-validation: missing column [created_by] in table [maintenance_items]
\`\`\`

이 발생해 Spring 부팅 자체가 실패. 운영 환경에서 \`/api/v1/auth/login\` 도 못 되니 로그인 화면이 \"서비스 API 로그인에 실패했습니다\" 만 반복.

V23 으로 두 테이블에 nullable UUID 컬럼 \`created_by\` / \`updated_by\` 를 추가. V22 자체는 그대로 두어 기존 Flyway 체크섬 유지.

## Immediate recovery (PR 머지 + 배포 전 EC2 에서 직접 SQL 실행으로도 가능)
PR 머지/배포를 기다리지 못하면 EC2 에서 다음 SQL 을 직접 실행해도 같은 효과:

\`\`\`bash
sudo -u postgres psql service_ops_api <<'SQL'
alter table maintenance_items
    add column created_by uuid,
    add column updated_by uuid;
alter table vehicle_maintenance_records
    add column created_by uuid,
    add column updated_by uuid;
insert into flyway_schema_history (installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success)
select coalesce(max(installed_rank), 0) + 1, '23', 'add maintenance audit columns', 'SQL', 'V23__add_maintenance_audit_columns.sql', 0, 'manual-recovery', now(), 0, true
from flyway_schema_history;
SQL
sudo systemctl restart thundercrew-service-ops-api
\`\`\`

수동 SQL 후 PR 이 배포될 때 V23 이 이미 적용된 상태라 Flyway 가 그냥 skip — 충돌 없음.

## Test plan
- [ ] PR 배포 후 \`sudo systemctl status thundercrew-service-ops-api\` 가 active (running) 유지 (crash loop 종결)
- [ ] \`sudo journalctl -u thundercrew-service-ops-api -n 50\` 에 SessionFactory 정상 init 로그
- [ ] AdminSeedRunner 가 빈 admin_users 테이블 보고 env 값으로 admin row 생성
- [ ] 로그인 페이지에서 id \`admin\`, 비번 \`nCNkCrl8pSFi4XVrX6DFI3d5xyBD+jlb\` 로 정상 로그인

🤖 Generated with [Claude Code](https://claude.com/claude-code)