### PR TITLE
Release: vehicle detail telemetry section

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -641,6 +641,23 @@ textarea { padding-top: 10px; min-height: 96px; }
    흘러들어가서 어색하게 붙어 보이는 문제를 막기 위한 명시적 컨테이너. */
 .vehicle-detail-view { display: flex; flex-direction: column; gap: 12px; }
 
+/* 차량 floating panel 의 "텔레메트리" 섹션 — 정비 위에 위치하며 같은 띠 톤
+   (top border, h4 크기) 으로 한 덩어리로 읽히도록. 행은 80px 라벨 + 가변 값
+   의 2-컬럼 grid 로 좁은 panel 폭(360px) 에서도 정렬 유지. */
+.telemetry-section { margin-top: 8px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
+.telemetry-section h4 { margin: 0 0 8px; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .02em; }
+.telemetry-list { margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.telemetry-row {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 8px;
+  font-size: 12px;
+}
+.telemetry-row-label { margin: 0; color: var(--color-text-muted); font-weight: 600; }
+.telemetry-row-value { margin: 0; color: var(--color-text-primary); font-variant-numeric: tabular-nums; }
+.telemetry-warn { color: var(--color-danger, #e0524a); font-weight: 600; }
+
 /* 차량 floating panel 안의 "정비 상태" 섹션 — 한 행을 2 줄(2x2 grid) 로 배치.
    좁은 panel 폭(360px) 에서 한국어 품목명이 글자 단위로 wrap 되는 사태를
    막기 위해, 첫 줄은 "품목명 · 상태 뱃지", 둘째 줄은 "주기 · 마지막 교환

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -171,6 +171,7 @@ export function VehicleDetailDialog({
             <DetailField label="연락처" value={row.riderPhone ?? "—"} />
             <DetailField label="IMEI" value={currentDeviceUid || "—"} />
           </div>
+          <TelemetrySection current={maintenance?.currentState ?? null} loading={maintenance === null} />
           <MaintenanceSection
             vehicleId={vehicleId}
             bundle={maintenance}
@@ -253,6 +254,152 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
   return "—";
+}
+
+// ============================================================================
+// 텔레메트리 섹션
+// ============================================================================
+
+/**
+ * 차량 상세 패널에서 정비 섹션 바로 위에 들어가는 "텔레메트리" 섹션. 운영자가
+ * 차량의 실시간 상태(연결 / 시동 / 배터리 / 누적 km / 마지막 수신 시각) 를
+ * 한눈에 보고 정비 판단을 빠르게 할 수 있게 한다.
+ *
+ * 데이터 자체는 정비 섹션과 같은 bundle 의 `currentState` 에서 온다 — 별도
+ * fetch 없음. 텔레메트리가 한 번도 안 들어온 차량은 null fallback.
+ */
+function TelemetrySection({
+  current,
+  loading
+}: {
+  current: {
+    odometerKm: number | null;
+    connectionStatus: string;
+    ignitionStatus: string;
+    batteryPercent: number | null;
+    batteryStatus: string;
+    speedKph: number | null;
+    drivingStatus: string;
+    lastReceivedAt: string;
+  } | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <section className="telemetry-section">
+        <h4>텔레메트리</h4>
+        <p className="muted">불러오는 중…</p>
+      </section>
+    );
+  }
+
+  if (!current) {
+    return (
+      <section className="telemetry-section">
+        <h4>텔레메트리</h4>
+        <p className="muted">아직 수신된 텔레메트리가 없습니다.</p>
+      </section>
+    );
+  }
+
+  const isOnline = current.connectionStatus === "ONLINE";
+
+  return (
+    <section className="telemetry-section">
+      <h4>텔레메트리</h4>
+      <dl className="telemetry-list">
+        <TelemetryRow
+          label="연결"
+          value={renderConnectionPill(current.connectionStatus, isOnline)}
+        />
+        <TelemetryRow label="시동" value={renderIgnitionLabel(current.ignitionStatus)} />
+        <TelemetryRow
+          label="배터리"
+          value={renderBatteryLabel(current.batteryPercent, current.batteryStatus)}
+        />
+        <TelemetryRow
+          label="누적 주행거리"
+          value={current.odometerKm !== null ? `${current.odometerKm.toLocaleString()} km` : "—"}
+        />
+        <TelemetryRow label="현재 속도" value={renderSpeedLabel(current.speedKph, current.drivingStatus)} />
+        <TelemetryRow label="마지막 수신" value={renderLastReceivedLabel(current.lastReceivedAt)} />
+      </dl>
+    </section>
+  );
+}
+
+function TelemetryRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="telemetry-row">
+      <dt className="telemetry-row-label">{label}</dt>
+      <dd className="telemetry-row-value">{value}</dd>
+    </div>
+  );
+}
+
+function renderConnectionPill(connectionStatus: string, isOnline: boolean): ReactNode {
+  if (isOnline) {
+    return <span className="vehicles-pill vehicles-pill--operating">온라인</span>;
+  }
+  // 모든 비-ONLINE 상태는 "오프라인" 한 단어로 노출. 세부 이유 (신호 끊김 /
+  // 시동 OFF) 를 운영자가 굳이 구분할 필요는 없고, 어차피 행 단위 status 셀
+  // 에서 cycle_km 품목이 "오프라인" 으로 뜨므로 여기서 더 가르지 않는다.
+  void connectionStatus;
+  return <span className="vehicles-pill vehicles-pill--idle">오프라인</span>;
+}
+
+function renderIgnitionLabel(ignitionStatus: string): string {
+  if (ignitionStatus === "ON") return "ON";
+  if (ignitionStatus === "OFF") return "OFF";
+  return "—";
+}
+
+function renderBatteryLabel(percent: number | null, status: string): ReactNode {
+  if (percent === null) return "—";
+  const rounded = Math.round(percent);
+  if (status === "CRITICAL" || status === "LOW") {
+    return <span className="telemetry-warn">{rounded}% · {status === "CRITICAL" ? "위험" : "낮음"}</span>;
+  }
+  return `${rounded}%`;
+}
+
+function renderSpeedLabel(speedKph: number | null, drivingStatus: string): string {
+  if (speedKph === null) {
+    if (drivingStatus === "PARKED") return "정차 · 시동 OFF";
+    if (drivingStatus === "STOPPED") return "정지";
+    return "—";
+  }
+  const rounded = Math.round(speedKph * 10) / 10;
+  if (drivingStatus === "DRIVING") return `${rounded} km/h · 주행 중`;
+  if (drivingStatus === "PARKED") return `${rounded} km/h · 시동 OFF`;
+  if (drivingStatus === "STOPPED") return `${rounded} km/h · 정지`;
+  return `${rounded} km/h`;
+}
+
+function renderLastReceivedLabel(lastReceivedAt: string): string {
+  const date = new Date(lastReceivedAt);
+  if (Number.isNaN(date.valueOf())) return lastReceivedAt;
+  const diffMs = Date.now() - date.valueOf();
+  const absolute = date.toLocaleString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+  return `${absolute} · ${relativeTimeKo(diffMs)}`;
+}
+
+function relativeTimeKo(diffMs: number): string {
+  if (diffMs < 0) return "방금";
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return `${seconds}초 전`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
 }
 
 // ============================================================================

--- a/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
+++ b/development/front-admin-web/lib/services/vehicle-maintenance-data.ts
@@ -8,18 +8,23 @@ import {
 } from "@/lib/services/service-ops-api";
 
 /**
- * 차량 floating panel 이 정비 섹션 렌더링에 함께 필요한 텔레메트리 현재 상태
- * 의 부분 집합. 전체 `FrontendBikeCurrentState` 가 아니라 derive 가 실제로
- * 보는 두 필드만 옮긴다 — 추후 다른 필드(배터리 등) 가 정비 derive 에 필요해
- * 지면 확장.
+ * 차량 floating panel 의 텔레메트리 + 정비 섹션이 함께 쓰는 텔레메트리
+ * 현재 상태의 요약. 전체 `FrontendBikeCurrentState` 가 아니라 화면이 실제로
+ * 출력 / 분류에 쓰는 필드만 옮긴다.
  *
- * `connectionStatus` 는 backend 의 V24 / V4 derive 그대로 ("ONLINE" /
+ * `connectionStatus` 는 backend 의 V4/V24 derive 그대로 ("ONLINE" /
  * "SIGNAL_LOST" / "PARKED_OFFLINE_NORMAL" / "STALE_UNKNOWN"). 화면은 ONLINE 만
  * "온라인" 으로 취급해 odometer 기반 자동 status 분류에 쓴다.
  */
 export type VehicleCurrentTelemetrySummary = {
   odometerKm: number | null;
-  connectionStatus: string | null;
+  connectionStatus: string;
+  ignitionStatus: string;
+  batteryPercent: number | null;
+  batteryStatus: string;
+  speedKph: number | null;
+  drivingStatus: string;
+  lastReceivedAt: string;
 };
 
 /**
@@ -86,7 +91,13 @@ export async function loadVehicleMaintenanceBundle(bikeId: string): Promise<Vehi
         .getBikeCurrentState(bikeId)
         .then((state) => ({
           odometerKm: state.odometerKm,
-          connectionStatus: state.connectionStatus
+          connectionStatus: state.connectionStatus,
+          ignitionStatus: state.ignitionStatus,
+          batteryPercent: state.batteryPercent,
+          batteryStatus: state.batteryStatus,
+          speedKph: state.speedKph,
+          drivingStatus: state.drivingStatus,
+          lastReceivedAt: state.lastReceivedAt
         }))
         .catch(() => null)
     ]);


### PR DESCRIPTION
## Summary
- 차량 상세 floating 패널에 새 "텔레메트리" 섹션 추가 — 연결/시동/배터리/누적 km/현재 속도/마지막 수신 시각 노출 (#276)

## Test plan
- [ ] ONLINE 차량 상세에서 텔레메트리 섹션의 모든 필드가 값으로 채워지는지 확인
- [ ] 오프라인 차량 상세에서 연결 셀이 "오프라인" 뱃지로 노출되는지
- [ ] 텔레메트리 미수신 차량에서 fallback 문구 노출
- [ ] 배터리 LOW / CRITICAL 케이스 강조 색

🤖 Generated with [Claude Code](https://claude.com/claude-code)