### PR TITLE
Stop MapShell first-fit cleanup from cancelling its own finalize

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -376,6 +376,17 @@ export function MapShell({
     }
 
     return () => {
+      // 첫 fit 이 이미 완료된 (hasFittedRef.current === true) 후에 bikePins
+      // identity 가 바뀌어 effect 가 재발화하는 케이스 (예: fleet 시뮬레이션이
+      // 매 tick 새 array 를 만드는 경우) 에서는 다음 effect 가 early return
+      // 으로 새 fit / listener / timer 를 만들지 않는다. 그러면 이전에 등록된
+      // rAF / idle listener / fallback timer 가 그대로 fire 해서 firstFitReady
+      // 를 set 해 줘야 로딩 오버레이가 사라진다. 이 cleanup 이 그걸 cancel
+      // 해 버리면 finalize 가 영영 호출되지 않아 로딩이 무한 노출된다.
+      //
+      // 정상 unmount / 첫 fit 진행 중 deps 가 바뀌는 케이스는 여전히 cleanup
+      // 이 필요하므로 hasFittedRef 가 true 일 때만 보존 분기.
+      if (hasFittedRef.current) return;
       cancelled = true;
       if (scheduledRaf !== null && typeof window !== "undefined") {
         window.cancelAnimationFrame(scheduledRaf);


### PR DESCRIPTION
## Summary
- 데모 시작 후 지도가 `지도 불러오는 중…` 스피너에서 영구히 멈춰 마커가 안 보이던 버그 수정
- 원인: `MapShell` 의 first-fit useEffect 가 `bikePins` 를 deps 로 갖고 있는데, fleet 시뮬레이션이 매초 새 array (overlay 결과) 를 주면서 effect 가 매 tick 재발화 → 직전 effect 의 cleanup 이 rAF / idle listener / fallback timer 를 모두 cancel → `finalize` 가 영영 호출되지 않아 `firstFitReady` = false 유지 → 로딩 오버레이가 마커를 영구히 가림
- 정적 dummy 시절엔 `bikePins` identity 가 안정적이라 안 보이던 잠재 버그가 fleet 시뮬레이션 도입으로 노출
- fix: cleanup 함수에서 `hasFittedRef.current === true` 면 early return → 이전 effect 의 timer/listener 가 살아남아 `finalize` 호출 → `firstFitReady` 정상 set

## Diagnosis (실제 prod 확인)
- React fiber traversal 로 확인: `simulated.size = 2`, 양쪽 차량 모두 `EN_ROUTE` phase, progress 0.65 → 0.67 진행, `speedKph: 30`, `ignitionStatus: ON`
- MapShell 이 받는 `bikePins` 도 새 위치 반영됨 (lat/lng 매초 변동)
- 그러나 화면엔 로딩 spinner — `firstFitReady = false` 가 마커를 가리는 것

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] prod 배포 후 데모 시작 → 지도 → 30초 안에 로딩 spinner 사라지고 마커 노출
- [ ] 마커가 시뮬레이션 위치 따라 천천히 이동 (5분 동안 origin → destination)
- [ ] 회귀: 정적 dummy 만 있는 상태 (데모 OFF) 에서도 첫 진입 시 정상 fit + 로딩 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)