### PR TITLE
Classify cycle_km maintenance with live odometer; offline notice

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -648,6 +648,19 @@ textarea { padding-top: 10px; min-height: 96px; }
    그룹 헤더와 묶음 시각화. */
 .maintenance-section { margin-top: 8px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
 .maintenance-section h4 { margin: 0 0 8px; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .02em; }
+/* 텔레메트리 오프라인 안내 — 정비 섹션 상단에 한 줄. soft warning 톤(노랑 계열)
+   으로 행 배경(`--color-bg-soft`) 과 구분, 본문 글자보다 한 단계 작게 시각적
+   비중을 낮춤. */
+.maintenance-offline-notice {
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  border-left: 3px solid var(--rm-warn-outline, var(--rm-accent-outline));
+  background: var(--rm-warn-soft, var(--color-bg-soft));
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: 4px;
+}
 .maintenance-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .maintenance-row { padding: 8px 10px; border-radius: 8px; background: var(--color-bg-soft); }
 .maintenance-row--child { margin-left: 12px; background: transparent; }

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -108,11 +108,11 @@ export function VehicleDetailDialog({
       .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
       .then((next) => {
         if (cancelled) return;
-        setMaintenance(next ?? { items: [], records: [] });
+        setMaintenance(next ?? { items: [], records: [], currentState: null });
       })
       .catch(() => {
         if (cancelled) return;
-        setMaintenance({ items: [], records: [] });
+        setMaintenance({ items: [], records: [], currentState: null });
       });
     return () => {
       cancelled = true;
@@ -255,6 +255,26 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   return "—";
 }
 
+/**
+ * 정비 섹션 상단에 들어가는 텔레메트리 오프라인 안내문. backend 의
+ * connectionStatus enum 을 운영자가 알아볼 수 있는 한 문장으로 풀어준다.
+ * `null` 은 텔레메트리가 한 번도 안 들어온 차량(예: 등록만 되고 단말기 미설치).
+ */
+function offlineNoticeText(
+  current: { odometerKm: number | null; connectionStatus: string | null } | null
+): string {
+  if (!current || current.connectionStatus === null) {
+    return "차량 텔레메트리가 아직 수신되지 않아 km 기반 정비 항목의 상태를 계산할 수 없습니다.";
+  }
+  if (current.connectionStatus === "SIGNAL_LOST") {
+    return "텔레메트리 신호가 끊겨 오프라인입니다 — km 기반 정비 상태는 마지막 수신 데이터 기준이라 실시간이 아닐 수 있습니다.";
+  }
+  if (current.connectionStatus === "PARKED_OFFLINE_NORMAL") {
+    return "차량이 시동 OFF 상태로 오프라인입니다 — km 기반 정비 상태는 마지막 운행 데이터 기준입니다.";
+  }
+  return "텔레메트리가 오프라인 상태입니다 — km 기반 정비 상태가 최신이 아닐 수 있습니다.";
+}
+
 // ============================================================================
 // 정비 상태 섹션
 // ============================================================================
@@ -274,7 +294,7 @@ function MaintenanceSection({
 }) {
   const rows = useMemo(() => {
     if (!bundle) return null;
-    return deriveMaintenanceRows(bundle.items, bundle.records);
+    return deriveMaintenanceRows(bundle.items, bundle.records, bundle.currentState ?? null);
   }, [bundle]);
 
   if (!bundle) {
@@ -301,9 +321,23 @@ function MaintenanceSection({
   // 신뢰하되 안전망 차원에서 다시 정렬.
   const ordered = [...rows].sort((a, b) => a.item.displayOrder - b.item.displayOrder);
 
+  // 텔레메트리 ONLINE 일 때만 km 기반 자동 분류가 작동. 그 외엔 운영자가 차량이
+  // 한동안 연결이 끊겼다는 걸 알 수 있게 한 줄 안내 — 안내 자체는 km 품목이
+  // 카탈로그에 있을 때만 의미가 있어서 cycle_km 품목 존재 시에만 노출.
+  const hasKmBasedItem = ordered.some((row) => row.item.cycleKm !== null);
+  const currentState = bundle.currentState;
+  const showOfflineNotice =
+    hasKmBasedItem && (!currentState || currentState.connectionStatus !== "ONLINE");
+  const offlineHint = offlineNoticeText(currentState);
+
   return (
     <section className="maintenance-section">
       <h4>정비 상태</h4>
+      {showOfflineNotice ? (
+        <p className="maintenance-offline-notice" role="status">
+          {offlineHint}
+        </p>
+      ) : null}
       <ul className="maintenance-list">
         {ordered.map((row) => (
           <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -10,9 +10,9 @@ import type {
  *
  * **카운팅 정책**:
  * - cycle_months 가 잡힌 품목은 servicedAt + months 로 다음 예정 일자 계산.
- *   (운영 시간 누적 추적은 V22 시점에 백엔드 인프라가 없어 운영 일수 기준 단순화)
- * - cycle_km 만 잡힌 품목은 odometer 텔레메트리가 없어 자동 상태 계산을 안 함 —
- *   "교환 완료" 시 운영자가 입력한 odometer 가 있으면 그걸 마지막 km 로 노출.
+ * - cycle_km 이 잡힌 품목은 V24 부터 들어온 텔레메트리 odometer 와 마지막 교환
+ *   시점 odometer 를 비교해 ratio 계산. 텔레메트리가 오프라인이거나 마지막
+ *   교환 시 odometer 미입력이면 UNKNOWN.
  * - cycle_label (자유 텍스트, 예: "12개월 이상") 만 있는 품목은 안내 텍스트 그대로
  *   노출하고 상태는 NONE.
  *
@@ -36,9 +36,22 @@ export type DerivedMaintenanceRow = {
 
 const APPROACH_RATIO = 0.9;
 
+/**
+ * 텔레메트리 현재 상태에서 derive 가 보는 부분 — odometer 가 자동 분류에 충분히
+ * 신뢰할만한 상태(online) 인지, 그리고 현재 누적 주행거리. 둘 다 채워져 있어야
+ * cycle_km 자동 분류가 작동한다. null 이거나 connection 이 ONLINE 이 아니면
+ * cycle_km 품목은 안전 모드로 UNKNOWN 처리.
+ */
+export type CurrentTelemetryForDerive = {
+  odometerKm: number | null;
+  /** backend 의 "ONLINE" | "SIGNAL_LOST" | "PARKED_OFFLINE_NORMAL" | "STALE_UNKNOWN". */
+  connectionStatus: string | null;
+};
+
 export function deriveMaintenanceRows(
   items: ReadonlyArray<ServiceOpsMaintenanceItem>,
   records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  current: CurrentTelemetryForDerive | null = null,
   now: Date = new Date()
 ): DerivedMaintenanceRow[] {
   // itemId → 가장 최근 기록 (records 가 이미 servicedAt desc 정렬이라 first hit).
@@ -48,6 +61,13 @@ export function deriveMaintenanceRows(
       latestByItem.set(record.itemId, record);
     }
   }
+
+  // 자동 km 분류 가능 조건: 텔레메트리 ONLINE + odometer 수치 존재. 그 외엔
+  // 마지막 알려진 odometer 가 stale 일 수 있어 cycle_km 자동 status 는 보류.
+  const currentOdometerKm =
+    current && current.connectionStatus === "ONLINE" && typeof current.odometerKm === "number"
+      ? current.odometerKm
+      : null;
 
   return items.map((item) => {
     const latest = latestByItem.get(item.id) ?? null;
@@ -84,8 +104,20 @@ export function deriveMaintenanceRows(
       }
     }
 
-    // cycle_km 만 있는 케이스 — odometer 텔레메트리 없어 자동 상태 derive 안 함.
-    // 운영자가 lastServicedAtOdometerKm + cycle_km 을 보고 직접 판단.
+    // cycle_km 자동 분류. 두 baseline (현재 odometer + 마지막 교환 odometer) 모두
+    // 있어야 가능. lastServicedAtOdometerKm 가 null 이면 운영자가 교환 시점
+    // odometer 를 안 적은 케이스 — 그 행만 UNKNOWN 처리하되 다른 행은 영향
+    // 안 받음.
+    if (
+      item.cycleKm !== null &&
+      currentOdometerKm !== null &&
+      lastServicedAtOdometerKm !== null &&
+      currentOdometerKm >= lastServicedAtOdometerKm
+    ) {
+      const status = classifyByKm(currentOdometerKm - lastServicedAtOdometerKm, item.cycleKm);
+      return { item, lastServicedAt, lastServicedAtOdometerKm, nextDueAt: null, status };
+    }
+
     return {
       item,
       lastServicedAt,
@@ -94,6 +126,14 @@ export function deriveMaintenanceRows(
       status: "UNKNOWN"
     };
   });
+}
+
+function classifyByKm(kmSinceService: number, cycleKm: number): MaintenanceStatus {
+  if (cycleKm <= 0) return "UNKNOWN";
+  const ratio = kmSinceService / cycleKm;
+  if (ratio < APPROACH_RATIO) return "HEALTHY";
+  if (ratio < 1) return "DUE_SOON";
+  return "OVERDUE";
 }
 
 /**
@@ -153,7 +193,10 @@ export function summarizeMaintenanceByBike(
     const bikeRecords = recordsByBike.get(bikeId) ?? [];
     // 다음 단계에선 servicedAt desc 정렬 가정 — recordsByBike push 순서가
     // 백엔드 응답(이미 정렬됨) 그대로라 별도 정렬 안 함.
-    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, now);
+    // 표 필터 단의 요약은 텔레메트리 odometer 를 (아직) 가져오지 않는다 — cycle_km
+    // 품목 자동 분류는 floating panel 안에서만. 표의 "임박/지연" 필터에 cycle_km
+    // 도 끼우려면 차량 별 current state map 을 page-level 에 추가하면 됨.
+    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, null, now);
     let overall: MaintenanceStatus = "UNKNOWN";
     let hasOverdue = false;
     let hasDueSoon = false;

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -8,18 +8,37 @@ import {
 } from "@/lib/services/service-ops-api";
 
 /**
+ * 차량 floating panel 이 정비 섹션 렌더링에 함께 필요한 텔레메트리 현재 상태
+ * 의 부분 집합. 전체 `FrontendBikeCurrentState` 가 아니라 derive 가 실제로
+ * 보는 두 필드만 옮긴다 — 추후 다른 필드(배터리 등) 가 정비 derive 에 필요해
+ * 지면 확장.
+ *
+ * `connectionStatus` 는 backend 의 V24 / V4 derive 그대로 ("ONLINE" /
+ * "SIGNAL_LOST" / "PARKED_OFFLINE_NORMAL" / "STALE_UNKNOWN"). 화면은 ONLINE 만
+ * "온라인" 으로 취급해 odometer 기반 자동 status 분류에 쓴다.
+ */
+export type VehicleCurrentTelemetrySummary = {
+  odometerKm: number | null;
+  connectionStatus: string | null;
+};
+
+/**
  * 차량 상세 floating panel 의 "정비 상태" 섹션이 lazy-fetch 하는 두 list 의
- * 결합 응답. 한 round-trip 으로 catalog + history 를 같이 받아 클라이언트가
- * 두 번 fetch 하지 않게 한다.
+ * 결합 응답. 한 round-trip 으로 catalog + history + 현재 텔레메트리를 같이
+ * 받아 클라이언트가 여러 번 fetch 하지 않게 한다.
  *
  * 미설정 / 미인증 환경에선 둘 다 빈 배열로 — UI 는 "데이터 없음" 으로 fallback.
+ *
+ * `currentState` 는 텔레메트리가 한 번도 안 들어온 차량 또는 조회 실패 시 null —
+ * UI 는 "오프라인" 안내문으로 fallback 하고 km 기반 품목은 자동 분류 안 함.
  */
 export type VehicleMaintenanceBundle = {
   items: ReadonlyArray<ServiceOpsMaintenanceItem>;
   records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+  currentState: VehicleCurrentTelemetrySummary | null;
 };
 
-const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
+const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [], currentState: null };
 
 /**
  * 차량 탭의 "정비 상태" 필터가 차량 별로 임박/지연 여부를 derive 할 때 쓰는
@@ -58,11 +77,20 @@ export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<Vehi
   if (!client) return EMPTY_BUNDLE;
 
   try {
-    const [items, records] = await Promise.all([
+    // current state 는 텔레메트리가 한 번도 안 들어온 차량에선 404. 그 케이스를
+    // bundle 전체 실패로 만들 이유는 없으니 fetch 단계에서 null fallback.
+    const [items, records, currentState] = await Promise.all([
       client.listMaintenanceItemsForBike(bikeId),
-      client.listMaintenanceRecordsForBike(bikeId)
+      client.listMaintenanceRecordsForBike(bikeId),
+      client
+        .getBikeCurrentState(bikeId)
+        .then((state) => ({
+          odometerKm: state.odometerKm,
+          connectionStatus: state.connectionStatus
+        }))
+        .catch(() => null)
     ]);
-    return { items, records };
+    return { items, records, currentState };
   } catch {
     // 조회 실패는 운영자 화면을 깨뜨리지 않게 빈 bundle. console.error 는 backend
     // log 가 잡고, 클라이언트엔 "정비 데이터 불러오기 실패" UI 가 추후 필요.


### PR DESCRIPTION
## Summary
- 차량 상세 floating 패널 정비 섹션의 km 기반 품목(브레이크 패드, 타이어, 모터오일 등)이 텔레메트리 odometer 기반으로 자동 분류되도록 derive 확장 (옵션 2 의 프런트엔드 단계)
- `loadVehicleMaintenanceBundle` 이 카탈로그/이력과 함께 차량 현재 텔레메트리 상태 (`odometerKm` + `connectionStatus`) 도 한 round-trip 으로 동봉
- `deriveMaintenanceRows` 에 `CurrentTelemetryForDerive | null` 인자 추가 — `connectionStatus === "ONLINE"` 이면서 양 baseline (현재 odometer + 마지막 교환 odometer) 이 모두 있을 때만 cycle_km 자동 분류
- 텔레메트리가 오프라인 상태이고 카탈로그에 km 기반 품목이 있으면 정비 섹션 상단에 한 줄 안내문 노출. 안내 문구는 `SIGNAL_LOST` / `PARKED_OFFLINE_NORMAL` / `STALE_UNKNOWN` / 텔레메트리 미수신 케이스별로 자연어로 풀어줌
- 차량 표의 정비 요약(`summarizeMaintenanceByBike`) 은 일단 `null` current state 로 호출 — 표 필터 정확도 향상은 후속 작업

## Notes
- PR #271 (백엔드 V24) 머지 후 후속. backend 가 `odometerKm` 을 응답에 포함하기 시작해야 자동 분류가 실제로 작동
- `--rm-warn-*` 같은 warning 톤 컬러 변수는 아직 미정의 — fallback 으로 accent 톤 사용. 차후 디자인 토큰 추가하면 같이 정리

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 텔레메트리 ONLINE 차량 상세 열고 km 기반 품목들이 정상/임박/지연으로 분류되는지 확인
- [ ] 동일 차량에서 마지막 교환 시 odometer 안 적은 row 가 그 자리만 "—" 로 유지되는지 확인 (그 행만, 다른 km 품목은 정상 분류)
- [ ] 텔레메트리가 한 번도 안 들어온 차량 상세 열고 오프라인 안내문이 노출되는지 확인
- [ ] cycle_months 만 있는 카탈로그 차량은 안내문이 안 뜨는지 확인 (`hasKmBasedItem` 가드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)