### PR TITLE
Collapse filter bars to one row; treat "no telemetry" as OFF

### DIFF
--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -127,7 +127,10 @@ export function RidersPanel({
         } else {
           if (!activeBikeId) return false;
           const status = ignitionStatusByBikeId?.get(activeBikeId);
-          if (status !== filters.ignition) return false;
+          // ON 은 명시적 ON 만. OFF 는 "ON 이 아닌 모든 것" — UNKNOWN /
+          // 텔레메트리 없음도 OFF 로 간주 (운영자 멘탈 모델과 일치).
+          if (filters.ignition === "ON" && status !== "ON") return false;
+          if (filters.ignition === "OFF" && status === "ON") return false;
         }
       }
       return true;
@@ -145,7 +148,7 @@ export function RidersPanel({
 
   return (
     <div className="vehicles-panel">
-      {/* Row 1: 검색 · 교육 · 차량 배정 · 카운트 */}
+      {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -180,12 +183,6 @@ export function RidersPanel({
           <option value="ASSIGNED">배정됨</option>
           <option value="UNASSIGNED">미배정</option>
         </select>
-        <span className="vehicles-filter-count">
-          {visibleRiders.length} / {data.riders.length}
-        </span>
-      </div>
-      {/* Row 2: 구독·렌탈 · 보험 · 시동 상태 */}
-      <div className="vehicles-filter-row">
         <select
           className="vehicles-filter-select"
           value={filters.contractCategory}
@@ -221,6 +218,9 @@ export function RidersPanel({
           <option value="OFF">OFF</option>
           <option value="UNASSIGNED">차량 미배정</option>
         </select>
+        <span className="vehicles-filter-count">
+          {visibleRiders.length} / {data.riders.length}
+        </span>
       </div>
 
       <div className="table-card">
@@ -317,7 +317,7 @@ export function RidersPanel({
                   <td>{renderReturnType(contract?.returnType ?? null)}</td>
                   <td>{renderDuration(contract?.durationLabel ?? null)}</td>
                   <td>{renderInsuranceProduct(insuranceLabel)}</td>
-                  <td>{renderIgnitionStatus(ignitionStatus)}</td>
+                  <td>{renderIgnitionStatus(ignitionStatus, Boolean(activeBikeId))}</td>
                   <td onClick={(event) => event.stopPropagation()}>
                     {activeBikeId ? (
                       <IgnitionControlButton bikeId={activeBikeId} initialBlocked={ignitionBlocked} />
@@ -348,10 +348,13 @@ function renderInsuranceProduct(label: string | null): ReactNode {
   return <Badge tone="active">{label}</Badge>;
 }
 
-function renderIgnitionStatus(status: string | null): ReactNode {
+function renderIgnitionStatus(status: string | null, hasBike: boolean): ReactNode {
+  // 라이더에 배정된 차량이 없으면 의미상 시동을 논할 수 없음 — \"—\" 유지.
+  if (!hasBike) return <span className="muted">—</span>;
+  // 차량은 있는데 ON 이 아닌 모든 케이스(OFF / UNKNOWN / 텔레메트리 없음) 는
+  // 운영자 멘탈 모델 상 "꺼짐". 차량 탭의 시동 셀과 동일 규칙.
   if (status === "ON") return <Badge tone="active">시동</Badge>;
-  if (status === "OFF") return <span className="muted">꺼짐</span>;
-  return <span className="muted">—</span>;
+  return <span className="muted">꺼짐</span>;
 }
 
 function renderEducationType(type: "ONLINE" | "OFFLINE" | null): ReactNode {

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -59,7 +59,9 @@ type FilterState = {
   engineType: "ALL" | "ELECTRIC" | "ICE";
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
   connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
-  ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
+  // 운영자 멘탈 모델 상 "상태없음" = 사실상 OFF. UNKNOWN / telemetry 없음은
+  // OFF 결과에 포함된다. 옵션은 전체 / ON / OFF 셋만.
+  ignition: "ALL" | "ON" | "OFF";
   // 정비 상태 — DUE_SOON 은 임박, OVERDUE 는 지연, ANY 는 둘 다.
   maintenance: "ALL" | "DUE_SOON" | "OVERDUE" | "ANY";
 };
@@ -169,9 +171,10 @@ export function VehiclesPanel({
       if (filters.ignition !== "ALL") {
         const pin = bikePinById.get(vehicleKey);
         const status = pin?.ignitionStatus;
+        // ON 은 명시적 ON 만. OFF 는 "ON 이 아닌 모든 것" (실제 OFF / UNKNOWN /
+        // 핀 없음). 표 셀 표시도 같은 규칙으로 통일.
         if (filters.ignition === "ON" && status !== "ON") return false;
-        if (filters.ignition === "OFF" && status !== "OFF") return false;
-        if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
+        if (filters.ignition === "OFF" && status === "ON") return false;
       }
       if (filters.maintenance !== "ALL") {
         const summary = maintenanceSummaryByBike?.get(vehicleKey);
@@ -212,7 +215,7 @@ export function VehiclesPanel({
 
   return (
     <div className="vehicles-panel">
-      {/* Row 1: 검색 · 구분 · 운영 상태 · 카운트 */}
+      {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -246,12 +249,6 @@ export function VehiclesPanel({
           <option value="IN_SERVICE">운행</option>
           <option value="READY">대기</option>
         </select>
-        <span className="vehicles-filter-count">
-          {visibleVehicles.length} / {data.vehicles.length}
-        </span>
-      </div>
-      {/* Row 2: 연결 상태 · 시동 · 정비 상태(준비중) */}
-      <div className="vehicles-filter-row">
         <select
           className="vehicles-filter-select"
           value={filters.connection}
@@ -273,7 +270,6 @@ export function VehiclesPanel({
           <option value="ALL">시동: 전체</option>
           <option value="ON">ON</option>
           <option value="OFF">OFF</option>
-          <option value="UNKNOWN">상태없음</option>
         </select>
         <select
           className="vehicles-filter-select"
@@ -287,6 +283,9 @@ export function VehiclesPanel({
           <option value="DUE_SOON">임박만</option>
           <option value="OVERDUE">지연만</option>
         </select>
+        <span className="vehicles-filter-count">
+          {visibleVehicles.length} / {data.vehicles.length}
+        </span>
       </div>
 
       <div className="table-card vehicles-table-scroll">
@@ -441,9 +440,10 @@ function renderConnection(status: string | undefined): ReactNode {
 }
 
 function renderIgnition(status: string | undefined): ReactNode {
+  // ON 은 명시적 ON 만. 그 외(OFF / UNKNOWN / 핀 없음) 는 모두 OFF — 운영자
+  // 멘탈 모델 ("상태없음 = 사실상 OFF") 과 필터 의미와 동일하게 통일.
   if (status === "ON") return <span className="vehicles-pill vehicles-pill--ignition-on">ON</span>;
-  if (status === "OFF") return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
-  return <span className="muted">—</span>;
+  return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
 }
 
 function renderSpeed(speedKph: number | null | undefined): ReactNode {


### PR DESCRIPTION
## Summary
운영자 피드백 반영 두 가지:

**1. 필터 바 한 줄로**
- 차량 탭 / 라이더 탭 둘 다 두 줄 → 한 줄
- 기존 \`flex-wrap\` 으로 좁은 폭에선 자연스럽게 두 줄로 떨어짐 (회귀 없음)
- 카운트 chip 의 \`margin-left: auto\` 가 우측 끝 고정 유지

**2. 시동 의미 통합 (\"상태없음 = 사실상 OFF\")**
- 차량 탭 \`시동\` 필터에서 \`상태없음\` 옵션 제거. 옵션: \`전체 / ON / OFF\`
- 필터 로직: \`OFF\` 는 명시적 OFF + UNKNOWN + 텔레메트리 없음 모두 매칭
- 차량 탭 \`시동 상태\` 컬럼 표시: \`—\` → \`OFF\` pill 로 통일
- 라이더 탭 \`시동 상태\` 컬럼: 배정된 차량이 있을 때 ON 아니면 \`꺼짐\`. 배정 자체가 없으면 \`—\` 유지 (의미가 다름)
- 라이더 탭 \`시동 상태\` 필터의 \`차량 미배정\` 옵션은 유지 — 다른 의미라서

## Test plan
- [ ] 차량 탭 필터들이 한 줄로 노출 (브라우저 폭이 충분할 때)
- [ ] 좁은 폭에선 자연스럽게 두 줄로 wrap
- [ ] 차량 탭 시동 필터 옵션이 \`전체 / ON / OFF\` 셋만
- [ ] \`OFF\` 필터 선택 시 텔레메트리 없는 차량 / UNKNOWN 차량도 결과에 포함
- [ ] 차량 탭 시동 상태 셀이 모두 \`ON\` 또는 \`OFF\` (이전 \`—\` 자리도 \`OFF\`)
- [ ] 라이더 탭 필터들도 한 줄
- [ ] 차량 배정 없는 라이더의 시동 상태 셀은 \`—\` 유지
- [ ] 차량 있는데 ON 아닌 라이더의 시동 상태 셀은 \`꺼짐\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)