### PR TITLE
Persist telemetry odometer_km through the ingest pipeline

### DIFF
--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -745,6 +745,11 @@ export type ServiceOpsBikeCurrentState = {
   longitude: number | string;
   speedKph: number | string | null;
   batteryPercent: number | string | null;
+  /**
+   * 누적 주행거리 (km). V24 부터 backend 가 응답에 포함; 텔레메트리 미수신이거나
+   * 벤더 페이로드에서 값이 빠지면 null.
+   */
+  odometerKm: number | null;
   ignitionStatus: string;
   telemetrySource: string;
   drivingStatus: string;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
@@ -39,6 +39,9 @@ public class BikeCurrentState {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /** 누적 주행거리 (km). 벤더 페이로드에 없으면 null. */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -65,6 +68,7 @@ public class BikeCurrentState {
         this.longitude = log.getLongitude();
         this.speedKph = log.getSpeedKph();
         this.batteryPercent = log.getBatteryPercent();
+        this.odometerKm = log.getOdometerKm();
         this.ignitionStatus = log.getIgnitionStatus();
         this.telemetrySource = log.getTelemetrySource();
         this.updatedAt = Instant.now();
@@ -108,6 +112,10 @@ public class BikeCurrentState {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
@@ -44,6 +44,9 @@ public class BikeRecentState {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /** 누적 주행거리 (km). 벤더 페이로드에 없으면 null. */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -65,6 +68,7 @@ public class BikeRecentState {
         state.longitude = log.getLongitude();
         state.speedKph = log.getSpeedKph();
         state.batteryPercent = log.getBatteryPercent();
+        state.odometerKm = log.getOdometerKm();
         state.ignitionStatus = log.getIgnitionStatus();
         state.telemetrySource = log.getTelemetrySource();
         return state;
@@ -115,6 +119,10 @@ public class BikeRecentState {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
@@ -54,6 +54,12 @@ public class DeviceTelemetryLog {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /**
+     * 누적 주행거리 (km). 벤더 페이로드가 줄 때 채움; 일시적으로 빠지면 null.
+     * 차량 상세의 정비 cycle_km 품목 상태 분류에 사용된다.
+     */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -81,6 +87,7 @@ public class DeviceTelemetryLog {
             BigDecimal longitude,
             BigDecimal speedKph,
             BigDecimal batteryPercent,
+            Integer odometerKm,
             TelemetryIgnitionStatus ignitionStatus,
             TelemetrySource telemetrySource,
             String rawPayload
@@ -97,6 +104,7 @@ public class DeviceTelemetryLog {
         log.longitude = longitude;
         log.speedKph = speedKph;
         log.batteryPercent = batteryPercent;
+        log.odometerKm = odometerKm;
         log.ignitionStatus = ignitionStatus;
         log.telemetrySource = telemetrySource;
         log.rawPayload = rawPayload;
@@ -160,6 +168,10 @@ public class DeviceTelemetryLog {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
@@ -17,6 +17,8 @@ public record BikeCurrentStateReadResponse(
         BigDecimal longitude,
         BigDecimal speedKph,
         BigDecimal batteryPercent,
+        /** 누적 주행거리 (km). 텔레메트리가 안 들어왔으면 null. */
+        Integer odometerKm,
         TelemetryIgnitionStatus ignitionStatus,
         String telemetrySource,
         String drivingStatus,
@@ -36,6 +38,7 @@ public record BikeCurrentStateReadResponse(
                 state.getLongitude(),
                 state.getSpeedKph(),
                 state.getBatteryPercent(),
+                state.getOdometerKm(),
                 state.getIgnitionStatus(),
                 state.getTelemetrySource().name(),
                 drivingStatus(state),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
@@ -23,6 +23,11 @@ public record TelemetryIngestRequest(
         @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
         @PositiveOrZero BigDecimal speedKph,
         @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal batteryPercent,
+        /**
+         * 누적 주행거리 (km). 벤더 페이로드가 줄 때만 채움; 누락된 이벤트는
+         * 그대로 받아들이고 odometer 없이 적재한다.
+         */
+        @PositiveOrZero Integer odometerKm,
         @NotNull TelemetryIgnitionStatus ignitionStatus,
         @NotNull TelemetrySource telemetrySource,
         JsonNode rawPayload

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
@@ -25,11 +25,11 @@ public class TelemetryWriteRepository {
                 insert into device_telemetry_logs (
                     id, device_id, device_uid, bike_id, vendor_event_id, payload_hash,
                     received_at, device_reported_at, latitude, longitude, speed_kph,
-                    battery_percent, ignition_status, telemetry_source, raw_payload
+                    battery_percent, odometer_km, ignition_status, telemetry_source, raw_payload
                 ) values (
                     ?, ?, ?, ?, ?, ?,
                     ?::timestamptz, ?::timestamptz, ?, ?, ?,
-                    ?, ?, ?, ?::jsonb
+                    ?, ?, ?, ?, ?::jsonb
                 )
                 %s
                 returning id
@@ -51,11 +51,11 @@ public class TelemetryWriteRepository {
             PreparedStatement ps = connection.prepareStatement("""
                     insert into bike_current_states (
                         bike_id, device_id, telemetry_log_id, last_received_at,
-                        latitude, longitude, speed_kph, battery_percent,
+                        latitude, longitude, speed_kph, battery_percent, odometer_km,
                         ignition_status, telemetry_source, updated_at
                     ) values (
                         ?, ?, ?, ?::timestamptz,
-                        ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?,
                         ?, ?, now()
                     )
                     on conflict (bike_id) do update set
@@ -66,6 +66,7 @@ public class TelemetryWriteRepository {
                         longitude = excluded.longitude,
                         speed_kph = excluded.speed_kph,
                         battery_percent = excluded.battery_percent,
+                        odometer_km = excluded.odometer_km,
                         ignition_status = excluded.ignition_status,
                         telemetry_source = excluded.telemetry_source,
                         updated_at = now()
@@ -79,8 +80,9 @@ public class TelemetryWriteRepository {
             ps.setBigDecimal(6, log.getLongitude());
             ps.setBigDecimal(7, log.getSpeedKph());
             ps.setBigDecimal(8, log.getBatteryPercent());
-            ps.setString(9, log.getIgnitionStatus().name());
-            ps.setString(10, log.getTelemetrySource().name());
+            setNullableInteger(ps, 9, log.getOdometerKm());
+            ps.setString(10, log.getIgnitionStatus().name());
+            ps.setString(11, log.getTelemetrySource().name());
             return ps;
         });
         return affectedRows > 0;
@@ -114,9 +116,10 @@ public class TelemetryWriteRepository {
         ps.setBigDecimal(10, log.getLongitude());
         ps.setBigDecimal(11, log.getSpeedKph());
         ps.setBigDecimal(12, log.getBatteryPercent());
-        ps.setString(13, log.getIgnitionStatus().name());
-        ps.setString(14, log.getTelemetrySource().name());
-        setNullableString(ps, 15, log.getRawPayload());
+        setNullableInteger(ps, 13, log.getOdometerKm());
+        ps.setString(14, log.getIgnitionStatus().name());
+        ps.setString(15, log.getTelemetrySource().name());
+        setNullableString(ps, 16, log.getRawPayload());
     }
 
     private void setUuid(PreparedStatement ps, int index, UUID value) throws SQLException {
@@ -141,5 +144,13 @@ public class TelemetryWriteRepository {
             return;
         }
         ps.setString(index, value);
+    }
+
+    private void setNullableInteger(PreparedStatement ps, int index, Integer value) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+            return;
+        }
+        ps.setInt(index, value);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
@@ -80,6 +80,7 @@ public class TelemetryIngestionService {
                 request.longitude(),
                 request.speedKph(),
                 request.batteryPercent(),
+                request.odometerKm(),
                 request.ignitionStatus(),
                 request.telemetrySource(),
                 rawPayload
@@ -173,6 +174,7 @@ public class TelemetryIngestionService {
                 request.longitude() == null ? "" : request.longitude().toPlainString(),
                 request.speedKph() == null ? "" : request.speedKph().toPlainString(),
                 request.batteryPercent() == null ? "" : request.batteryPercent().toPlainString(),
+                request.odometerKm() == null ? "" : request.odometerKm().toString(),
                 request.ignitionStatus().name(),
                 request.telemetrySource().name(),
                 rawPayload == null ? "" : rawPayload

--- a/development/service-ops-api/src/main/resources/db/migration/V24__add_telemetry_odometer_km.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V24__add_telemetry_odometer_km.sql
@@ -1,0 +1,32 @@
+-- 텔레메트리 페이로드의 "총 주행거리(km)" 를 세 단계 (raw log / recent history /
+-- current state) 에 모두 보존한다. 차량 정비 cycle_km 품목 (브레이크 패드,
+-- 타이어, 모터오일 등) 의 상태 분류와 표시에 직접 쓰인다.
+--
+-- 값은 벤더가 보내는 누적 주행거리 정수 km. 정밀도가 미세하지 않아 integer 로
+-- 충분 — V22 의 `vehicle_maintenance_records.serviced_at_odometer_km` 와 동일한
+-- 타입을 맞춰 비교 / 차분 계산 코드를 단순화한다.
+--
+-- 기존 행에는 null 로 채워지고, 다음 텔레메트리 수신 시점부터 자연스럽게
+-- 값이 채워진다. nullable 유지 — 벤더가 일시적으로 odometer 필드를 빠뜨려도
+-- 다른 필드 (위치 / 시동) 는 정상 적재되어야 하기 때문.
+
+alter table device_telemetry_logs
+    add column odometer_km integer;
+
+alter table device_telemetry_logs
+    add constraint ck_device_telemetry_logs_odometer
+    check (odometer_km is null or odometer_km >= 0);
+
+alter table bike_recent_states
+    add column odometer_km integer;
+
+alter table bike_recent_states
+    add constraint ck_bike_recent_states_odometer
+    check (odometer_km is null or odometer_km >= 0);
+
+alter table bike_current_states
+    add column odometer_km integer;
+
+alter table bike_current_states
+    add constraint ck_bike_current_states_odometer
+    check (odometer_km is null or odometer_km >= 0);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
@@ -104,6 +104,7 @@ class VendorTelemetryAdapterTests {
                 new BigDecimal("127.0270000"),
                 new BigDecimal("12.5"),
                 new BigDecimal("75"),
+                1234,
                 TelemetryIgnitionStatus.ON,
                 TelemetrySource.POLLING,
                 null);


### PR DESCRIPTION
## Summary
- V24 마이그레이션 — `device_telemetry_logs`, `bike_recent_states`, `bike_current_states` 세 테이블에 `odometer_km integer` 컬럼 + non-negative 체크 추가 (nullable, 기존 행은 null)
- `TelemetryIngestRequest` 에 `@PositiveOrZero Integer odometerKm` 옵션 필드 추가 → `DeviceTelemetryLog.create` → recent state 복사 → current state upsert 까지 흘러감
- payload hash 와 idempotent insert SQL 도 odometer 포함하도록 갱신 → 같은 이벤트 재전송 시 중복 검출 정상 동작
- `BikeCurrentStateReadResponse` API 응답에 `odometerKm` 노출 + 프런트엔드 `ServiceOpsBikeCurrentState` 타입에도 동기화
- 옵션 2 (km 기반 정비 cycle 자동 분류 + 오프라인 안내) 의 백엔드 인프라 단계. 프런트엔드 derive + UI 는 후속 PR

## Notes
- 벤더 페이로드의 어떤 키를 `odometerKm` 으로 매핑할지는 벤더 어댑터 레이어에서 별도 결정. 이 PR 은 인제스트 API 가 그 필드를 받을 수 있는 surface 만 추가
- `ArchitectureBoundaryTests` 2건 실패는 dev 에서 이미 존재하는 pre-existing 이슈 (AuthController.changePassword + MaintenanceCommandController, V20 시절 architectural rule 위반). 이 PR 과 무관
- 로컬 환경에서 testcontainers Docker 미연결로 통합 테스트 27건 initialization 실패 — CI 에서 검증 필요

## Test plan
- [x] `./gradlew compileJava` — 성공
- [x] `./gradlew test --tests VendorTelemetryAdapterTests` — 통과 (100%)
- [x] 프런트엔드 `npm run typecheck` — 통과
- [ ] V24 마이그레이션 EC2 적용 시 기존 행 null 유지 확인 (`select count(*) from bike_current_states where odometer_km is null`)
- [ ] 벤더 텔레메트리 인제스트 시 odometer_km 값이 raw log → recent → current 까지 흐르는지 확인
- [ ] `GET /api/v1/telemetry/bikes/{id}/current` 응답에 `odometerKm` 키 포함되는지 확인
- [ ] payload hash 가 odometer 변경에 sensitive — 같은 odometer 면 IDEMPOTENT_REPLAY, 다르면 새 이벤트로 적재

🤖 Generated with [Claude Code](https://claude.com/claude-code)