### PR TITLE
Road-following movement + delivery status badges (PR-C)

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -630,7 +630,7 @@ function bikeMarkerHtml(
   deliveryPhase?: DeliveryPhase | null
 ): string {
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
-  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  const badge = deliveryPhase != null ? deliveryBadgeMarkup(deliveryPhase) : "";
   if (!showLabel && !badge) return wrapped;
   return (
     `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -11,6 +11,7 @@ import type {
   NaverMapOptions,
   NaverMarkerInstance
 } from "@/types/naver-maps";
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
 const NCP_STYLE_ID_LIGHT = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT;
@@ -67,7 +68,7 @@ export interface MapShellProps {
   children?: ReactNode;
   initialCenter?: { lat: number; lng: number };
   initialZoom?: number;
-  bikePins?: FrontendDashboardBikePin[];
+  bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }>;
   stationPins?: FrontendDashboardStationPin[];
   onBikeSelect?: (bikeId: string) => void;
   onStationSelect?: (stationId: string) => void;
@@ -418,7 +419,7 @@ export function MapShell({
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase);
       const icon = {
         content: html,
         anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
@@ -559,6 +560,26 @@ function labelMarkup(text: string): string {
   return `<span class="map-marker-label">${safe}</span>`;
 }
 
+/**
+ * 배송 상태 배지 HTML. IDLE 이면 빈 문자열.
+ * 마커 컨테이너(relative 28×28) 아래에 absolute 로 위치 — 아이콘 밑에 노출.
+ */
+function deliveryBadgeMarkup(phase: DeliveryPhase): string {
+  if (phase === "IDLE") return "";
+  const config: Record<Exclude<DeliveryPhase, "IDLE">, { text: string; bg: string }> = {
+    ASSIGNED: { text: "배정됨", bg: "#f59e0b" },
+    EN_ROUTE: { text: "배송 중", bg: "#3b82f6" },
+    ARRIVED: { text: "배송 완료", bg: "#22c55e" }
+  };
+  const { text, bg } = config[phase];
+  return (
+    `<div style="position:absolute;top:100%;left:50%;transform:translateX(-50%);` +
+    `margin-top:2px;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:600;` +
+    `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
+    `${text}</div>`
+  );
+}
+
 // 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
 const ICON_SVG_PROPS = `width="${ICON_PX}" height="${ICON_PX}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
 
@@ -602,9 +623,18 @@ function stationMarkerHtml(name: string, showLabel: boolean): string {
   return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(name)}${wrapped}</div>`;
 }
 
-/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨. */
-function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
+/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨 + (옵션) 배송 상태 배지. */
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  deliveryPhase?: DeliveryPhase | null
+): string {
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
-  if (!showLabel) return wrapped;
-  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
+  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  if (!showLabel && !badge) return wrapped;
+  return (
+    `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
+    `${showLabel ? labelMarkup(plateNumber) : ""}${wrapped}${badge}` +
+    `</div>`
+  );
 }

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -53,6 +53,15 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
    * ref 라 React 렌더를 트리거하지 않음.
    */
   const pendingFetchesRef = useRef<Set<string>>(new Set());
+  /** コンポーネントのマウント状態を追跡。アンマウント後のsetSimulated呼び出しを防ぐ。 */
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
@@ -169,6 +178,7 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
       pendingFetchesRef.current.add(bikeId);
       fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
         pendingFetchesRef.current.delete(bikeId);
+        if (!mountedRef.current) return; // コンポーネントがアンマウント済み
         if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
         setSimulated((prev) => {
           const current = prev.get(bikeId);

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/services/fleet-simulation";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { generateVirtualFleet, type VirtualFleet } from "@/lib/services/virtual-fleet";
+import { fetchOsrmRoute } from "@/lib/services/osrm";
 
 /**
  * Fleet 배송 시뮬레이션 — 모든 클라이언트 트리가 공유하는 in-memory 시뮬레이터.
@@ -47,6 +48,11 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
   const [simulated, setSimulated] = useState<ReadonlyMap<string, SimulatedBikeState>>(() => new Map());
   const [virtualFleet, setVirtualFleet] = useState<VirtualFleet | null>(null);
   const pinsRef = useRef<ReadonlyArray<FrontendDashboardBikePin>>([]);
+  /**
+   * OSRM fetch 중인 bikeId Set. 동일 bike 에 중복 fetch 방지.
+   * ref 라 React 렌더를 트리거하지 않음.
+   */
+  const pendingFetchesRef = useRef<Set<string>>(new Set());
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
@@ -146,6 +152,35 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
     }, TICK_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [fleetRunning, simulated.size]);
