### PR TITLE
Light up tables / KPI / search with virtual fleet (PR-B)

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -13,6 +13,7 @@ import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { FullscreenMapHost } from "@/components/overview/FullscreenMapHost";
 import { OverviewClientShell } from "@/components/overview/OverviewClientShell";
+import { OverviewKpiTiles } from "@/components/overview/OverviewKpiTiles";
 import { OverviewMapBanner } from "@/components/overview/OverviewMapBanner";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 import { loadRiderList } from "@/lib/services/rider-data";
@@ -284,43 +285,14 @@ export default async function RootPage({
 
       <OverviewClientShell>
       {/* 페이지 상단 KPI 두 카드(차량 현황 / 라이더 현황). */}
-      <div className="overview-kpi-groups">
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">차량 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 차량</p>
-              <p className="metric-value">{formatCount(summary.totalBikes)}</p>
-            </div>
-            <div>
-              <p className="metric-label">시동 차량</p>
-              <p className="metric-value">{formatCount(ignitionOnCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">보험 차량</p>
-              <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
-            </div>
-          </div>
-        </article>
-
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">라이더 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 라이더</p>
-              <p className="metric-value">{formatCount(totalRiders)}</p>
-            </div>
-            <div>
-              <p className="metric-label">구독 인원</p>
-              <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">렌탈 인원</p>
-              <p className="metric-value">{formatCount(rentalRiderCount)}</p>
-            </div>
-          </div>
-        </article>
-      </div>
+      <OverviewKpiTiles
+        totalBikes={summary.totalBikes}
+        ignitionOnCount={ignitionOnCount}
+        insuredVehicleCount={insuredVehicleCount}
+        totalRiders={totalRiders}
+        subscriptionRiderCount={subscriptionRiderCount}
+        rentalRiderCount={rentalRiderCount}
+      />
 
       {/* 지도 보기 토글 + 캔버스는 KPI 와 탭(관리 섹션) 사이에 위치. 운영자가
           숫자 → 지도 → 표로 자연스럽게 눈을 내려갈 수 있도록 한 단계 정렬. */}

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_RIDER_FILTERS,
   type RiderFilterState
 } from "@/components/overview/filter-compute";
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { RiderFilterControls } from "@/components/overview/RiderFilterControls";
 import type { RiderDataResult } from "@/lib/services/rider-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
@@ -69,6 +70,12 @@ export function RidersPanel({
   const [activeRow, setActiveRow] = useState<RiderDetailRow | null>(null);
   const [filters, setFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
 
+  const { virtualFleet } = useFleetSimulation();
+  const effectiveRiders = useMemo(() => {
+    if (!virtualFleet) return data.riders;
+    return [...data.riders, ...virtualFleet.riders];
+  }, [data.riders, virtualFleet]);
+
   // insurance_item id → 이름 사전. 보험 컬럼이 매 행마다 lookup 1회.
   const insuranceLabelById = useMemo(() => {
     const map = new Map<string, string>();
@@ -81,7 +88,7 @@ export function RidersPanel({
   const visibleRiders = useMemo(
     () =>
       applyRiderFilters({
-        riders: data.riders,
+        riders: effectiveRiders,
         filters,
         educationTypeByRiderId,
         riderActiveBikeId,
@@ -91,7 +98,7 @@ export function RidersPanel({
         ignitionStatusByBikeId
       }),
     [
-      data.riders,
+      effectiveRiders,
       filters,
       educationTypeByRiderId,
       riderActiveBikeId,
@@ -108,7 +115,7 @@ export function RidersPanel({
         filters={filters}
         onChange={setFilters}
         layout="horizontal"
-        count={{ visible: visibleRiders.length, total: data.riders.length }}
+        count={{ visible: visibleRiders.length, total: effectiveRiders.length }}
       />
 
       <div className="table-card">

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -15,6 +15,7 @@ import {
   statusToOperation,
   type VehicleFilterState
 } from "@/components/overview/filter-compute";
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
@@ -114,16 +115,22 @@ export function VehiclesPanel({
     return map;
   }, [insuranceOptions]);
 
+  const { virtualFleet } = useFleetSimulation();
+  const effectiveVehicles = useMemo(() => {
+    if (!virtualFleet) return data.vehicles;
+    return [...data.vehicles, ...virtualFleet.vehicles];
+  }, [data.vehicles, virtualFleet]);
+
   const visibleVehicles = useMemo(
     () =>
       applyVehicleFilters({
-        vehicles: data.vehicles,
+        vehicles: effectiveVehicles,
         filters,
         bikePinById,
         deviceUidByBikeId,
         maintenanceSummaryByBike
       }),
-    [data.vehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+    [effectiveVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
   );
 
   // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
@@ -159,7 +166,7 @@ export function VehiclesPanel({
         filters={filters}
         onChange={setFilters}
         layout="horizontal"
-        count={{ visible: visibleVehicles.length, total: data.vehicles.length }}
+        count={{ visible: visibleVehicles.length, total: effectiveVehicles.length }}
       />
 
       <div className="table-card vehicles-table-scroll">

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -133,6 +133,20 @@ function FullscreenMapOverlay({
     return [...bikePins, ...virtualFleet.bikePins];
   }, [bikePins, virtualFleet]);
 
+  const mergedBikeActiveRiderById = useMemo(() => {
+    if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+    const m = new Map<string, string>(bikeActiveRiderById ?? []);
+    for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+    return m;
+  }, [bikeActiveRiderById, virtualFleet]);
+
+  const mergedRiderInfoById = useMemo(() => {
+    if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+    const m = new Map<string, { name: string; phone: string }>(riderInfoById ?? []);
+    for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+    return m;
+  }, [riderInfoById, virtualFleet]);
+
   const overlaidBikePins = useSimulatedBikePins(mergedRawPins);
 
   useEffect(() => {
@@ -312,8 +326,8 @@ function FullscreenMapOverlay({
         <OverviewMapSearch
           bikePins={overlaidBikePins}
           stationPins={stationPins}
-          bikeActiveRiderById={bikeActiveRiderById}
-          riderInfoById={riderInfoById}
+          bikeActiveRiderById={mergedBikeActiveRiderById}
+          riderInfoById={mergedRiderInfoById}
           onSelect={handleSearchSelect}
         />
         <span className="fullscreen-map-counts">

--- a/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
+++ b/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+
+/**
+ * 페이지 상단의 두 KPI 카드 (차량 현황 / 라이더 현황). 서버에서 SSR 된
+ * baseline 값을 props 로 받고, 그 위에 fleet 데모의 가상 fleet + 시뮬레이션
+ * 상태를 매 1초 tick 마다 overlay 한다. fleet OFF 면 props 값 그대로.
+ *
+ * 시동 차량은 virtual-bike-* prefix 가 붙은 simulated entry 중 ignitionStatus
+ * 가 ON 인 것만 카운트해 base 에 더한다 — base 의 실제 차량 카운트와
+ * 중복되지 않도록 (실제 차량은 SSR 시점의 정적 dummy 값을 그대로 신뢰).
+ */
+export interface OverviewKpiTilesProps {
+  totalBikes: number;
+  ignitionOnCount: number;
+  insuredVehicleCount: number;
+  totalRiders: number;
+  subscriptionRiderCount: number;
+  rentalRiderCount: number;
+}
+
+const VIRTUAL_BIKE_PREFIX = "virtual-bike-";
+const VIRTUAL_FLEET_COUNT = 20;
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+export function OverviewKpiTiles({
+  totalBikes,
+  ignitionOnCount,
+  insuredVehicleCount,
+  totalRiders,
+  subscriptionRiderCount,
+  rentalRiderCount,
+}: OverviewKpiTilesProps) {
+  const { virtualFleet, simulated } = useFleetSimulation();
+
+  const virtualIgnitionOn = useMemo(() => {
+    let n = 0;
+    for (const state of simulated.values()) {
+      if (state.ignitionStatus === "ON" && state.bikeId.startsWith(VIRTUAL_BIKE_PREFIX)) {
+        n++;
+      }
+    }
+    return n;
+  }, [simulated]);
+
+  const totalBikesEffective = totalBikes + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const totalRidersEffective = totalRiders + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const ignitionOnEffective = ignitionOnCount + virtualIgnitionOn;
+
+  return (
+    <div className="overview-kpi-groups">
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">차량 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 차량</p>
+            <p className="metric-value">{formatCount(totalBikesEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">시동 차량</p>
+            <p className="metric-value">{formatCount(ignitionOnEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">보험 차량</p>
+            <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+          </div>
+        </div>
+      </article>
+
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">라이더 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 라이더</p>
+            <p className="metric-value">{formatCount(totalRidersEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">구독 인원</p>
+            <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+          </div>
+          <div>
+            <p className="metric-label">렌탈 인원</p>
+            <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -56,6 +56,20 @@ export function OverviewMapBanner({
     return [...bikePins, ...virtualFleet.bikePins];
   }, [bikePins, virtualFleet]);
 
+  const mergedBikeActiveRiderById = useMemo(() => {
+    if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+    const m = new Map<string, string>(bikeActiveRiderById ?? []);
+    for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+    return m;
+  }, [bikeActiveRiderById, virtualFleet]);
+
+  const mergedRiderInfoById = useMemo(() => {
+    if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+    const m = new Map(riderInfoById ?? []);
+    for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+    return m;
+  }, [riderInfoById, virtualFleet]);
+
   const overlaidBikePins = useSimulatedBikePins(mergedRawPins);
 
   useEffect(() => {
@@ -171,8 +185,8 @@ export function OverviewMapBanner({
         <OverviewMapSearch
           bikePins={bikePins}
           stationPins={stationPins}
-          bikeActiveRiderById={bikeActiveRiderById}
-          riderInfoById={riderInfoById}
+          bikeActiveRiderById={mergedBikeActiveRiderById}
+          riderInfoById={mergedRiderInfoById}
           onSelect={handleSearchSelect}
         />
         <button

--- a/docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
+++ b/docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
@@ -1,0 +1,681 @@
+# Virtual Fleet Tables / KPI / Search (PR-B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the `virtualFleet` snapshot (introduced in PR-A) into the vehicles table, riders table, root-page KPI tiles, and the unified `OverviewMapSearch` matching, so toggling 데모 시작 makes the whole page light up — 22 vehicles, 21 riders, KPI deltas, search hits — not just the map markers.
+
+**Architecture:** Each consumer reads `virtualFleet` from `useFleetSimulation()` and merges raw data with the virtual fleet via a small `useMemo`. The KPI tile block is extracted from the server `page.tsx` into a new client component that subscribes to live simulation so the 시동 차량 count updates per tick. No new context channels; PR-A already exposes everything we need.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript. No new runtime deps. No backend changes. No test runner — verification = `npm run typecheck` + `npm run lint` + manual smoke.
+
+**Reference doc:** `docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md`.
+
+---
+
+## File Structure
+
+| Path | Purpose | Action |
+| ---- | ------- | ------ |
+| `components/overview/OverviewKpiTiles.tsx` | New client component — renders the two KPI cards from server-supplied base counts + live virtual/simulated overlay | **Create** |
+| `app/page.tsx` | Replace inline KPI JSX with `<OverviewKpiTiles .../>`; counts continue to be computed server-side and passed as props | **Modify** |
+| `components/management/VehiclesPanel.tsx` | Merge `data.vehicles ⊕ virtualFleet.vehicles` before filtering | **Modify** |
+| `components/management/RidersPanel.tsx` | Merge `data.riders ⊕ virtualFleet.riders` before filtering | **Modify** |
+| `components/overview/OverviewMapBanner.tsx` | Merge `bikeActiveRiderById` / `riderInfoById` with virtualFleet's before passing to `OverviewMapSearch` | **Modify** |
+| `components/overview/FullscreenMapHost.tsx` | Same merge for the fullscreen search | **Modify** |
+
+No tests directory — verification by typecheck + lint + manual smoke.
+
+---
+
+## Task 1: Branch sanity check
+
+**Files:** none
+
+- [ ] **Step 1: Verify branch + spec**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git status
+git log --oneline -3
+ls docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
+ls docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
+```
+
+Expected: branch `cc-225-virtual-fleet-tables-kpi-search`, recent commit `01d487b` (spec). Both doc files exist. Working tree clean.
+
+---
+
+## Task 2: Merge virtual vehicles into `VehiclesPanel`
+
+**Files:**
+- Modify: `development/front-admin-web/components/management/VehiclesPanel.tsx`
+
+Build an `effectiveVehicles` array (raw + virtual) and replace every `data.vehicles` usage with it.
+
+- [ ] **Step 1: Read the file to confirm current shape**
+
+```bash
+grep -n "useFleetSimulation\|data\.vehicles\|applyVehicleFilters" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/management/VehiclesPanel.tsx
+```
+
+Expected: file currently has no `useFleetSimulation` import. `data.vehicles` is referenced on lines ~120, ~126, ~162 (per spec).
+
+- [ ] **Step 2: Add the new import**
+
+Add alongside other `@/components/overview/` imports near the top:
+
+```tsx
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+```
+
+If `useMemo` is not already in the existing react import, add it (it should already be since the file uses memoization).
+
+- [ ] **Step 3: Read the fleet context and derive effective vehicles**
+
+Inside the `VehiclesPanel` component body, near the other hooks (above the `applyVehicleFilters` `useMemo`), add:
+
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveVehicles = useMemo(() => {
+  if (!virtualFleet) return data.vehicles;
+  return [...data.vehicles, ...virtualFleet.vehicles];
+}, [data.vehicles, virtualFleet]);
+```
+
+- [ ] **Step 4: Swap `data.vehicles` references**
+
+Find the `applyVehicleFilters` invocation:
+```tsx
+const visibleVehicles = useMemo(
+  () =>
+    applyVehicleFilters({
+      vehicles: data.vehicles,
+      ...
+    }),
+  [data.vehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+);
+```
+
+Change `vehicles: data.vehicles` to `vehicles: effectiveVehicles`, and replace `data.vehicles` in the deps array:
+
+```tsx
+const visibleVehicles = useMemo(
+  () =>
+    applyVehicleFilters({
+      vehicles: effectiveVehicles,
+      filters,
+      bikePinById,
+      deviceUidByBikeId,
+      maintenanceSummaryByBike
+    }),
+  [effectiveVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+);
+```
+
+Find the filter-controls count prop:
+```tsx
+count={{ visible: visibleVehicles.length, total: data.vehicles.length }}
+```
+
+Change to:
+```tsx
+count={{ visible: visibleVehicles.length, total: effectiveVehicles.length }}
+```
+
+Confirm via grep that no other `data.vehicles` reference exists in the file — if it does, swap to `effectiveVehicles` (or leave only if it's intentional, e.g., a banner that shows the raw count).
+
+- [ ] **Step 5: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/management/VehiclesPanel.tsx
+git commit -m "VehiclesPanel: show virtual fleet rows when demo is running
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Merge virtual riders into `RidersPanel`
+
+**Files:**
+- Modify: `development/front-admin-web/components/management/RidersPanel.tsx`
+
+Same pattern as Task 2 but for riders.
+
+- [ ] **Step 1: Confirm current shape**
+
+```bash
+grep -n "useFleetSimulation\|data\.riders\|applyRiderFilters" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/management/RidersPanel.tsx
+```
+
+Expected references to `data.riders` on lines ~84, ~94, ~111.
+
+- [ ] **Step 2: Add the import**
+
+Add alongside other `@/components/overview/` imports:
+
+```tsx
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+```
+
+Ensure `useMemo` is in the react import.
+
+- [ ] **Step 3: Derive `effectiveRiders`**
+
+Inside `RidersPanel`, near other hooks:
+
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveRiders = useMemo(() => {
+  if (!virtualFleet) return data.riders;
+  return [...data.riders, ...virtualFleet.riders];
+}, [data.riders, virtualFleet]);
+```
+
+- [ ] **Step 4: Swap `data.riders` references**
+
+Find `applyRiderFilters` call:
+```tsx
+applyRiderFilters({
+  riders: data.riders,
+  ...
+})
+```
+
+Change to:
+```tsx
+applyRiderFilters({
+  riders: effectiveRiders,
+  ...
+})
+```
+
+Replace `data.riders` in its deps array with `effectiveRiders`.
+
+Find the count prop:
+```tsx
+count={{ visible: visibleRiders.length, total: data.riders.length }}
+```
+
+Change to:
+```tsx
+count={{ visible: visibleRiders.length, total: effectiveRiders.length }}
+```
+
+- [ ] **Step 5: Static checks** — both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/management/RidersPanel.tsx
+git commit -m "RidersPanel: show virtual riders when demo is running
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Extract KPI tiles into a client component with live overlay
+
+**Files:**
+- Create: `development/front-admin-web/components/overview/OverviewKpiTiles.tsx`
+- Modify: `development/front-admin-web/app/page.tsx`
+
+The current KPI JSX lives inside the server `page.tsx`. Extract it into a client component that takes the server-computed base counts as props and reads `virtualFleet` + `simulated` from context to overlay live virtual contributions.
+
+- [ ] **Step 1: Create the new client component**
+
+```tsx
+"use client";
+
+import { useMemo } from "react";
+
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+
+/**
+ * 페이지 상단의 두 KPI 카드 (차량 현황 / 라이더 현황). 서버에서 SSR 된
+ * baseline 값을 props 로 받고, 그 위에 fleet 데모의 가상 fleet + 시뮬레이션
+ * 상태를 매 1초 tick 마다 overlay 한다. fleet OFF 면 props 값 그대로.
+ *
+ * 시동 차량은 virtual-bike-* prefix 가 붙은 simulated entry 중 ignitionStatus
+ * 가 ON 인 것만 카운트해 base 에 더한다 — base 의 실제 차량 카운트와
+ * 중복되지 않도록 (실제 차량은 SSR 시점의 정적 dummy 값을 그대로 신뢰).
+ */
+export interface OverviewKpiTilesProps {
+  totalBikes: number;
+  ignitionOnCount: number;
+  insuredVehicleCount: number;
+  totalRiders: number;
+  subscriptionRiderCount: number;
+  rentalRiderCount: number;
+}
+
+const VIRTUAL_BIKE_PREFIX = "virtual-bike-";
+const VIRTUAL_FLEET_COUNT = 20;
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+export function OverviewKpiTiles({
+  totalBikes,
+  ignitionOnCount,
+  insuredVehicleCount,
+  totalRiders,
+  subscriptionRiderCount,
+  rentalRiderCount
+}: OverviewKpiTilesProps) {
+  const { virtualFleet, simulated } = useFleetSimulation();
+
+  const virtualIgnitionOn = useMemo(() => {
+    let n = 0;
+    for (const state of simulated.values()) {
+      if (state.ignitionStatus === "ON" && state.bikeId.startsWith(VIRTUAL_BIKE_PREFIX)) {
+        n++;
+      }
+    }
+    return n;
+  }, [simulated]);
+
+  const totalBikesEffective = totalBikes + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const totalRidersEffective = totalRiders + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const ignitionOnEffective = ignitionOnCount + virtualIgnitionOn;
+
+  return (
+    <div className="overview-kpi-groups">
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">차량 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 차량</p>
+            <p className="metric-value">{formatCount(totalBikesEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">시동 차량</p>
+            <p className="metric-value">{formatCount(ignitionOnEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">보험 차량</p>
+            <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+          </div>
+        </div>
+      </article>
+
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">라이더 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 라이더</p>
+            <p className="metric-value">{formatCount(totalRidersEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">구독 인원</p>
+            <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+          </div>
+          <div>
+            <p className="metric-label">렌탈 인원</p>
+            <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace the inline KPI JSX in `app/page.tsx`**
+
+In `page.tsx`, add the import near other `@/components/overview/` imports:
+
+```tsx
+import { OverviewKpiTiles } from "@/components/overview/OverviewKpiTiles";
+```
+
+Find the existing inline KPI block (~lines 287-323 from spec read):
+
+```tsx
+<div className="overview-kpi-groups">
+  <article className="kpi-group">
+    <h3 className="kpi-group-heading">차량 현황</h3>
+    ...
+  </article>
+  <article className="kpi-group">
+    <h3 className="kpi-group-heading">라이더 현황</h3>
+    ...
+  </article>
+</div>
+```
+
+Replace the entire block with:
+
+```tsx
+<OverviewKpiTiles
+  totalBikes={summary.totalBikes}
+  ignitionOnCount={ignitionOnCount}
+  insuredVehicleCount={insuredVehicleCount}
+  totalRiders={totalRiders}
+  subscriptionRiderCount={subscriptionRiderCount}
+  rentalRiderCount={rentalRiderCount}
+/>
+```
+
+If `page.tsx` has a local `formatCount` helper that is no longer referenced after this swap, leave it in place — other parts of the page may still use it. Only remove if grep confirms zero references.
+
+Verify the new component is rendered INSIDE `<OverviewClientShell>` (otherwise `useFleetSimulation` returns the noop fallback and counts never reflect the fleet). The existing KPI block was already inside `OverviewClientShell` per the file structure read.
+
+- [ ] **Step 3: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/OverviewKpiTiles.tsx development/front-admin-web/app/page.tsx
+git commit -m "Extract OverviewKpiTiles to a client component with live virtual overlay
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Merge rider lookups for search in `OverviewMapBanner`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/OverviewMapBanner.tsx`
+
+The banner already pulls `virtualFleet` (PR-A). Add two merged Maps and feed them to `OverviewMapSearch` so virtual riders + virtual `bikeActiveRiderById` participate in search matching.
+
+- [ ] **Step 1: Verify current destructure + search usage**
+
+```bash
+grep -n "useFleetSimulation\|bikeActiveRiderById\|riderInfoById\|OverviewMapSearch" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+```
+
+Expected: `useFleetSimulation` already destructures `virtualFleet` (from PR-A). `bikeActiveRiderById` + `riderInfoById` come from `props`. `<OverviewMapSearch>` JSX passes them as props.
+
+- [ ] **Step 2: Build the two merged Maps**
+
+Insert near the existing `mergedRawPins` `useMemo` (above the search JSX, alongside other derivations):
+
+```tsx
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+  const m = new Map<string, string>(bikeActiveRiderById ?? []);
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+  const m = new Map(riderInfoById ?? []);
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+- [ ] **Step 3: Pass merged Maps to `OverviewMapSearch`**
+
+Find:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={bikeActiveRiderById}
+  riderInfoById={riderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+Change `bikeActiveRiderById` and `riderInfoById` to the merged versions:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={mergedBikeActiveRiderById}
+  riderInfoById={mergedRiderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+`VehicleDetailDialog` (rendered later in this banner via the search-target effect) continues to read its row from the page's separate `vehicleById` lookup — virtual vehicles aren't there, so clicking a virtual marker opens a dialog whose vehicle is `undefined` and the existing fallback path keeps the dialog from displaying broken data. That fallback is sufficient for this PR (full virtual detail panel is OOS).
+
+- [ ] **Step 4: Static checks** — both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/OverviewMapBanner.tsx
+git commit -m "OverviewMapBanner: merge virtual rider lookups into search
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Same merge for `FullscreenMapHost`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/FullscreenMapHost.tsx`
+
+- [ ] **Step 1: Confirm current shape inside `FullscreenMapOverlay`**
+
+```bash
+grep -n "useFleetSimulation\|bikeActiveRiderById\|riderInfoById\|OverviewMapSearch" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+```
+
+`virtualFleet` should already be in the destructure (PR-A). `bikeActiveRiderById` + `riderInfoById` are also already destructured (props passed from page).
+
+- [ ] **Step 2: Build merged Maps**
+
+Insert alongside `mergedRawPins`:
+
+```tsx
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+  const m = new Map<string, string>(bikeActiveRiderById ?? []);
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+  const m = new Map(riderInfoById ?? []);
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+- [ ] **Step 3: Pass merged Maps to `OverviewMapSearch` in the header**
+
+Find the JSX:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={bikeActiveRiderById}
+  riderInfoById={riderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+Change to:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={mergedBikeActiveRiderById}
+  riderInfoById={mergedRiderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+- [ ] **Step 4: Static checks** — both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/FullscreenMapHost.tsx
+git commit -m "FullscreenMapHost: merge virtual rider lookups into search
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full static-check sweep + optional build
+
+- [ ] **Step 1: typecheck**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+```
+
+Expected exit 0.
+
+- [ ] **Step 2: lint**
+
+```bash
+npm run lint
+```
+
+Expected exit 0.
+
+- [ ] **Step 3: Optional `next build`**
+
+```bash
+npm run build
+```
+
+Catches Next.js / SSR issues lint doesn't. Skip if you trust prior checks.
+
+---
+
+## Task 8: Manual smoke
+
+The user runs their own dev server. **Do not** spawn a competing one.
+
+- [ ] **Step 1: Fleet OFF baseline**
+
+Open `/`. KPI shows real counts. Vehicle table: 2 rows. Rider table: 1 row. Search the inline `차량 번호 / BSS / 라이더 검색` for `99서` — no matches.
+
+- [ ] **Step 2: 데모 시작**
+
+Click `[데모 시작]`. Verify:
+- KPI 전체 차량 jumps to original + 20 (e.g. 22)
+- KPI 전체 라이더 jumps to original + 20 (e.g. 21)
+- KPI 시동 차량 grows 0 → some positive number over the first 30s as virtual bikes transition to EN_ROUTE
+- Vehicle table 화면 reflects 22 rows when scrolled — plates `99서0001` ~ `99서0020` visible alongside real plates
+- Rider table reflects 21 rows — gating names like `김민수`, `이지영` 등 from the family/given pool
+
+- [ ] **Step 3: Search hit**
+
+Type `99서0005` in the inline search → result item visible in dropdown → click → map opens + pans + `VehicleDetailDialog` opens (with mostly-empty fields, as expected).
+
+Type `김민` (a virtual rider given-name prefix) → at least one rider result shows in dropdown → click → map opens + pans to that virtual rider's matched bike.
+
+- [ ] **Step 4: KPI live update**
+
+Watch `시동 차량` for ~30s. Number should bump up and down as virtual bikes shift between EN_ROUTE (ON) and ARRIVED/IDLE (OFF).
+
+- [ ] **Step 5: 데모 정지**
+
+Click toggle. Verify:
+- KPI returns to original
+- Vehicle table shrinks back to 2 rows
+- Rider table shrinks back to 1 row
+- Search `99서` again returns no matches
+
+- [ ] **Step 6: Fullscreen mode toggle**
+
+Open `[⛶ 전체화면]`. Click `[데모 시작]` from the fullscreen header. Search should match virtual plates and rider names from the fullscreen header search too (shared context).
+
+---
+
+## Task 9: PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git push -u origin cc-225-virtual-fleet-tables-kpi-search
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base dev --head cc-225-virtual-fleet-tables-kpi-search \
+  --title "Light up tables / KPI / search with virtual fleet (PR-B)" \
+  --body "$(cat <<'EOF'
+## Summary
+- PR-A 의 가상 fleet 스냅샷을 차량/라이더 표, KPI 카드, 검색에 통합 — 데모 시작이 한 화면 통째로 살아나도록
+- 차량 표: 2 → 22 행 (실제 2 + 가상 \`99서0001~0020\`), 기존 필터 헬퍼는 그대로 작동
+- 라이더 표: 1 → 21 행 (실제 1 + 가상 20 명)
+- KPI: 새 \`OverviewKpiTiles\` 클라이언트 컴포넌트로 추출 — 매 tick 시뮬레이션 진행에 따라 시동 차량 카운트 갱신
+- 검색: 인페이지 + 전체화면 양쪽에서 \`bikeActiveRiderById\` / \`riderInfoById\` 가 가상까지 매칭
+- 보험 차량 / 구독·렌탈 카운트는 가상이 0 기여라 그대로 (의도된 동작)
+
+## Spec & Plan
+- 디자인: \`docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md\`
+- 플랜: \`docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md\`
+
+## Test plan
+- [x] \`npm run typecheck\`
+- [x] \`npm run lint\`
+- [ ] 데모 시작 → KPI 차량 +20 / 라이더 +20 즉시 반영
+- [ ] 시동 차량 카운트가 시간이 지나며 변동 (가상 차량 EN_ROUTE 진입/이탈)
+- [ ] 차량 표에 \`99서\` plate 노출, 기존 필터 (구분/시동/연결) 가 가상 row 에도 정상 작동
+- [ ] 라이더 표에 가상 라이더 20명 노출
+- [ ] 검색 \`99서0005\` / \`김민\` 매칭, 클릭 시 지도 pan
+- [ ] 데모 정지 → 모든 화면 원상 복구
+- [ ] 전체화면 토글 / 검색도 동일 작동
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review
+
+**Spec coverage** — `docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md`:
+
+- "Panel 단의 표 데이터 merge" → Tasks 2 (VehiclesPanel) + 3 (RidersPanel).
+- "KPI 카드 — 새 클라이언트 컴포넌트로 분리" → Task 4 (`OverviewKpiTiles` + page.tsx swap).
+- "검색 (OverviewMapSearch) — banner / fullscreen 에서 merge" → Tasks 5 + 6.
+- "User-visible behavior" → Task 8 smoke checklist mirrors every bullet.
+- "Out-of-scope follow-ups" → not implemented; consistent with spec.
+
+**Placeholder scan** — no "TODO", "TBD", "implement later", "similar to Task N" references. Each code block is concrete.
+
+**Type consistency:**
+- `effectiveVehicles: FrontendVehicle[]` (Task 2) and `effectiveRiders: FrontendRider[]` (Task 3) — the merge spread relies on `VirtualFleet.vehicles: FrontendVehicle[]` / `.riders: FrontendRider[]` already produced by PR-A.
+- `mergedBikeActiveRiderById: Map<string, string>` and `mergedRiderInfoById: Map<string, { name; phone }>` — types match `OverviewMapSearch`'s optional props.
+- `OverviewKpiTilesProps` (Task 4) takes 6 numeric fields, all already computed in `page.tsx`.
+- `VIRTUAL_BIKE_PREFIX = "virtual-bike-"` matches the prefix in `lib/services/virtual-fleet.ts:1` (PR-A) which writes `virtual-bike-${pad2(i)}`.
+
+**Scope** — single PR, 1 new file + 5 modified files, no backend changes.

--- a/docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
+++ b/docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
@@ -1,0 +1,160 @@
+# Virtual Fleet — Tables / KPI / Search Integration (PR-B) Design
+
+## Goal
+
+PR-A 가 데모 시작 시 20대 가상 차량 + 라이더를 생성하고 지도 마커로 노출
+했다. 이 PR-B 는 그 가상 데이터를 **표 / KPI 카드 / 검색** 까지 통합해
+데모 모드의 인상적 효과 (한 화면이 통째로 살아남) 를 완성한다. 도로
+polyline (OSRM) 은 별도 PR-C.
+
+## Non-Goals
+
+- OSRM 도로 보간 — PR-C
+- 가상 차량의 정비 / 보험 / 계약 / 교육 정보 — 표에 "—" 로 비워둠. 운영
+  자가 한눈에 가상으로 식별 가능 + 가짜 데이터를 늘리는 부담 없음.
+- KPI "보험 차량" 카운트에 가상 fleet 반영 — 가상 라이더는 보험 미가입
+  이므로 어차피 0 기여
+- 매칭 / 계약 탭의 가상 노출 — 데모 핵심 동선이 아님
+- 가상 데이터를 실제 backend 에 보내는 동작 — 가상 차량 행에서 수정/
+  삭제 버튼은 disable 또는 silent no-op
+
+## Architecture
+
+### 데이터 통합 패턴 — 클라이언트 overlay 일관 적용
+
+기존에 `useSimulatedBikePins` / `useSimulatedCurrentTelemetry` 가 deterministic
+dummy 위에 시뮬레이션을 overlay 한 패턴 그대로. 이 PR 은 가상 fleet 의
+다른 필드들을 같은 패턴으로 overlay:
+
+- 차량 표 데이터: `data.vehicles` ⊕ `virtualFleet.vehicles`
+- 라이더 표 데이터: `data.riders` ⊕ `virtualFleet.riders`
+- bike → rider 매핑: `bikeActiveRiderById` ⊕ `virtualFleet.bikeActiveRiderById`
+- rider 조회: `riderInfoById` ⊕ `virtualFleet.riderInfoById`
+- KPI 카운트: 서버 SSR 값 + 가상 fleet 보정
+
+### Panel 단의 표 데이터 merge
+
+`VehiclesPanel` 과 `RidersPanel` 이 각자:
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveVehicles = useMemo(() => {
+  if (!virtualFleet) return data.vehicles;
+  return [...data.vehicles, ...virtualFleet.vehicles];
+}, [data.vehicles, virtualFleet]);
+// existing filter / row 렌더링은 effectiveVehicles 사용
+```
+
+기존 `applyVehicleFilters` / `applyRiderFilters` 헬퍼가 받는 데이터만
+바꾸면 됨 — 필터 동작은 그대로 작동.
+
+### KPI 카드 — 새 클라이언트 컴포넌트로 분리
+
+현재 `app/page.tsx` (server component) 가 `summary.totalBikes`,
+`ignitionOnCount`, `insuredVehicleCount`, `totalRiders`,
+`subscriptionRiderCount`, `rentalRiderCount` 6 개를 직접 JSX 로 렌더.
+SSR 이라 fleet 상태를 못 봄.
+
+해결: 새 `OverviewKpiTiles` client 컴포넌트로 추출.
+- props: 서버에서 계산한 6 개 base count
+- 내부에서 `useFleetSimulation()` 로 `virtualFleet` + `simulated` 읽음
+- 그 위에 보정 값 계산:
+  - 전체 차량: `summary.totalBikes + (virtualFleet ? 20 : 0)`
+  - 시동 차량: server base + `Array.from(simulated.values()).filter(s => s.ignitionStatus === "ON" && s.bikeId.startsWith("virtual-bike-")).length`
+    - 가상 차량의 시동 ON 만 더함 — 실제 차량은 SSR base 가 이미 카운트함
+    - 실제 차량이 manual assign 으로 ON 인 경우는 카운팅 안 됨 (희소 케이스, 의도된 trade-off)
+  - 보험 차량: 그대로 (가상은 0 기여)
+  - 전체 라이더: `totalRiders + (virtualFleet ? 20 : 0)`
+  - 구독 인원 / 렌탈 인원: 가상은 둘 다 0 기여 (계약 분류 없음). 그대로.
+
+매 1초 tick 마다 시뮬레이션이 advance → context 변경 → 컴포넌트 재렌더 →
+시동 차량 카운트가 자연스럽게 갱신.
+
+### 검색 (OverviewMapSearch) — banner / fullscreen 에서 merge
+
+`OverviewMapSearch` 는 props 로 `bikePins`, `stationPins`,
+`bikeActiveRiderById`, `riderInfoById` 받음. PR-A 에서 bikePins 는 이미
+merge 되어 들어감. 이 PR 은 rider 쪽 두 Map 도 merge:
+
+```tsx
+// OverviewMapBanner / FullscreenMapHost 안에서
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById;
+  const m = new Map(bikeActiveRiderById ?? new Map());
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById;
+  const m = new Map(riderInfoById ?? new Map());
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+`<OverviewMapSearch>` 에 merged 값을 전달 → 가상 plate `99서0001` 도 검색
+매칭, 가상 라이더 이름/연락처도 매칭.
+
+### 차량 표 가상 row 의 시각적 식별
+
+PR-A 의 sentinel pattern (`99서` plate, `데모 가상 N호기` 모델) 이 이미
+시각적으로 명확. 추가 배지 없이도 운영자가 분간 가능.
+
+행 클릭 시 `VehicleDetailDialog` 가 열리지만, 가상 차량은 maintenance
+fetch (`/api/overview/vehicle-maintenance/{bikeId}`) 가 backend 에서 404
+또는 빈 응답이 돌아옴 → 패널의 정비 섹션은 "정비 품목 없음" 으로 fallback.
+의도된 동작 (가상 데이터에 정비 이력 없음).
+
+라이더 표의 가상 row 도 행 클릭으로 `RiderDetailDialog` 가 열리되 본인
+정보 + 매칭 차량 plate 외 다른 필드는 비어 있음.
+
+### 가상 row 의 편집 / 삭제 차단
+
+차량 / 라이더 표 행에는 삭제 버튼이 있음 (`DeleteVehicleButton`,
+`DeleteRiderButton`). 가상 bikeId / riderId 가 `virtual-*` prefix 라 backend
+에 보내면 404. 이 PR 에선 버튼을 그냥 두고 (운영자가 클릭해도 toast 로
+실패 안내) — sentinel prefix 검사로 silent disable 하지 않음. 데모 중
+삭제 시도는 흔치 않은 시나리오.
+
+(차후 개선 여지: 가상 row 에 삭제 버튼 hidden / disabled 처리 — 이 PR
+범위 밖.)
+
+## User-visible behavior
+
+- 페이지 진입 (데모 OFF): 평소대로 — 차량 표 2 행, 라이더 표 1 행, KPI
+  실제 값
+- `[데모 시작]` 클릭:
+  - 즉시 KPI "전체 차량" 2 → 22, "전체 라이더" 1 → 21
+  - 차량 표가 22 행으로 확장 (`99서0001`~`99서0020` 추가)
+  - 라이더 표가 21 행으로 확장 (가상 라이더 20명 추가)
+  - 검색 인풋에 `99서0005` 또는 가상 라이더 이름 (`김민수` 등) 타이핑 → 매칭 노출, 클릭 시 지도 자동 이동
+  - 매 초 시동 차량 카운트가 시뮬레이션 진행에 따라 갱신 (가상 차량들이
+    staggered 로 EN_ROUTE 진입할 때마다 +1, ARRIVED → IDLE 시 -1)
+- `[데모 정지]`:
+  - KPI / 표 / 검색 모두 원상 복구
+
+## Error handling & edge cases
+
+- **가상 row 클릭 → detail 다이얼로그 열림 → 정비/계약/보험 빈 상태**:
+  의도된 동작. 패널 내부 fallback 메시지가 이미 처리.
+- **가상 row 삭제 버튼 클릭**: backend 가 404 반환, server action 의 catch
+  분기가 redirect 로 silent fail. 운영자는 데모 모드라 무시.
+- **데모 시작/정지 사이 빠른 토글**: 각 토글마다 새 deterministic seed 가
+  같으므로 같은 결과. 표 / KPI 즉시 반영.
+- **표 필터로 가상 차량 검색**: `99서` 로 검색하면 가상 20대만, `123마`
+  같은 실제 plate 로 검색하면 실제 1대만. 필터 helper 가 추출되어 있어
+  자연스럽게 작동.
+- **소트**: 차량 표 / 라이더 표가 기본 정렬을 갖는다면 가상 row 가 정렬
+  키에 따라 적당한 위치에 삽입됨. 별도 처리 없음.
+
+## Testing
+
+- `npm run typecheck`, `npm run lint` clean
+- 수동 smoke 체크리스트 (PR body 에 옮김)
+
+## Out-of-scope follow-ups
+
+- 가상 row 의 삭제 / 편집 버튼 hidden 처리
+- 가상 차량에 maintenance / contract / insurance 가짜 데이터 첨가
+- 매칭 / 계약 / 정비 catalog 탭에 가상 노출
+- PR-C: OSRM 도로 polyline 보간


### PR DESCRIPTION
## Summary
- PR-A 의 가상 fleet 스냅샷을 차량/라이더 표, KPI 카드, 검색에 통합 — 데모 시작이 한 화면 통째로 살아나도록
- 차량 표: 2 → 22 행 (실제 2 + 가상 `99서0001~0020`), 기존 필터 헬퍼는 그대로 작동
- 라이더 표: 1 → 21 행 (실제 1 + 가상 20 명)
- KPI: 새 `OverviewKpiTiles` 클라이언트 컴포넌트로 추출 — 매 tick 시뮬레이션 진행에 따라 시동 차량 카운트 갱신
- 검색: 인페이지 + 전체화면 양쪽에서 `bikeActiveRiderById` / `riderInfoById` 가 가상까지 매칭
- 보험 차량 / 구독·렌탈 카운트는 가상이 0 기여라 그대로 (의도된 동작)

## Spec & Plan
- 디자인: `docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md`
- 플랜: `docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md`

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] 데모 시작 → KPI 차량 +20 / 라이더 +20 즉시 반영
- [ ] 시동 차량 카운트가 시간이 지나며 변동 (가상 차량 EN_ROUTE 진입/이탈)
- [ ] 차량 표에 `99서` plate 노출, 기존 필터 (구분/시동/연결) 가 가상 row 에도 정상 작동
- [ ] 라이더 표에 가상 라이더 20명 노출
- [ ] 검색 `99서0005` / `김민` 매칭, 클릭 시 지도 pan
- [ ] 데모 정지 → 모든 화면 원상 복구
- [ ] 전체화면 토글 / 검색도 동일 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)