### PR TITLE
Release: V23 hotfix — restore audit columns on maintenance tables

### DIFF
--- a/development/service-ops-api/src/main/resources/db/migration/V23__add_maintenance_audit_columns.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V23__add_maintenance_audit_columns.sql
@@ -1,0 +1,16 @@
+-- V22 가 정비 두 테이블을 만들 때 audit 컬럼 중 `created_by` / `updated_by` 두
+-- 개를 빠뜨려서 Hibernate schema-validation 이 startup 시 실패했다 (entity 의
+-- `AuditableEntity` 슈퍼클래스는 두 컬럼을 기대). 핫픽스로 두 테이블에 nullable
+-- UUID 컬럼을 더한다.
+--
+-- 시스템 계정이 record 를 만드는 경로(seed / 자동 작업) 가 있어 nullable 로
+-- 둔다. 기존 행은 null 로 채워지고, 새 row 는 @PrePersist 가 채워주는 것이
+-- 운영자 UUID 일 때만 값이 박힌다.
+
+alter table maintenance_items
+    add column created_by uuid,
+    add column updated_by uuid;
+
+alter table vehicle_maintenance_records
+    add column created_by uuid,
+    add column updated_by uuid;


### PR DESCRIPTION
## Summary
긴급 핫픽스 — V22 가 \`maintenance_items\` / \`vehicle_maintenance_records\` 두 테이블에 \`created_by\` / \`updated_by\` audit 컬럼을 빠뜨려서 운영 환경에서 service-ops-api 가 schema-validation 실패로 crash loop 중이었음.

V23 으로 두 테이블에 nullable UUID 컬럼 \`created_by\` / \`updated_by\` 추가. V22 자체는 그대로 유지 (Flyway 체크섬 충돌 방지).

(#261)

## Test plan
- [ ] 배포 후 \`sudo systemctl status thundercrew-service-ops-api\` 가 active (running) 유지 (crash loop 종결)
- [ ] \`sudo journalctl -u thundercrew-service-ops-api -n 50\` 에 SessionFactory 정상 init 로그
- [ ] AdminSeedRunner 가 빈 admin_users 테이블 보고 env 값으로 admin row 생성
- [ ] 로그인 페이지에서 id \`admin\`, env 의 \`THUNDERCREW_ADMIN_SEED_PASSWORD\` 값으로 정상 로그인

🤖 Generated with [Claude Code](https://claude.com/claude-code)