### PR TITLE
Let operators collapse the fullscreen filter bar

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -621,6 +621,27 @@ textarea { padding-top: 10px; min-height: 96px; }
 .fullscreen-map-filter-bar .vehicles-filter-row {
   display: contents;
 }
+/* 접힌 상태 — 11개 select 가 unmount 되고 토글 pill 만 남는다. right: auto 로
+   바꿔 너비가 콘텐츠에 맞춰 줄어들도록 (펼침 상태는 right: 16 로 가로 풀폭). */
+.fullscreen-map-filter-bar--collapsed {
+  right: auto;
+}
+.fullscreen-map-filter-bar-toggle {
+  flex-shrink: 0;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--rm-line-subtle);
+  background: transparent;
+  color: var(--rm-text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+.fullscreen-map-filter-bar-toggle:hover {
+  background: var(--rm-bg-section);
+}
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만
    쓰지만 다른 곳 재사용 가능하도록 클래스로 분리. */

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -121,6 +121,9 @@ function FullscreenMapOverlay({
   const [riderFilters, setRiderFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
   const [stationFilters, setStationFilters] = useState<StationFilterState>(DEFAULT_STATION_FILTERS);
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
+  // 필터 바 펼침/접힘. 기본 펼침 — 운영자가 들어오자마자 필터들이 보이게.
+  // 닫으면 11개 select 가 숨겨지고 토글 버튼만 작은 pill 로 남는다.
+  const [filtersOpen, setFiltersOpen] = useState(true);
 
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
@@ -282,29 +285,42 @@ function FullscreenMapOverlay({
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
       </header>
-      <div className="fullscreen-map-filter-bar">
-        {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
-            CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
-            컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
-            wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
-        <VehicleFilterControls
-          filters={vehicleFilters}
-          onChange={setVehicleFilters}
-          layout="horizontal"
-          hideSearch
-        />
-        <RiderFilterControls
-          filters={riderFilters}
-          onChange={setRiderFilters}
-          layout="horizontal"
-          hideSearch
-        />
-        <StationFilterControls
-          filters={stationFilters}
-          onChange={setStationFilters}
-          layout="horizontal"
-          hideSearch
-        />
+      <div className={filtersOpen ? "fullscreen-map-filter-bar" : "fullscreen-map-filter-bar fullscreen-map-filter-bar--collapsed"}>
+        <button
+          type="button"
+          className="fullscreen-map-filter-bar-toggle"
+          onClick={() => setFiltersOpen((v) => !v)}
+          aria-expanded={filtersOpen}
+          title={filtersOpen ? "필터 닫기" : "필터 열기"}
+        >
+          필터 {filtersOpen ? "▾" : "▸"}
+        </button>
+        {filtersOpen ? (
+          <>
+            {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
+                CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
+                컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
+                wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
+            <VehicleFilterControls
+              filters={vehicleFilters}
+              onChange={setVehicleFilters}
+              layout="horizontal"
+              hideSearch
+            />
+            <RiderFilterControls
+              filters={riderFilters}
+              onChange={setRiderFilters}
+              layout="horizontal"
+              hideSearch
+            />
+            <StationFilterControls
+              filters={stationFilters}
+              onChange={setStationFilters}
+              layout="horizontal"
+              hideSearch
+            />
+          </>
+        ) : null}
       </div>
       <main className="fullscreen-map-canvas">
         <MapShell


### PR DESCRIPTION
## Summary
- 전체화면 필터 바 좌측에 `필터 ▾/▸` 토글 pill 추가 — 펼침/접힘 가능
- 접힌 상태: 11개 select 가 unmount, 토글만 작은 floating pill 로 남음 → 지도 시야 확보
- 펼침 상태: 전체 바가 가로 풀폭으로 다시 자라남
- 기본 펼침 상태로 진입 — 운영자가 들어오자마자 필터가 보이도록
- state 는 오버레이 내부 — 전체화면 종료 후 재진입 시 자동으로 펼침으로 reset (스펙의 "fullscreen state 는 unmount 시 사라짐" 정책과 일치)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 전체화면 진입 → 필터 바 펼친 상태로 노출, 11개 select 보임
- [ ] `필터 ▾` 토글 클릭 → 11개 select 숨김, 토글 pill 만 남음, 우측 공간 비어 지도 보임
- [ ] `필터 ▸` 토글 클릭 → 다시 펼침
- [ ] 닫고 재진입 → 다시 펼침 상태 (state 리셋)

🤖 Generated with [Claude Code](https://claude.com/claude-code)