### PR TITLE
Flatten fullscreen filters into a single horizontal bar

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -596,51 +596,30 @@ textarea { padding-top: 10px; min-height: 96px; }
   box-shadow: var(--shadow-panel);
 }
 
-/* 필터 행들 — header 아래에 가로로 쫙 펼쳐진 차량/라이더/BSS 세 줄. 각 줄은
-   "관리" 탭의 필터 row 와 동일한 느낌이지만 검색 인풋은 빠지고 (상단 공통
-   OverviewMapSearch 가 차량+BSS+라이더 한 번에 처리), 좌측에 카테고리
-   라벨이 붙는다. 행들 사이는 pointer-events: none 으로 비어 있어 지도 드래그
-   가능. */
-.fullscreen-map-filter-rows {
+/* 필터 바 — header 아래에 가로로 한 줄, 차량/라이더/BSS 11개 select 가 모두
+   같은 flex 컨테이너의 자식으로 평탄화. 좁은 폭에선 select 단위로 wrap.
+   FilterControls 컴포넌트들이 자체적으로 갖고 있는 `.vehicles-filter-row`
+   wrapper 는 `display: contents` 로 사라져 그 안의 select 들이 부모의 직접
+   자식이 된다. */
+.fullscreen-map-filter-bar {
   position: absolute;
   top: 68px;
   left: 16px;
   right: 16px;
   z-index: 110;
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  pointer-events: none;
-}
-.fullscreen-map-filter-row {
-  pointer-events: auto;
-  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  padding: 6px 14px;
+  gap: 8px;
+  padding: 8px 14px;
   background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
   border: 1px solid var(--rm-line-subtle);
   border-radius: 12px;
   box-shadow: var(--shadow-panel);
   backdrop-filter: blur(8px);
 }
-.fullscreen-map-filter-row-label {
-  flex-shrink: 0;
-  min-width: 44px;
-  font-size: 11px;
-  font-weight: 800;
-  color: var(--rm-text-secondary);
-  letter-spacing: .05em;
-  text-transform: uppercase;
-}
-/* 행 안의 `.vehicles-filter-row` 는 단순 flex 컨테이너로만 동작. 자체 padding/
-   배경 없이 outer row 만 시각적 박스를 책임. */
-.fullscreen-map-filter-row .vehicles-filter-row {
-  flex: 1;
-  margin: 0;
-  padding: 0;
-  background: transparent;
-  border: none;
+.fullscreen-map-filter-bar .vehicles-filter-row {
+  display: contents;
 }
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -276,37 +276,29 @@ function FullscreenMapOverlay({
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
       </header>
-      <div className="fullscreen-map-filter-rows">
-        <div className="fullscreen-map-filter-row">
-          <span className="fullscreen-map-filter-row-label">차량</span>
-          <VehicleFilterControls
-            filters={vehicleFilters}
-            onChange={setVehicleFilters}
-            layout="horizontal"
-            hideSearch
-            count={{ visible: visibleVehicles.length, total: vehicles.length }}
-          />
-        </div>
-        <div className="fullscreen-map-filter-row">
-          <span className="fullscreen-map-filter-row-label">라이더</span>
-          <RiderFilterControls
-            filters={riderFilters}
-            onChange={setRiderFilters}
-            layout="horizontal"
-            hideSearch
-            count={{ visible: visibleRiders.length, total: riders.length }}
-          />
-        </div>
-        <div className="fullscreen-map-filter-row">
-          <span className="fullscreen-map-filter-row-label">BSS</span>
-          <StationFilterControls
-            filters={stationFilters}
-            onChange={setStationFilters}
-            layout="horizontal"
-            hideSearch
-            count={{ visible: visibleStations.length, total: stations.length }}
-          />
-        </div>
+      <div className="fullscreen-map-filter-bar">
+        {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
+            CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
+            컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
+            wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
+        <VehicleFilterControls
+          filters={vehicleFilters}
+          onChange={setVehicleFilters}
+          layout="horizontal"
+          hideSearch
+        />
+        <RiderFilterControls
+          filters={riderFilters}
+          onChange={setRiderFilters}
+          layout="horizontal"
+          hideSearch
+        />
+        <StationFilterControls
+          filters={stationFilters}
+          onChange={setStationFilters}
+          layout="horizontal"
+          hideSearch
+        />
       </div>
       <main className="fullscreen-map-canvas">
         <MapShell


### PR DESCRIPTION
## Summary
- 전체화면 모드의 차량/라이더/BSS 3 줄 분리 제거 → 11개 select 가 모두 한 glass 바 안에 평탄하게 가로로 배치
- 좁은 폭에선 select 단위로 wrap (관리 탭 필터 row 와 동일 동작)
- 카테고리 라벨 + 행 wrapper 제거. CSS `display: contents` 로 `.vehicles-filter-row` 내부를 평탄화해 select 들이 부모 flex 컨테이너의 직접 자식이 됨

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 전체화면 진입 → 상단에 11개 select 가 한 줄로 가로 배치
- [ ] 좁은 폭에서 select 단위로 wrap 되는지
- [ ] 회귀: 차량/라이더/BSS 탭의 본인 필터 row 동작 동일 (`display: contents` 가 fullscreen 컨텍스트 안에서만 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)