### PR TITLE
Float fullscreen map controls over the map instead of a grid layout

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -505,10 +505,10 @@ textarea { padding-top: 10px; min-height: 96px; }
   max-width: 200px;
 }
 
-/* 전체화면 지도 모드. viewport 전체를 덮는 fixed overlay. 좌측 collapsible
-   aside (필터 3 섹션 accordion) + 상단 header (닫기/검색/카운트) + 메인
-   캔버스 (MapShell + VehicleDetailDialog). 닫으면 unmount 되어 state 가
-   사라진다. */
+/* 전체화면 지도 모드. viewport 전체를 지도가 차지하고, 헤더(닫기/검색/카운트) 와
+   좌측 필터 패널은 그 위에 floating 으로 떠 있는 형태. grid 분할 레이아웃이
+   아니라 절대 위치 오버레이라 운영자가 지도 전체를 시야로 쓰면서 필요한 컨트롤
+   만 위에 노출. 닫으면 컴포넌트 자체가 unmount 되어 state 가 사라진다. */
 .overview-map-fullscreen-button {
   height: 32px;
   padding: 0 12px;
@@ -531,56 +531,90 @@ textarea { padding-top: 10px; min-height: 96px; }
   z-index: 100;
   background: var(--rm-bg-page);
   color: var(--rm-text-primary);
-  display: grid;
-  grid-template-columns: 320px 1fr;
-  grid-template-rows: 56px 1fr;
-  grid-template-areas:
-    "header header"
-    "filters canvas";
+  /* grid 레이아웃 제거 — 자식들이 absolute 로 떠다닌다. canvas 가 base layer,
+     header/aside 가 그 위에 z-index 110. */
 }
+
+/* 지도 캔버스가 overlay 전체를 채운다 — header/aside 가 그 위에 떠 있을 뿐
+   지도 자체는 잘리지 않는다 (운영자가 좌상단 필터 패널 아래쪽으로도 마커를
+   드래그할 수 있다). */
+.fullscreen-map-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+/* Header — 좌상단 close + 가운데 search + 우상단 counts 가 모두 floating
+   pill 처럼 보이게. header 자체 배경은 없음 (지도가 비치게). pointer-events
+   는 header 영역의 빈 공간으로는 지도를 드래그할 수 있도록 자식에만 활성화. */
 .fullscreen-map-header {
-  grid-area: header;
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  right: 16px;
+  z-index: 110;
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--rm-line-subtle);
-  background: var(--rm-bg-panel-soft);
+  pointer-events: none;
 }
+.fullscreen-map-header > * {
+  pointer-events: auto;
+}
+.fullscreen-map-header .overview-map-search {
+  /* header 안의 search 인풋은 본인 width 를 가지되 양쪽으로 자라지는 않게. */
+  flex: 0 1 360px;
+}
+
 .fullscreen-map-close {
-  height: 32px;
-  padding: 0 12px;
-  border-radius: 8px;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 18px;
   border: 1px solid var(--rm-line-subtle);
-  background: var(--rm-bg-page);
+  background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
   color: var(--rm-text-primary);
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
   font-family: inherit;
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-panel);
 }
 .fullscreen-map-close:hover {
   background: var(--rm-bg-section);
 }
 .fullscreen-map-counts {
   margin-left: auto;
+  padding: 8px 14px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
+  border: 1px solid var(--rm-line-subtle);
   font-size: 12px;
-  color: var(--rm-text-secondary);
+  color: var(--rm-text-primary);
   font-variant-numeric: tabular-nums;
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-panel);
 }
+
+/* Aside (필터 패널) — header 아래에 좌측 floating panel 로 떠 있다. 높이는
+   하단까지. 반투명 배경 + blur 로 지도 컨텐츠가 살짝 비치는 glass 효과. */
 .fullscreen-map-filters {
-  grid-area: filters;
-  border-right: 1px solid var(--rm-line-subtle);
-  background: var(--rm-bg-panel-soft);
+  position: absolute;
+  top: 68px;
+  left: 16px;
+  bottom: 16px;
+  width: 320px;
+  z-index: 110;
+  background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
+  border: 1px solid var(--rm-line-subtle);
+  border-radius: 12px;
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(8px);
   overflow-y: auto;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-.fullscreen-map-canvas {
-  grid-area: canvas;
-  position: relative;
 }
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만


### PR DESCRIPTION
## Summary
- 전체화면 지도 모드의 레이아웃을 grid 분할(좌측 320px aside + 상단 56px header + 우측 canvas) → 지도가 viewport 전체를 채우고 컨트롤들이 그 위에 floating 으로 떠 있는 형태로 변경
- header(닫기/검색/카운트) — 상단에 pill 모양 floating, 배경 band 없음. `pointer-events: none` on the bar so empty spaces pass clicks through to the map
- 좌측 필터 패널 — `position: absolute; left: 16px; top: 68px` rounded glass panel (color-mix + backdrop-filter)
- 닫기 / 카운트도 각각 floating pill 로 변경
- CSS-only 변경, JSX 그대로

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 전체화면 클릭 → 지도가 viewport 전체에 표시, 좌상단 닫기/검색/카운트가 floating
- [ ] 좌측 필터 패널이 glass 효과로 떠 있고 지도가 패널 아래로도 보임 (마커가 패널 영역에 있어도 부분 시인성)
- [ ] header 의 빈 공간을 드래그하면 지도가 움직임 (pointer-events 패스스루)
- [ ] ESC / 닫기 → 정상 종료

🤖 Generated with [Claude Code](https://claude.com/claude-code)