### PR TITLE
Make fullscreen fitBounds account for the floating filter bar

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -77,7 +77,15 @@ export interface MapShellProps {
    * 새 객체로 넘긴다. null 이면 아무 동작 없음.
    */
   targetLocation?: { lat: number; lng: number; zoom?: number } | null;
+  /**
+   * 첫 마커 fit 시 적용할 padding (NCP `fitBounds` 옵션). 기본 사방 48px.
+   * 전체화면 모드처럼 캔버스 위에 floating 헤더 / 필터 바가 떠 있는 화면은
+   * 상단 padding 을 더 크게 줘서 마커가 그 floating 영역 뒤에 박히지 않게.
+   */
+  fitBoundsPadding?: { top: number; right: number; bottom: number; left: number };
 }
+
+const DEFAULT_FIT_BOUNDS_PADDING = { top: 48, right: 48, bottom: 48, left: 48 };
 
 export function MapShell({
   children,
@@ -88,6 +96,7 @@ export function MapShell({
   onBikeSelect,
   onStationSelect,
   targetLocation = null,
+  fitBoundsPadding = DEFAULT_FIT_BOUNDS_PADDING,
 }: MapShellProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<NaverMapInstance | null>(null);
@@ -358,8 +367,10 @@ export function MapShell({
       for (let i = 1; i < all.length; i++) {
         bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
       }
-      // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
-      map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
+      // 가장자리 마커가 dot/label 까지 잘리지 않도록 패딩 적용. 기본은 사방
+      // 48px; 전체화면 모드는 상단의 floating 필터 바를 피하려고 더 큰 top
+      // padding 을 부모가 prop 으로 박아 넘긴다.
+      map.fitBounds(bounds, fitBoundsPadding);
       hasFittedRef.current = true;
       waitForIdle();
     }
@@ -379,7 +390,7 @@ export function MapShell({
         fallbackTimer = null;
       }
     };
-  }, [sdkReady, bikePins, stationPins, mapVersion]);
+  }, [sdkReady, bikePins, stationPins, mapVersion, fitBoundsPadding]);
 
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
   // 겹치는 점은 alpha 합성으로 색이 짙어져 밀도 시각화. 줌 무관 고정 크기.

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -31,6 +31,12 @@ import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-s
 import type { BatteryStation } from "@/types/domain";
 import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 
+// 모듈 레벨 상수 — `MapShell` 의 `fitBoundsPadding` deps 가 매 렌더마다 새
+// 객체로 트리거되지 않도록 안정된 reference 를 유지한다. 값 조정 시 여기
+// 한 곳만 바꾸면 됨. top 은 헤더(56px) + filter bar (≤ 100px wrap 포함)
+// + 안전 margin 합산.
+const FULLSCREEN_FIT_BOUNDS_PADDING = { top: 180, right: 48, bottom: 48, left: 48 };
+
 /**
  * 전체화면 지도 모드. `OverviewMapBanner` 의 [⛶ 전체화면] 버튼이
  * `setFullscreenMapOpen(true)` 를 호출하면 이 컴포넌트가 viewport 전체를
@@ -306,6 +312,12 @@ function FullscreenMapOverlay({
           stationPins={[...visibleStationPins]}
           targetLocation={targetLocation}
           onBikeSelect={setSelectedBikeId}
+          // 전체화면은 상단에 floating header (≈ 52px) + 가로 필터 바 (좁은
+          // 폭에서 1~2 줄로 wrap, 최대 ≈ 100px 까지) 가 떠 있어, 기본 사방
+          // 48px 패딩으로 fit 하면 마커가 그 floating 영역 뒤에 가려진다.
+          // top 만 충분히 크게 잡아서 fitBounds 가 마커를 항상 바 아래로
+          // 밀어 넣게 한다.
+          fitBoundsPadding={FULLSCREEN_FIT_BOUNDS_PADDING}
         />
         <VehicleDetailDialog
           key={detailRow ? (detailRow.vehicle.id ?? detailRow.vehicle.slug) : "none"}


### PR DESCRIPTION
## Summary
- 전체화면 모드에서 첫 마커 fit 시 사방 48px 패딩만 적용해 상단 floating header(56px) + filter bar(wrap 시 최대 ~100px) 뒤로 마커가 가려지던 문제 수정
- `MapShell` 에 `fitBoundsPadding` prop 추가 (기본 사방 48px)
- `FullscreenMapHost` 가 `{ top: 180, right: 48, bottom: 48, left: 48 }` 넘김 — 상단 floating 영역을 충분히 비워서 마커가 항상 그 아래에 위치
- 상수는 모듈 레벨에 박아서 useEffect deps 가 매 렌더마다 새 객체로 재발화 안 함

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 전체화면 진입 시 모든 마커가 floating header/filter bar 아래에 위치하는지 (특히 2~3개 마커가 좁게 분포된 케이스)
- [ ] 회귀: 일반 in-page 지도(`OverviewMapBanner` 의 canvas) 의 첫 fit padding 은 기본 48px 그대로

🤖 Generated with [Claude Code](https://claude.com/claude-code)