### PR TITLE
Release: horizontal fullscreen filters + unified search

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -596,25 +596,51 @@ textarea { padding-top: 10px; min-height: 96px; }
   box-shadow: var(--shadow-panel);
 }
 
-/* Aside (필터 패널) — header 아래에 좌측 floating panel 로 떠 있다. 높이는
-   하단까지. 반투명 배경 + blur 로 지도 컨텐츠가 살짝 비치는 glass 효과. */
-.fullscreen-map-filters {
+/* 필터 행들 — header 아래에 가로로 쫙 펼쳐진 차량/라이더/BSS 세 줄. 각 줄은
+   "관리" 탭의 필터 row 와 동일한 느낌이지만 검색 인풋은 빠지고 (상단 공통
+   OverviewMapSearch 가 차량+BSS+라이더 한 번에 처리), 좌측에 카테고리
+   라벨이 붙는다. 행들 사이는 pointer-events: none 으로 비어 있어 지도 드래그
+   가능. */
+.fullscreen-map-filter-rows {
   position: absolute;
   top: 68px;
   left: 16px;
-  bottom: 16px;
-  width: 320px;
+  right: 16px;
   z-index: 110;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  pointer-events: none;
+}
+.fullscreen-map-filter-row {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
   background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
   border: 1px solid var(--rm-line-subtle);
   border-radius: 12px;
   box-shadow: var(--shadow-panel);
   backdrop-filter: blur(8px);
-  overflow-y: auto;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+}
+.fullscreen-map-filter-row-label {
+  flex-shrink: 0;
+  min-width: 44px;
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--rm-text-secondary);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+/* 행 안의 `.vehicles-filter-row` 는 단순 flex 컨테이너로만 동작. 자체 padding/
+   배경 없이 outer row 만 시각적 박스를 책임. */
+.fullscreen-map-filter-row .vehicles-filter-row {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
 }
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import type { ReactNode } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
@@ -277,32 +276,38 @@ function FullscreenMapOverlay({
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
       </header>
-      <aside className="fullscreen-map-filters">
-        <FilterAccordion title="차량">
+      <div className="fullscreen-map-filter-rows">
+        <div className="fullscreen-map-filter-row">
+          <span className="fullscreen-map-filter-row-label">차량</span>
           <VehicleFilterControls
             filters={vehicleFilters}
             onChange={setVehicleFilters}
-            layout="vertical"
+            layout="horizontal"
+            hideSearch
             count={{ visible: visibleVehicles.length, total: vehicles.length }}
           />
-        </FilterAccordion>
-        <FilterAccordion title="라이더">
+        </div>
+        <div className="fullscreen-map-filter-row">
+          <span className="fullscreen-map-filter-row-label">라이더</span>
           <RiderFilterControls
             filters={riderFilters}
             onChange={setRiderFilters}
-            layout="vertical"
+            layout="horizontal"
+            hideSearch
             count={{ visible: visibleRiders.length, total: riders.length }}
           />
-        </FilterAccordion>
-        <FilterAccordion title="BSS">
+        </div>
+        <div className="fullscreen-map-filter-row">
+          <span className="fullscreen-map-filter-row-label">BSS</span>
           <StationFilterControls
             filters={stationFilters}
             onChange={setStationFilters}
-            layout="vertical"
+            layout="horizontal"
+            hideSearch
             count={{ visible: visibleStations.length, total: stations.length }}
           />
-        </FilterAccordion>
-      </aside>
+        </div>
+      </div>
       <main className="fullscreen-map-canvas">
         <MapShell
           bikePins={[...visibleBikePins]}
@@ -320,20 +325,3 @@ function FullscreenMapOverlay({
   );
 }
 
-function FilterAccordion({ title, children }: { title: string; children: ReactNode }) {
-  const [open, setOpen] = useState(true);
-  return (
-    <section className={open ? "filter-accordion filter-accordion--open" : "filter-accordion"}>
-      <button
-        type="button"
-        className="filter-accordion-header"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-      >
-        <span>{title}</span>
-        <span aria-hidden="true">{open ? "▾" : "▸"}</span>
-      </button>
-      {open ? <div className="filter-accordion-body">{children}</div> : null}
-    </section>
-  );
-}

--- a/development/front-admin-web/components/overview/RiderFilterControls.tsx
+++ b/development/front-admin-web/components/overview/RiderFilterControls.tsx
@@ -13,22 +13,26 @@ export interface RiderFilterControlsProps {
   onChange: (next: RiderFilterState) => void;
   layout: "horizontal" | "vertical";
   count?: { visible: number; total: number };
+  /** true 면 검색 인풋을 안 그린다. */
+  hideSearch?: boolean;
 }
 
-export function RiderFilterControls({ filters, onChange, layout, count }: RiderFilterControlsProps) {
+export function RiderFilterControls({ filters, onChange, layout, count, hideSearch }: RiderFilterControlsProps) {
   const rowClass = layout === "horizontal" ? "vehicles-filter-row" : "filter-stack";
   return (
     <div className={rowClass}>
-      <div className="vehicles-filter-search-wrap">
-        <input
-          className="vehicles-filter-search"
-          type="search"
-          placeholder="이름, 연락처, 차량번호 검색"
-          value={filters.query}
-          onChange={(event) => onChange({ ...filters, query: event.target.value })}
-        />
-        <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
-      </div>
+      {hideSearch ? null : (
+        <div className="vehicles-filter-search-wrap">
+          <input
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="이름, 연락처, 차량번호 검색"
+            value={filters.query}
+            onChange={(event) => onChange({ ...filters, query: event.target.value })}
+          />
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+      )}
       <select
         className="vehicles-filter-select"
         value={filters.education}

--- a/development/front-admin-web/components/overview/StationFilterControls.tsx
+++ b/development/front-admin-web/components/overview/StationFilterControls.tsx
@@ -12,22 +12,26 @@ export interface StationFilterControlsProps {
   onChange: (next: StationFilterState) => void;
   layout: "horizontal" | "vertical";
   count?: { visible: number; total: number };
+  /** true 면 검색 인풋을 안 그린다. */
+  hideSearch?: boolean;
 }
 
-export function StationFilterControls({ filters, onChange, layout, count }: StationFilterControlsProps) {
+export function StationFilterControls({ filters, onChange, layout, count, hideSearch }: StationFilterControlsProps) {
   const rowClass = layout === "horizontal" ? "vehicles-filter-row" : "filter-stack";
   return (
     <div className={rowClass}>
-      <div className="vehicles-filter-search-wrap">
-        <input
-          className="vehicles-filter-search"
-          type="search"
-          placeholder="주소 검색"
-          value={filters.query}
-          onChange={(event) => onChange({ ...filters, query: event.target.value })}
-        />
-        <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
-      </div>
+      {hideSearch ? null : (
+        <div className="vehicles-filter-search-wrap">
+          <input
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="주소 검색"
+            value={filters.query}
+            onChange={(event) => onChange({ ...filters, query: event.target.value })}
+          />
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+      )}
       <select
         className="vehicles-filter-select"
         value={filters.stock}

--- a/development/front-admin-web/components/overview/VehicleFilterControls.tsx
+++ b/development/front-admin-web/components/overview/VehicleFilterControls.tsx
@@ -15,22 +15,27 @@ export interface VehicleFilterControlsProps {
   onChange: (next: VehicleFilterState) => void;
   layout: "horizontal" | "vertical";
   count?: { visible: number; total: number };
+  /** true 면 검색 인풋을 안 그린다 — 전체화면 모드처럼 상단 공통 검색이 따로
+   *  있는 화면에서 중복을 피하기 위해. */
+  hideSearch?: boolean;
 }
 
-export function VehicleFilterControls({ filters, onChange, layout, count }: VehicleFilterControlsProps) {
+export function VehicleFilterControls({ filters, onChange, layout, count, hideSearch }: VehicleFilterControlsProps) {
   const rowClass = layout === "horizontal" ? "vehicles-filter-row" : "filter-stack";
   return (
     <div className={rowClass}>
-      <div className="vehicles-filter-search-wrap">
-        <input
-          className="vehicles-filter-search"
-          type="search"
-          placeholder="차량번호, 모델명, IMEI 검색"
-          value={filters.query}
-          onChange={(event) => onChange({ ...filters, query: event.target.value })}
-        />
-        <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
-      </div>
+      {hideSearch ? null : (
+        <div className="vehicles-filter-search-wrap">
+          <input
+            className="vehicles-filter-search"
+            type="search"
+            placeholder="차량번호, 모델명, IMEI 검색"
+            value={filters.query}
+            onChange={(event) => onChange({ ...filters, query: event.target.value })}
+          />
+          <span className="vehicles-filter-search-icon" aria-hidden="true">🔍</span>
+        </div>
+      )}
       <select
         className="vehicles-filter-select"
         value={filters.engineType}


### PR DESCRIPTION
## Summary
- 전체화면 모드 필터를 상단 가로 행 3개 (차량 / 라이더 / BSS) 로 재배치, 검색은 상단 통합 (#290)

## Test plan
- [ ] 전체화면 진입 → 상단 닫기/검색/카운트 한 줄 + 가로 필터 행 3개
- [ ] 검색은 상단에서만 노출
- [ ] 표 패널 필터는 기존 동작 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)