### PR TITLE
Release: fullscreen fitBounds padding + collapsible filter bar

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -621,6 +621,27 @@ textarea { padding-top: 10px; min-height: 96px; }
 .fullscreen-map-filter-bar .vehicles-filter-row {
   display: contents;
 }
+/* 접힌 상태 — 11개 select 가 unmount 되고 토글 pill 만 남는다. right: auto 로
+   바꿔 너비가 콘텐츠에 맞춰 줄어들도록 (펼침 상태는 right: 16 로 가로 풀폭). */
+.fullscreen-map-filter-bar--collapsed {
+  right: auto;
+}
+.fullscreen-map-filter-bar-toggle {
+  flex-shrink: 0;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--rm-line-subtle);
+  background: transparent;
+  color: var(--rm-text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+.fullscreen-map-filter-bar-toggle:hover {
+  background: var(--rm-bg-section);
+}
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만
    쓰지만 다른 곳 재사용 가능하도록 클래스로 분리. */

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -77,7 +77,15 @@ export interface MapShellProps {
    * 새 객체로 넘긴다. null 이면 아무 동작 없음.
    */
   targetLocation?: { lat: number; lng: number; zoom?: number } | null;
+  /**
+   * 첫 마커 fit 시 적용할 padding (NCP `fitBounds` 옵션). 기본 사방 48px.
+   * 전체화면 모드처럼 캔버스 위에 floating 헤더 / 필터 바가 떠 있는 화면은
+   * 상단 padding 을 더 크게 줘서 마커가 그 floating 영역 뒤에 박히지 않게.
+   */
+  fitBoundsPadding?: { top: number; right: number; bottom: number; left: number };
 }
+
+const DEFAULT_FIT_BOUNDS_PADDING = { top: 48, right: 48, bottom: 48, left: 48 };
 
 export function MapShell({
   children,
@@ -88,6 +96,7 @@ export function MapShell({
   onBikeSelect,
   onStationSelect,
   targetLocation = null,
+  fitBoundsPadding = DEFAULT_FIT_BOUNDS_PADDING,
 }: MapShellProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<NaverMapInstance | null>(null);
@@ -358,8 +367,10 @@ export function MapShell({
       for (let i = 1; i < all.length; i++) {
         bounds.extend(new naver.maps.LatLng(all[i].lat, all[i].lng));
       }
-      // 가장자리 마커가 dot/label 까지 잘리지 않도록 사방 48px 패딩.
-      map.fitBounds(bounds, { top: 48, right: 48, bottom: 48, left: 48 });
+      // 가장자리 마커가 dot/label 까지 잘리지 않도록 패딩 적용. 기본은 사방
+      // 48px; 전체화면 모드는 상단의 floating 필터 바를 피하려고 더 큰 top
+      // padding 을 부모가 prop 으로 박아 넘긴다.
+      map.fitBounds(bounds, fitBoundsPadding);
       hasFittedRef.current = true;
       waitForIdle();
     }
@@ -379,7 +390,7 @@ export function MapShell({
         fallbackTimer = null;
       }
     };
-  }, [sdkReady, bikePins, stationPins, mapVersion]);
+  }, [sdkReady, bikePins, stationPins, mapVersion, fitBoundsPadding]);
 
   // Bike markers — DotMap 스타일 (10px translucent solid dot + white stroke).
   // 겹치는 점은 alpha 합성으로 색이 짙어져 밀도 시각화. 줌 무관 고정 크기.

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -121,6 +121,9 @@ function FullscreenMapOverlay({
   const [riderFilters, setRiderFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
   const [stationFilters, setStationFilters] = useState<StationFilterState>(DEFAULT_STATION_FILTERS);
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
+  // 필터 바 펼침/접힘. 기본 펼침 — 운영자가 들어오자마자 필터들이 보이게.
+  // 닫으면 11개 select 가 숨겨지고 토글 버튼만 작은 pill 로 남는다.
+  const [filtersOpen, setFiltersOpen] = useState(true);
 
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
@@ -282,29 +285,42 @@ function FullscreenMapOverlay({
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
       </header>
-      <div className="fullscreen-map-filter-bar">
-        {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
-            CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
-            컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
-            wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
-        <VehicleFilterControls
-          filters={vehicleFilters}
-          onChange={setVehicleFilters}
-          layout="horizontal"
-          hideSearch
-        />
-        <RiderFilterControls
-          filters={riderFilters}
-          onChange={setRiderFilters}
-          layout="horizontal"
-          hideSearch
-        />
-        <StationFilterControls
-          filters={stationFilters}
-          onChange={setStationFilters}
-          layout="horizontal"
-          hideSearch
-        />
+      <div className={filtersOpen ? "fullscreen-map-filter-bar" : "fullscreen-map-filter-bar fullscreen-map-filter-bar--collapsed"}>
+        <button
+          type="button"
+          className="fullscreen-map-filter-bar-toggle"
+          onClick={() => setFiltersOpen((v) => !v)}
+          aria-expanded={filtersOpen}
+          title={filtersOpen ? "필터 닫기" : "필터 열기"}
+        >
+          필터 {filtersOpen ? "▾" : "▸"}
+        </button>
+        {filtersOpen ? (
+          <>
+            {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
+                CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
+                컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
+                wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
+            <VehicleFilterControls
+              filters={vehicleFilters}
+              onChange={setVehicleFilters}
+              layout="horizontal"
+              hideSearch
+            />
+            <RiderFilterControls
+              filters={riderFilters}
+              onChange={setRiderFilters}
+              layout="horizontal"
+              hideSearch
+            />
+            <StationFilterControls
+              filters={stationFilters}
+              onChange={setStationFilters}
+              layout="horizontal"
+              hideSearch
+            />
+          </>
+        ) : null}
       </div>
       <main className="fullscreen-map-canvas">
         <MapShell

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -31,6 +31,12 @@ import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-s
 import type { BatteryStation } from "@/types/domain";
 import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 
+// 모듈 레벨 상수 — `MapShell` 의 `fitBoundsPadding` deps 가 매 렌더마다 새
+// 객체로 트리거되지 않도록 안정된 reference 를 유지한다. 값 조정 시 여기
+// 한 곳만 바꾸면 됨. top 은 헤더(56px) + filter bar (≤ 100px wrap 포함)
+// + 안전 margin 합산.
+const FULLSCREEN_FIT_BOUNDS_PADDING = { top: 180, right: 48, bottom: 48, left: 48 };
+
 /**
  * 전체화면 지도 모드. `OverviewMapBanner` 의 [⛶ 전체화면] 버튼이
  * `setFullscreenMapOpen(true)` 를 호출하면 이 컴포넌트가 viewport 전체를
@@ -306,6 +312,12 @@ function FullscreenMapOverlay({
           stationPins={[...visibleStationPins]}
           targetLocation={targetLocation}
           onBikeSelect={setSelectedBikeId}
+          // 전체화면은 상단에 floating header (≈ 52px) + 가로 필터 바 (좁은
+          // 폭에서 1~2 줄로 wrap, 최대 ≈ 100px 까지) 가 떠 있어, 기본 사방
+          // 48px 패딩으로 fit 하면 마커가 그 floating 영역 뒤에 가려진다.
+          // top 만 충분히 크게 잡아서 fitBounds 가 마커를 항상 바 아래로
+          // 밀어 넣게 한다.
+          fitBoundsPadding={FULLSCREEN_FIT_BOUNDS_PADDING}
         />
         <VehicleDetailDialog
           key={detailRow ? (detailRow.vehicle.id ?? detailRow.vehicle.slug) : "none"}


### PR DESCRIPTION
## Summary
- 전체화면 진입 시 fitBounds 가 floating header + filter bar 영역을 피하도록 상단 padding 180px 적용 (#294)
- 전체화면 필터 바를 `필터 ▾/▸` 토글로 접을 수 있게 추가 (#295)

## Test plan
- [ ] 전체화면 첫 진입 → 모든 마커가 floating 영역 아래에 위치
- [ ] 필터 바 토글 → select 숨김/노출 정상 동작
- [ ] 닫고 재진입 → 필터 바 다시 펼침 상태

🤖 Generated with [Claude Code](https://claude.com/claude-code)