### PR TITLE
Move fullscreen counts pill next to the search bar

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -584,7 +584,8 @@ textarea { padding-top: 10px; min-height: 96px; }
   background: var(--rm-bg-section);
 }
 .fullscreen-map-counts {
-  margin-left: auto;
+  /* 검색 바 바로 옆에 붙는다 — margin-left: auto 로 우측 끝까지 미는 옛 동작
+     은 운영자 요청으로 제거. 헤더 children 순서가 시각 순서를 그대로 결정. */
   padding: 8px 14px;
   border-radius: 18px;
   background: color-mix(in srgb, var(--rm-bg-panel-soft) 92%, transparent);


### PR DESCRIPTION
## Summary
- 전체화면 헤더의 차량/BSS 카운트 pill 위치를 우측 끝 → 검색 바 바로 옆으로 이동
- `.fullscreen-map-counts` 의 `margin-left: auto` 제거 → 헤더 children flex 자연 순서대로 정렬 (`[✕ 닫기]` `[필터]` `[검색]` `[카운트]`)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 전체화면 진입 → 카운트 pill 이 검색 바 바로 오른쪽에 붙어 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)