### PR TITLE
Release: live maintenance refresh + odometer-driven cycle_km status

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -520,25 +520,34 @@ function optionalInteger(value: FormDataEntryValue | null): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export type MarkVehicleMaintenanceServicedResult =
+  | { ok: true }
+  | { ok: false; reason: "not-configured" | "session-required" | "missing-item" | "record-error" };
+
 export async function markVehicleMaintenanceServicedAction(
   vehicleId: string,
   formData: FormData
-): Promise<void> {
+): Promise<MarkVehicleMaintenanceServicedResult> {
   // 차량 floating panel 의 "교환 완료" 버튼이 호출. 같은 차량 + 같은 품목에
   // 대해 row 를 한 건 새로 추가하기만 한다 — 다음 교환 예정 / 임박 / 지연
   // 등은 derived 라 클라이언트가 list 재조회로 갱신.
+  //
+  // **Return semantics**: redirect 를 던지지 않고 결과를 객체로 돌려준다. 호출자
+  // (`MaintenanceRowView`) 가 await 으로 완료를 감지한 직후 panel 안의 정비
+  // bundle 을 재페치해 새 record 가 즉시 반영되도록 하기 위함. 페이지의 다른
+  // 영역 (차량 표의 정비 요약 배지 등) 은 `revalidatePath("/")` 로 갱신.
   if (!serviceOpsApiConfigured()) {
-    redirect("/?tab=vehicles");
+    return { ok: false, reason: "not-configured" };
   }
 
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
-    redirect("/login?status=session-required");
+    return { ok: false, reason: "session-required" };
   }
 
   const itemId = String(formData.get("itemId") ?? "").trim();
   if (!itemId) {
-    redirect("/?tab=vehicles&status=maintenance-missing-item");
+    return { ok: false, reason: "missing-item" };
   }
   const odoRaw = String(formData.get("servicedAtOdometerKm") ?? "").trim();
   const odo = odoRaw ? Number.parseInt(odoRaw, 10) : null;
@@ -551,11 +560,11 @@ export async function markVehicleMaintenanceServicedAction(
       memo: null
     });
   } catch {
-    redirect("/?tab=vehicles&status=maintenance-record-error");
+    return { ok: false, reason: "record-error" };
   }
 
   revalidatePath("/");
