### PR TITLE
Float vehicle detail inside the map; open it from marker clicks too

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -576,18 +576,17 @@ textarea { padding-top: 10px; min-height: 96px; }
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
 
-/* 차량 floating 상세 패널 — 모달 대신 지도 우측 상단에 떠 있는 비-모달
-   카드. 운영자가 panel 을 띄운 채로도 표/지도와 상호작용할 수 있어야 해서
-   `position: fixed` + 우측 anchor + max-height 로 viewport 안에 고정.
-   `pointer-events: auto` 는 명시 — 부모 wrapper 의 events: none 같은 패턴이
-   상위에 들어와도 패널 자체는 클릭 가능하게 보호. */
+/* 차량 floating 상세 패널 — 옛 /monitoring 의 BikeDetailPanel 패턴 그대로
+   지도 캔버스 내부 우상단에 absolute 로 떠 있는 비-모달 카드. 캔버스 컨테
+   이너(`.overview-map-canvas`) 가 `position: relative` 라 그 안에서 위치가
+   잡힌다. 표 / 탭 / 지도와 상호작용을 안 가린다. */
 .vehicle-floating-panel {
-  position: fixed;
-  top: 96px;
-  right: 24px;
-  width: 380px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 360px;
   max-width: calc(100% - 32px);
-  max-height: calc(100vh - 120px);
+  max-height: calc(100% - 32px);
   overflow: auto;
   padding: 20px 24px;
   border-radius: 12px;

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -324,6 +324,9 @@ export default async function RootPage({
       <OverviewMapBanner
         bikePins={mapState.data.bikePins}
         stationPins={mapState.data.stationPins}
+        vehicles={vehicleData.vehicles}
+        bikeActiveRiderById={matching.bikeActiveRiderById}
+        riderInfoById={riderInfoById}
       />
 
       <h2 className="overview-section-heading">관리</h2>

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -7,7 +7,6 @@ import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
-import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
@@ -114,7 +113,6 @@ export function VehiclesPanel({
   /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
   maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
 }) {
-  const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
@@ -206,16 +204,8 @@ export function VehiclesPanel({
     return () => setFilteredBikeIds(null);
   }, [setFilteredBikeIds]);
 
-  // 행 클릭으로 activeRow 가 잡히면 context 의 selectedBikeId 도 같이 publish
-  // 해 지도가 자동으로 켜지고 그 차량으로 pan 한다. 닫힐 때 (activeRow=null)
-  // 는 selection 도 함께 해제. 언마운트(탭 전환) 시에도 잔존 방지.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const id = activeRow?.vehicle.id ?? null;
-    const handle = window.requestAnimationFrame(() => setSelectedBikeId(id));
-    return () => window.cancelAnimationFrame(handle);
-  }, [activeRow, setSelectedBikeId]);
-
+  // 탭 언마운트(다른 탭으로 전환) 시 선택 상태도 해제. 마커 클릭 / 행 클릭
+  // 으로 잡힌 selectedBikeId 가 다른 탭에서 잔존하지 않게.
   useEffect(() => {
     return () => setSelectedBikeId(null);
   }, [setSelectedBikeId]);
@@ -355,13 +345,12 @@ export function VehiclesPanel({
                     event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
                     event.dataTransfer.effectAllowed = "copy";
                   }}
-                  onClick={() =>
-                    setActiveRow({
-                      vehicle,
-                      riderName: riderInfo?.name ?? null,
-                      riderPhone: riderInfo?.phone ?? null
-                    })
-                  }
+                  onClick={() => {
+                    // selectedBikeId 만 publish — 지도 위 floating panel 이
+                    // 컨텍스트를 읽어 자동으로 열린다. rider 정보 lookup 은
+                    // OverviewMapBanner 가 직접 함.
+                    if (vehicle.id) setSelectedBikeId(vehicle.id);
+                  }}
                 >
                   <td onClick={(event) => event.stopPropagation()}>
                     {vehicle.id ? (
@@ -403,11 +392,9 @@ export function VehiclesPanel({
         </table>
       </div>
 
-      <VehicleDetailDialog
-        key={activeRow ? (activeRow.vehicle.id ?? activeRow.vehicle.slug) : "none"}
-        row={activeRow}
-        onClose={() => setActiveRow(null)}
-      />
+      {/* 차량 상세 floating panel 은 더 이상 이 패널이 직접 렌더하지 않는다.
+          OverviewMapBanner 가 selectedBikeId 를 읽어 지도 캔버스 내부 우상단
+          에 띄우고, 마커 클릭으로도 같은 panel 이 열린다. */}
     </div>
   );
 }

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
+import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type {
   FrontendDashboardBikePin,
-  FrontendDashboardStationPin
+  FrontendDashboardStationPin,
+  FrontendVehicle
 } from "@/lib/services/service-ops-api";
 
 /**
@@ -19,19 +21,32 @@ import type {
  * `filteredBikeIds` 로 부분 집합만 마커로 노출. 다른 탭에선 VehiclesPanel 이
  * 언마운트되며 context 가 null 로 되돌아가 전체 핀 복귀.
  *
- * 차량 행 클릭 시(VehiclesPanel 이 `selectedBikeId` 를 context 에 publish)
- * 지도가 자동으로 열리고 그 차량 위치로 pan. 이미 열려 있으면 pan 만. 운영자
- * 가 토글로 다시 끄기 전까지 자동으로 닫지 않는다.
+ * 차량 상세 floating panel:
+ *   - 행 클릭(VehiclesPanel) 또는 지도 마커 클릭 → `selectedBikeId` 가 context
+ *     에 publish 됨
+ *   - 지도가 닫혀 있으면 자동으로 켜지고 그 차량 위치로 pan
+ *   - VehicleDetailDialog 를 **지도 캔버스 내부** 우상단에 floating 으로
+ *     렌더링 (옛 /monitoring 의 BikeDetailPanel 패턴). 페이지의 다른 영역
+ *     (표 / 탭) 과 상호작용을 막지 않는 비-모달
  */
 export function OverviewMapBanner({
   bikePins,
-  stationPins
+  stationPins,
+  vehicles,
+  bikeActiveRiderById,
+  riderInfoById
 }: {
   bikePins: ReadonlyArray<FrontendDashboardBikePin>;
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
+  /** 차량 단위 lookup. selectedBikeId 로 FrontendVehicle 을 derive 하는 데 쓴다. */
+  vehicles: ReadonlyArray<FrontendVehicle>;
+  /** bikeId → 활성 라이더 id. detail panel 의 "이름/연락처" 컬럼 lookup 시작점. */
+  bikeActiveRiderById?: Map<string, string>;
+  /** riderId → {name, phone}. */
+  riderInfoById?: Map<string, { name: string; phone: string }>;
 }) {
   const [open, setOpen] = useState(false);
-  const { filteredBikeIds, selectedBikeId } = useVehicleFilter();
+  const { filteredBikeIds, selectedBikeId, setSelectedBikeId } = useVehicleFilter();
 
   const effectiveBikePins = useMemo(() => {
     if (filteredBikeIds === null) return bikePins;
@@ -44,9 +59,18 @@ export function OverviewMapBanner({
     return map;
   }, [bikePins]);
 
-  // 행 클릭 시 자동으로 토글 ON. setState in effect 는 rAF 한 프레임 양보로
-  // 회피 — 같은 commit 안에서 동기 호출하면 lint(`react-hooks/set-state-in-
-  // effect`) 가 잡는다.
+  const vehicleById = useMemo(() => {
+    const map = new Map<string, FrontendVehicle>();
+    for (const vehicle of vehicles) {
+      const key = vehicle.id ?? vehicle.slug;
+      if (key) map.set(key, vehicle);
+    }
+    return map;
+  }, [vehicles]);
+
+  // 행 클릭이든 마커 클릭이든 selectedBikeId 가 잡히면 지도가 자동으로 켜진다.
+  // setState in effect 는 rAF 한 프레임 양보로 회피 (`react-hooks/set-state-in-
+  // effect` 규칙).
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (selectedBikeId && !open) {
@@ -55,14 +79,29 @@ export function OverviewMapBanner({
     }
   }, [selectedBikeId, open]);
 
-  // 선택 차량의 위치로 pan. 객체 identity 가 매번 새로 생성되어 MapShell 의
-  // targetLocation effect 가 재발화 (같은 차량을 두 번 골라도 다시 panning).
   const targetLocation = useMemo(() => {
     if (!selectedBikeId) return null;
     const pin = bikePinById.get(selectedBikeId);
     if (!pin) return null;
+    // 매 호출마다 새 객체 — MapShell 의 targetLocation effect 가 같은 차량
+    // 두 번 클릭에도 재발화.
     return { lat: pin.latitude, lng: pin.longitude };
   }, [selectedBikeId, bikePinById]);
+
+  // VehicleDetailDialog 에 넘길 row 데이터. selectedBikeId 가 잡힌 순간 lookup
+  // — vehicle 자체가 없으면(예: 옛 ID 잔존) panel 도 안 뜬다.
+  const detailRow: VehicleDetailRow | null = useMemo(() => {
+    if (!selectedBikeId) return null;
+    const vehicle = vehicleById.get(selectedBikeId);
+    if (!vehicle) return null;
+    const riderId = bikeActiveRiderById?.get(selectedBikeId) ?? null;
+    const riderInfo = riderId ? riderInfoById?.get(riderId) ?? null : null;
+    return {
+      vehicle,
+      riderName: riderInfo?.name ?? null,
+      riderPhone: riderInfo?.phone ?? null
+    };
+  }, [selectedBikeId, vehicleById, bikeActiveRiderById, riderInfoById]);
 
   const totalLabel =
     filteredBikeIds === null
@@ -90,6 +129,14 @@ export function OverviewMapBanner({
             bikePins={[...effectiveBikePins]}
             stationPins={[...stationPins]}
             targetLocation={targetLocation}
+            onBikeSelect={setSelectedBikeId}
+          />
+          {/* 지도 위 floating 상세 패널 — 캔버스 내부 우상단. ESC / 닫기 누르면
+              context 의 selectedBikeId 만 해제, 지도는 그대로 둔다. */}
+          <VehicleDetailDialog
+            key={detailRow ? (detailRow.vehicle.id ?? detailRow.vehicle.slug) : "none"}
+            row={detailRow}
+            onClose={() => setSelectedBikeId(null)}
           />
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
옛 \`/monitoring\` 의 BikeDetailPanel 패턴 복원 + 지도 마커 클릭으로 상세 열기.

**1. 차량 상세 floating panel 을 지도 캔버스 내부로**
- 기존: \`position: fixed; top: 96px; right: 24px\` — viewport 우상단
- 변경: \`position: absolute; top: 16px; right: 16px\` — \`.overview-map-canvas\` 우상단
- 렌더링 책임을 \`VehiclesPanel\` → \`OverviewMapBanner\` 로 이전. \`VehiclesPanel\` 는 더 이상 \`VehicleDetailDialog\` 안 렌더

**2. 지도 마커 클릭 → 상세 panel 열기**
- \`OverviewMapBanner\` 가 \`onBikeSelect={setSelectedBikeId}\` 를 \`MapShell\` 에 전달
- 마커 클릭이든 행 클릭이든 같은 \`VehicleFilterContext.selectedBikeId\` 가 잡혀서 동일한 panel 흐름

**State 단일화**
- \`VehiclesPanel.activeRow\` useState + publish effect 제거
- context 의 \`selectedBikeId\` 가 single source of truth
- \`OverviewMapBanner\` 가 vehicle / rider lookup props 로 \`VehicleDetailRow\` derive

## Test plan
- [ ] 차량 표 행 클릭 → 지도 자동 ON → 그 차량 위치로 pan → **지도 우상단에** floating panel 노출
- [ ] panel 띄운 채로 표 / 다른 마커 / 지도 panning 모두 가능 (비-모달)
- [ ] 지도 마커 클릭 → 같은 panel 이 그 차량으로 열림
- [ ] 같은 마커 두 번 클릭해도 pan 재발화
- [ ] × 버튼 / ESC 키 → panel 닫힘, 지도는 계속 열려 있음
- [ ] 라이더 / BSS 탭 이동 시 panel 닫힘 (cleanup)
- [ ] panel 내 수정 모드 → 저장 → revalidate 후 panel 닫히고 표 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)