### PR TITLE
Release: floating detail in map + marker click + filter UX polish

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -576,18 +576,17 @@ textarea { padding-top: 10px; min-height: 96px; }
 .overview-create-dialog::backdrop { background: rgba(0, 0, 0, .4); }
 .overview-create-dialog h3 { margin: 0 0 16px; font-size: 18px; }
 
-/* 차량 floating 상세 패널 — 모달 대신 지도 우측 상단에 떠 있는 비-모달
-   카드. 운영자가 panel 을 띄운 채로도 표/지도와 상호작용할 수 있어야 해서
-   `position: fixed` + 우측 anchor + max-height 로 viewport 안에 고정.
-   `pointer-events: auto` 는 명시 — 부모 wrapper 의 events: none 같은 패턴이
-   상위에 들어와도 패널 자체는 클릭 가능하게 보호. */
+/* 차량 floating 상세 패널 — 옛 /monitoring 의 BikeDetailPanel 패턴 그대로
+   지도 캔버스 내부 우상단에 absolute 로 떠 있는 비-모달 카드. 캔버스 컨테
+   이너(`.overview-map-canvas`) 가 `position: relative` 라 그 안에서 위치가
+   잡힌다. 표 / 탭 / 지도와 상호작용을 안 가린다. */
 .vehicle-floating-panel {
-  position: fixed;
-  top: 96px;
-  right: 24px;
-  width: 380px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 360px;
   max-width: calc(100% - 32px);
-  max-height: calc(100vh - 120px);
+  max-height: calc(100% - 32px);
   overflow: auto;
   padding: 20px 24px;
   border-radius: 12px;

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -324,6 +324,9 @@ export default async function RootPage({
       <OverviewMapBanner
         bikePins={mapState.data.bikePins}
         stationPins={mapState.data.stationPins}
+        vehicles={vehicleData.vehicles}
+        bikeActiveRiderById={matching.bikeActiveRiderById}
+        riderInfoById={riderInfoById}
       />
 
       <h2 className="overview-section-heading">관리</h2>

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -127,7 +127,10 @@ export function RidersPanel({
         } else {
           if (!activeBikeId) return false;
           const status = ignitionStatusByBikeId?.get(activeBikeId);
-          if (status !== filters.ignition) return false;
+          // ON 은 명시적 ON 만. OFF 는 "ON 이 아닌 모든 것" — UNKNOWN /
+          // 텔레메트리 없음도 OFF 로 간주 (운영자 멘탈 모델과 일치).
+          if (filters.ignition === "ON" && status !== "ON") return false;
+          if (filters.ignition === "OFF" && status === "ON") return false;
         }
       }
       return true;
@@ -145,7 +148,7 @@ export function RidersPanel({
 
   return (
     <div className="vehicles-panel">
-      {/* Row 1: 검색 · 교육 · 차량 배정 · 카운트 */}
+      {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -180,12 +183,6 @@ export function RidersPanel({
           <option value="ASSIGNED">배정됨</option>
           <option value="UNASSIGNED">미배정</option>
         </select>
-        <span className="vehicles-filter-count">
-          {visibleRiders.length} / {data.riders.length}
-        </span>
-      </div>
-      {/* Row 2: 구독·렌탈 · 보험 · 시동 상태 */}
-      <div className="vehicles-filter-row">
         <select
           className="vehicles-filter-select"
           value={filters.contractCategory}
@@ -221,6 +218,9 @@ export function RidersPanel({
           <option value="OFF">OFF</option>
           <option value="UNASSIGNED">차량 미배정</option>
         </select>
+        <span className="vehicles-filter-count">
+          {visibleRiders.length} / {data.riders.length}
+        </span>
       </div>
 
       <div className="table-card">
@@ -317,7 +317,7 @@ export function RidersPanel({
                   <td>{renderReturnType(contract?.returnType ?? null)}</td>
                   <td>{renderDuration(contract?.durationLabel ?? null)}</td>
                   <td>{renderInsuranceProduct(insuranceLabel)}</td>
-                  <td>{renderIgnitionStatus(ignitionStatus)}</td>
+                  <td>{renderIgnitionStatus(ignitionStatus, Boolean(activeBikeId))}</td>
                   <td onClick={(event) => event.stopPropagation()}>
                     {activeBikeId ? (
                       <IgnitionControlButton bikeId={activeBikeId} initialBlocked={ignitionBlocked} />
@@ -348,10 +348,13 @@ function renderInsuranceProduct(label: string | null): ReactNode {
   return <Badge tone="active">{label}</Badge>;
 }
 
-function renderIgnitionStatus(status: string | null): ReactNode {
+function renderIgnitionStatus(status: string | null, hasBike: boolean): ReactNode {
+  // 라이더에 배정된 차량이 없으면 의미상 시동을 논할 수 없음 — \"—\" 유지.
+  if (!hasBike) return <span className="muted">—</span>;
+  // 차량은 있는데 ON 이 아닌 모든 케이스(OFF / UNKNOWN / 텔레메트리 없음) 는
+  // 운영자 멘탈 모델 상 "꺼짐". 차량 탭의 시동 셀과 동일 규칙.
   if (status === "ON") return <Badge tone="active">시동</Badge>;
-  if (status === "OFF") return <span className="muted">꺼짐</span>;
-  return <span className="muted">—</span>;
+  return <span className="muted">꺼짐</span>;
 }
 
 function renderEducationType(type: "ONLINE" | "OFFLINE" | null): ReactNode {

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -7,7 +7,6 @@ import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton
 import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
 import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
-import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
@@ -114,7 +113,6 @@ export function VehiclesPanel({
   /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
   maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
 }) {
-  const [activeRow, setActiveRow] = useState<VehicleDetailRow | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
@@ -206,16 +204,8 @@ export function VehiclesPanel({
     return () => setFilteredBikeIds(null);
   }, [setFilteredBikeIds]);
 
-  // 행 클릭으로 activeRow 가 잡히면 context 의 selectedBikeId 도 같이 publish
-  // 해 지도가 자동으로 켜지고 그 차량으로 pan 한다. 닫힐 때 (activeRow=null)
-  // 는 selection 도 함께 해제. 언마운트(탭 전환) 시에도 잔존 방지.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const id = activeRow?.vehicle.id ?? null;
-    const handle = window.requestAnimationFrame(() => setSelectedBikeId(id));
-    return () => window.cancelAnimationFrame(handle);
-  }, [activeRow, setSelectedBikeId]);
-
+  // 탭 언마운트(다른 탭으로 전환) 시 선택 상태도 해제. 마커 클릭 / 행 클릭
+  // 으로 잡힌 selectedBikeId 가 다른 탭에서 잔존하지 않게.
   useEffect(() => {
     return () => setSelectedBikeId(null);
   }, [setSelectedBikeId]);
@@ -355,13 +345,12 @@ export function VehiclesPanel({
                     event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
                     event.dataTransfer.effectAllowed = "copy";
                   }}
-                  onClick={() =>
-                    setActiveRow({
-                      vehicle,
-                      riderName: riderInfo?.name ?? null,
-                      riderPhone: riderInfo?.phone ?? null
-                    })
-                  }
+                  onClick={() => {
+                    // selectedBikeId 만 publish — 지도 위 floating panel 이
+                    // 컨텍스트를 읽어 자동으로 열린다. rider 정보 lookup 은
+                    // OverviewMapBanner 가 직접 함.
+                    if (vehicle.id) setSelectedBikeId(vehicle.id);
+                  }}
                 >
                   <td onClick={(event) => event.stopPropagation()}>
                     {vehicle.id ? (
@@ -403,11 +392,9 @@ export function VehiclesPanel({
         </table>
       </div>
 
-      <VehicleDetailDialog
-        key={activeRow ? (activeRow.vehicle.id ?? activeRow.vehicle.slug) : "none"}
-        row={activeRow}
-        onClose={() => setActiveRow(null)}
-      />
+      {/* 차량 상세 floating panel 은 더 이상 이 패널이 직접 렌더하지 않는다.
+          OverviewMapBanner 가 selectedBikeId 를 읽어 지도 캔버스 내부 우상단
+          에 띄우고, 마커 클릭으로도 같은 panel 이 열린다. */}
     </div>
   );
 }

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -59,7 +59,9 @@ type FilterState = {
   engineType: "ALL" | "ELECTRIC" | "ICE";
   operationStatus: "ALL" | "READY" | "IN_SERVICE";
   connection: "ALL" | "ONLINE" | "ANY_OFFLINE";
-  ignition: "ALL" | "ON" | "OFF" | "UNKNOWN";
+  // 운영자 멘탈 모델 상 "상태없음" = 사실상 OFF. UNKNOWN / telemetry 없음은
+  // OFF 결과에 포함된다. 옵션은 전체 / ON / OFF 셋만.
+  ignition: "ALL" | "ON" | "OFF";
   // 정비 상태 — DUE_SOON 은 임박, OVERDUE 는 지연, ANY 는 둘 다.
   maintenance: "ALL" | "DUE_SOON" | "OVERDUE" | "ANY";
 };
@@ -169,9 +171,10 @@ export function VehiclesPanel({
       if (filters.ignition !== "ALL") {
         const pin = bikePinById.get(vehicleKey);
         const status = pin?.ignitionStatus;
+        // ON 은 명시적 ON 만. OFF 는 "ON 이 아닌 모든 것" (실제 OFF / UNKNOWN /
+        // 핀 없음). 표 셀 표시도 같은 규칙으로 통일.
         if (filters.ignition === "ON" && status !== "ON") return false;
-        if (filters.ignition === "OFF" && status !== "OFF") return false;
-        if (filters.ignition === "UNKNOWN" && (status === "ON" || status === "OFF")) return false;
+        if (filters.ignition === "OFF" && status === "ON") return false;
       }
       if (filters.maintenance !== "ALL") {
         const summary = maintenanceSummaryByBike?.get(vehicleKey);
@@ -212,7 +215,7 @@ export function VehiclesPanel({
 
   return (
     <div className="vehicles-panel">
-      {/* Row 1: 검색 · 구분 · 운영 상태 · 카운트 */}
+      {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <div className="vehicles-filter-row">
         <div className="vehicles-filter-search-wrap">
           <input
@@ -246,12 +249,6 @@ export function VehiclesPanel({
           <option value="IN_SERVICE">운행</option>
           <option value="READY">대기</option>
         </select>
-        <span className="vehicles-filter-count">
-          {visibleVehicles.length} / {data.vehicles.length}
-        </span>
-      </div>
-      {/* Row 2: 연결 상태 · 시동 · 정비 상태(준비중) */}
-      <div className="vehicles-filter-row">
         <select
           className="vehicles-filter-select"
           value={filters.connection}
@@ -273,7 +270,6 @@ export function VehiclesPanel({
           <option value="ALL">시동: 전체</option>
           <option value="ON">ON</option>
           <option value="OFF">OFF</option>
-          <option value="UNKNOWN">상태없음</option>
         </select>
         <select
           className="vehicles-filter-select"
@@ -287,6 +283,9 @@ export function VehiclesPanel({
           <option value="DUE_SOON">임박만</option>
           <option value="OVERDUE">지연만</option>
         </select>
+        <span className="vehicles-filter-count">
+          {visibleVehicles.length} / {data.vehicles.length}
+        </span>
       </div>
 
       <div className="table-card vehicles-table-scroll">
@@ -441,9 +440,10 @@ function renderConnection(status: string | undefined): ReactNode {
 }
 
 function renderIgnition(status: string | undefined): ReactNode {
+  // ON 은 명시적 ON 만. 그 외(OFF / UNKNOWN / 핀 없음) 는 모두 OFF — 운영자
+  // 멘탈 모델 ("상태없음 = 사실상 OFF") 과 필터 의미와 동일하게 통일.
   if (status === "ON") return <span className="vehicles-pill vehicles-pill--ignition-on">ON</span>;
-  if (status === "OFF") return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
-  return <span className="muted">—</span>;
+  return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
 }
 
 function renderSpeed(speedKph: number | null | undefined): ReactNode {

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
+import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type {
   FrontendDashboardBikePin,
-  FrontendDashboardStationPin
+  FrontendDashboardStationPin,
+  FrontendVehicle
 } from "@/lib/services/service-ops-api";
 
 /**
@@ -19,19 +21,32 @@ import type {
  * `filteredBikeIds` 로 부분 집합만 마커로 노출. 다른 탭에선 VehiclesPanel 이
  * 언마운트되며 context 가 null 로 되돌아가 전체 핀 복귀.
  *
- * 차량 행 클릭 시(VehiclesPanel 이 `selectedBikeId` 를 context 에 publish)
- * 지도가 자동으로 열리고 그 차량 위치로 pan. 이미 열려 있으면 pan 만. 운영자
- * 가 토글로 다시 끄기 전까지 자동으로 닫지 않는다.
+ * 차량 상세 floating panel:
+ *   - 행 클릭(VehiclesPanel) 또는 지도 마커 클릭 → `selectedBikeId` 가 context
+ *     에 publish 됨
+ *   - 지도가 닫혀 있으면 자동으로 켜지고 그 차량 위치로 pan
+ *   - VehicleDetailDialog 를 **지도 캔버스 내부** 우상단에 floating 으로
+ *     렌더링 (옛 /monitoring 의 BikeDetailPanel 패턴). 페이지의 다른 영역
+ *     (표 / 탭) 과 상호작용을 막지 않는 비-모달
  */
 export function OverviewMapBanner({
   bikePins,
-  stationPins
+  stationPins,
+  vehicles,
+  bikeActiveRiderById,
+  riderInfoById
 }: {
   bikePins: ReadonlyArray<FrontendDashboardBikePin>;
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
+  /** 차량 단위 lookup. selectedBikeId 로 FrontendVehicle 을 derive 하는 데 쓴다. */
+  vehicles: ReadonlyArray<FrontendVehicle>;
+  /** bikeId → 활성 라이더 id. detail panel 의 "이름/연락처" 컬럼 lookup 시작점. */
+  bikeActiveRiderById?: Map<string, string>;
+  /** riderId → {name, phone}. */
+  riderInfoById?: Map<string, { name: string; phone: string }>;
 }) {
   const [open, setOpen] = useState(false);
-  const { filteredBikeIds, selectedBikeId } = useVehicleFilter();
+  const { filteredBikeIds, selectedBikeId, setSelectedBikeId } = useVehicleFilter();
 
   const effectiveBikePins = useMemo(() => {
     if (filteredBikeIds === null) return bikePins;
@@ -44,9 +59,18 @@ export function OverviewMapBanner({
     return map;
   }, [bikePins]);
 
-  // 행 클릭 시 자동으로 토글 ON. setState in effect 는 rAF 한 프레임 양보로
-  // 회피 — 같은 commit 안에서 동기 호출하면 lint(`react-hooks/set-state-in-
-  // effect`) 가 잡는다.
+  const vehicleById = useMemo(() => {
+    const map = new Map<string, FrontendVehicle>();
+    for (const vehicle of vehicles) {
+      const key = vehicle.id ?? vehicle.slug;
+      if (key) map.set(key, vehicle);
+    }
+    return map;
+  }, [vehicles]);
+
+  // 행 클릭이든 마커 클릭이든 selectedBikeId 가 잡히면 지도가 자동으로 켜진다.
+  // setState in effect 는 rAF 한 프레임 양보로 회피 (`react-hooks/set-state-in-
+  // effect` 규칙).
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (selectedBikeId && !open) {
@@ -55,14 +79,29 @@ export function OverviewMapBanner({
     }
   }, [selectedBikeId, open]);
 
-  // 선택 차량의 위치로 pan. 객체 identity 가 매번 새로 생성되어 MapShell 의
-  // targetLocation effect 가 재발화 (같은 차량을 두 번 골라도 다시 panning).
   const targetLocation = useMemo(() => {
     if (!selectedBikeId) return null;
     const pin = bikePinById.get(selectedBikeId);
     if (!pin) return null;
+    // 매 호출마다 새 객체 — MapShell 의 targetLocation effect 가 같은 차량
+    // 두 번 클릭에도 재발화.
     return { lat: pin.latitude, lng: pin.longitude };
   }, [selectedBikeId, bikePinById]);
+
+  // VehicleDetailDialog 에 넘길 row 데이터. selectedBikeId 가 잡힌 순간 lookup
+  // — vehicle 자체가 없으면(예: 옛 ID 잔존) panel 도 안 뜬다.
+  const detailRow: VehicleDetailRow | null = useMemo(() => {
+    if (!selectedBikeId) return null;
+    const vehicle = vehicleById.get(selectedBikeId);
+    if (!vehicle) return null;
+    const riderId = bikeActiveRiderById?.get(selectedBikeId) ?? null;
+    const riderInfo = riderId ? riderInfoById?.get(riderId) ?? null : null;
+    return {
+      vehicle,
+      riderName: riderInfo?.name ?? null,
+      riderPhone: riderInfo?.phone ?? null
+    };
+  }, [selectedBikeId, vehicleById, bikeActiveRiderById, riderInfoById]);
 
   const totalLabel =
     filteredBikeIds === null
@@ -90,6 +129,14 @@ export function OverviewMapBanner({
             bikePins={[...effectiveBikePins]}
             stationPins={[...stationPins]}
             targetLocation={targetLocation}
+            onBikeSelect={setSelectedBikeId}
+          />
+          {/* 지도 위 floating 상세 패널 — 캔버스 내부 우상단. ESC / 닫기 누르면
+              context 의 selectedBikeId 만 해제, 지도는 그대로 둔다. */}
+          <VehicleDetailDialog
+            key={detailRow ? (detailRow.vehicle.id ?? detailRow.vehicle.slug) : "none"}
+            row={detailRow}
+            onClose={() => setSelectedBikeId(null)}
           />
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- 차량 상세 floating panel 을 viewport → 지도 캔버스 내부 우상단으로 이동. 옛 \`/monitoring\` 의 BikeDetailPanel 패턴 복원 (#263)
- 지도 마커 클릭으로 같은 상세 panel 열림 (#263)
- 차량/라이더 탭 필터 바 2줄 → 1줄 (좁은 폭 자동 wrap) (#264)
- 차량 탭 시동 필터에서 \`상태없음\` 제거. \`OFF\` 가 UNKNOWN / 텔레메트리 없음도 포함 (#264)
- 셀 표시도 \`—\` → \`OFF\` 로 통일 (#264)

## Test plan
- [ ] 차량 표 행 클릭 → 지도 자동 ON → 지도 우상단에 floating panel
- [ ] 지도 마커 클릭 → 같은 panel 열림
- [ ] × 또는 ESC 로 panel 닫으면 지도는 그대로 유지
- [ ] 차량/라이더 탭 필터들 한 줄로 노출
- [ ] 시동 필터 옵션 \`전체 / ON / OFF\` 셋만
- [ ] OFF 선택 시 텔레메트리 없는 차량도 결과에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)