### PR TITLE
Pull the maintenance section out of the IMEI grid column

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -636,6 +636,11 @@ textarea { padding-top: 10px; min-height: 96px; }
 .maintenance-panel-section-title { margin: 0; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
 .maintenance-panel-indent { color: var(--color-text-muted); margin-right: 4px; }
 
+/* 차량 floating panel 의 view 모드 — field grid / 정비 섹션 / 액션 버튼 세
+   블록을 위에서 아래로 쌓는다. 정비 섹션을 grid 안에 두면 IMEI 오른쪽 셀로
+   흘러들어가서 어색하게 붙어 보이는 문제를 막기 위한 명시적 컨테이너. */
+.vehicle-detail-view { display: flex; flex-direction: column; gap: 12px; }
+
 /* 차량 floating panel 안의 "정비 상태" 섹션 — 한 행을 2 줄(2x2 grid) 로 배치.
    좁은 panel 폭(360px) 에서 한국어 품목명이 글자 단위로 wrap 되는 사태를
    막기 위해, 첫 줄은 "품목명 · 상태 뱃지", 둘째 줄은 "주기 · 마지막 교환

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -149,14 +149,20 @@ export function VehicleDetailDialog({
         </button>
       </div>
       {mode === "view" ? (
-        <div className="detail-row-grid">
-          <DetailField label="차량번호" value={vehicle.plateNumber} />
-          <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
-          <DetailField label="모델명" value={vehicle.model || "—"} />
-          <DetailField label="운영 상태" value={vehicle.status} />
-          <DetailField label="이름" value={row.riderName ?? "—"} />
-          <DetailField label="연락처" value={row.riderPhone ?? "—"} />
-          <DetailField label="IMEI" value={currentDeviceUid || "—"} />
+        // view 모드 내부 구조: 위에서 아래로 (1) 2-컬럼 field grid, (2) 정비
+        // 섹션, (3) 액션 버튼. 정비 섹션을 grid 안에 두면 IMEI 오른쪽 셀로
+        // 흘러들어가서 어색하게 붙어 보이는 문제를 막기 위해 grid 밖으로
+        // 분리. 액션 버튼도 같이 빠져 나와서 패널 하단에 자연스럽게 위치.
+        <div className="vehicle-detail-view">
+          <div className="detail-row-grid">
+            <DetailField label="차량번호" value={vehicle.plateNumber} />
+            <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
+            <DetailField label="모델명" value={vehicle.model || "—"} />
+            <DetailField label="운영 상태" value={vehicle.status} />
+            <DetailField label="이름" value={row.riderName ?? "—"} />
+            <DetailField label="연락처" value={row.riderPhone ?? "—"} />
+            <DetailField label="IMEI" value={currentDeviceUid || "—"} />
+          </div>
           <MaintenanceSection vehicleId={vehicleId} bundle={maintenance} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>


### PR DESCRIPTION
## Summary
- 차량 상세 패널의 정비 섹션이 `.detail-row-grid` 의 2번째 컬럼에 잡혀 IMEI 라벨 옆에 붙어 보이던 문제 수정
- view 모드 전체를 `.vehicle-detail-view` flex column 으로 감싸 필드 그리드 / 정비 섹션 / 액션 버튼을 독립 블록으로 분리
- 그리드는 이제 단순 필드 7개만 담고, 정비 섹션은 패널 폭 전체를 사용

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 지도에서 마커 클릭 → floating 패널에서 정비 섹션이 IMEI 옆이 아니라 그리드 하단에 풀폭으로 표시되는지 확인
- [ ] 정비 섹션 토글 / 입력 폼이 그리드와 겹치지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)