-  redirect("/?tab=vehicles");
+  return { ok: true };
 }
 
 export async function setVehicleIgnitionBlockFromOverviewAction(

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -648,6 +648,19 @@ textarea { padding-top: 10px; min-height: 96px; }
    그룹 헤더와 묶음 시각화. */
 .maintenance-section { margin-top: 8px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
 .maintenance-section h4 { margin: 0 0 8px; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .02em; }
+/* 텔레메트리 오프라인 안내 — 정비 섹션 상단에 한 줄. soft warning 톤(노랑 계열)
+   으로 행 배경(`--color-bg-soft`) 과 구분, 본문 글자보다 한 단계 작게 시각적
+   비중을 낮춤. */
+.maintenance-offline-notice {
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  border-left: 3px solid var(--rm-warn-outline, var(--rm-accent-outline));
+  background: var(--rm-warn-soft, var(--color-bg-soft));
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: 4px;
+}
 .maintenance-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .maintenance-row { padding: 8px 10px; border-radius: 8px; background: var(--color-bg-soft); }
 .maintenance-row--child { margin-left: 12px; background: transparent; }

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -54,6 +54,9 @@ export function VehicleDetailDialog({
   const [deviceState, setDeviceState] = useState<VehicleDeviceResult | null>(null);
   // 정비 catalog + 이력. 차량별 두 list 를 한 round-trip 으로 받아 캐싱.
   const [maintenance, setMaintenance] = useState<VehicleMaintenanceBundle | null>(null);
+  // 정비 bundle 재페치 트리거. "교환 완료" 액션이 끝나면 +1 → maintenance
+  // useEffect 가 같은 vehicleId 라도 다시 발화해 새 record 를 반영.
+  const [maintenanceReloadTick, setMaintenanceReloadTick] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // ESC 로 패널 닫기. 모달이 아니라 floating 이라 page interaction 을 막지는
@@ -93,7 +96,8 @@ export function VehicleDetailDialog({
     };
   }, [vehicleIdForFetch]);
 
-  // 정비 catalog + 이력 lazy fetch. 같은 차량에 대해 한 번만 호출.
+  // 정비 catalog + 이력 lazy fetch. `maintenanceReloadTick` 증가 시에도
+  // 재발화 — "교환 완료" 후 즉시 갱신이 보이도록.
   useEffect(() => {
     if (!vehicleIdForFetch) return;
     let cancelled = false;
@@ -113,7 +117,11 @@ export function VehicleDetailDialog({
     return () => {
       cancelled = true;
     };
-  }, [vehicleIdForFetch]);
+  }, [vehicleIdForFetch, maintenanceReloadTick]);
+
+  const handleMaintenanceChanged = useCallback(() => {
+    setMaintenanceReloadTick((tick) => tick + 1);
+  }, []);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -163,7 +171,11 @@ export function VehicleDetailDialog({
             <DetailField label="연락처" value={row.riderPhone ?? "—"} />
             <DetailField label="IMEI" value={currentDeviceUid || "—"} />
           </div>
-          <MaintenanceSection vehicleId={vehicleId} bundle={maintenance} />
+          <MaintenanceSection
+            vehicleId={vehicleId}
+            bundle={maintenance}
+            onChanged={handleMaintenanceChanged}
+          />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>
               닫기
@@ -249,10 +261,16 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
 
 function MaintenanceSection({
   vehicleId,
-  bundle
+  bundle,
+  onChanged
 }: {
   vehicleId: string;
   bundle: VehicleMaintenanceBundle | null;
+  /**
+   * "교환 완료" 액션이 백엔드에 성공적으로 적용된 직후 호출. 부모가
+   * maintenance bundle 을 재페치해 새 record 를 즉시 노출하도록 한다.
+   */
+  onChanged: () => void;
 }) {
   const rows = useMemo(() => {
     if (!bundle) return null;
@@ -289,7 +307,7 @@ function MaintenanceSection({
       <ul className="maintenance-list">
         {ordered.map((row) => (
           <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>
-            <MaintenanceRowView vehicleId={vehicleId} row={row} />
+            <MaintenanceRowView vehicleId={vehicleId} row={row} onChanged={onChanged} />
           </li>
         ))}
       </ul>
@@ -299,10 +317,12 @@ function MaintenanceSection({
 
 function MaintenanceRowView({
   vehicleId,
-  row
+  row,
+  onChanged
 }: {
   vehicleId: string;
   row: DerivedMaintenanceRow;
+  onChanged: () => void;
 }) {
   const [pending, startTransition] = useTransition();
   const cycleLabel = renderCycleLabel(row);
@@ -313,8 +333,18 @@ function MaintenanceRowView({
     if (!window.confirm(`"${row.item.name}" 교환 완료 처리하시겠습니까?`)) return;
     const fd = new FormData();
     fd.append("itemId", row.item.id);
-    startTransition(() => {
-      void markVehicleMaintenanceServicedAction(vehicleId, fd);
+    startTransition(async () => {
+      // 액션이 redirect 대신 result 를 반환하므로 await 으로 완료를 잡고
+      // 성공 시에만 부모에게 재페치 시그널을 보낸다. 실패 케이스는 일단
+      // alert 으로 알리는 정도 — 더 정교한 toast 는 추후.
+      const result = await markVehicleMaintenanceServicedAction(vehicleId, fd);
+      if (result.ok) {
+        onChanged();
+      } else if (result.reason === "session-required") {
+        window.location.href = "/login?status=session-required";
+      } else {
+        window.alert("교환 완료 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+      }
     });
   };
 

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -108,11 +108,11 @@ export function VehicleDetailDialog({
       .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
       .then((next) => {
         if (cancelled) return;
-        setMaintenance(next ?? { items: [], records: [] });
+        setMaintenance(next ?? { items: [], records: [], currentState: null });
       })
       .catch(() => {
         if (cancelled) return;
-        setMaintenance({ items: [], records: [] });
+        setMaintenance({ items: [], records: [], currentState: null });
       });
     return () => {
       cancelled = true;
@@ -255,6 +255,26 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   return "—";
 }
 
+/**
+ * 정비 섹션 상단에 들어가는 텔레메트리 오프라인 안내문. backend 의
+ * connectionStatus enum 을 운영자가 알아볼 수 있는 한 문장으로 풀어준다.
+ * `null` 은 텔레메트리가 한 번도 안 들어온 차량(예: 등록만 되고 단말기 미설치).
+ */
+function offlineNoticeText(
+  current: { odometerKm: number | null; connectionStatus: string | null } | null
+): string {
+  if (!current || current.connectionStatus === null) {
+    return "차량 텔레메트리가 아직 수신되지 않아 km 기반 정비 항목의 상태를 계산할 수 없습니다.";
+  }
+  if (current.connectionStatus === "SIGNAL_LOST") {
+    return "텔레메트리 신호가 끊겨 오프라인입니다 — km 기반 정비 상태는 마지막 수신 데이터 기준이라 실시간이 아닐 수 있습니다.";
+  }
+  if (current.connectionStatus === "PARKED_OFFLINE_NORMAL") {
+    return "차량이 시동 OFF 상태로 오프라인입니다 — km 기반 정비 상태는 마지막 운행 데이터 기준입니다.";
+  }
+  return "텔레메트리가 오프라인 상태입니다 — km 기반 정비 상태가 최신이 아닐 수 있습니다.";
+}
+
 // ============================================================================
 // 정비 상태 섹션
 // ============================================================================
@@ -274,7 +294,7 @@ function MaintenanceSection({
 }) {
   const rows = useMemo(() => {
     if (!bundle) return null;
-    return deriveMaintenanceRows(bundle.items, bundle.records);
+    return deriveMaintenanceRows(bundle.items, bundle.records, bundle.currentState ?? null);
   }, [bundle]);
 
   if (!bundle) {
@@ -301,9 +321,23 @@ function MaintenanceSection({
   // 신뢰하되 안전망 차원에서 다시 정렬.
   const ordered = [...rows].sort((a, b) => a.item.displayOrder - b.item.displayOrder);
 
+  // 텔레메트리 ONLINE 일 때만 km 기반 자동 분류가 작동. 그 외엔 운영자가 차량이
+  // 한동안 연결이 끊겼다는 걸 알 수 있게 한 줄 안내 — 안내 자체는 km 품목이
+  // 카탈로그에 있을 때만 의미가 있어서 cycle_km 품목 존재 시에만 노출.
+  const hasKmBasedItem = ordered.some((row) => row.item.cycleKm !== null);
+  const currentState = bundle.currentState;
+  const showOfflineNotice =
+    hasKmBasedItem && (!currentState || currentState.connectionStatus !== "ONLINE");
+  const offlineHint = offlineNoticeText(currentState);
+
   return (
     <section className="maintenance-section">
       <h4>정비 상태</h4>
+      {showOfflineNotice ? (
+        <p className="maintenance-offline-notice" role="status">
+          {offlineHint}
+        </p>
+      ) : null}
       <ul className="maintenance-list">
         {ordered.map((row) => (
           <li key={row.item.id} className={row.item.parentItemId ? "maintenance-row maintenance-row--child" : "maintenance-row"}>

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -10,9 +10,9 @@ import type {
  *
  * **카운팅 정책**:
  * - cycle_months 가 잡힌 품목은 servicedAt + months 로 다음 예정 일자 계산.
- *   (운영 시간 누적 추적은 V22 시점에 백엔드 인프라가 없어 운영 일수 기준 단순화)
- * - cycle_km 만 잡힌 품목은 odometer 텔레메트리가 없어 자동 상태 계산을 안 함 —
- *   "교환 완료" 시 운영자가 입력한 odometer 가 있으면 그걸 마지막 km 로 노출.
+ * - cycle_km 이 잡힌 품목은 V24 부터 들어온 텔레메트리 odometer 와 마지막 교환
+ *   시점 odometer 를 비교해 ratio 계산. 텔레메트리가 오프라인이거나 마지막
+ *   교환 시 odometer 미입력이면 UNKNOWN.
  * - cycle_label (자유 텍스트, 예: "12개월 이상") 만 있는 품목은 안내 텍스트 그대로
  *   노출하고 상태는 NONE.
  *
@@ -36,9 +36,22 @@ export type DerivedMaintenanceRow = {
 
 const APPROACH_RATIO = 0.9;
 
+/**
+ * 텔레메트리 현재 상태에서 derive 가 보는 부분 — odometer 가 자동 분류에 충분히
+ * 신뢰할만한 상태(online) 인지, 그리고 현재 누적 주행거리. 둘 다 채워져 있어야
+ * cycle_km 자동 분류가 작동한다. null 이거나 connection 이 ONLINE 이 아니면
+ * cycle_km 품목은 안전 모드로 UNKNOWN 처리.
+ */
+export type CurrentTelemetryForDerive = {
+  odometerKm: number | null;
+  /** backend 의 "ONLINE" | "SIGNAL_LOST" | "PARKED_OFFLINE_NORMAL" | "STALE_UNKNOWN". */
+  connectionStatus: string | null;
+};
+
 export function deriveMaintenanceRows(
   items: ReadonlyArray<ServiceOpsMaintenanceItem>,
   records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
+  current: CurrentTelemetryForDerive | null = null,
   now: Date = new Date()
 ): DerivedMaintenanceRow[] {
   // itemId → 가장 최근 기록 (records 가 이미 servicedAt desc 정렬이라 first hit).
@@ -48,6 +61,13 @@ export function deriveMaintenanceRows(
       latestByItem.set(record.itemId, record);
     }
   }
+
+  // 자동 km 분류 가능 조건: 텔레메트리 ONLINE + odometer 수치 존재. 그 외엔
+  // 마지막 알려진 odometer 가 stale 일 수 있어 cycle_km 자동 status 는 보류.
+  const currentOdometerKm =
+    current && current.connectionStatus === "ONLINE" && typeof current.odometerKm === "number"
+      ? current.odometerKm
+      : null;
 
   return items.map((item) => {
     const latest = latestByItem.get(item.id) ?? null;
@@ -84,8 +104,20 @@ export function deriveMaintenanceRows(
       }
     }
 
-    // cycle_km 만 있는 케이스 — odometer 텔레메트리 없어 자동 상태 derive 안 함.
-    // 운영자가 lastServicedAtOdometerKm + cycle_km 을 보고 직접 판단.
+    // cycle_km 자동 분류. 두 baseline (현재 odometer + 마지막 교환 odometer) 모두
+    // 있어야 가능. lastServicedAtOdometerKm 가 null 이면 운영자가 교환 시점
+    // odometer 를 안 적은 케이스 — 그 행만 UNKNOWN 처리하되 다른 행은 영향
+    // 안 받음.
+    if (
+      item.cycleKm !== null &&
+      currentOdometerKm !== null &&
+      lastServicedAtOdometerKm !== null &&
+      currentOdometerKm >= lastServicedAtOdometerKm
+    ) {
+      const status = classifyByKm(currentOdometerKm - lastServicedAtOdometerKm, item.cycleKm);
+      return { item, lastServicedAt, lastServicedAtOdometerKm, nextDueAt: null, status };
+    }
+
     return {
       item,
       lastServicedAt,
@@ -94,6 +126,14 @@ export function deriveMaintenanceRows(
       status: "UNKNOWN"
     };
   });
+}
+
+function classifyByKm(kmSinceService: number, cycleKm: number): MaintenanceStatus {
+  if (cycleKm <= 0) return "UNKNOWN";
+  const ratio = kmSinceService / cycleKm;
+  if (ratio < APPROACH_RATIO) return "HEALTHY";
+  if (ratio < 1) return "DUE_SOON";
+  return "OVERDUE";
 }
 
 /**
@@ -153,7 +193,10 @@ export function summarizeMaintenanceByBike(
     const bikeRecords = recordsByBike.get(bikeId) ?? [];
     // 다음 단계에선 servicedAt desc 정렬 가정 — recordsByBike push 순서가
     // 백엔드 응답(이미 정렬됨) 그대로라 별도 정렬 안 함.
-    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, now);
+    // 표 필터 단의 요약은 텔레메트리 odometer 를 (아직) 가져오지 않는다 — cycle_km
+    // 품목 자동 분류는 floating panel 안에서만. 표의 "임박/지연" 필터에 cycle_km
+    // 도 끼우려면 차량 별 current state map 을 page-level 에 추가하면 됨.
+    const rows = deriveMaintenanceRows(applicableItems, bikeRecords, null, now);
     let overall: MaintenanceStatus = "UNKNOWN";
     let hasOverdue = false;
     let hasDueSoon = false;

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -745,6 +745,11 @@ export type ServiceOpsBikeCurrentState = {
   longitude: number | string;
   speedKph: number | string | null;
   batteryPercent: number | string | null;
+  /**
+   * 누적 주행거리 (km). V24 부터 backend 가 응답에 포함; 텔레메트리 미수신이거나
+   * 벤더 페이로드에서 값이 빠지면 null.
+   */
+  odometerKm: number | null;
   ignitionStatus: string;
   telemetrySource: string;
   drivingStatus: string;

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -8,18 +8,37 @@ import {
 } from "@/lib/services/service-ops-api";
 
 /**
+ * 차량 floating panel 이 정비 섹션 렌더링에 함께 필요한 텔레메트리 현재 상태
+ * 의 부분 집합. 전체 `FrontendBikeCurrentState` 가 아니라 derive 가 실제로
+ * 보는 두 필드만 옮긴다 — 추후 다른 필드(배터리 등) 가 정비 derive 에 필요해
+ * 지면 확장.
+ *
+ * `connectionStatus` 는 backend 의 V24 / V4 derive 그대로 ("ONLINE" /
+ * "SIGNAL_LOST" / "PARKED_OFFLINE_NORMAL" / "STALE_UNKNOWN"). 화면은 ONLINE 만
+ * "온라인" 으로 취급해 odometer 기반 자동 status 분류에 쓴다.
+ */
+export type VehicleCurrentTelemetrySummary = {
+  odometerKm: number | null;
+  connectionStatus: string | null;
+};
+
+/**
  * 차량 상세 floating panel 의 "정비 상태" 섹션이 lazy-fetch 하는 두 list 의
- * 결합 응답. 한 round-trip 으로 catalog + history 를 같이 받아 클라이언트가
- * 두 번 fetch 하지 않게 한다.
+ * 결합 응답. 한 round-trip 으로 catalog + history + 현재 텔레메트리를 같이
+ * 받아 클라이언트가 여러 번 fetch 하지 않게 한다.
  *
  * 미설정 / 미인증 환경에선 둘 다 빈 배열로 — UI 는 "데이터 없음" 으로 fallback.
+ *
+ * `currentState` 는 텔레메트리가 한 번도 안 들어온 차량 또는 조회 실패 시 null —
+ * UI 는 "오프라인" 안내문으로 fallback 하고 km 기반 품목은 자동 분류 안 함.
  */
 export type VehicleMaintenanceBundle = {
   items: ReadonlyArray<ServiceOpsMaintenanceItem>;
   records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>;
+  currentState: VehicleCurrentTelemetrySummary | null;
 };
 
-const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [] };
+const EMPTY_BUNDLE: VehicleMaintenanceBundle = { items: [], records: [], currentState: null };
 
 /**
  * 차량 탭의 "정비 상태" 필터가 차량 별로 임박/지연 여부를 derive 할 때 쓰는
@@ -58,11 +77,20 @@ export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<Vehi
   if (!client) return EMPTY_BUNDLE;
 
   try {
-    const [items, records] = await Promise.all([
+    // current state 는 텔레메트리가 한 번도 안 들어온 차량에선 404. 그 케이스를
+    // bundle 전체 실패로 만들 이유는 없으니 fetch 단계에서 null fallback.
+    const [items, records, currentState] = await Promise.all([
       client.listMaintenanceItemsForBike(bikeId),
-      client.listMaintenanceRecordsForBike(bikeId)
+      client.listMaintenanceRecordsForBike(bikeId),
+      client
+        .getBikeCurrentState(bikeId)
+        .then((state) => ({
+          odometerKm: state.odometerKm,
+          connectionStatus: state.connectionStatus
+        }))
+        .catch(() => null)
     ]);
-    return { items, records };
+    return { items, records, currentState };
   } catch {
     // 조회 실패는 운영자 화면을 깨뜨리지 않게 빈 bundle. console.error 는 backend
     // log 가 잡고, 클라이언트엔 "정비 데이터 불러오기 실패" UI 가 추후 필요.

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeCurrentState.java
@@ -39,6 +39,9 @@ public class BikeCurrentState {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /** 누적 주행거리 (km). 벤더 페이로드에 없으면 null. */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -65,6 +68,7 @@ public class BikeCurrentState {
         this.longitude = log.getLongitude();
         this.speedKph = log.getSpeedKph();
         this.batteryPercent = log.getBatteryPercent();
+        this.odometerKm = log.getOdometerKm();
         this.ignitionStatus = log.getIgnitionStatus();
         this.telemetrySource = log.getTelemetrySource();
         this.updatedAt = Instant.now();
@@ -108,6 +112,10 @@ public class BikeCurrentState {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/BikeRecentState.java
@@ -44,6 +44,9 @@ public class BikeRecentState {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /** 누적 주행거리 (km). 벤더 페이로드에 없으면 null. */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -65,6 +68,7 @@ public class BikeRecentState {
         state.longitude = log.getLongitude();
         state.speedKph = log.getSpeedKph();
         state.batteryPercent = log.getBatteryPercent();
+        state.odometerKm = log.getOdometerKm();
         state.ignitionStatus = log.getIgnitionStatus();
         state.telemetrySource = log.getTelemetrySource();
         return state;
@@ -115,6 +119,10 @@ public class BikeRecentState {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/domain/DeviceTelemetryLog.java
@@ -54,6 +54,12 @@ public class DeviceTelemetryLog {
     @Column(precision = 5, scale = 2)
     private BigDecimal batteryPercent;
 
+    /**
+     * 누적 주행거리 (km). 벤더 페이로드가 줄 때 채움; 일시적으로 빠지면 null.
+     * 차량 상세의 정비 cycle_km 품목 상태 분류에 사용된다.
+     */
+    private Integer odometerKm;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private TelemetryIgnitionStatus ignitionStatus;
@@ -81,6 +87,7 @@ public class DeviceTelemetryLog {
             BigDecimal longitude,
             BigDecimal speedKph,
             BigDecimal batteryPercent,
+            Integer odometerKm,
             TelemetryIgnitionStatus ignitionStatus,
             TelemetrySource telemetrySource,
             String rawPayload
@@ -97,6 +104,7 @@ public class DeviceTelemetryLog {
         log.longitude = longitude;
         log.speedKph = speedKph;
         log.batteryPercent = batteryPercent;
+        log.odometerKm = odometerKm;
         log.ignitionStatus = ignitionStatus;
         log.telemetrySource = telemetrySource;
         log.rawPayload = rawPayload;
@@ -160,6 +168,10 @@ public class DeviceTelemetryLog {
 
     public BigDecimal getBatteryPercent() {
         return batteryPercent;
+    }
+
+    public Integer getOdometerKm() {
+        return odometerKm;
     }
 
     public TelemetryIgnitionStatus getIgnitionStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
@@ -17,6 +17,8 @@ public record BikeCurrentStateReadResponse(
         BigDecimal longitude,
         BigDecimal speedKph,
         BigDecimal batteryPercent,
+        /** 누적 주행거리 (km). 텔레메트리가 안 들어왔으면 null. */
+        Integer odometerKm,
         TelemetryIgnitionStatus ignitionStatus,
         String telemetrySource,
         String drivingStatus,
@@ -36,6 +38,7 @@ public record BikeCurrentStateReadResponse(
                 state.getLongitude(),
                 state.getSpeedKph(),
                 state.getBatteryPercent(),
+                state.getOdometerKm(),
                 state.getIgnitionStatus(),
                 state.getTelemetrySource().name(),
                 drivingStatus(state),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
@@ -23,6 +23,11 @@ public record TelemetryIngestRequest(
         @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
         @PositiveOrZero BigDecimal speedKph,
         @DecimalMin("0.0") @DecimalMax("100.0") BigDecimal batteryPercent,
+        /**
+         * 누적 주행거리 (km). 벤더 페이로드가 줄 때만 채움; 누락된 이벤트는
+         * 그대로 받아들이고 odometer 없이 적재한다.
+         */
+        @PositiveOrZero Integer odometerKm,
         @NotNull TelemetryIgnitionStatus ignitionStatus,
         @NotNull TelemetrySource telemetrySource,
         JsonNode rawPayload

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
@@ -25,11 +25,11 @@ public class TelemetryWriteRepository {
                 insert into device_telemetry_logs (
                     id, device_id, device_uid, bike_id, vendor_event_id, payload_hash,
                     received_at, device_reported_at, latitude, longitude, speed_kph,
-                    battery_percent, ignition_status, telemetry_source, raw_payload
+                    battery_percent, odometer_km, ignition_status, telemetry_source, raw_payload
                 ) values (
                     ?, ?, ?, ?, ?, ?,
                     ?::timestamptz, ?::timestamptz, ?, ?, ?,
-                    ?, ?, ?, ?::jsonb
+                    ?, ?, ?, ?, ?::jsonb
                 )
                 %s
                 returning id
@@ -51,11 +51,11 @@ public class TelemetryWriteRepository {
             PreparedStatement ps = connection.prepareStatement("""
                     insert into bike_current_states (
                         bike_id, device_id, telemetry_log_id, last_received_at,
-                        latitude, longitude, speed_kph, battery_percent,
+                        latitude, longitude, speed_kph, battery_percent, odometer_km,
                         ignition_status, telemetry_source, updated_at
                     ) values (
                         ?, ?, ?, ?::timestamptz,
-                        ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?,
                         ?, ?, now()
                     )
                     on conflict (bike_id) do update set
@@ -66,6 +66,7 @@ public class TelemetryWriteRepository {
                         longitude = excluded.longitude,
                         speed_kph = excluded.speed_kph,
                         battery_percent = excluded.battery_percent,
+                        odometer_km = excluded.odometer_km,
                         ignition_status = excluded.ignition_status,
                         telemetry_source = excluded.telemetry_source,
                         updated_at = now()
@@ -79,8 +80,9 @@ public class TelemetryWriteRepository {
             ps.setBigDecimal(6, log.getLongitude());
             ps.setBigDecimal(7, log.getSpeedKph());
             ps.setBigDecimal(8, log.getBatteryPercent());
-            ps.setString(9, log.getIgnitionStatus().name());
-            ps.setString(10, log.getTelemetrySource().name());
+            setNullableInteger(ps, 9, log.getOdometerKm());
+            ps.setString(10, log.getIgnitionStatus().name());
+            ps.setString(11, log.getTelemetrySource().name());
             return ps;
         });
         return affectedRows > 0;
@@ -114,9 +116,10 @@ public class TelemetryWriteRepository {
         ps.setBigDecimal(10, log.getLongitude());
         ps.setBigDecimal(11, log.getSpeedKph());
         ps.setBigDecimal(12, log.getBatteryPercent());
-        ps.setString(13, log.getIgnitionStatus().name());
-        ps.setString(14, log.getTelemetrySource().name());
-        setNullableString(ps, 15, log.getRawPayload());
+        setNullableInteger(ps, 13, log.getOdometerKm());
+        ps.setString(14, log.getIgnitionStatus().name());
+        ps.setString(15, log.getTelemetrySource().name());
+        setNullableString(ps, 16, log.getRawPayload());
     }
 
     private void setUuid(PreparedStatement ps, int index, UUID value) throws SQLException {
@@ -141,5 +144,13 @@ public class TelemetryWriteRepository {
             return;
         }
         ps.setString(index, value);
+    }
+
+    private void setNullableInteger(PreparedStatement ps, int index, Integer value) throws SQLException {
+        if (value == null) {
+            ps.setNull(index, Types.INTEGER);
+            return;
+        }
+        ps.setInt(index, value);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
@@ -80,6 +80,7 @@ public class TelemetryIngestionService {
                 request.longitude(),
                 request.speedKph(),
                 request.batteryPercent(),
+                request.odometerKm(),
                 request.ignitionStatus(),
                 request.telemetrySource(),
                 rawPayload
@@ -173,6 +174,7 @@ public class TelemetryIngestionService {
                 request.longitude() == null ? "" : request.longitude().toPlainString(),
                 request.speedKph() == null ? "" : request.speedKph().toPlainString(),
                 request.batteryPercent() == null ? "" : request.batteryPercent().toPlainString(),
+                request.odometerKm() == null ? "" : request.odometerKm().toString(),
                 request.ignitionStatus().name(),
                 request.telemetrySource().name(),
                 rawPayload == null ? "" : rawPayload

--- a/development/service-ops-api/src/main/resources/db/migration/V24__add_telemetry_odometer_km.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V24__add_telemetry_odometer_km.sql
@@ -1,0 +1,32 @@
+-- 텔레메트리 페이로드의 "총 주행거리(km)" 를 세 단계 (raw log / recent history /
+-- current state) 에 모두 보존한다. 차량 정비 cycle_km 품목 (브레이크 패드,
+-- 타이어, 모터오일 등) 의 상태 분류와 표시에 직접 쓰인다.
+--
+-- 값은 벤더가 보내는 누적 주행거리 정수 km. 정밀도가 미세하지 않아 integer 로
+-- 충분 — V22 의 `vehicle_maintenance_records.serviced_at_odometer_km` 와 동일한
+-- 타입을 맞춰 비교 / 차분 계산 코드를 단순화한다.
+--
+-- 기존 행에는 null 로 채워지고, 다음 텔레메트리 수신 시점부터 자연스럽게
+-- 값이 채워진다. nullable 유지 — 벤더가 일시적으로 odometer 필드를 빠뜨려도
+-- 다른 필드 (위치 / 시동) 는 정상 적재되어야 하기 때문.
+
+alter table device_telemetry_logs
+    add column odometer_km integer;
+
+alter table device_telemetry_logs
+    add constraint ck_device_telemetry_logs_odometer
+    check (odometer_km is null or odometer_km >= 0);
+
+alter table bike_recent_states
+    add column odometer_km integer;
+
+alter table bike_recent_states
+    add constraint ck_bike_recent_states_odometer
+    check (odometer_km is null or odometer_km >= 0);
+
+alter table bike_current_states
+    add column odometer_km integer;
+
+alter table bike_current_states
+    add constraint ck_bike_current_states_odometer
+    check (odometer_km is null or odometer_km >= 0);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
@@ -104,6 +104,7 @@ class VendorTelemetryAdapterTests {
                 new BigDecimal("127.0270000"),
                 new BigDecimal("12.5"),
                 new BigDecimal("75"),
+                1234,
                 TelemetryIgnitionStatus.ON,
                 TelemetrySource.POLLING,
                 null);


### PR DESCRIPTION
## Summary
- 차량 상세 floating 패널의 "교환 완료" 가 패널을 닫지 않고도 즉시 반영 (#270)
- 텔레메트리 odometer 백엔드 인프라 — V24 마이그레이션 + `TelemetryIngestRequest` ↔ 도메인 ↔ current state DTO 까지 흐름 추가 (#271)
- cycle_km 정비 품목(모터오일/브레이크 패드/타이어)이 텔레메트리 odometer 기반으로 자동 분류, 오프라인 시 안내문 노출 (#272)

## Deployment
- EC2 백엔드에 V24 마이그레이션 적용됨 — `bike_current_states.odometer_km` 등 3 테이블에 nullable integer 컬럼 추가
- 벤더 텔레메트리 어댑터가 `odometerKm` 필드를 인제스트에 채워서 보내야 자동 분류가 실제로 동작 (필드 매핑은 별도 작업)

## Test plan
- [ ] 텔레메트리 ONLINE 차량 상세에서 km 기반 품목들이 정상/임박/지연으로 분류되는지 확인
- [ ] 텔레메트리 오프라인 차량 상세에서 정비 섹션 상단에 안내문이 노출되는지 확인
- [ ] "교환 완료" 클릭 시 패널을 닫지 않은 상태에서 상태 뱃지 / 마지막 교환 셀이 즉시 갱신되는지 확인
- [ ] 벤더 텔레메트리 인제스트 시 odometer 값이 raw log → recent → current 까지 흐르는지 확인 (`GET /api/v1/telemetry/bikes/{id}/current-state` 응답의 `odometerKm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)