### PR TITLE
Release: filter bar X close + header reopen button

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -621,26 +621,54 @@ textarea { padding-top: 10px; min-height: 96px; }
 .fullscreen-map-filter-bar .vehicles-filter-row {
   display: contents;
 }
-/* 접힌 상태 — 11개 select 가 unmount 되고 토글 pill 만 남는다. right: auto 로
-   바꿔 너비가 콘텐츠에 맞춰 줄어들도록 (펼침 상태는 right: 16 로 가로 풀폭). */
-.fullscreen-map-filter-bar--collapsed {
-  right: auto;
-}
-.fullscreen-map-filter-bar-toggle {
+
+/* 필터 바 우측 끝의 X 버튼 — 누르면 바 자체가 unmount. 다시 열려면 헤더의
+   `필터` pill 을 눌러야 한다. margin-left: auto 로 우측 끝으로 밀어둠. */
+.fullscreen-map-filter-bar-close {
+  margin-left: auto;
   flex-shrink: 0;
+  width: 32px;
   height: 32px;
-  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 8px;
   border: 1px solid var(--rm-line-subtle);
   background: transparent;
+  color: var(--rm-text-secondary);
+  font-size: 14px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.fullscreen-map-filter-bar-close:hover {
+  background: var(--rm-bg-section);
+  color: var(--rm-text-primary);
+}
+
+/* 헤더에 박힌 `필터` 토글 pill — 필터 바를 다시 열거나 (현재 열려 있으면)
+   닫는다. active 상태는 강조 색으로 칠해 운영자가 현재 필터가 떠 있는지
+   한눈에 알 수 있게. */
+.fullscreen-map-filter-reopen {
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 18px;
+  border: 1px solid var(--rm-line-subtle);
+  background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);
   color: var(--rm-text-primary);
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
   font-family: inherit;
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-panel);
 }
-.fullscreen-map-filter-bar-toggle:hover {
+.fullscreen-map-filter-reopen:hover {
   background: var(--rm-bg-section);
+}
+.fullscreen-map-filter-reopen--active {
+  background: var(--rm-accent-soft, var(--rm-bg-section));
+  border-color: var(--rm-accent-outline, var(--rm-line-subtle));
+  color: var(--rm-accent, var(--rm-text-primary));
 }
 
 /* 필터 accordion — 헤더 클릭으로 본문 펼침/접힘. 풀스크린 좌측 aside 안에서만

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -274,6 +274,18 @@ function FullscreenMapOverlay({
         >
           ✕ 닫기
         </button>
+        {/* 필터 바를 다시 노출하는 헤더 버튼. 필터가 열려 있을 때도 같은 버튼이
+            존재하며 클릭으로 닫을 수 있다. 즉 헤더 버튼 = 필터 바 X 버튼 의
+            대칭 트리거. */}
+        <button
+          type="button"
+          className={filtersOpen ? "fullscreen-map-filter-reopen fullscreen-map-filter-reopen--active" : "fullscreen-map-filter-reopen"}
+          onClick={() => setFiltersOpen((v) => !v)}
+          aria-pressed={filtersOpen}
+          title={filtersOpen ? "필터 숨기기" : "필터 보기"}
+        >
+          필터
+        </button>
         <OverviewMapSearch
           bikePins={bikePins}
           stationPins={stationPins}
@@ -285,43 +297,41 @@ function FullscreenMapOverlay({
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
       </header>
-      <div className={filtersOpen ? "fullscreen-map-filter-bar" : "fullscreen-map-filter-bar fullscreen-map-filter-bar--collapsed"}>
-        <button
-          type="button"
-          className="fullscreen-map-filter-bar-toggle"
-          onClick={() => setFiltersOpen((v) => !v)}
-          aria-expanded={filtersOpen}
-          title={filtersOpen ? "필터 닫기" : "필터 열기"}
-        >
-          필터 {filtersOpen ? "▾" : "▸"}
-        </button>
-        {filtersOpen ? (
-          <>
-            {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
-                CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
-                컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
-                wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
-            <VehicleFilterControls
-              filters={vehicleFilters}
-              onChange={setVehicleFilters}
-              layout="horizontal"
-              hideSearch
-            />
-            <RiderFilterControls
-              filters={riderFilters}
-              onChange={setRiderFilters}
-              layout="horizontal"
-              hideSearch
-            />
-            <StationFilterControls
-              filters={stationFilters}
-              onChange={setStationFilters}
-              layout="horizontal"
-              hideSearch
-            />
-          </>
-        ) : null}
-      </div>
+      {filtersOpen ? (
+        <div className="fullscreen-map-filter-bar">
+          {/* 차량/라이더/BSS 필터를 한 줄에 평탄하게 — 각 컨트롤의 wrapper 는
+              CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
+              컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
+              wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
+          <VehicleFilterControls
+            filters={vehicleFilters}
+            onChange={setVehicleFilters}
+            layout="horizontal"
+            hideSearch
+          />
+          <RiderFilterControls
+            filters={riderFilters}
+            onChange={setRiderFilters}
+            layout="horizontal"
+            hideSearch
+          />
+          <StationFilterControls
+            filters={stationFilters}
+            onChange={setStationFilters}
+            layout="horizontal"
+            hideSearch
+          />
+          <button
+            type="button"
+            className="fullscreen-map-filter-bar-close"
+            onClick={() => setFiltersOpen(false)}
+            title="필터 숨기기"
+            aria-label="필터 바 닫기"
+          >
+            ✕
+          </button>
+        </div>
+      ) : null}
       <main className="fullscreen-map-canvas">
         <MapShell
           bikePins={[...visibleBikePins]}


### PR DESCRIPTION
## Summary
- 전체화면 필터 바 우측에 X 닫기 → 바 전체 unmount + 헤더에 `필터` 토글 pill 로 다시 열기 (#297)

## Test plan
- [ ] 필터 바 X → 바 unmount, 헤더 필터 버튼 inactive
- [ ] 헤더 필터 → 바 다시 노출, 헤더 active
- [ ] 닫고 재진입 → 다시 펼침

🤖 Generated with [Claude Code](https://claude.com/claude-code)