+
+  // ASSIGNED 상태이면서 routeWaypoints 가 아직 없는 bike 를 발견하면
+  // OSRM 경로를 fetch 해서 state 에 주입. pendingFetchesRef 로 중복 방지.
+  useEffect(() => {
+    for (const [bikeId, state] of simulated) {
+      if (
+        state.phase !== "ASSIGNED" ||
+        state.routeWaypoints !== null ||
+        pendingFetchesRef.current.has(bikeId)
+      ) {
+        continue;
+      }
+      if (!state.destination) continue; // ASSIGNED 에서 destination 은 항상 있지만 타입 guard
+
+      pendingFetchesRef.current.add(bikeId);
+      fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
+        pendingFetchesRef.current.delete(bikeId);
+        if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
+        setSimulated((prev) => {
+          const current = prev.get(bikeId);
+          // stale guard: bike 가 이미 IDLE 로 돌아갔으면 주입 무시
+          if (!current || current.phase === "IDLE") return prev;
+          const next = new Map(prev);
+          next.set(bikeId, { ...current, routeWaypoints: waypoints });
+          return next;
+        });
+      });
+    }
+  }, [simulated]);
 
   const value = useMemo<FleetSimulationContextValue>(
     () => ({ fleetRunning, setFleetRunning, simulated, assignSingleBike, cancelSingleBike, seedBikePins, virtualFleet }),

--- a/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+++ b/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
@@ -5,6 +5,15 @@ import { useMemo } from "react";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-maintenance-data";
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+
+/**
+ * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
+ * FrontendDashboardBikePin 위에 deliveryPhase 를 overlay 한다.
+ */
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: DeliveryPhase | null;
+};
 
 /**
  * 지도 마커용 — raw bikePins 배열 위에 fleet 시뮬레이션 상태를 overlay 한다.
@@ -14,14 +23,16 @@ import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-main
  */
 export function useSimulatedBikePins(
   rawPins: ReadonlyArray<FrontendDashboardBikePin>
-): FrontendDashboardBikePin[] {
+): SimulatedBikePin[] {
   const { simulated } = useFleetSimulation();
   return useMemo(() => {
-    if (simulated.size === 0) return rawPins.slice();
+    if (simulated.size === 0) {
+      return rawPins.map((pin) => ({ ...pin, deliveryPhase: null }));
+    }
     const nowIso = new Date().toISOString();
     return rawPins.map((pin) => {
       const sim = simulated.get(pin.bikeId);
-      if (!sim) return pin;
+      if (!sim) return { ...pin, deliveryPhase: null };
       const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
         sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
       const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
@@ -36,7 +47,8 @@ export function useSimulatedBikePins(
         connectionStatus: "ONLINE",
         drivingStatus,
         batteryStatus,
-        lastReceivedAt: nowIso
+        lastReceivedAt: nowIso,
+        deliveryPhase: sim.phase
       };
     });
   }, [rawPins, simulated]);

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -31,6 +31,11 @@ export type SimulatedBikeState = {
   batteryPercent: number;
   /** 운영자가 단일 차량 수동 배정으로 만든 entry 인지. fleet 정지 후에도 살아 있는다. */
   manualOrigin: boolean;
+  /**
+   * OSRM 경로 waypoints. ASSIGNED 진입 시 fetch, EN_ROUTE 중 이동 경로 결정.
+   * null = 아직 경로 없음 또는 fetch 실패 → 직선 lerp fallback.
+   */
+  routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
 };
 
 // Phase 길이 (ms). 스펙 표 참고.
@@ -81,6 +86,26 @@ export function lerpPosition(from: { lat: number; lng: number }, to: { lat: numb
 }
 
 /**
+ * progress t (0..1) 로 polyline 위 좌표를 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배:
+ *   t=0 → waypoints[0], t=1 → waypoints[N-1].
+ * 1개 이하면 첫 번째(또는 서울 기본) 좌표 반환.
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 0) return { lat: 37.5665, lng: 126.978 };
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+
+/**
  * 1초 tick 마다 호출되어 prev 의 phase / position / 부속 값을 advance.
  * `nowMs` 는 호출자가 주입 — 테스트 결정성 + 동일 tick 의 여러 차량이 같은
  * 기준 시각을 보도록.
@@ -101,7 +126,9 @@ export function advanceBikeState(
     const total = prev.phaseEndsAt - prev.phaseStartedAt;
     const elapsed = nowMs - prev.phaseStartedAt;
     const progress = total > 0 ? elapsed / total : 1;
-    const position = lerpPosition(prev.origin, prev.destination, progress);
+    const position = prev.routeWaypoints
+      ? walkPolyline(prev.routeWaypoints, progress)
+      : lerpPosition(prev.origin, prev.destination, progress);
     // 1 tick = 1초 가정. 거리 / 시간 = 속도 → 시간당 거리 / 3600 = 초당 거리.
     const distanceKm = approxDistanceKm(prev.origin, prev.destination);
     const totalSeconds = EN_ROUTE_DURATION_MS / 1_000;
@@ -132,7 +159,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
     case "ASSIGNED": {
@@ -160,7 +188,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: nowMs + ARRIVED_DURATION_MS,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
     case "ARRIVED": {
@@ -174,7 +203,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: idleWindow === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : nowMs + idleWindow,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
   }
@@ -221,7 +251,8 @@ export function makeInitialState(input: {
       ignitionStatus: "OFF",
       odometerKm: initialOdometerKm,
       batteryPercent: initialBatteryPercent,
-      manualOrigin
+      manualOrigin,
+      routeWaypoints: null
     };
   }
   const stagger = staggerMs ?? Math.floor(random() * IDLE_FLEET_MAX_MS);
@@ -238,6 +269,7 @@ export function makeInitialState(input: {
     ignitionStatus: "OFF",
     odometerKm: initialOdometerKm,
     batteryPercent: initialBatteryPercent,
-    manualOrigin
+    manualOrigin,
+    routeWaypoints: null
   };
 }

--- a/development/front-admin-web/lib/services/osrm.ts
+++ b/development/front-admin-web/lib/services/osrm.ts
@@ -1,0 +1,33 @@
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ *
+ * 반환: 경유점 배열 ({lat, lng}[]). 실패(네트워크 오류, timeout, 4xx/5xx)
+ * 시 빈 배열 반환 — 호출부는 빈 배열을 받으면 routeWaypoints 를 null 로
+ * 유지해 직선 lerp fallback 으로 처리한다.
+ *
+ * OSRM 좌표 순서는 [lng, lat] — 반환 시 {lat, lng} 로 변환.
+ * `AbortSignal.timeout` 은 Node 17.3+ / 모던 브라우저에서 지원.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      routes?: Array<{
+        geometry?: { coordinates?: Array<[number, number]> };
+      }>;
+    };
+    const coords = json.routes?.[0]?.geometry?.coordinates ?? [];
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}

--- a/docs/superpowers/plans/2026-05-25-osrm-road-routing.md
+++ b/docs/superpowers/plans/2026-05-25-osrm-road-routing.md
@@ -1,0 +1,725 @@
+# OSRM Road Routing + Delivery Status Labels (PR-C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace straight-line lerp movement with real Seoul road routes (OSRM) during EN_ROUTE, and add delivery status badges (배정됨 / 배송 중 / 배송 완료) on map markers.
+
+**Architecture:** A new pure `fetchOsrmRoute` service fetches GeoJSON polylines from the public OSRM demo server. `SimulatedBikeState` gains a `routeWaypoints` field; the context watches `simulated` for newly-ASSIGNED bikes and injects routes asynchronously. `advanceBikeState` uses `walkPolyline` (time-proportional polyline walk) when waypoints are available, falling back to the existing `lerpPosition` if not. `useSimulatedBikePins` adds a `deliveryPhase` field so `MapShell` can render per-marker status badges.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, public OSRM API (`router.project-osrm.org`). No new runtime deps. No backend changes.
+
+**Reference doc:** `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`
+
+---
+
+## File Structure
+
+| Path | Purpose | Action |
+| ---- | ------- | ------ |
+| `lib/services/osrm.ts` | Pure async OSRM fetch function with error → empty-array fallback | **Create** |
+| `lib/services/fleet-simulation.ts` | Add `routeWaypoints` field, `walkPolyline` fn, use in `advanceBikeState`, init in `makeInitialState` | **Modify** |
+| `components/overview/FleetSimulationContext.tsx` | `pendingFetchesRef` + `useEffect` to fire OSRM fetch on ASSIGNED transition | **Modify** |
+| `components/overview/use-simulated-bike-pins.ts` | Export `SimulatedBikePin` type, add `deliveryPhase` overlay | **Modify** |
+| `components/dashboard/MapShell.tsx` | Accept extended `bikePins` type, add `deliveryBadgeMarkup`, extend `bikeMarkerHtml` | **Modify** |
+
+---
+
+## Task 1: Branch sanity check
+
+**Files:** none
+
+- [ ] **Step 1: Verify branch + spec**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git status
+git log --oneline -3
+ls docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
+ls docs/superpowers/plans/2026-05-25-osrm-road-routing.md
+```
+
+Expected: branch `cc-226-osrm-road-routing`, recent commit is the spec commit `96eb894`. Working tree clean. Both doc files exist.
+
+---
+
+## Task 2: Create `lib/services/osrm.ts`
+
+**Files:**
+- Create: `development/front-admin-web/lib/services/osrm.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ *
+ * 반환: 경유점 배열 ({lat, lng}[]). 실패(네트워크 오류, timeout, 4xx/5xx)
+ * 시 빈 배열 반환 — 호출부는 빈 배열을 받으면 routeWaypoints 를 null 로
+ * 유지해 직선 lerp fallback 으로 처리한다.
+ *
+ * OSRM 좌표 순서는 [lng, lat] — 반환 시 {lat, lng} 로 변환.
+ * `AbortSignal.timeout` 은 Node 17.3+ / 모던 브라우저에서 지원.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      routes?: Array<{
+        geometry?: { coordinates?: Array<[number, number]> };
+      }>;
+    };
+    const coords = json.routes?.[0]?.geometry?.coordinates ?? [];
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 2: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/lib/services/osrm.ts
+git commit -m "Add fetchOsrmRoute service for road-following paths
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Extend `fleet-simulation.ts`
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/fleet-simulation.ts`
+
+This task makes four targeted edits:
+1. Add `routeWaypoints` field to `SimulatedBikeState` type
+2. Add `walkPolyline` helper function after `lerpPosition`
+3. Modify EN_ROUTE within-phase position update to use `walkPolyline` when waypoints are present
+4. Add `routeWaypoints: null` to IDLE→ASSIGNED, EN_ROUTE→ARRIVED, ARRIVED→IDLE transitions, and both `makeInitialState` returns
+
+- [ ] **Step 1: Read the file to confirm current line numbers**
+
+```bash
+grep -n "routeWaypoints\|manualOrigin\|lerpPosition\|walkPolyline\|case \"IDLE\"\|case \"EN_ROUTE\"\|case \"ARRIVED\"\|makeInitialState" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/lib/services/fleet-simulation.ts
+```
+
+Confirm: no `routeWaypoints` yet, `manualOrigin` is the last field in `SimulatedBikeState` (~line 33), `lerpPosition` ends ~line 81.
+
+- [ ] **Step 2: Add `routeWaypoints` field to `SimulatedBikeState`**
+
+In the `SimulatedBikeState` type, after the `manualOrigin` field (currently line 33):
+
+```ts
+  /** 운영자가 단일 차량 수동 배정으로 만든 entry 인지. fleet 정지 후에도 살아 있는다. */
+  manualOrigin: boolean;
+  /**
+   * OSRM 경로 waypoints. ASSIGNED 진입 시 fetch, EN_ROUTE 중 이동 경로 결정.
+   * null = 아직 경로 없음 또는 fetch 실패 → 직선 lerp fallback.
+   */
+  routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
+```
+
+- [ ] **Step 3: Add `walkPolyline` after `lerpPosition`**
+
+After the closing `}` of `lerpPosition` (currently ~line 81), insert:
+
+```ts
+
+/**
+ * progress t (0..1) 로 polyline 위 좌표를 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배:
+ *   t=0 → waypoints[0], t=1 → waypoints[N-1].
+ * 1개 이하면 첫 번째(또는 서울 기본) 좌표 반환.
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 0) return { lat: 37.5665, lng: 126.978 };
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+```
+
+- [ ] **Step 4: Modify EN_ROUTE within-phase position update**
+
+Find the EN_ROUTE within-phase section (currently ~lines 98-116). The line:
+```ts
+    const position = lerpPosition(prev.origin, prev.destination, progress);
+```
+
+Replace with:
+```ts
+    const position = prev.routeWaypoints
+      ? walkPolyline(prev.routeWaypoints, progress)
+      : lerpPosition(prev.origin, prev.destination, progress);
+```
+
+- [ ] **Step 5: Add `routeWaypoints: null` to phase transitions**
+
+**IDLE → ASSIGNED** (currently ~lines 126-136): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "ASSIGNED",
+        destination,
+        progress: 0,
+        position: prev.origin,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+**EN_ROUTE → ARRIVED** (currently ~lines 152-164): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "ARRIVED",
+        progress: 1,
+        position: finalPosition,
+        origin: finalPosition,
+        destination: null,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: nowMs + ARRIVED_DURATION_MS,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+**ARRIVED → IDLE** (currently ~lines 169-178): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "IDLE",
+        progress: 0,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: idleWindow === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : nowMs + idleWindow,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+- [ ] **Step 6: Add `routeWaypoints: null` to `makeInitialState`**
+
+`makeInitialState` has two return statements — the ASSIGNED path (~lines 211-225) and the IDLE path (~lines 228-242). Add `routeWaypoints: null` to both, after `manualOrigin`:
+
+ASSIGNED path:
+```ts
+    return {
+      bikeId,
+      phase: "ASSIGNED",
+      origin,
+      destination: randomSeoulPoint(random),
+      progress: 0,
+      position: origin,
+      phaseStartedAt: nowMs,
+      phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
+      speedKph: 0,
+      ignitionStatus: "OFF",
+      odometerKm: initialOdometerKm,
+      batteryPercent: initialBatteryPercent,
+      manualOrigin,
+      routeWaypoints: null
+    };
+```
+
+IDLE path:
+```ts
+  return {
+    bikeId,
+    phase: "IDLE",
+    origin,
+    destination: null,
+    progress: 0,
+    position: origin,
+    phaseStartedAt: nowMs,
+    phaseEndsAt: nowMs + stagger,
+    speedKph: 0,
+    ignitionStatus: "OFF",
+    odometerKm: initialOdometerKm,
+    batteryPercent: initialBatteryPercent,
+    manualOrigin,
+    routeWaypoints: null
+  };
+```
+
+- [ ] **Step 7: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. Fix any issues (likely missing `routeWaypoints` in some spread).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/lib/services/fleet-simulation.ts
+git commit -m "fleet-simulation: add routeWaypoints field and walkPolyline for road routing
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: OSRM fetch trigger in `FleetSimulationContext.tsx`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/FleetSimulationContext.tsx`
+
+- [ ] **Step 1: Read the file**
+
+Read `C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/FleetSimulationContext.tsx` fully (177 lines).
+
+- [ ] **Step 2: Add the import**
+
+After the existing imports at the top of the file, add:
+
+```tsx
+import { fetchOsrmRoute } from "@/lib/services/osrm";
+```
+
+- [ ] **Step 3: Add `pendingFetchesRef` inside `FleetSimulationProvider`**
+
+Inside the `FleetSimulationProvider` component body, near the other `useRef` calls:
+
+```tsx
+/**
+ * OSRM fetch 중인 bikeId Set. 동일 bike 에 중복 fetch 방지.
+ * ref 라 React 렌더를 트리거하지 않음.
+ */
+const pendingFetchesRef = useRef<Set<string>>(new Set());
+```
+
+- [ ] **Step 4: Add the OSRM fetch `useEffect`**
+
+After the existing tick `useEffect` (the `setInterval` effect), add a new effect:
+
+```tsx
+// ASSIGNED 상태이면서 routeWaypoints 가 아직 없는 bike 를 발견하면
+// OSRM 경로를 fetch 해서 state 에 주입. pendingFetchesRef 로 중복 방지.
+useEffect(() => {
+  for (const [bikeId, state] of simulated) {
+    if (
+      state.phase !== "ASSIGNED" ||
+      state.routeWaypoints !== null ||
+      pendingFetchesRef.current.has(bikeId)
+    ) {
+      continue;
+    }
+    if (!state.destination) continue; // ASSIGNED 에서 destination 은 항상 있지만 타입 guard
+
+    pendingFetchesRef.current.add(bikeId);
+    fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
+      pendingFetchesRef.current.delete(bikeId);
+      if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
+      setSimulated((prev) => {
+        const current = prev.get(bikeId);
+        // stale guard: bike 가 이미 IDLE 로 돌아갔으면 주입 무시
+        if (!current || current.phase === "IDLE") return prev;
+        const next = new Map(prev);
+        next.set(bikeId, { ...current, routeWaypoints: waypoints });
+        return next;
+      });
+    });
+  }
+}, [simulated]);
+```
+
+- [ ] **Step 5: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. If ESLint flags the `for...of` with `continue` pattern, note that the existing codebase (FleetSimulationContext tick loop) already uses this pattern — it is lint-approved.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/FleetSimulationContext.tsx
+git commit -m "FleetSimulationContext: fetch OSRM route on ASSIGNED and inject into state
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add `deliveryPhase` overlay to `use-simulated-bike-pins.ts`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/use-simulated-bike-pins.ts`
+
+Current file (75 lines): `useSimulatedBikePins` returns `FrontendDashboardBikePin[]`. We extend the return type to include `deliveryPhase`.
+
+- [ ] **Step 1: Add the import and export the new type**
+
+After existing imports at the top of the file (currently lines 1-7), add:
+
+```ts
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+
+/**
+ * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
+ * FrontendDashboardBikePin 위에 deliveryPhase 를 overlay 한다.
+ */
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: DeliveryPhase | null;
+};
+```
+
+- [ ] **Step 2: Change `useSimulatedBikePins` return type and body**
+
+Replace the entire `useSimulatedBikePins` function (lines 15-43) with:
+
+```ts
+export function useSimulatedBikePins(
+  rawPins: ReadonlyArray<FrontendDashboardBikePin>
+): SimulatedBikePin[] {
+  const { simulated } = useFleetSimulation();
+  return useMemo(() => {
+    if (simulated.size === 0) {
+      return rawPins.map((pin) => ({ ...pin, deliveryPhase: null }));
+    }
+    const nowIso = new Date().toISOString();
+    return rawPins.map((pin) => {
+      const sim = simulated.get(pin.bikeId);
+      if (!sim) return { ...pin, deliveryPhase: null };
+      const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
+        sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
+      const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
+        sim.ignitionStatus === "ON" ? (sim.speedKph >= 3 ? "DRIVING" : "STOPPED") : "PARKED";
+      return {
+        ...pin,
+        latitude: sim.position.lat,
+        longitude: sim.position.lng,
+        speedKph: sim.speedKph,
+        batteryPercent: Math.round(sim.batteryPercent),
+        ignitionStatus: sim.ignitionStatus,
+        connectionStatus: "ONLINE",
+        drivingStatus,
+        batteryStatus,
+        lastReceivedAt: nowIso,
+        deliveryPhase: sim.phase
+      };
+    });
+  }, [rawPins, simulated]);
+}
+```
+
+Leave `useSimulatedCurrentTelemetry` (lines 50-74) completely untouched.
+
+- [ ] **Step 3: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. TypeScript will verify that `SimulatedBikePin[]` is assignable to existing consumers (`MapShell.bikePins`, `OverviewMapSearch.bikePins`) — since `SimulatedBikePin extends FrontendDashboardBikePin`, structural compatibility holds. If any consumer errors, check whether its prop type needs updating (covered in Task 6 for MapShell).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+git commit -m "useSimulatedBikePins: overlay deliveryPhase for map marker badges
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Add delivery status badge to `MapShell.tsx`
+
+**Files:**
+- Modify: `development/front-admin-web/components/dashboard/MapShell.tsx`
+
+- [ ] **Step 1: Add the import**
+
+Near the top of the file, after existing imports, add:
+
+```tsx
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+```
+
+- [ ] **Step 2: Extend `MapShellProps.bikePins` type**
+
+`MapShellProps.bikePins` is currently (line 70):
+```ts
+  bikePins?: FrontendDashboardBikePin[];
+```
+
+Change to:
+```ts
+  bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }>;
+```
+
+This is backward compatible: `FrontendDashboardBikePin[]` still satisfies the new type (optional field can be absent), and `SimulatedBikePin[]` (from Task 5) satisfies it too.
+
+- [ ] **Step 3: Add `deliveryBadgeMarkup` helper**
+
+After the `labelMarkup` function (currently lines 553-560), add:
+
+```ts
+/**
+ * 배송 상태 배지 HTML. IDLE 이면 빈 문자열.
+ * 마커 컨테이너(relative 28×28) 아래에 absolute 로 위치 — 아이콘 밑에 노출.
+ */
+function deliveryBadgeMarkup(phase: DeliveryPhase): string {
+  if (phase === "IDLE") return "";
+  const config: Record<Exclude<DeliveryPhase, "IDLE">, { text: string; bg: string }> = {
+    ASSIGNED: { text: "배정됨", bg: "#f59e0b" },
+    EN_ROUTE: { text: "배송 중", bg: "#3b82f6" },
+    ARRIVED: { text: "배송 완료", bg: "#22c55e" }
+  };
+  const { text, bg } = config[phase];
+  return (
+    `<div style="position:absolute;top:100%;left:50%;transform:translateX(-50%);` +
+    `margin-top:2px;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:600;` +
+    `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
+    `${text}</div>`
+  );
+}
+```
+
+- [ ] **Step 4: Modify `bikeMarkerHtml` to accept and render the badge**
+
+Replace the current `bikeMarkerHtml` (lines 606-610):
+
+```ts
+function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
+}
+```
+
+With:
+
+```ts
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  deliveryPhase?: DeliveryPhase | null
+): string {
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  if (!showLabel && !badge) return wrapped;
+  return (
+    `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
+    `${showLabel ? labelMarkup(plateNumber) : ""}${wrapped}${badge}` +
+    `</div>`
+  );
+}
+```
+
+- [ ] **Step 5: Pass `deliveryPhase` in the marker creation loop**
+
+In the marker creation loop (~lines 418-445), find:
+
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
+```
+
+Change to:
+
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase);
+```
+
+`pin` is now typed as `FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }` (from the updated `MapShellProps`), so `pin.deliveryPhase` is type-safe.
+
+- [ ] **Step 6: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/dashboard/MapShell.tsx
+git commit -m "MapShell: add delivery status badge on bike markers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full static-check sweep
+
+- [ ] **Step 1: typecheck**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+```
+
+Expected: exit 0, no errors.
+
+- [ ] **Step 2: lint**
+
+```bash
+npm run lint
+```
+
+Expected: exit 0, no warnings.
+
+---
+
+## Task 8: Manual smoke
+
+The user runs their own dev server on localhost. **Do not** start a competing one.
+
+- [ ] **Step 1: Fleet OFF baseline**
+
+Open `/`. Map shows 2 real bike markers with no delivery badges. Normal behavior.
+
+- [ ] **Step 2: 데모 시작 → ASSIGNED badge**
+
+Click `[데모 시작]`. Within 5 seconds, virtual bike markers should show `배정됨` (amber) badge. Check the browser Network tab — OSRM requests to `router.project-osrm.org` appear for each bike.
+
+- [ ] **Step 3: EN_ROUTE → road movement + 배송 중 badge**
+
+After ~5 seconds (ASSIGNED phase), markers should:
+- Switch to `배송 중` (blue) badge
+- Begin moving — **following Seoul roads** rather than flying in a straight line
+- Open the browser Network tab and confirm each bike made an OSRM request returning coordinates
+
+Compare with PR-A/B behavior: bikes should visibly curve around streets rather than cutting across buildings.
+
+- [ ] **Step 4: ARRIVED badge**
+
+After 5 minutes (EN_ROUTE), markers should show `배송 완료` (green) badge for ~10 seconds, then badge disappears (IDLE). Verify the cycle repeats.
+
+- [ ] **Step 5: OSRM failure fallback**
+
+In DevTools, block `router.project-osrm.org` (Network tab → right-click → Block request domain). Start/restart demo. Bikes should still move (straight-line lerp) with badges showing — no errors in console beyond the blocked-network 브라우저 message.
+
+Unblock the domain after this test.
+
+- [ ] **Step 6: 데모 정지**
+
+Click toggle. Virtual markers disappear. Real bikes (if in sim) revert to their last simulated position or go static. No `배정됨`/`배송 중`/`배송 완료` badges remain on any marker.
+
+---
+
+## Task 9: PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git push -u origin cc-226-osrm-road-routing
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base dev --head cc-226-osrm-road-routing \
+  --title "Road-following movement + delivery status badges (PR-C)" \
+  --body "$(cat <<'EOF'
+## Summary
+- EN_ROUTE 이동이 직선 lerp → OSRM 실제 도로 경로로 교체 — 서울 도로망을 따라 이동
+- 지도 마커에 배송 상태 배지 추가: 배정됨(노랑) → 배송 중(파랑) → 배송 완료(초록)
+- 실패 시 자동 직선 fallback (OSRM 응답 없으면 기존 lerp 그대로)
+- 가상 차량 + 실제 차량 모두 적용
+
+## Architecture
+- `lib/services/osrm.ts`: OSRM fetch 순수 함수 (5 초 timeout, 에러 → 빈 배열 fallback)
+- `SimulatedBikeState.routeWaypoints`: OSRM 경유점 배열 | null
+- `FleetSimulationContext`: ASSIGNED 전환 감지 → async fetch → state 주입
+- `useSimulatedBikePins`: `SimulatedBikePin` 타입으로 확장, `deliveryPhase` overlay
+- `MapShell`: `deliveryBadgeMarkup` + `bikeMarkerHtml` 확장
+
+## Spec & Plan
+- 디자인: `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`
+- 플랜: `docs/superpowers/plans/2026-05-25-osrm-road-routing.md`
+
+## Test plan
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [ ] 데모 시작 → OSRM API 호출 확인 (Network 탭)
+- [ ] 차량이 서울 도로를 따라 이동 (직선 X)
+- [ ] 배정됨 → 배송 중 → 배송 완료 배지 순서 확인
+- [ ] OSRM 차단 시 직선 이동 fallback 정상 작동
+- [ ] 데모 정지 → 배지 사라짐
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`:
+
+- "새 모듈 `lib/services/osrm.ts`" → Task 2. ✅
+- "`SimulatedBikeState` 확장 (`routeWaypoints`)" → Task 3 step 2. ✅
+- "`walkPolyline` 함수" → Task 3 step 3. ✅
+- "`advanceBikeState` EN_ROUTE 분기 변경" → Task 3 step 4. ✅
+- "ASSIGNED 진입 시 / ARRIVED→IDLE 시 null 초기화" → Task 3 step 5. ✅
+- "`makeInitialState` 에 `routeWaypoints: null`" → Task 3 step 6. ✅
+- "OSRM fetch 트리거 (`FleetSimulationContext`)" → Task 4. ✅
+- "배송 상태 레이블 — 마커 overlay" → Tasks 5 + 6. ✅
+- "Error handling: 5초 timeout, 빈 배열 fallback, stale guard" → Task 2 (timeout in osrm.ts), Task 4 (stale guard + empty array check). ✅
+- "OSRM 실패 시 직선 이동 fallback" → Task 3 step 4 (null check before walkPolyline). ✅
+
+**Placeholder scan** — no "TBD", "TODO", "implement later". All code blocks are concrete. ✅
+
+**Type consistency**:
+- `routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null` — matches `fetchOsrmRoute` return type `Promise<ReadonlyArray<{ lat: number; lng: number }>>`. ✅
+- `walkPolyline(waypoints: ReadonlyArray<{ lat: number; lng: number }>, t: number)` — same shape. ✅
+- `SimulatedBikePin = FrontendDashboardBikePin & { deliveryPhase: DeliveryPhase | null }` — `deliveryPhase` is `DeliveryPhase | null` (non-optional). `MapShellProps.bikePins` uses `deliveryPhase?: DeliveryPhase | null` (optional) — `SimulatedBikePin` satisfies this since required ⊂ optional. ✅
+- `deliveryBadgeMarkup(phase: DeliveryPhase)` — called with `pin.deliveryPhase` typed as `DeliveryPhase | null | undefined`. The guard `deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : ""` narrows to `DeliveryPhase` before the call. ✅
+
+**Scope** — 1 new file + 4 modified files, no backend changes, no new runtime deps. ✅

--- a/docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
+++ b/docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
@@ -1,0 +1,216 @@
+# OSRM Road Routing (PR-C) Design
+
+## Goal
+
+PR-A/B 가 가상 20대 + 실제 차량을 지도에 올리고 표/KPI/검색까지 통합했다.
+이 PR-C 는 EN_ROUTE 중 차량 이동을 **직선 lerp → 실제 도로 경로(OSRM)**로
+교체하고, 지도 마커에 **배송 상태 레이블** (배정됨 / 배송 중 / 배송 완료) 을
+추가해 데모의 현실감을 완성한다.
+
+## Non-Goals
+
+- OSRM 자체 호스팅 — 공개 demo 서버 (`router.project-osrm.org`) 사용
+- EN_ROUTE 소요 시간 변경 — 300 초 고정 유지 (경로 모양만 OSRM)
+- 실제 배송 도메인 로직 — 시뮬레이션 전용
+- 마커 클릭 팝업 / 상세 다이얼로그 변경
+- BSS 마커 변경
+
+## Architecture
+
+### 새 모듈 `lib/services/osrm.ts`
+
+```ts
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ * 실패(네트워크 오류, timeout, rate limit) 시 빈 배열 반환 →
+ * 호출부는 null routeWaypoints 로 직선 lerp fallback.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return [];
+    const json = await res.json();
+    const coords: [number, number][] = json.routes?.[0]?.geometry?.coordinates ?? [];
+    // OSRM 좌표 순서: [lng, lat] → {lat, lng} 변환
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- `AbortSignal.timeout(5000)` — 5 초 내 응답 없으면 abort, 빈 배열 fallback
+- CORS: `router.project-osrm.org` 는 공개 CORS 허용
+
+### `SimulatedBikeState` 확장 (`lib/services/fleet-simulation.ts`)
+
+새 필드 추가:
+
+```ts
+routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
+```
+
+- `null` = 아직 OSRM 경로 없음 → 직선 lerp fallback
+- 배열 = OSRM 경유점 배열
+- ASSIGNED 진입 시 `null` 로 초기화 (이전 사이클 경로 클리어)
+- ARRIVED → IDLE 전환 시에도 `null` 로 초기화
+
+### `walkPolyline` 함수 (`lib/services/fleet-simulation.ts`)
+
+```ts
+/**
+ * 0..1 의 progress t 로 polyline 위 좌표 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배.
+ * t=0 → waypoints[0], t=1 → waypoints[N-1].
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+```
+
+`advanceBikeState` EN_ROUTE 분기 변경:
+
+```ts
+// 기존
+position: lerpPosition(state.origin, state.destination, progress),
+
+// 변경
+position: state.routeWaypoints
+  ? walkPolyline(state.routeWaypoints, progress)
+  : lerpPosition(state.origin, state.destination, progress),
+```
+
+### OSRM fetch 트리거 (`FleetSimulationContext.tsx`)
+
+`pendingFetchesRef: React.MutableRefObject<Set<string>>` 를 컨텍스트 내에 추가.
+
+새 `useEffect` — `simulated` 변경을 감시해 ASSIGNED 상태이면서 `routeWaypoints === null` 이고 아직 fetch 중이지 않은 bike 를 발견하면 fetch 실행:
+
+```tsx
+const pendingFetchesRef = useRef<Set<string>>(new Set());
+
+useEffect(() => {
+  for (const [bikeId, state] of simulated) {
+    if (
+      state.phase === "ASSIGNED" &&
+      state.routeWaypoints === null &&
+      !pendingFetchesRef.current.has(bikeId)
+    ) {
+      pendingFetchesRef.current.add(bikeId);
+      fetchOsrmRoute(state.origin, state.destination!).then((waypoints) => {
+        pendingFetchesRef.current.delete(bikeId);
+        if (waypoints.length === 0) return; // fallback: null 유지 → 직선 lerp
+        setSimulated((prev) => {
+          const current = prev.get(bikeId);
+          // stale guard: bike 가 이미 IDLE 로 돌아갔으면 무시
+          if (!current || current.phase === "IDLE") return prev;
+          const next = new Map(prev);
+          next.set(bikeId, { ...current, routeWaypoints: waypoints });
+          return next;
+        });
+      });
+    }
+  }
+}, [simulated]);
+```
+
+- ASSIGNED 5 초 → OSRM 응답 보통 200–500 ms → EN_ROUTE 진입 전 경로 준비 완료
+- 응답 미도착 시 EN_ROUTE 진입 → 직선 이동 → route 도착 시 남은 구간부터 도로 경로 전환 (자연스러운 점진 교체)
+
+### 배송 상태 레이블 — 마커 overlay
+
+`useSimulatedBikePins` 훅이 `FrontendDashboardBikePin[]` 를 반환하는 대신
+클라이언트 전용 타입 `SimulatedBikePin` 을 반환하도록 확장:
+
+```ts
+// hooks/useSimulatedBikePins.ts (또는 현재 위치)
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: "IDLE" | "ASSIGNED" | "EN_ROUTE" | "ARRIVED" | null;
+};
+```
+
+`useSimulatedBikePins` 내부에서 `simulated.get(bikeId)?.phase` 를 읽어
+`deliveryPhase` 를 overlay. simulated 에 없으면 `null`.
+
+`MapShell` (또는 마커 렌더링 레이어) 에서 `deliveryPhase` 에 따라 마커 HTML
+에 배지 추가:
+
+| `deliveryPhase` | 배지 텍스트 | 색상 |
+|---|---|---|
+| `null` / `"IDLE"` | (없음) | — |
+| `"ASSIGNED"` | `배정됨` | 노란색 |
+| `"EN_ROUTE"` | `배송 중` | 파란색 |
+| `"ARRIVED"` | `배송 완료` | 초록색 |
+
+마커 HTML 구조 (현재 plate 라벨 아래에 배지 추가):
+```html
+<div class="bike-marker">
+  <div class="bike-marker__plate">99서0001</div>
+  <!-- deliveryPhase 가 ASSIGNED/EN_ROUTE/ARRIVED 일 때만 렌더 -->
+  <div class="bike-marker__badge bike-marker__badge--en-route">배송 중</div>
+</div>
+```
+
+마커 아이콘은 Naver Maps `naver.maps.Marker` 의 `icon.content` (HTML string)
+방식으로 교체하거나, 기존 방식에 맞게 적용. 현재 마커 렌더 방식을 먼저
+확인하고 최소 변경으로 적용.
+
+## 파일 구조
+
+| 경로 | 목적 | Action |
+|---|---|---|
+| `lib/services/osrm.ts` | OSRM fetch 순수 함수 | **Create** |
+| `lib/services/fleet-simulation.ts` | `routeWaypoints` 필드, `walkPolyline`, `advanceBikeState` 수정 | **Modify** |
+| `components/overview/FleetSimulationContext.tsx` | `pendingFetchesRef` + OSRM fetch `useEffect` | **Modify** |
+| `hooks/useSimulatedBikePins.ts` (위치 확인 필요) | `SimulatedBikePin` 타입, `deliveryPhase` overlay | **Modify** |
+| `components/dashboard/MapShell.tsx` | 마커 HTML에 배송 배지 추가 | **Modify** |
+| (CSS) | `.bike-marker__badge` 스타일 | **Modify** |
+
+## User-visible behavior
+
+- **fleet OFF**: 평소대로 — 마커 레이블 없음, 직선 이동
+- **데모 시작 → 차량 ASSIGNED**: 마커에 `배정됨` 배지 노출
+- **EN_ROUTE**: `배송 중` 배지 + 서울 도로망을 따라 이동 (직선 X)
+- **ARRIVED**: `배송 완료` 배지 + 차량 멈춤 (10초)
+- **IDLE**: 배지 사라짐, 다음 사이클 대기
+- **OSRM 실패**: 배지는 그대로, 이동만 직선 — 사용자가 차이를 느끼기 어려움
+
+## Error handling & edge cases
+
+- **OSRM 응답 5 초 초과**: abort → 빈 배열 → 직선 lerp fallback
+- **fetch 중 fleet 정지**: stale guard (`phase === "IDLE"` 체크) → 무시
+- **EN_ROUTE 진입 전 route 미도착**: 직선 이동 → route 도착 시 도로 경로로 점진 전환
+- **동일 bikeId 중복 fetch**: `pendingFetchesRef` Set 으로 방지
+- **가상 + 실제 차량 모두 적용**: `routeWaypoints` 로직은 bikeId prefix 무관하게 동작
+
+## Testing
+
+- `npm run typecheck`, `npm run lint` clean
+- 수동 smoke:
+  - 데모 시작 → 차량이 도로를 따라 이동하는지 확인
+  - 배지 ASSIGNED → 배송 중 → 배송 완료 → 사라짐 순서 확인
+  - 네트워크 탭에서 OSRM API 호출 확인
+  - 오프라인 모드 or OSRM 차단 시 직선 이동으로 graceful fallback 확인
+
+## Out-of-scope follow-ups
+
+- OSRM 자체 호스팅 / Kakao 지도 Directions API 교체
+- EN_ROUTE 소요 시간을 OSRM 실제 duration 으로 스케일
+- 경로 polyline 을 지도에 선으로 표시 (차량 이동 궤적 시각화)


