### PR TITLE
Reflect maintenance 교환 완료 in the open detail panel

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -520,25 +520,34 @@ function optionalInteger(value: FormDataEntryValue | null): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export type MarkVehicleMaintenanceServicedResult =
+  | { ok: true }
+  | { ok: false; reason: "not-configured" | "session-required" | "missing-item" | "record-error" };
+
 export async function markVehicleMaintenanceServicedAction(
   vehicleId: string,
   formData: FormData
-): Promise<void> {
+): Promise<MarkVehicleMaintenanceServicedResult> {
   // 차량 floating panel 의 "교환 완료" 버튼이 호출. 같은 차량 + 같은 품목에
   // 대해 row 를 한 건 새로 추가하기만 한다 — 다음 교환 예정 / 임박 / 지연
   // 등은 derived 라 클라이언트가 list 재조회로 갱신.
+  //
+  // **Return semantics**: redirect 를 던지지 않고 결과를 객체로 돌려준다. 호출자
+  // (`MaintenanceRowView`) 가 await 으로 완료를 감지한 직후 panel 안의 정비
+  // bundle 을 재페치해 새 record 가 즉시 반영되도록 하기 위함. 페이지의 다른
+  // 영역 (차량 표의 정비 요약 배지 등) 은 `revalidatePath("/")` 로 갱신.
   if (!serviceOpsApiConfigured()) {
-    redirect("/?tab=vehicles");
+    return { ok: false, reason: "not-configured" };
   }
 
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
-    redirect("/login?status=session-required");
+    return { ok: false, reason: "session-required" };
   }
 
   const itemId = String(formData.get("itemId") ?? "").trim();
   if (!itemId) {
-    redirect("/?tab=vehicles&status=maintenance-missing-item");
+    return { ok: false, reason: "missing-item" };
   }
   const odoRaw = String(formData.get("servicedAtOdometerKm") ?? "").trim();
   const odo = odoRaw ? Number.parseInt(odoRaw, 10) : null;
@@ -551,11 +560,11 @@ export async function markVehicleMaintenanceServicedAction(
       memo: null
     });
   } catch {
-    redirect("/?tab=vehicles&status=maintenance-record-error");
+    return { ok: false, reason: "record-error" };
   }
 
   revalidatePath("/");