### PR DESCRIPTION
## Summary
- EN_ROUTE 이동이 직선 lerp → OSRM 실제 도로 경로로 교체 — 서울 도로망을 따라 이동
- 지도 마커에 배송 상태 배지 추가: 배정됨(노랑) → 배송 중(파랑) → 배송 완료(초록)
- 실패 시 자동 직선 fallback (OSRM 응답 없으면 기존 lerp 그대로)
- 가상 차량 + 실제 차량 모두 적용

## Architecture
- `lib/services/osrm.ts`: OSRM fetch 순수 함수 (5초 timeout, 에러 → 빈 배열 fallback)
- `SimulatedBikeState.routeWaypoints`: OSRM 경유점 배열 | null
- `FleetSimulationContext`: ASSIGNED 전환 감지 → async fetch → state 주입 (unmount-safe)
- `useSimulatedBikePins`: `SimulatedBikePin` 타입으로 확장, `deliveryPhase` overlay
- `MapShell`: `deliveryBadgeMarkup` + `bikeMarkerHtml` 확장

## Spec & Plan
- 디자인: `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`
- 플랜: `docs/superpowers/plans/2026-05-25-osrm-road-routing.md`

## Test plan
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [ ] 데모 시작 → OSRM API 호출 확인 (Network 탭)
- [ ] 차량이 서울 도로를 따라 이동 (직선 X)
- [ ] 배정됨 → 배송 중 → 배송 완료 배지 순서 확인
- [ ] OSRM 차단 시 직선 이동 fallback 정상 작동
- [ ] 데모 정지 → 배지 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)