-  redirect("/?tab=vehicles");
+  return { ok: true };
 }
 
 export async function setVehicleIgnitionBlockFromOverviewAction(

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -54,6 +54,9 @@ export function VehicleDetailDialog({
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
   // 정비 catalog + 이력. 차량별 두 list 를 한 round-trip 으로 받아 캐싱.
   const [maintenance, setMaintenance] = useState<VehicleMaintenanceBundle | null>(null);
+  // 정비 bundle 재페치 트리거. "교환 완료" 액션이 끝나면 +1 → maintenance
+  // useEffect 가 같은 vehicleId 라도 다시 발화해 새 record 를 반영.
+  const [maintenanceReloadTick, setMaintenanceReloadTick] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
@@ -93,7 +96,8 @@ export function VehicleDetailDialog({
     };
   }, [vehicleIdForFetch]);
 
-  // 정비 catalog + 이력 lazy fetch. 같은 차량에 대해 한 번만 호출.
+  // 정비 catalog + 이력 lazy fetch. `maintenanceReloadTick` 증가 시에도
+  // 재발화 — "교환 완료" 후 즉시 갱신이 보이도록.
   useEffect(() => {
     if (!vehicleIdForFetch) return;
     let cancelled = false;
@@ -113,7 +117,11 @@ export function VehicleDetailDialog({
     return () => {
       cancelled = true;
     };
-  }, [vehicleIdForFetch]);
+  }, [vehicleIdForFetch, maintenanceReloadTick]);
+
+  const handleMaintenanceChanged = useCallback(() => {
+    setMaintenanceReloadTick((tick) => tick + 1);
+  }, []);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -163,7 +171,11 @@ export function VehicleDetailDialog({
             <DetailField label="연락처" value={row.riderPhone ?? "—"} />
             <DetailField label="IMEI" value={currentDeviceUid || "—"} />
           </div>
-          <MaintenanceSection vehicleId={vehicleId} bundle={maintenance} />
+          <MaintenanceSection
+            vehicleId={vehicleId}
+            bundle={maintenance}
+            onChanged={handleMaintenanceChanged}
+          />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>
               닫기
@@ -249,10 +261,16 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
 
 function MaintenanceSection({
   vehicleId,
-  bundle
+  bundle,
+  onChanged
 }: {
   vehicleId: string;
   bundle: VehicleMaintenanceBundle | null;
+  /**
+   * "교환 완료" 액션이 백엔드에 성공적으로 적용된 직후 호출. 부모가
+   * maintenance bundle 을 재페치해 새 record 를 즉시 노출하도록 한다.
+   */
+  onChanged: () => void;
 }) {
   const rows = useMemo(() => {
     if (!bundle) return null;
@@ -289,7 +307,7 @@ function MaintenanceSection({
       <ul className="maintenance-list">
         {ordered.map((row) => (
           <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>
-            <MaintenanceRowView vehicleId={vehicleId} row={row} />
+            <MaintenanceRowView vehicleId={vehicleId} row={row} onChanged={onChanged} />
           </li>
         ))}
       </ul>
@@ -299,10 +317,12 @@ function MaintenanceSection({
 
 function MaintenanceRowView({
   vehicleId,
-  row
+  row,
+  onChanged
 }: {
   vehicleId: string;
   row: DerivedMaintenanceRow;
+  onChanged: () => void;
 }) {
   const [pending, startTransition] = useTransition();
   const cycleLabel = renderCycleLabel(row);
@@ -313,8 +333,18 @@ function MaintenanceRowView({
     if (!window.confirm(`"${row.item.name}" 교환 완료 처리하시겠습니까?`)) return;
     const fd = new FormData();
     fd.append("itemId", row.item.id);
-    startTransition(() => {
-      void markVehicleMaintenanceServicedAction(vehicleId, fd);
+    startTransition(async () => {
+      // 액션이 redirect 대신 result 를 반환하므로 await 으로 완료를 잡고
+      // 성공 시에만 부모에게 재페치 시그널을 보낸다. 실패 케이스는 일단
+      // alert 으로 알리는 정도 — 더 정교한 toast 는 추후.
+      const result = await markVehicleMaintenanceServicedAction(vehicleId, fd);
+      if (result.ok) {
+        onChanged();
+      } else if (result.reason === "session-required") {
+        window.location.href = "/login?status=session-required";
+      } else {
+        window.alert("교환 완료 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+      }
     });
   };
 


### PR DESCRIPTION
## Summary
- 차량 상세 floating 패널에서 "교환 완료" 클릭 시 즉시 상태 뱃지 / 마지막 교환 셀이 갱신되도록 수정 (옵션 A — refresh counter)
- `markVehicleMaintenanceServicedAction` 이 redirect 대신 `{ ok, reason }` 결과를 반환하도록 변경 → 호출자가 `await` 로 완료 시점을 잡을 수 있음
- `VehicleDetailDialog` 의 maintenance fetch effect 에 `maintenanceReloadTick` deps 추가 → 같은 vehicleId 에서도 재페치
- 액션 실패 시 세션 만료는 `/login` 으로, 그 외는 alert 으로 사용자에게 알림

## Notes
- 옵션 2 (odometer 텔레메트리 + 오프라인 안내) 는 백엔드 인프라(`bike_current_states.odometer_km` 컬럼 + 인제스트 DTO) 가 빠져 있어 별도 PR 로 분할 예정. 벤더 페이로드에 총주행거리가 들어온다는 점은 확인됨.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 차량 상세 panel 열고 정비 행의 "교환 완료" 클릭 → confirm 수락 → 패널을 닫지 않은 상태에서 상태 뱃지 / 마지막 교환 셀이 즉시 갱신되는지 확인
- [ ] 세션 만료 상태에서 "교환 완료" 누르면 `/login?status=session-required` 로 이동
- [ ] 차량 표의 정비 요약 배지도 `revalidatePath` 로 갱신되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)