### PR TITLE
Virtual fleet demo: OSRM road routing + delivery status badges

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -13,6 +13,7 @@ import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { FullscreenMapHost } from "@/components/overview/FullscreenMapHost";
 import { OverviewClientShell } from "@/components/overview/OverviewClientShell";
+import { OverviewKpiTiles } from "@/components/overview/OverviewKpiTiles";
 import { OverviewMapBanner } from "@/components/overview/OverviewMapBanner";
 import { loadDashboardMapState } from "@/lib/services/dashboard-map-state-data";
 import { loadRiderList } from "@/lib/services/rider-data";
@@ -284,43 +285,14 @@ export default async function RootPage({
 
       <OverviewClientShell>
       {/* 페이지 상단 KPI 두 카드(차량 현황 / 라이더 현황). */}
-      <div className="overview-kpi-groups">
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">차량 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 차량</p>
-              <p className="metric-value">{formatCount(summary.totalBikes)}</p>
-            </div>
-            <div>
-              <p className="metric-label">시동 차량</p>
-              <p className="metric-value">{formatCount(ignitionOnCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">보험 차량</p>
-              <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
-            </div>
-          </div>
-        </article>
-
-        <article className="kpi-group">
-          <h3 className="kpi-group-heading">라이더 현황</h3>
-          <div className="kpi-group-metrics">
-            <div>
-              <p className="metric-label">전체 라이더</p>
-              <p className="metric-value">{formatCount(totalRiders)}</p>
-            </div>
-            <div>
-              <p className="metric-label">구독 인원</p>
-              <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
-            </div>
-            <div>
-              <p className="metric-label">렌탈 인원</p>
-              <p className="metric-value">{formatCount(rentalRiderCount)}</p>
-            </div>
-          </div>
-        </article>
-      </div>
+      <OverviewKpiTiles
+        totalBikes={summary.totalBikes}
+        ignitionOnCount={ignitionOnCount}
+        insuredVehicleCount={insuredVehicleCount}
+        totalRiders={totalRiders}
+        subscriptionRiderCount={subscriptionRiderCount}
+        rentalRiderCount={rentalRiderCount}
+      />
 
       {/* 지도 보기 토글 + 캔버스는 KPI 와 탭(관리 섹션) 사이에 위치. 운영자가
           숫자 → 지도 → 표로 자연스럽게 눈을 내려갈 수 있도록 한 단계 정렬. */}

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -630,7 +630,7 @@ function bikeMarkerHtml(
   deliveryPhase?: DeliveryPhase | null
 ): string {
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
-  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  const badge = deliveryPhase != null ? deliveryBadgeMarkup(deliveryPhase) : "";
   if (!showLabel && !badge) return wrapped;
   return (
     `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -11,6 +11,7 @@ import type {
   NaverMapOptions,
   NaverMarkerInstance
 } from "@/types/naver-maps";
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
 const NCP_STYLE_ID_LIGHT = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT;
@@ -67,7 +68,7 @@ export interface MapShellProps {
   children?: ReactNode;
   initialCenter?: { lat: number; lng: number };
   initialZoom?: number;
-  bikePins?: FrontendDashboardBikePin[];
+  bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }>;
   stationPins?: FrontendDashboardStationPin[];
   onBikeSelect?: (bikeId: string) => void;
   onStationSelect?: (stationId: string) => void;
@@ -418,7 +419,7 @@ export function MapShell({
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase);
       const icon = {
         content: html,
         anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
@@ -559,6 +560,26 @@ function labelMarkup(text: string): string {
   return `<span class="map-marker-label">${safe}</span>`;
 }
 
+/**
+ * 배송 상태 배지 HTML. IDLE 이면 빈 문자열.
+ * 마커 컨테이너(relative 28×28) 아래에 absolute 로 위치 — 아이콘 밑에 노출.
+ */
+function deliveryBadgeMarkup(phase: DeliveryPhase): string {
+  if (phase === "IDLE") return "";
+  const config: Record<Exclude<DeliveryPhase, "IDLE">, { text: string; bg: string }> = {
+    ASSIGNED: { text: "배정됨", bg: "#f59e0b" },
+    EN_ROUTE: { text: "배송 중", bg: "#3b82f6" },
+    ARRIVED: { text: "배송 완료", bg: "#22c55e" }
+  };
+  const { text, bg } = config[phase];
+  return (
+    `<div style="position:absolute;top:100%;left:50%;transform:translateX(-50%);` +
+    `margin-top:2px;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:600;` +
+    `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
+    `${text}</div>`
+  );
+}
+
 // 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
 const ICON_SVG_PROPS = `width="${ICON_PX}" height="${ICON_PX}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
 
@@ -602,9 +623,18 @@ function stationMarkerHtml(name: string, showLabel: boolean): string {
   return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(name)}${wrapped}</div>`;
 }
 
-/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨. */
-function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
+/** 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨 + (옵션) 배송 상태 배지. */
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  deliveryPhase?: DeliveryPhase | null
+): string {
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
-  if (!showLabel) return wrapped;
-  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
+  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  if (!showLabel && !badge) return wrapped;
+  return (
+    `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
+    `${showLabel ? labelMarkup(plateNumber) : ""}${wrapped}${badge}` +
+    `</div>`
+  );
 }

--- a/development/front-admin-web/components/management/RidersPanel.tsx
+++ b/development/front-admin-web/components/management/RidersPanel.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_RIDER_FILTERS,
   type RiderFilterState
 } from "@/components/overview/filter-compute";
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { RiderFilterControls } from "@/components/overview/RiderFilterControls";
 import type { RiderDataResult } from "@/lib/services/rider-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
@@ -69,6 +70,12 @@ export function RidersPanel({
   const [activeRow, setActiveRow] = useState<RiderDetailRow | null>(null);
   const [filters, setFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
 
+  const { virtualFleet } = useFleetSimulation();
+  const effectiveRiders = useMemo(() => {
+    if (!virtualFleet) return data.riders;
+    return [...data.riders, ...virtualFleet.riders];
+  }, [data.riders, virtualFleet]);
+
   // insurance_item id → 이름 사전. 보험 컬럼이 매 행마다 lookup 1회.
   const insuranceLabelById = useMemo(() => {
     const map = new Map<string, string>();
@@ -81,7 +88,7 @@ export function RidersPanel({
   const visibleRiders = useMemo(
     () =>
       applyRiderFilters({
-        riders: data.riders,
+        riders: effectiveRiders,
         filters,
         educationTypeByRiderId,
         riderActiveBikeId,
@@ -91,7 +98,7 @@ export function RidersPanel({
         ignitionStatusByBikeId
       }),
     [
-      data.riders,
+      effectiveRiders,
       filters,
       educationTypeByRiderId,
       riderActiveBikeId,
@@ -108,7 +115,7 @@ export function RidersPanel({
         filters={filters}
         onChange={setFilters}
         layout="horizontal"
-        count={{ visible: visibleRiders.length, total: data.riders.length }}
+        count={{ visible: visibleRiders.length, total: effectiveRiders.length }}
       />
 
       <div className="table-card">

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -15,6 +15,7 @@ import {
   statusToOperation,
   type VehicleFilterState
 } from "@/components/overview/filter-compute";
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
@@ -114,16 +115,22 @@ export function VehiclesPanel({
     return map;
   }, [insuranceOptions]);
 
+  const { virtualFleet } = useFleetSimulation();
+  const effectiveVehicles = useMemo(() => {
+    if (!virtualFleet) return data.vehicles;
+    return [...data.vehicles, ...virtualFleet.vehicles];
+  }, [data.vehicles, virtualFleet]);
+
   const visibleVehicles = useMemo(
     () =>
       applyVehicleFilters({
-        vehicles: data.vehicles,
+        vehicles: effectiveVehicles,
         filters,
         bikePinById,
         deviceUidByBikeId,
         maintenanceSummaryByBike
       }),
-    [data.vehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+    [effectiveVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
   );
 
   // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
@@ -159,7 +166,7 @@ export function VehiclesPanel({
         filters={filters}
         onChange={setFilters}
         layout="horizontal"
-        count={{ visible: visibleVehicles.length, total: data.vehicles.length }}
+        count={{ visible: visibleVehicles.length, total: effectiveVehicles.length }}
       />
 
       <div className="table-card vehicles-table-scroll">

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -53,6 +53,15 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
    * ref 라 React 렌더를 트리거하지 않음.
    */
   const pendingFetchesRef = useRef<Set<string>>(new Set());
+  /** コンポーネントのマウント状態を追跡。アンマウント後のsetSimulated呼び出しを防ぐ。 */
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
@@ -169,6 +178,7 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
       pendingFetchesRef.current.add(bikeId);
       fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
         pendingFetchesRef.current.delete(bikeId);
+        if (!mountedRef.current) return; // コンポーネントがアンマウント済み
         if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
         setSimulated((prev) => {
           const current = prev.get(bikeId);

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/services/fleet-simulation";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { generateVirtualFleet, type VirtualFleet } from "@/lib/services/virtual-fleet";
+import { fetchOsrmRoute } from "@/lib/services/osrm";
 
 /**
  * Fleet 배송 시뮬레이션 — 모든 클라이언트 트리가 공유하는 in-memory 시뮬레이터.
@@ -47,6 +48,11 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
   const [simulated, setSimulated] = useState<ReadonlyMap<string, SimulatedBikeState>>(() => new Map());
   const [virtualFleet, setVirtualFleet] = useState<VirtualFleet | null>(null);
   const pinsRef = useRef<ReadonlyArray<FrontendDashboardBikePin>>([]);
+  /**
+   * OSRM fetch 중인 bikeId Set. 동일 bike 에 중복 fetch 방지.
+   * ref 라 React 렌더를 트리거하지 않음.
+   */
+  const pendingFetchesRef = useRef<Set<string>>(new Set());
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
@@ -146,6 +152,35 @@ export function FleetSimulationProvider({ children }: { children: ReactNode }) {
     }, TICK_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [fleetRunning, simulated.size]);
+
+  // ASSIGNED 상태이면서 routeWaypoints 가 아직 없는 bike 를 발견하면
+  // OSRM 경로를 fetch 해서 state 에 주입. pendingFetchesRef 로 중복 방지.
+  useEffect(() => {
+    for (const [bikeId, state] of simulated) {
+      if (
+        state.phase !== "ASSIGNED" ||
+        state.routeWaypoints !== null ||
+        pendingFetchesRef.current.has(bikeId)
+      ) {
+        continue;
+      }
+      if (!state.destination) continue; // ASSIGNED 에서 destination 은 항상 있지만 타입 guard
+
+      pendingFetchesRef.current.add(bikeId);
+      fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
+        pendingFetchesRef.current.delete(bikeId);
+        if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
+        setSimulated((prev) => {
+          const current = prev.get(bikeId);
+          // stale guard: bike 가 이미 IDLE 로 돌아갔으면 주입 무시
+          if (!current || current.phase === "IDLE") return prev;
+          const next = new Map(prev);
+          next.set(bikeId, { ...current, routeWaypoints: waypoints });
+          return next;
+        });
+      });
+    }
+  }, [simulated]);
 
   const value = useMemo<FleetSimulationContextValue>(
     () => ({ fleetRunning, setFleetRunning, simulated, assignSingleBike, cancelSingleBike, seedBikePins, virtualFleet }),

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -133,6 +133,20 @@ function FullscreenMapOverlay({
     return [...bikePins, ...virtualFleet.bikePins];
   }, [bikePins, virtualFleet]);
 
+  const mergedBikeActiveRiderById = useMemo(() => {
+    if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+    const m = new Map<string, string>(bikeActiveRiderById ?? []);
+    for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+    return m;
+  }, [bikeActiveRiderById, virtualFleet]);
+
+  const mergedRiderInfoById = useMemo(() => {
+    if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+    const m = new Map<string, { name: string; phone: string }>(riderInfoById ?? []);
+    for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+    return m;
+  }, [riderInfoById, virtualFleet]);
+
   const overlaidBikePins = useSimulatedBikePins(mergedRawPins);
 
   useEffect(() => {
@@ -312,8 +326,8 @@ function FullscreenMapOverlay({
         <OverviewMapSearch
           bikePins={overlaidBikePins}
           stationPins={stationPins}
-          bikeActiveRiderById={bikeActiveRiderById}
-          riderInfoById={riderInfoById}
+          bikeActiveRiderById={mergedBikeActiveRiderById}
+          riderInfoById={mergedRiderInfoById}
           onSelect={handleSearchSelect}
         />
         <span className="fullscreen-map-counts">

--- a/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
+++ b/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+
+/**
+ * 페이지 상단의 두 KPI 카드 (차량 현황 / 라이더 현황). 서버에서 SSR 된
+ * baseline 값을 props 로 받고, 그 위에 fleet 데모의 가상 fleet + 시뮬레이션
+ * 상태를 매 1초 tick 마다 overlay 한다. fleet OFF 면 props 값 그대로.
+ *
+ * 시동 차량은 virtual-bike-* prefix 가 붙은 simulated entry 중 ignitionStatus
+ * 가 ON 인 것만 카운트해 base 에 더한다 — base 의 실제 차량 카운트와
+ * 중복되지 않도록 (실제 차량은 SSR 시점의 정적 dummy 값을 그대로 신뢰).
+ */
+export interface OverviewKpiTilesProps {
+  totalBikes: number;
+  ignitionOnCount: number;
+  insuredVehicleCount: number;
+  totalRiders: number;
+  subscriptionRiderCount: number;
+  rentalRiderCount: number;
+}
+
+const VIRTUAL_BIKE_PREFIX = "virtual-bike-";
+const VIRTUAL_FLEET_COUNT = 20;
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+export function OverviewKpiTiles({
+  totalBikes,
+  ignitionOnCount,
+  insuredVehicleCount,
+  totalRiders,
+  subscriptionRiderCount,
+  rentalRiderCount,
+}: OverviewKpiTilesProps) {
+  const { virtualFleet, simulated } = useFleetSimulation();
+
+  const virtualIgnitionOn = useMemo(() => {
+    let n = 0;
+    for (const state of simulated.values()) {
+      if (state.ignitionStatus === "ON" && state.bikeId.startsWith(VIRTUAL_BIKE_PREFIX)) {
+        n++;
+      }
+    }
+    return n;
+  }, [simulated]);
+
+  const totalBikesEffective = totalBikes + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const totalRidersEffective = totalRiders + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const ignitionOnEffective = ignitionOnCount + virtualIgnitionOn;
+
+  return (
+    <div className="overview-kpi-groups">
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">차량 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 차량</p>
+            <p className="metric-value">{formatCount(totalBikesEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">시동 차량</p>
+            <p className="metric-value">{formatCount(ignitionOnEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">보험 차량</p>
+            <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+          </div>
+        </div>
+      </article>
+
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">라이더 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 라이더</p>
+            <p className="metric-value">{formatCount(totalRidersEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">구독 인원</p>
+            <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+          </div>
+          <div>
+            <p className="metric-label">렌탈 인원</p>
+            <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -56,6 +56,20 @@ export function OverviewMapBanner({
     return [...bikePins, ...virtualFleet.bikePins];
   }, [bikePins, virtualFleet]);
 
+  const mergedBikeActiveRiderById = useMemo(() => {
+    if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+    const m = new Map<string, string>(bikeActiveRiderById ?? []);
+    for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+    return m;
+  }, [bikeActiveRiderById, virtualFleet]);
+
+  const mergedRiderInfoById = useMemo(() => {
+    if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+    const m = new Map(riderInfoById ?? []);
+    for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+    return m;
+  }, [riderInfoById, virtualFleet]);
+
   const overlaidBikePins = useSimulatedBikePins(mergedRawPins);
 
   useEffect(() => {
@@ -171,8 +185,8 @@ export function OverviewMapBanner({
         <OverviewMapSearch
           bikePins={bikePins}
           stationPins={stationPins}
-          bikeActiveRiderById={bikeActiveRiderById}
-          riderInfoById={riderInfoById}
+          bikeActiveRiderById={mergedBikeActiveRiderById}
+          riderInfoById={mergedRiderInfoById}
           onSelect={handleSearchSelect}
         />
         <button

--- a/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+++ b/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
@@ -5,6 +5,15 @@ import { useMemo } from "react";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-maintenance-data";
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+
+/**
+ * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
+ * FrontendDashboardBikePin 위에 deliveryPhase 를 overlay 한다.
+ */
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: DeliveryPhase | null;
+};
 
 /**
  * 지도 마커용 — raw bikePins 배열 위에 fleet 시뮬레이션 상태를 overlay 한다.
@@ -14,14 +23,16 @@ import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-main
  */
 export function useSimulatedBikePins(
   rawPins: ReadonlyArray<FrontendDashboardBikePin>
-): FrontendDashboardBikePin[] {
+): SimulatedBikePin[] {
   const { simulated } = useFleetSimulation();
   return useMemo(() => {
-    if (simulated.size === 0) return rawPins.slice();
+    if (simulated.size === 0) {
+      return rawPins.map((pin) => ({ ...pin, deliveryPhase: null }));
+    }
     const nowIso = new Date().toISOString();
     return rawPins.map((pin) => {
       const sim = simulated.get(pin.bikeId);
-      if (!sim) return pin;
+      if (!sim) return { ...pin, deliveryPhase: null };
       const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
         sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
       const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
@@ -36,7 +47,8 @@ export function useSimulatedBikePins(
         connectionStatus: "ONLINE",
         drivingStatus,
         batteryStatus,
-        lastReceivedAt: nowIso
+        lastReceivedAt: nowIso,
+        deliveryPhase: sim.phase
       };
     });
   }, [rawPins, simulated]);

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -31,6 +31,11 @@ export type SimulatedBikeState = {
   batteryPercent: number;
   /** 운영자가 단일 차량 수동 배정으로 만든 entry 인지. fleet 정지 후에도 살아 있는다. */
   manualOrigin: boolean;
+  /**
+   * OSRM 경로 waypoints. ASSIGNED 진입 시 fetch, EN_ROUTE 중 이동 경로 결정.
+   * null = 아직 경로 없음 또는 fetch 실패 → 직선 lerp fallback.
+   */
+  routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
 };
 
 // Phase 길이 (ms). 스펙 표 참고.
@@ -81,6 +86,26 @@ export function lerpPosition(from: { lat: number; lng: number }, to: { lat: numb
 }
 
 /**
+ * progress t (0..1) 로 polyline 위 좌표를 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배:
+ *   t=0 → waypoints[0], t=1 → waypoints[N-1].
+ * 1개 이하면 첫 번째(또는 서울 기본) 좌표 반환.
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 0) return { lat: 37.5665, lng: 126.978 };
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+
+/**
  * 1초 tick 마다 호출되어 prev 의 phase / position / 부속 값을 advance.
  * `nowMs` 는 호출자가 주입 — 테스트 결정성 + 동일 tick 의 여러 차량이 같은
  * 기준 시각을 보도록.
@@ -101,7 +126,9 @@ export function advanceBikeState(
     const total = prev.phaseEndsAt - prev.phaseStartedAt;
     const elapsed = nowMs - prev.phaseStartedAt;
     const progress = total > 0 ? elapsed / total : 1;
-    const position = lerpPosition(prev.origin, prev.destination, progress);
+    const position = prev.routeWaypoints
+      ? walkPolyline(prev.routeWaypoints, progress)
+      : lerpPosition(prev.origin, prev.destination, progress);
     // 1 tick = 1초 가정. 거리 / 시간 = 속도 → 시간당 거리 / 3600 = 초당 거리.
     const distanceKm = approxDistanceKm(prev.origin, prev.destination);
     const totalSeconds = EN_ROUTE_DURATION_MS / 1_000;
@@ -132,7 +159,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
     case "ASSIGNED": {
@@ -160,7 +188,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: nowMs + ARRIVED_DURATION_MS,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
     case "ARRIVED": {
@@ -174,7 +203,8 @@ export function advanceBikeState(
         phaseStartedAt: nowMs,
         phaseEndsAt: idleWindow === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : nowMs + idleWindow,
         speedKph: 0,
-        ignitionStatus: "OFF"
+        ignitionStatus: "OFF",
+        routeWaypoints: null
       };
     }
   }
@@ -221,7 +251,8 @@ export function makeInitialState(input: {
       ignitionStatus: "OFF",
       odometerKm: initialOdometerKm,
       batteryPercent: initialBatteryPercent,
-      manualOrigin
+      manualOrigin,
+      routeWaypoints: null
     };
   }
   const stagger = staggerMs ?? Math.floor(random() * IDLE_FLEET_MAX_MS);
@@ -238,6 +269,7 @@ export function makeInitialState(input: {
     ignitionStatus: "OFF",
     odometerKm: initialOdometerKm,
     batteryPercent: initialBatteryPercent,
-    manualOrigin
+    manualOrigin,
+    routeWaypoints: null
   };
 }

--- a/development/front-admin-web/lib/services/osrm.ts
+++ b/development/front-admin-web/lib/services/osrm.ts
@@ -1,0 +1,33 @@
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ *
+ * 반환: 경유점 배열 ({lat, lng}[]). 실패(네트워크 오류, timeout, 4xx/5xx)
+ * 시 빈 배열 반환 — 호출부는 빈 배열을 받으면 routeWaypoints 를 null 로
+ * 유지해 직선 lerp fallback 으로 처리한다.
+ *
+ * OSRM 좌표 순서는 [lng, lat] — 반환 시 {lat, lng} 로 변환.
+ * `AbortSignal.timeout` 은 Node 17.3+ / 모던 브라우저에서 지원.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      routes?: Array<{
+        geometry?: { coordinates?: Array<[number, number]> };
+      }>;
+    };
+    const coords = json.routes?.[0]?.geometry?.coordinates ?? [];
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}

--- a/docs/superpowers/plans/2026-05-25-osrm-road-routing.md
+++ b/docs/superpowers/plans/2026-05-25-osrm-road-routing.md
@@ -1,0 +1,725 @@
+# OSRM Road Routing + Delivery Status Labels (PR-C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace straight-line lerp movement with real Seoul road routes (OSRM) during EN_ROUTE, and add delivery status badges (배정됨 / 배송 중 / 배송 완료) on map markers.
+
+**Architecture:** A new pure `fetchOsrmRoute` service fetches GeoJSON polylines from the public OSRM demo server. `SimulatedBikeState` gains a `routeWaypoints` field; the context watches `simulated` for newly-ASSIGNED bikes and injects routes asynchronously. `advanceBikeState` uses `walkPolyline` (time-proportional polyline walk) when waypoints are available, falling back to the existing `lerpPosition` if not. `useSimulatedBikePins` adds a `deliveryPhase` field so `MapShell` can render per-marker status badges.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, public OSRM API (`router.project-osrm.org`). No new runtime deps. No backend changes.
+
+**Reference doc:** `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`
+
+---
+
+## File Structure
+
+| Path | Purpose | Action |
+| ---- | ------- | ------ |
+| `lib/services/osrm.ts` | Pure async OSRM fetch function with error → empty-array fallback | **Create** |
+| `lib/services/fleet-simulation.ts` | Add `routeWaypoints` field, `walkPolyline` fn, use in `advanceBikeState`, init in `makeInitialState` | **Modify** |
+| `components/overview/FleetSimulationContext.tsx` | `pendingFetchesRef` + `useEffect` to fire OSRM fetch on ASSIGNED transition | **Modify** |
+| `components/overview/use-simulated-bike-pins.ts` | Export `SimulatedBikePin` type, add `deliveryPhase` overlay | **Modify** |
+| `components/dashboard/MapShell.tsx` | Accept extended `bikePins` type, add `deliveryBadgeMarkup`, extend `bikeMarkerHtml` | **Modify** |
+
+---
+
+## Task 1: Branch sanity check
+
+**Files:** none
+
+- [ ] **Step 1: Verify branch + spec**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git status
+git log --oneline -3
+ls docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
+ls docs/superpowers/plans/2026-05-25-osrm-road-routing.md
+```
+
+Expected: branch `cc-226-osrm-road-routing`, recent commit is the spec commit `96eb894`. Working tree clean. Both doc files exist.
+
+---
+
+## Task 2: Create `lib/services/osrm.ts`
+
+**Files:**
+- Create: `development/front-admin-web/lib/services/osrm.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ *
+ * 반환: 경유점 배열 ({lat, lng}[]). 실패(네트워크 오류, timeout, 4xx/5xx)
+ * 시 빈 배열 반환 — 호출부는 빈 배열을 받으면 routeWaypoints 를 null 로
+ * 유지해 직선 lerp fallback 으로 처리한다.
+ *
+ * OSRM 좌표 순서는 [lng, lat] — 반환 시 {lat, lng} 로 변환.
+ * `AbortSignal.timeout` 은 Node 17.3+ / 모던 브라우저에서 지원.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      routes?: Array<{
+        geometry?: { coordinates?: Array<[number, number]> };
+      }>;
+    };
+    const coords = json.routes?.[0]?.geometry?.coordinates ?? [];
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 2: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/lib/services/osrm.ts
+git commit -m "Add fetchOsrmRoute service for road-following paths
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Extend `fleet-simulation.ts`
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/fleet-simulation.ts`
+
+This task makes four targeted edits:
+1. Add `routeWaypoints` field to `SimulatedBikeState` type
+2. Add `walkPolyline` helper function after `lerpPosition`
+3. Modify EN_ROUTE within-phase position update to use `walkPolyline` when waypoints are present
+4. Add `routeWaypoints: null` to IDLE→ASSIGNED, EN_ROUTE→ARRIVED, ARRIVED→IDLE transitions, and both `makeInitialState` returns
+
+- [ ] **Step 1: Read the file to confirm current line numbers**
+
+```bash
+grep -n "routeWaypoints\|manualOrigin\|lerpPosition\|walkPolyline\|case \"IDLE\"\|case \"EN_ROUTE\"\|case \"ARRIVED\"\|makeInitialState" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/lib/services/fleet-simulation.ts
+```
+
+Confirm: no `routeWaypoints` yet, `manualOrigin` is the last field in `SimulatedBikeState` (~line 33), `lerpPosition` ends ~line 81.
+
+- [ ] **Step 2: Add `routeWaypoints` field to `SimulatedBikeState`**
+
+In the `SimulatedBikeState` type, after the `manualOrigin` field (currently line 33):
+
+```ts
+  /** 운영자가 단일 차량 수동 배정으로 만든 entry 인지. fleet 정지 후에도 살아 있는다. */
+  manualOrigin: boolean;
+  /**
+   * OSRM 경로 waypoints. ASSIGNED 진입 시 fetch, EN_ROUTE 중 이동 경로 결정.
+   * null = 아직 경로 없음 또는 fetch 실패 → 직선 lerp fallback.
+   */
+  routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
+```
+
+- [ ] **Step 3: Add `walkPolyline` after `lerpPosition`**
+
+After the closing `}` of `lerpPosition` (currently ~line 81), insert:
+
+```ts
+
+/**
+ * progress t (0..1) 로 polyline 위 좌표를 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배:
+ *   t=0 → waypoints[0], t=1 → waypoints[N-1].
+ * 1개 이하면 첫 번째(또는 서울 기본) 좌표 반환.
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 0) return { lat: 37.5665, lng: 126.978 };
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+```
+
+- [ ] **Step 4: Modify EN_ROUTE within-phase position update**
+
+Find the EN_ROUTE within-phase section (currently ~lines 98-116). The line:
+```ts
+    const position = lerpPosition(prev.origin, prev.destination, progress);
+```
+
+Replace with:
+```ts
+    const position = prev.routeWaypoints
+      ? walkPolyline(prev.routeWaypoints, progress)
+      : lerpPosition(prev.origin, prev.destination, progress);
+```
+
+- [ ] **Step 5: Add `routeWaypoints: null` to phase transitions**
+
+**IDLE → ASSIGNED** (currently ~lines 126-136): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "ASSIGNED",
+        destination,
+        progress: 0,
+        position: prev.origin,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+**EN_ROUTE → ARRIVED** (currently ~lines 152-164): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "ARRIVED",
+        progress: 1,
+        position: finalPosition,
+        origin: finalPosition,
+        destination: null,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: nowMs + ARRIVED_DURATION_MS,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+**ARRIVED → IDLE** (currently ~lines 169-178): add `routeWaypoints: null` after `ignitionStatus: "OFF"`:
+
+```ts
+      return {
+        ...prev,
+        phase: "IDLE",
+        progress: 0,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: idleWindow === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : nowMs + idleWindow,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        routeWaypoints: null
+      };
+```
+
+- [ ] **Step 6: Add `routeWaypoints: null` to `makeInitialState`**
+
+`makeInitialState` has two return statements — the ASSIGNED path (~lines 211-225) and the IDLE path (~lines 228-242). Add `routeWaypoints: null` to both, after `manualOrigin`:
+
+ASSIGNED path:
+```ts
+    return {
+      bikeId,
+      phase: "ASSIGNED",
+      origin,
+      destination: randomSeoulPoint(random),
+      progress: 0,
+      position: origin,
+      phaseStartedAt: nowMs,
+      phaseEndsAt: nowMs + ASSIGNED_DURATION_MS,
+      speedKph: 0,
+      ignitionStatus: "OFF",
+      odometerKm: initialOdometerKm,
+      batteryPercent: initialBatteryPercent,
+      manualOrigin,
+      routeWaypoints: null
+    };
+```
+
+IDLE path:
+```ts
+  return {
+    bikeId,
+    phase: "IDLE",
+    origin,
+    destination: null,
+    progress: 0,
+    position: origin,
+    phaseStartedAt: nowMs,
+    phaseEndsAt: nowMs + stagger,
+    speedKph: 0,
+    ignitionStatus: "OFF",
+    odometerKm: initialOdometerKm,
+    batteryPercent: initialBatteryPercent,
+    manualOrigin,
+    routeWaypoints: null
+  };
+```
+
+- [ ] **Step 7: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. Fix any issues (likely missing `routeWaypoints` in some spread).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/lib/services/fleet-simulation.ts
+git commit -m "fleet-simulation: add routeWaypoints field and walkPolyline for road routing
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: OSRM fetch trigger in `FleetSimulationContext.tsx`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/FleetSimulationContext.tsx`
+
+- [ ] **Step 1: Read the file**
+
+Read `C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/FleetSimulationContext.tsx` fully (177 lines).
+
+- [ ] **Step 2: Add the import**
+
+After the existing imports at the top of the file, add:
+
+```tsx
+import { fetchOsrmRoute } from "@/lib/services/osrm";
+```
+
+- [ ] **Step 3: Add `pendingFetchesRef` inside `FleetSimulationProvider`**
+
+Inside the `FleetSimulationProvider` component body, near the other `useRef` calls:
+
+```tsx
+/**
+ * OSRM fetch 중인 bikeId Set. 동일 bike 에 중복 fetch 방지.
+ * ref 라 React 렌더를 트리거하지 않음.
+ */
+const pendingFetchesRef = useRef<Set<string>>(new Set());
+```
+
+- [ ] **Step 4: Add the OSRM fetch `useEffect`**
+
+After the existing tick `useEffect` (the `setInterval` effect), add a new effect:
+
+```tsx
+// ASSIGNED 상태이면서 routeWaypoints 가 아직 없는 bike 를 발견하면
+// OSRM 경로를 fetch 해서 state 에 주입. pendingFetchesRef 로 중복 방지.
+useEffect(() => {
+  for (const [bikeId, state] of simulated) {
+    if (
+      state.phase !== "ASSIGNED" ||
+      state.routeWaypoints !== null ||
+      pendingFetchesRef.current.has(bikeId)
+    ) {
+      continue;
+    }
+    if (!state.destination) continue; // ASSIGNED 에서 destination 은 항상 있지만 타입 guard
+
+    pendingFetchesRef.current.add(bikeId);
+    fetchOsrmRoute(state.origin, state.destination).then((waypoints) => {
+      pendingFetchesRef.current.delete(bikeId);
+      if (waypoints.length === 0) return; // 빈 배열 = 실패 → null 유지, 직선 fallback
+      setSimulated((prev) => {
+        const current = prev.get(bikeId);
+        // stale guard: bike 가 이미 IDLE 로 돌아갔으면 주입 무시
+        if (!current || current.phase === "IDLE") return prev;
+        const next = new Map(prev);
+        next.set(bikeId, { ...current, routeWaypoints: waypoints });
+        return next;
+      });
+    });
+  }
+}, [simulated]);
+```
+
+- [ ] **Step 5: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. If ESLint flags the `for...of` with `continue` pattern, note that the existing codebase (FleetSimulationContext tick loop) already uses this pattern — it is lint-approved.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/FleetSimulationContext.tsx
+git commit -m "FleetSimulationContext: fetch OSRM route on ASSIGNED and inject into state
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add `deliveryPhase` overlay to `use-simulated-bike-pins.ts`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/use-simulated-bike-pins.ts`
+
+Current file (75 lines): `useSimulatedBikePins` returns `FrontendDashboardBikePin[]`. We extend the return type to include `deliveryPhase`.
+
+- [ ] **Step 1: Add the import and export the new type**
+
+After existing imports at the top of the file (currently lines 1-7), add:
+
+```ts
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+
+/**
+ * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
+ * FrontendDashboardBikePin 위에 deliveryPhase 를 overlay 한다.
+ */
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: DeliveryPhase | null;
+};
+```
+
+- [ ] **Step 2: Change `useSimulatedBikePins` return type and body**
+
+Replace the entire `useSimulatedBikePins` function (lines 15-43) with:
+
+```ts
+export function useSimulatedBikePins(
+  rawPins: ReadonlyArray<FrontendDashboardBikePin>
+): SimulatedBikePin[] {
+  const { simulated } = useFleetSimulation();
+  return useMemo(() => {
+    if (simulated.size === 0) {
+      return rawPins.map((pin) => ({ ...pin, deliveryPhase: null }));
+    }
+    const nowIso = new Date().toISOString();
+    return rawPins.map((pin) => {
+      const sim = simulated.get(pin.bikeId);
+      if (!sim) return { ...pin, deliveryPhase: null };
+      const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
+        sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
+      const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
+        sim.ignitionStatus === "ON" ? (sim.speedKph >= 3 ? "DRIVING" : "STOPPED") : "PARKED";
+      return {
+        ...pin,
+        latitude: sim.position.lat,
+        longitude: sim.position.lng,
+        speedKph: sim.speedKph,
+        batteryPercent: Math.round(sim.batteryPercent),
+        ignitionStatus: sim.ignitionStatus,
+        connectionStatus: "ONLINE",
+        drivingStatus,
+        batteryStatus,
+        lastReceivedAt: nowIso,
+        deliveryPhase: sim.phase
+      };
+    });
+  }, [rawPins, simulated]);
+}
+```
+
+Leave `useSimulatedCurrentTelemetry` (lines 50-74) completely untouched.
+
+- [ ] **Step 3: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0. TypeScript will verify that `SimulatedBikePin[]` is assignable to existing consumers (`MapShell.bikePins`, `OverviewMapSearch.bikePins`) — since `SimulatedBikePin extends FrontendDashboardBikePin`, structural compatibility holds. If any consumer errors, check whether its prop type needs updating (covered in Task 6 for MapShell).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+git commit -m "useSimulatedBikePins: overlay deliveryPhase for map marker badges
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Add delivery status badge to `MapShell.tsx`
+
+**Files:**
+- Modify: `development/front-admin-web/components/dashboard/MapShell.tsx`
+
+- [ ] **Step 1: Add the import**
+
+Near the top of the file, after existing imports, add:
+
+```tsx
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+```
+
+- [ ] **Step 2: Extend `MapShellProps.bikePins` type**
+
+`MapShellProps.bikePins` is currently (line 70):
+```ts
+  bikePins?: FrontendDashboardBikePin[];
+```
+
+Change to:
+```ts
+  bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }>;
+```
+
+This is backward compatible: `FrontendDashboardBikePin[]` still satisfies the new type (optional field can be absent), and `SimulatedBikePin[]` (from Task 5) satisfies it too.
+
+- [ ] **Step 3: Add `deliveryBadgeMarkup` helper**
+
+After the `labelMarkup` function (currently lines 553-560), add:
+
+```ts
+/**
+ * 배송 상태 배지 HTML. IDLE 이면 빈 문자열.
+ * 마커 컨테이너(relative 28×28) 아래에 absolute 로 위치 — 아이콘 밑에 노출.
+ */
+function deliveryBadgeMarkup(phase: DeliveryPhase): string {
+  if (phase === "IDLE") return "";
+  const config: Record<Exclude<DeliveryPhase, "IDLE">, { text: string; bg: string }> = {
+    ASSIGNED: { text: "배정됨", bg: "#f59e0b" },
+    EN_ROUTE: { text: "배송 중", bg: "#3b82f6" },
+    ARRIVED: { text: "배송 완료", bg: "#22c55e" }
+  };
+  const { text, bg } = config[phase];
+  return (
+    `<div style="position:absolute;top:100%;left:50%;transform:translateX(-50%);` +
+    `margin-top:2px;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:600;` +
+    `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
+    `${text}</div>`
+  );
+}
+```
+
+- [ ] **Step 4: Modify `bikeMarkerHtml` to accept and render the badge**
+
+Replace the current `bikeMarkerHtml` (lines 606-610):
+
+```ts
+function bikeMarkerHtml(plateNumber: string, showLabel: boolean): string {
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  if (!showLabel) return wrapped;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(plateNumber)}${wrapped}</div>`;
+}
+```
+
+With:
+
+```ts
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  deliveryPhase?: DeliveryPhase | null
+): string {
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent");
+  const badge = deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : "";
+  if (!showLabel && !badge) return wrapped;
+  return (
+    `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
+    `${showLabel ? labelMarkup(plateNumber) : ""}${wrapped}${badge}` +
+    `</div>`
+  );
+}
+```
+
+- [ ] **Step 5: Pass `deliveryPhase` in the marker creation loop**
+
+In the marker creation loop (~lines 418-445), find:
+
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel);
+```
+
+Change to:
+
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase);
+```
+
+`pin` is now typed as `FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null }` (from the updated `MapShellProps`), so `pin.deliveryPhase` is type-safe.
+
+- [ ] **Step 6: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/dashboard/MapShell.tsx
+git commit -m "MapShell: add delivery status badge on bike markers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full static-check sweep
+
+- [ ] **Step 1: typecheck**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+```
+
+Expected: exit 0, no errors.
+
+- [ ] **Step 2: lint**
+
+```bash
+npm run lint
+```
+
+Expected: exit 0, no warnings.
+
+---
+
+## Task 8: Manual smoke
+
+The user runs their own dev server on localhost. **Do not** start a competing one.
+
+- [ ] **Step 1: Fleet OFF baseline**
+
+Open `/`. Map shows 2 real bike markers with no delivery badges. Normal behavior.
+
+- [ ] **Step 2: 데모 시작 → ASSIGNED badge**
+
+Click `[데모 시작]`. Within 5 seconds, virtual bike markers should show `배정됨` (amber) badge. Check the browser Network tab — OSRM requests to `router.project-osrm.org` appear for each bike.
+
+- [ ] **Step 3: EN_ROUTE → road movement + 배송 중 badge**
+
+After ~5 seconds (ASSIGNED phase), markers should:
+- Switch to `배송 중` (blue) badge
+- Begin moving — **following Seoul roads** rather than flying in a straight line
+- Open the browser Network tab and confirm each bike made an OSRM request returning coordinates
+
+Compare with PR-A/B behavior: bikes should visibly curve around streets rather than cutting across buildings.
+
+- [ ] **Step 4: ARRIVED badge**
+
+After 5 minutes (EN_ROUTE), markers should show `배송 완료` (green) badge for ~10 seconds, then badge disappears (IDLE). Verify the cycle repeats.
+
+- [ ] **Step 5: OSRM failure fallback**
+
+In DevTools, block `router.project-osrm.org` (Network tab → right-click → Block request domain). Start/restart demo. Bikes should still move (straight-line lerp) with badges showing — no errors in console beyond the blocked-network 브라우저 message.
+
+Unblock the domain after this test.
+
+- [ ] **Step 6: 데모 정지**
+
+Click toggle. Virtual markers disappear. Real bikes (if in sim) revert to their last simulated position or go static. No `배정됨`/`배송 중`/`배송 완료` badges remain on any marker.
+
+---
+
+## Task 9: PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git push -u origin cc-226-osrm-road-routing
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base dev --head cc-226-osrm-road-routing \
+  --title "Road-following movement + delivery status badges (PR-C)" \
+  --body "$(cat <<'EOF'
+## Summary
+- EN_ROUTE 이동이 직선 lerp → OSRM 실제 도로 경로로 교체 — 서울 도로망을 따라 이동
+- 지도 마커에 배송 상태 배지 추가: 배정됨(노랑) → 배송 중(파랑) → 배송 완료(초록)
+- 실패 시 자동 직선 fallback (OSRM 응답 없으면 기존 lerp 그대로)
+- 가상 차량 + 실제 차량 모두 적용
+
+## Architecture
+- `lib/services/osrm.ts`: OSRM fetch 순수 함수 (5 초 timeout, 에러 → 빈 배열 fallback)
+- `SimulatedBikeState.routeWaypoints`: OSRM 경유점 배열 | null
+- `FleetSimulationContext`: ASSIGNED 전환 감지 → async fetch → state 주입
+- `useSimulatedBikePins`: `SimulatedBikePin` 타입으로 확장, `deliveryPhase` overlay
+- `MapShell`: `deliveryBadgeMarkup` + `bikeMarkerHtml` 확장
+
+## Spec & Plan
+- 디자인: `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`
+- 플랜: `docs/superpowers/plans/2026-05-25-osrm-road-routing.md`
+
+## Test plan
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [ ] 데모 시작 → OSRM API 호출 확인 (Network 탭)
+- [ ] 차량이 서울 도로를 따라 이동 (직선 X)
+- [ ] 배정됨 → 배송 중 → 배송 완료 배지 순서 확인
+- [ ] OSRM 차단 시 직선 이동 fallback 정상 작동
+- [ ] 데모 정지 → 배지 사라짐
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — `docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md`:
+
+- "새 모듈 `lib/services/osrm.ts`" → Task 2. ✅
+- "`SimulatedBikeState` 확장 (`routeWaypoints`)" → Task 3 step 2. ✅
+- "`walkPolyline` 함수" → Task 3 step 3. ✅
+- "`advanceBikeState` EN_ROUTE 분기 변경" → Task 3 step 4. ✅
+- "ASSIGNED 진입 시 / ARRIVED→IDLE 시 null 초기화" → Task 3 step 5. ✅
+- "`makeInitialState` 에 `routeWaypoints: null`" → Task 3 step 6. ✅
+- "OSRM fetch 트리거 (`FleetSimulationContext`)" → Task 4. ✅
+- "배송 상태 레이블 — 마커 overlay" → Tasks 5 + 6. ✅
+- "Error handling: 5초 timeout, 빈 배열 fallback, stale guard" → Task 2 (timeout in osrm.ts), Task 4 (stale guard + empty array check). ✅
+- "OSRM 실패 시 직선 이동 fallback" → Task 3 step 4 (null check before walkPolyline). ✅
+
+**Placeholder scan** — no "TBD", "TODO", "implement later". All code blocks are concrete. ✅
+
+**Type consistency**:
+- `routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null` — matches `fetchOsrmRoute` return type `Promise<ReadonlyArray<{ lat: number; lng: number }>>`. ✅
+- `walkPolyline(waypoints: ReadonlyArray<{ lat: number; lng: number }>, t: number)` — same shape. ✅
+- `SimulatedBikePin = FrontendDashboardBikePin & { deliveryPhase: DeliveryPhase | null }` — `deliveryPhase` is `DeliveryPhase | null` (non-optional). `MapShellProps.bikePins` uses `deliveryPhase?: DeliveryPhase | null` (optional) — `SimulatedBikePin` satisfies this since required ⊂ optional. ✅
+- `deliveryBadgeMarkup(phase: DeliveryPhase)` — called with `pin.deliveryPhase` typed as `DeliveryPhase | null | undefined`. The guard `deliveryPhase ? deliveryBadgeMarkup(deliveryPhase) : ""` narrows to `DeliveryPhase` before the call. ✅
+
+**Scope** — 1 new file + 4 modified files, no backend changes, no new runtime deps. ✅

--- a/docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
+++ b/docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
@@ -1,0 +1,681 @@
+# Virtual Fleet Tables / KPI / Search (PR-B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the `virtualFleet` snapshot (introduced in PR-A) into the vehicles table, riders table, root-page KPI tiles, and the unified `OverviewMapSearch` matching, so toggling 데모 시작 makes the whole page light up — 22 vehicles, 21 riders, KPI deltas, search hits — not just the map markers.
+
+**Architecture:** Each consumer reads `virtualFleet` from `useFleetSimulation()` and merges raw data with the virtual fleet via a small `useMemo`. The KPI tile block is extracted from the server `page.tsx` into a new client component that subscribes to live simulation so the 시동 차량 count updates per tick. No new context channels; PR-A already exposes everything we need.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript. No new runtime deps. No backend changes. No test runner — verification = `npm run typecheck` + `npm run lint` + manual smoke.
+
+**Reference doc:** `docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md`.
+
+---
+
+## File Structure
+
+| Path | Purpose | Action |
+| ---- | ------- | ------ |
+| `components/overview/OverviewKpiTiles.tsx` | New client component — renders the two KPI cards from server-supplied base counts + live virtual/simulated overlay | **Create** |
+| `app/page.tsx` | Replace inline KPI JSX with `<OverviewKpiTiles .../>`; counts continue to be computed server-side and passed as props | **Modify** |
+| `components/management/VehiclesPanel.tsx` | Merge `data.vehicles ⊕ virtualFleet.vehicles` before filtering | **Modify** |
+| `components/management/RidersPanel.tsx` | Merge `data.riders ⊕ virtualFleet.riders` before filtering | **Modify** |
+| `components/overview/OverviewMapBanner.tsx` | Merge `bikeActiveRiderById` / `riderInfoById` with virtualFleet's before passing to `OverviewMapSearch` | **Modify** |
+| `components/overview/FullscreenMapHost.tsx` | Same merge for the fullscreen search | **Modify** |
+
+No tests directory — verification by typecheck + lint + manual smoke.
+
+---
+
+## Task 1: Branch sanity check
+
+**Files:** none
+
+- [ ] **Step 1: Verify branch + spec**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git status
+git log --oneline -3
+ls docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
+ls docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md
+```
+
+Expected: branch `cc-225-virtual-fleet-tables-kpi-search`, recent commit `01d487b` (spec). Both doc files exist. Working tree clean.
+
+---
+
+## Task 2: Merge virtual vehicles into `VehiclesPanel`
+
+**Files:**
+- Modify: `development/front-admin-web/components/management/VehiclesPanel.tsx`
+
+Build an `effectiveVehicles` array (raw + virtual) and replace every `data.vehicles` usage with it.
+
+- [ ] **Step 1: Read the file to confirm current shape**
+
+```bash
+grep -n "useFleetSimulation\|data\.vehicles\|applyVehicleFilters" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/management/VehiclesPanel.tsx
+```
+
+Expected: file currently has no `useFleetSimulation` import. `data.vehicles` is referenced on lines ~120, ~126, ~162 (per spec).
+
+- [ ] **Step 2: Add the new import**
+
+Add alongside other `@/components/overview/` imports near the top:
+
+```tsx
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+```
+
+If `useMemo` is not already in the existing react import, add it (it should already be since the file uses memoization).
+
+- [ ] **Step 3: Read the fleet context and derive effective vehicles**
+
+Inside the `VehiclesPanel` component body, near the other hooks (above the `applyVehicleFilters` `useMemo`), add:
+
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveVehicles = useMemo(() => {
+  if (!virtualFleet) return data.vehicles;
+  return [...data.vehicles, ...virtualFleet.vehicles];
+}, [data.vehicles, virtualFleet]);
+```
+
+- [ ] **Step 4: Swap `data.vehicles` references**
+
+Find the `applyVehicleFilters` invocation:
+```tsx
+const visibleVehicles = useMemo(
+  () =>
+    applyVehicleFilters({
+      vehicles: data.vehicles,
+      ...
+    }),
+  [data.vehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+);
+```
+
+Change `vehicles: data.vehicles` to `vehicles: effectiveVehicles`, and replace `data.vehicles` in the deps array:
+
+```tsx
+const visibleVehicles = useMemo(
+  () =>
+    applyVehicleFilters({
+      vehicles: effectiveVehicles,
+      filters,
+      bikePinById,
+      deviceUidByBikeId,
+      maintenanceSummaryByBike
+    }),
+  [effectiveVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+);
+```
+
+Find the filter-controls count prop:
+```tsx
+count={{ visible: visibleVehicles.length, total: data.vehicles.length }}
+```
+
+Change to:
+```tsx
+count={{ visible: visibleVehicles.length, total: effectiveVehicles.length }}
+```
+
+Confirm via grep that no other `data.vehicles` reference exists in the file — if it does, swap to `effectiveVehicles` (or leave only if it's intentional, e.g., a banner that shows the raw count).
+
+- [ ] **Step 5: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both must exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/management/VehiclesPanel.tsx
+git commit -m "VehiclesPanel: show virtual fleet rows when demo is running
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Merge virtual riders into `RidersPanel`
+
+**Files:**
+- Modify: `development/front-admin-web/components/management/RidersPanel.tsx`
+
+Same pattern as Task 2 but for riders.
+
+- [ ] **Step 1: Confirm current shape**
+
+```bash
+grep -n "useFleetSimulation\|data\.riders\|applyRiderFilters" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/management/RidersPanel.tsx
+```
+
+Expected references to `data.riders` on lines ~84, ~94, ~111.
+
+- [ ] **Step 2: Add the import**
+
+Add alongside other `@/components/overview/` imports:
+
+```tsx
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+```
+
+Ensure `useMemo` is in the react import.
+
+- [ ] **Step 3: Derive `effectiveRiders`**
+
+Inside `RidersPanel`, near other hooks:
+
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveRiders = useMemo(() => {
+  if (!virtualFleet) return data.riders;
+  return [...data.riders, ...virtualFleet.riders];
+}, [data.riders, virtualFleet]);
+```
+
+- [ ] **Step 4: Swap `data.riders` references**
+
+Find `applyRiderFilters` call:
+```tsx
+applyRiderFilters({
+  riders: data.riders,
+  ...
+})
+```
+
+Change to:
+```tsx
+applyRiderFilters({
+  riders: effectiveRiders,
+  ...
+})
+```
+
+Replace `data.riders` in its deps array with `effectiveRiders`.
+
+Find the count prop:
+```tsx
+count={{ visible: visibleRiders.length, total: data.riders.length }}
+```
+
+Change to:
+```tsx
+count={{ visible: visibleRiders.length, total: effectiveRiders.length }}
+```
+
+- [ ] **Step 5: Static checks** — both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/management/RidersPanel.tsx
+git commit -m "RidersPanel: show virtual riders when demo is running
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Extract KPI tiles into a client component with live overlay
+
+**Files:**
+- Create: `development/front-admin-web/components/overview/OverviewKpiTiles.tsx`
+- Modify: `development/front-admin-web/app/page.tsx`
+
+The current KPI JSX lives inside the server `page.tsx`. Extract it into a client component that takes the server-computed base counts as props and reads `virtualFleet` + `simulated` from context to overlay live virtual contributions.
+
+- [ ] **Step 1: Create the new client component**
+
+```tsx
+"use client";
+
+import { useMemo } from "react";
+
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+
+/**
+ * 페이지 상단의 두 KPI 카드 (차량 현황 / 라이더 현황). 서버에서 SSR 된
+ * baseline 값을 props 로 받고, 그 위에 fleet 데모의 가상 fleet + 시뮬레이션
+ * 상태를 매 1초 tick 마다 overlay 한다. fleet OFF 면 props 값 그대로.
+ *
+ * 시동 차량은 virtual-bike-* prefix 가 붙은 simulated entry 중 ignitionStatus
+ * 가 ON 인 것만 카운트해 base 에 더한다 — base 의 실제 차량 카운트와
+ * 중복되지 않도록 (실제 차량은 SSR 시점의 정적 dummy 값을 그대로 신뢰).
+ */
+export interface OverviewKpiTilesProps {
+  totalBikes: number;
+  ignitionOnCount: number;
+  insuredVehicleCount: number;
+  totalRiders: number;
+  subscriptionRiderCount: number;
+  rentalRiderCount: number;
+}
+
+const VIRTUAL_BIKE_PREFIX = "virtual-bike-";
+const VIRTUAL_FLEET_COUNT = 20;
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+export function OverviewKpiTiles({
+  totalBikes,
+  ignitionOnCount,
+  insuredVehicleCount,
+  totalRiders,
+  subscriptionRiderCount,
+  rentalRiderCount
+}: OverviewKpiTilesProps) {
+  const { virtualFleet, simulated } = useFleetSimulation();
+
+  const virtualIgnitionOn = useMemo(() => {
+    let n = 0;
+    for (const state of simulated.values()) {
+      if (state.ignitionStatus === "ON" && state.bikeId.startsWith(VIRTUAL_BIKE_PREFIX)) {
+        n++;
+      }
+    }
+    return n;
+  }, [simulated]);
+
+  const totalBikesEffective = totalBikes + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const totalRidersEffective = totalRiders + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
+  const ignitionOnEffective = ignitionOnCount + virtualIgnitionOn;
+
+  return (
+    <div className="overview-kpi-groups">
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">차량 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 차량</p>
+            <p className="metric-value">{formatCount(totalBikesEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">시동 차량</p>
+            <p className="metric-value">{formatCount(ignitionOnEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">보험 차량</p>
+            <p className="metric-value">{formatCount(insuredVehicleCount)}</p>
+          </div>
+        </div>
+      </article>
+
+      <article className="kpi-group">
+        <h3 className="kpi-group-heading">라이더 현황</h3>
+        <div className="kpi-group-metrics">
+          <div>
+            <p className="metric-label">전체 라이더</p>
+            <p className="metric-value">{formatCount(totalRidersEffective)}</p>
+          </div>
+          <div>
+            <p className="metric-label">구독 인원</p>
+            <p className="metric-value">{formatCount(subscriptionRiderCount)}</p>
+          </div>
+          <div>
+            <p className="metric-label">렌탈 인원</p>
+            <p className="metric-value">{formatCount(rentalRiderCount)}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace the inline KPI JSX in `app/page.tsx`**
+
+In `page.tsx`, add the import near other `@/components/overview/` imports:
+
+```tsx
+import { OverviewKpiTiles } from "@/components/overview/OverviewKpiTiles";
+```
+
+Find the existing inline KPI block (~lines 287-323 from spec read):
+
+```tsx
+<div className="overview-kpi-groups">
+  <article className="kpi-group">
+    <h3 className="kpi-group-heading">차량 현황</h3>
+    ...
+  </article>
+  <article className="kpi-group">
+    <h3 className="kpi-group-heading">라이더 현황</h3>
+    ...
+  </article>
+</div>
+```
+
+Replace the entire block with:
+
+```tsx
+<OverviewKpiTiles
+  totalBikes={summary.totalBikes}
+  ignitionOnCount={ignitionOnCount}
+  insuredVehicleCount={insuredVehicleCount}
+  totalRiders={totalRiders}
+  subscriptionRiderCount={subscriptionRiderCount}
+  rentalRiderCount={rentalRiderCount}
+/>
+```
+
+If `page.tsx` has a local `formatCount` helper that is no longer referenced after this swap, leave it in place — other parts of the page may still use it. Only remove if grep confirms zero references.
+
+Verify the new component is rendered INSIDE `<OverviewClientShell>` (otherwise `useFleetSimulation` returns the noop fallback and counts never reflect the fleet). The existing KPI block was already inside `OverviewClientShell` per the file structure read.
+
+- [ ] **Step 3: Static checks**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+npm run lint
+```
+
+Both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/OverviewKpiTiles.tsx development/front-admin-web/app/page.tsx
+git commit -m "Extract OverviewKpiTiles to a client component with live virtual overlay
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Merge rider lookups for search in `OverviewMapBanner`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/OverviewMapBanner.tsx`
+
+The banner already pulls `virtualFleet` (PR-A). Add two merged Maps and feed them to `OverviewMapSearch` so virtual riders + virtual `bikeActiveRiderById` participate in search matching.
+
+- [ ] **Step 1: Verify current destructure + search usage**
+
+```bash
+grep -n "useFleetSimulation\|bikeActiveRiderById\|riderInfoById\|OverviewMapSearch" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+```
+
+Expected: `useFleetSimulation` already destructures `virtualFleet` (from PR-A). `bikeActiveRiderById` + `riderInfoById` come from `props`. `<OverviewMapSearch>` JSX passes them as props.
+
+- [ ] **Step 2: Build the two merged Maps**
+
+Insert near the existing `mergedRawPins` `useMemo` (above the search JSX, alongside other derivations):
+
+```tsx
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+  const m = new Map<string, string>(bikeActiveRiderById ?? []);
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+  const m = new Map(riderInfoById ?? []);
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+- [ ] **Step 3: Pass merged Maps to `OverviewMapSearch`**
+
+Find:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={bikeActiveRiderById}
+  riderInfoById={riderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+Change `bikeActiveRiderById` and `riderInfoById` to the merged versions:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={mergedBikeActiveRiderById}
+  riderInfoById={mergedRiderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+`VehicleDetailDialog` (rendered later in this banner via the search-target effect) continues to read its row from the page's separate `vehicleById` lookup — virtual vehicles aren't there, so clicking a virtual marker opens a dialog whose vehicle is `undefined` and the existing fallback path keeps the dialog from displaying broken data. That fallback is sufficient for this PR (full virtual detail panel is OOS).
+
+- [ ] **Step 4: Static checks** — both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/OverviewMapBanner.tsx
+git commit -m "OverviewMapBanner: merge virtual rider lookups into search
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Same merge for `FullscreenMapHost`
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/FullscreenMapHost.tsx`
+
+- [ ] **Step 1: Confirm current shape inside `FullscreenMapOverlay`**
+
+```bash
+grep -n "useFleetSimulation\|bikeActiveRiderById\|riderInfoById\|OverviewMapSearch" C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+```
+
+`virtualFleet` should already be in the destructure (PR-A). `bikeActiveRiderById` + `riderInfoById` are also already destructured (props passed from page).
+
+- [ ] **Step 2: Build merged Maps**
+
+Insert alongside `mergedRawPins`:
+
+```tsx
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById ?? new Map<string, string>();
+  const m = new Map<string, string>(bikeActiveRiderById ?? []);
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById ?? new Map<string, { name: string; phone: string }>();
+  const m = new Map(riderInfoById ?? []);
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+- [ ] **Step 3: Pass merged Maps to `OverviewMapSearch` in the header**
+
+Find the JSX:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={bikeActiveRiderById}
+  riderInfoById={riderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+Change to:
+```tsx
+<OverviewMapSearch
+  bikePins={overlaidBikePins}
+  stationPins={stationPins}
+  bikeActiveRiderById={mergedBikeActiveRiderById}
+  riderInfoById={mergedRiderInfoById}
+  onSelect={handleSearchSelect}
+/>
+```
+
+- [ ] **Step 4: Static checks** — both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git add development/front-admin-web/components/overview/FullscreenMapHost.tsx
+git commit -m "FullscreenMapHost: merge virtual rider lookups into search
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full static-check sweep + optional build
+
+- [ ] **Step 1: typecheck**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web
+npm run typecheck
+```
+
+Expected exit 0.
+
+- [ ] **Step 2: lint**
+
+```bash
+npm run lint
+```
+
+Expected exit 0.
+
+- [ ] **Step 3: Optional `next build`**
+
+```bash
+npm run build
+```
+
+Catches Next.js / SSR issues lint doesn't. Skip if you trust prior checks.
+
+---
+
+## Task 8: Manual smoke
+
+The user runs their own dev server. **Do not** spawn a competing one.
+
+- [ ] **Step 1: Fleet OFF baseline**
+
+Open `/`. KPI shows real counts. Vehicle table: 2 rows. Rider table: 1 row. Search the inline `차량 번호 / BSS / 라이더 검색` for `99서` — no matches.
+
+- [ ] **Step 2: 데모 시작**
+
+Click `[데모 시작]`. Verify:
+- KPI 전체 차량 jumps to original + 20 (e.g. 22)
+- KPI 전체 라이더 jumps to original + 20 (e.g. 21)
+- KPI 시동 차량 grows 0 → some positive number over the first 30s as virtual bikes transition to EN_ROUTE
+- Vehicle table 화면 reflects 22 rows when scrolled — plates `99서0001` ~ `99서0020` visible alongside real plates
+- Rider table reflects 21 rows — gating names like `김민수`, `이지영` 등 from the family/given pool
+
+- [ ] **Step 3: Search hit**
+
+Type `99서0005` in the inline search → result item visible in dropdown → click → map opens + pans + `VehicleDetailDialog` opens (with mostly-empty fields, as expected).
+
+Type `김민` (a virtual rider given-name prefix) → at least one rider result shows in dropdown → click → map opens + pans to that virtual rider's matched bike.
+
+- [ ] **Step 4: KPI live update**
+
+Watch `시동 차량` for ~30s. Number should bump up and down as virtual bikes shift between EN_ROUTE (ON) and ARRIVED/IDLE (OFF).
+
+- [ ] **Step 5: 데모 정지**
+
+Click toggle. Verify:
+- KPI returns to original
+- Vehicle table shrinks back to 2 rows
+- Rider table shrinks back to 1 row
+- Search `99서` again returns no matches
+
+- [ ] **Step 6: Fullscreen mode toggle**
+
+Open `[⛶ 전체화면]`. Click `[데모 시작]` from the fullscreen header. Search should match virtual plates and rider names from the fullscreen header search too (shared context).
+
+---
+
+## Task 9: PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd C:/Users/user/repositories/clever/thundercrew-domain
+git push -u origin cc-225-virtual-fleet-tables-kpi-search
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base dev --head cc-225-virtual-fleet-tables-kpi-search \
+  --title "Light up tables / KPI / search with virtual fleet (PR-B)" \
+  --body "$(cat <<'EOF'
+## Summary
+- PR-A 의 가상 fleet 스냅샷을 차량/라이더 표, KPI 카드, 검색에 통합 — 데모 시작이 한 화면 통째로 살아나도록
+- 차량 표: 2 → 22 행 (실제 2 + 가상 \`99서0001~0020\`), 기존 필터 헬퍼는 그대로 작동
+- 라이더 표: 1 → 21 행 (실제 1 + 가상 20 명)
+- KPI: 새 \`OverviewKpiTiles\` 클라이언트 컴포넌트로 추출 — 매 tick 시뮬레이션 진행에 따라 시동 차량 카운트 갱신
+- 검색: 인페이지 + 전체화면 양쪽에서 \`bikeActiveRiderById\` / \`riderInfoById\` 가 가상까지 매칭
+- 보험 차량 / 구독·렌탈 카운트는 가상이 0 기여라 그대로 (의도된 동작)
+
+## Spec & Plan
+- 디자인: \`docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md\`
+- 플랜: \`docs/superpowers/plans/2026-05-25-virtual-fleet-tables-kpi-search.md\`
+
+## Test plan
+- [x] \`npm run typecheck\`
+- [x] \`npm run lint\`
+- [ ] 데모 시작 → KPI 차량 +20 / 라이더 +20 즉시 반영
+- [ ] 시동 차량 카운트가 시간이 지나며 변동 (가상 차량 EN_ROUTE 진입/이탈)
+- [ ] 차량 표에 \`99서\` plate 노출, 기존 필터 (구분/시동/연결) 가 가상 row 에도 정상 작동
+- [ ] 라이더 표에 가상 라이더 20명 노출
+- [ ] 검색 \`99서0005\` / \`김민\` 매칭, 클릭 시 지도 pan
+- [ ] 데모 정지 → 모든 화면 원상 복구
+- [ ] 전체화면 토글 / 검색도 동일 작동
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review
+
+**Spec coverage** — `docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md`:
+
+- "Panel 단의 표 데이터 merge" → Tasks 2 (VehiclesPanel) + 3 (RidersPanel).
+- "KPI 카드 — 새 클라이언트 컴포넌트로 분리" → Task 4 (`OverviewKpiTiles` + page.tsx swap).
+- "검색 (OverviewMapSearch) — banner / fullscreen 에서 merge" → Tasks 5 + 6.
+- "User-visible behavior" → Task 8 smoke checklist mirrors every bullet.
+- "Out-of-scope follow-ups" → not implemented; consistent with spec.
+
+**Placeholder scan** — no "TODO", "TBD", "implement later", "similar to Task N" references. Each code block is concrete.
+
+**Type consistency:**
+- `effectiveVehicles: FrontendVehicle[]` (Task 2) and `effectiveRiders: FrontendRider[]` (Task 3) — the merge spread relies on `VirtualFleet.vehicles: FrontendVehicle[]` / `.riders: FrontendRider[]` already produced by PR-A.
+- `mergedBikeActiveRiderById: Map<string, string>` and `mergedRiderInfoById: Map<string, { name; phone }>` — types match `OverviewMapSearch`'s optional props.
+- `OverviewKpiTilesProps` (Task 4) takes 6 numeric fields, all already computed in `page.tsx`.
+- `VIRTUAL_BIKE_PREFIX = "virtual-bike-"` matches the prefix in `lib/services/virtual-fleet.ts:1` (PR-A) which writes `virtual-bike-${pad2(i)}`.
+
+**Scope** — single PR, 1 new file + 5 modified files, no backend changes.

--- a/docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
+++ b/docs/superpowers/specs/2026-05-25-osrm-road-routing-design.md
@@ -1,0 +1,216 @@
+# OSRM Road Routing (PR-C) Design
+
+## Goal
+
+PR-A/B 가 가상 20대 + 실제 차량을 지도에 올리고 표/KPI/검색까지 통합했다.
+이 PR-C 는 EN_ROUTE 중 차량 이동을 **직선 lerp → 실제 도로 경로(OSRM)**로
+교체하고, 지도 마커에 **배송 상태 레이블** (배정됨 / 배송 중 / 배송 완료) 을
+추가해 데모의 현실감을 완성한다.
+
+## Non-Goals
+
+- OSRM 자체 호스팅 — 공개 demo 서버 (`router.project-osrm.org`) 사용
+- EN_ROUTE 소요 시간 변경 — 300 초 고정 유지 (경로 모양만 OSRM)
+- 실제 배송 도메인 로직 — 시뮬레이션 전용
+- 마커 클릭 팝업 / 상세 다이얼로그 변경
+- BSS 마커 변경
+
+## Architecture
+
+### 새 모듈 `lib/services/osrm.ts`
+
+```ts
+/**
+ * OSRM public demo 서버에서 두 좌표 간 도로 경로를 fetch.
+ * 실패(네트워크 오류, timeout, rate limit) 시 빈 배열 반환 →
+ * 호출부는 null routeWaypoints 로 직선 lerp fallback.
+ */
+export async function fetchOsrmRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number }
+): Promise<ReadonlyArray<{ lat: number; lng: number }>> {
+  const url =
+    `https://router.project-osrm.org/route/v1/driving/` +
+    `${origin.lng},${origin.lat};${destination.lng},${destination.lat}` +
+    `?overview=full&geometries=geojson`;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return [];
+    const json = await res.json();
+    const coords: [number, number][] = json.routes?.[0]?.geometry?.coordinates ?? [];
+    // OSRM 좌표 순서: [lng, lat] → {lat, lng} 변환
+    return coords.map(([lng, lat]) => ({ lat, lng }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- `AbortSignal.timeout(5000)` — 5 초 내 응답 없으면 abort, 빈 배열 fallback
+- CORS: `router.project-osrm.org` 는 공개 CORS 허용
+
+### `SimulatedBikeState` 확장 (`lib/services/fleet-simulation.ts`)
+
+새 필드 추가:
+
+```ts
+routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
+```
+
+- `null` = 아직 OSRM 경로 없음 → 직선 lerp fallback
+- 배열 = OSRM 경유점 배열
+- ASSIGNED 진입 시 `null` 로 초기화 (이전 사이클 경로 클리어)
+- ARRIVED → IDLE 전환 시에도 `null` 로 초기화
+
+### `walkPolyline` 함수 (`lib/services/fleet-simulation.ts`)
+
+```ts
+/**
+ * 0..1 의 progress t 로 polyline 위 좌표 계산.
+ * N 개 waypoint → N-1 세그먼트를 시간 균등 분배.
+ * t=0 → waypoints[0], t=1 → waypoints[N-1].
+ */
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+```
+
+`advanceBikeState` EN_ROUTE 분기 변경:
+
+```ts
+// 기존
+position: lerpPosition(state.origin, state.destination, progress),
+
+// 변경
+position: state.routeWaypoints
+  ? walkPolyline(state.routeWaypoints, progress)
+  : lerpPosition(state.origin, state.destination, progress),
+```
+
+### OSRM fetch 트리거 (`FleetSimulationContext.tsx`)
+
+`pendingFetchesRef: React.MutableRefObject<Set<string>>` 를 컨텍스트 내에 추가.
+
+새 `useEffect` — `simulated` 변경을 감시해 ASSIGNED 상태이면서 `routeWaypoints === null` 이고 아직 fetch 중이지 않은 bike 를 발견하면 fetch 실행:
+
+```tsx
+const pendingFetchesRef = useRef<Set<string>>(new Set());
+
+useEffect(() => {
+  for (const [bikeId, state] of simulated) {
+    if (
+      state.phase === "ASSIGNED" &&
+      state.routeWaypoints === null &&
+      !pendingFetchesRef.current.has(bikeId)
+    ) {
+      pendingFetchesRef.current.add(bikeId);
+      fetchOsrmRoute(state.origin, state.destination!).then((waypoints) => {
+        pendingFetchesRef.current.delete(bikeId);
+        if (waypoints.length === 0) return; // fallback: null 유지 → 직선 lerp
+        setSimulated((prev) => {
+          const current = prev.get(bikeId);
+          // stale guard: bike 가 이미 IDLE 로 돌아갔으면 무시
+          if (!current || current.phase === "IDLE") return prev;
+          const next = new Map(prev);
+          next.set(bikeId, { ...current, routeWaypoints: waypoints });
+          return next;
+        });
+      });
+    }
+  }
+}, [simulated]);
+```
+
+- ASSIGNED 5 초 → OSRM 응답 보통 200–500 ms → EN_ROUTE 진입 전 경로 준비 완료
+- 응답 미도착 시 EN_ROUTE 진입 → 직선 이동 → route 도착 시 남은 구간부터 도로 경로 전환 (자연스러운 점진 교체)
+
+### 배송 상태 레이블 — 마커 overlay
+
+`useSimulatedBikePins` 훅이 `FrontendDashboardBikePin[]` 를 반환하는 대신
+클라이언트 전용 타입 `SimulatedBikePin` 을 반환하도록 확장:
+
+```ts
+// hooks/useSimulatedBikePins.ts (또는 현재 위치)
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  deliveryPhase: "IDLE" | "ASSIGNED" | "EN_ROUTE" | "ARRIVED" | null;
+};
+```
+
+`useSimulatedBikePins` 내부에서 `simulated.get(bikeId)?.phase` 를 읽어
+`deliveryPhase` 를 overlay. simulated 에 없으면 `null`.
+
+`MapShell` (또는 마커 렌더링 레이어) 에서 `deliveryPhase` 에 따라 마커 HTML
+에 배지 추가:
+
+| `deliveryPhase` | 배지 텍스트 | 색상 |
+|---|---|---|
+| `null` / `"IDLE"` | (없음) | — |
+| `"ASSIGNED"` | `배정됨` | 노란색 |
+| `"EN_ROUTE"` | `배송 중` | 파란색 |
+| `"ARRIVED"` | `배송 완료` | 초록색 |
+
+마커 HTML 구조 (현재 plate 라벨 아래에 배지 추가):
+```html
+<div class="bike-marker">
+  <div class="bike-marker__plate">99서0001</div>
+  <!-- deliveryPhase 가 ASSIGNED/EN_ROUTE/ARRIVED 일 때만 렌더 -->
+  <div class="bike-marker__badge bike-marker__badge--en-route">배송 중</div>
+</div>
+```
+
+마커 아이콘은 Naver Maps `naver.maps.Marker` 의 `icon.content` (HTML string)
+방식으로 교체하거나, 기존 방식에 맞게 적용. 현재 마커 렌더 방식을 먼저
+확인하고 최소 변경으로 적용.
+
+## 파일 구조
+
+| 경로 | 목적 | Action |
+|---|---|---|
+| `lib/services/osrm.ts` | OSRM fetch 순수 함수 | **Create** |
+| `lib/services/fleet-simulation.ts` | `routeWaypoints` 필드, `walkPolyline`, `advanceBikeState` 수정 | **Modify** |
+| `components/overview/FleetSimulationContext.tsx` | `pendingFetchesRef` + OSRM fetch `useEffect` | **Modify** |
+| `hooks/useSimulatedBikePins.ts` (위치 확인 필요) | `SimulatedBikePin` 타입, `deliveryPhase` overlay | **Modify** |
+| `components/dashboard/MapShell.tsx` | 마커 HTML에 배송 배지 추가 | **Modify** |
+| (CSS) | `.bike-marker__badge` 스타일 | **Modify** |
+
+## User-visible behavior
+
+- **fleet OFF**: 평소대로 — 마커 레이블 없음, 직선 이동
+- **데모 시작 → 차량 ASSIGNED**: 마커에 `배정됨` 배지 노출
+- **EN_ROUTE**: `배송 중` 배지 + 서울 도로망을 따라 이동 (직선 X)
+- **ARRIVED**: `배송 완료` 배지 + 차량 멈춤 (10초)
+- **IDLE**: 배지 사라짐, 다음 사이클 대기
+- **OSRM 실패**: 배지는 그대로, 이동만 직선 — 사용자가 차이를 느끼기 어려움
+
+## Error handling & edge cases
+
+- **OSRM 응답 5 초 초과**: abort → 빈 배열 → 직선 lerp fallback
+- **fetch 중 fleet 정지**: stale guard (`phase === "IDLE"` 체크) → 무시
+- **EN_ROUTE 진입 전 route 미도착**: 직선 이동 → route 도착 시 도로 경로로 점진 전환
+- **동일 bikeId 중복 fetch**: `pendingFetchesRef` Set 으로 방지
+- **가상 + 실제 차량 모두 적용**: `routeWaypoints` 로직은 bikeId prefix 무관하게 동작
+
+## Testing
+
+- `npm run typecheck`, `npm run lint` clean
+- 수동 smoke:
+  - 데모 시작 → 차량이 도로를 따라 이동하는지 확인
+  - 배지 ASSIGNED → 배송 중 → 배송 완료 → 사라짐 순서 확인
+  - 네트워크 탭에서 OSRM API 호출 확인
+  - 오프라인 모드 or OSRM 차단 시 직선 이동으로 graceful fallback 확인
+
+## Out-of-scope follow-ups
+
+- OSRM 자체 호스팅 / Kakao 지도 Directions API 교체
+- EN_ROUTE 소요 시간을 OSRM 실제 duration 으로 스케일
+- 경로 polyline 을 지도에 선으로 표시 (차량 이동 궤적 시각화)

--- a/docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
+++ b/docs/superpowers/specs/2026-05-25-virtual-fleet-tables-kpi-search-design.md
@@ -1,0 +1,160 @@
+# Virtual Fleet — Tables / KPI / Search Integration (PR-B) Design
+
+## Goal
+
+PR-A 가 데모 시작 시 20대 가상 차량 + 라이더를 생성하고 지도 마커로 노출
+했다. 이 PR-B 는 그 가상 데이터를 **표 / KPI 카드 / 검색** 까지 통합해
+데모 모드의 인상적 효과 (한 화면이 통째로 살아남) 를 완성한다. 도로
+polyline (OSRM) 은 별도 PR-C.
+
+## Non-Goals
+
+- OSRM 도로 보간 — PR-C
+- 가상 차량의 정비 / 보험 / 계약 / 교육 정보 — 표에 "—" 로 비워둠. 운영
+  자가 한눈에 가상으로 식별 가능 + 가짜 데이터를 늘리는 부담 없음.
+- KPI "보험 차량" 카운트에 가상 fleet 반영 — 가상 라이더는 보험 미가입
+  이므로 어차피 0 기여
+- 매칭 / 계약 탭의 가상 노출 — 데모 핵심 동선이 아님
+- 가상 데이터를 실제 backend 에 보내는 동작 — 가상 차량 행에서 수정/
+  삭제 버튼은 disable 또는 silent no-op
+
+## Architecture
+
+### 데이터 통합 패턴 — 클라이언트 overlay 일관 적용
+
+기존에 `useSimulatedBikePins` / `useSimulatedCurrentTelemetry` 가 deterministic
+dummy 위에 시뮬레이션을 overlay 한 패턴 그대로. 이 PR 은 가상 fleet 의
+다른 필드들을 같은 패턴으로 overlay:
+
+- 차량 표 데이터: `data.vehicles` ⊕ `virtualFleet.vehicles`
+- 라이더 표 데이터: `data.riders` ⊕ `virtualFleet.riders`
+- bike → rider 매핑: `bikeActiveRiderById` ⊕ `virtualFleet.bikeActiveRiderById`
+- rider 조회: `riderInfoById` ⊕ `virtualFleet.riderInfoById`
+- KPI 카운트: 서버 SSR 값 + 가상 fleet 보정
+
+### Panel 단의 표 데이터 merge
+
+`VehiclesPanel` 과 `RidersPanel` 이 각자:
+```tsx
+const { virtualFleet } = useFleetSimulation();
+const effectiveVehicles = useMemo(() => {
+  if (!virtualFleet) return data.vehicles;
+  return [...data.vehicles, ...virtualFleet.vehicles];
+}, [data.vehicles, virtualFleet]);
+// existing filter / row 렌더링은 effectiveVehicles 사용
+```
+
+기존 `applyVehicleFilters` / `applyRiderFilters` 헬퍼가 받는 데이터만
+바꾸면 됨 — 필터 동작은 그대로 작동.
+
+### KPI 카드 — 새 클라이언트 컴포넌트로 분리
+
+현재 `app/page.tsx` (server component) 가 `summary.totalBikes`,
+`ignitionOnCount`, `insuredVehicleCount`, `totalRiders`,
+`subscriptionRiderCount`, `rentalRiderCount` 6 개를 직접 JSX 로 렌더.
+SSR 이라 fleet 상태를 못 봄.
+
+해결: 새 `OverviewKpiTiles` client 컴포넌트로 추출.
+- props: 서버에서 계산한 6 개 base count
+- 내부에서 `useFleetSimulation()` 로 `virtualFleet` + `simulated` 읽음
+- 그 위에 보정 값 계산:
+  - 전체 차량: `summary.totalBikes + (virtualFleet ? 20 : 0)`
+  - 시동 차량: server base + `Array.from(simulated.values()).filter(s => s.ignitionStatus === "ON" && s.bikeId.startsWith("virtual-bike-")).length`
+    - 가상 차량의 시동 ON 만 더함 — 실제 차량은 SSR base 가 이미 카운트함
+    - 실제 차량이 manual assign 으로 ON 인 경우는 카운팅 안 됨 (희소 케이스, 의도된 trade-off)
+  - 보험 차량: 그대로 (가상은 0 기여)
+  - 전체 라이더: `totalRiders + (virtualFleet ? 20 : 0)`
+  - 구독 인원 / 렌탈 인원: 가상은 둘 다 0 기여 (계약 분류 없음). 그대로.
+
+매 1초 tick 마다 시뮬레이션이 advance → context 변경 → 컴포넌트 재렌더 →
+시동 차량 카운트가 자연스럽게 갱신.
+
+### 검색 (OverviewMapSearch) — banner / fullscreen 에서 merge
+
+`OverviewMapSearch` 는 props 로 `bikePins`, `stationPins`,
+`bikeActiveRiderById`, `riderInfoById` 받음. PR-A 에서 bikePins 는 이미
+merge 되어 들어감. 이 PR 은 rider 쪽 두 Map 도 merge:
+
+```tsx
+// OverviewMapBanner / FullscreenMapHost 안에서
+const mergedBikeActiveRiderById = useMemo(() => {
+  if (!virtualFleet) return bikeActiveRiderById;
+  const m = new Map(bikeActiveRiderById ?? new Map());
+  for (const [k, v] of virtualFleet.bikeActiveRiderById) m.set(k, v);
+  return m;
+}, [bikeActiveRiderById, virtualFleet]);
+
+const mergedRiderInfoById = useMemo(() => {
+  if (!virtualFleet) return riderInfoById;
+  const m = new Map(riderInfoById ?? new Map());
+  for (const [k, v] of virtualFleet.riderInfoById) m.set(k, v);
+  return m;
+}, [riderInfoById, virtualFleet]);
+```
+
+`<OverviewMapSearch>` 에 merged 값을 전달 → 가상 plate `99서0001` 도 검색
+매칭, 가상 라이더 이름/연락처도 매칭.
+
+### 차량 표 가상 row 의 시각적 식별
+
+PR-A 의 sentinel pattern (`99서` plate, `데모 가상 N호기` 모델) 이 이미
+시각적으로 명확. 추가 배지 없이도 운영자가 분간 가능.
+
+행 클릭 시 `VehicleDetailDialog` 가 열리지만, 가상 차량은 maintenance
+fetch (`/api/overview/vehicle-maintenance/{bikeId}`) 가 backend 에서 404
+또는 빈 응답이 돌아옴 → 패널의 정비 섹션은 "정비 품목 없음" 으로 fallback.
+의도된 동작 (가상 데이터에 정비 이력 없음).
+
+라이더 표의 가상 row 도 행 클릭으로 `RiderDetailDialog` 가 열리되 본인
+정보 + 매칭 차량 plate 외 다른 필드는 비어 있음.
+
+### 가상 row 의 편집 / 삭제 차단
+
+차량 / 라이더 표 행에는 삭제 버튼이 있음 (`DeleteVehicleButton`,
+`DeleteRiderButton`). 가상 bikeId / riderId 가 `virtual-*` prefix 라 backend
+에 보내면 404. 이 PR 에선 버튼을 그냥 두고 (운영자가 클릭해도 toast 로
+실패 안내) — sentinel prefix 검사로 silent disable 하지 않음. 데모 중
+삭제 시도는 흔치 않은 시나리오.
+
+(차후 개선 여지: 가상 row 에 삭제 버튼 hidden / disabled 처리 — 이 PR
+범위 밖.)
+
+## User-visible behavior
+
+- 페이지 진입 (데모 OFF): 평소대로 — 차량 표 2 행, 라이더 표 1 행, KPI
+  실제 값
+- `[데모 시작]` 클릭:
+  - 즉시 KPI "전체 차량" 2 → 22, "전체 라이더" 1 → 21
+  - 차량 표가 22 행으로 확장 (`99서0001`~`99서0020` 추가)
+  - 라이더 표가 21 행으로 확장 (가상 라이더 20명 추가)
+  - 검색 인풋에 `99서0005` 또는 가상 라이더 이름 (`김민수` 등) 타이핑 → 매칭 노출, 클릭 시 지도 자동 이동
+  - 매 초 시동 차량 카운트가 시뮬레이션 진행에 따라 갱신 (가상 차량들이
+    staggered 로 EN_ROUTE 진입할 때마다 +1, ARRIVED → IDLE 시 -1)
+- `[데모 정지]`:
+  - KPI / 표 / 검색 모두 원상 복구
+
+## Error handling & edge cases
+
+- **가상 row 클릭 → detail 다이얼로그 열림 → 정비/계약/보험 빈 상태**:
+  의도된 동작. 패널 내부 fallback 메시지가 이미 처리.
+- **가상 row 삭제 버튼 클릭**: backend 가 404 반환, server action 의 catch
+  분기가 redirect 로 silent fail. 운영자는 데모 모드라 무시.
+- **데모 시작/정지 사이 빠른 토글**: 각 토글마다 새 deterministic seed 가
+  같으므로 같은 결과. 표 / KPI 즉시 반영.
+- **표 필터로 가상 차량 검색**: `99서` 로 검색하면 가상 20대만, `123마`
+  같은 실제 plate 로 검색하면 실제 1대만. 필터 helper 가 추출되어 있어
+  자연스럽게 작동.
+- **소트**: 차량 표 / 라이더 표가 기본 정렬을 갖는다면 가상 row 가 정렬
+  키에 따라 적당한 위치에 삽입됨. 별도 처리 없음.
+
+## Testing
+
+- `npm run typecheck`, `npm run lint` clean
+- 수동 smoke 체크리스트 (PR body 에 옮김)
+
+## Out-of-scope follow-ups
+
+- 가상 row 의 삭제 / 편집 버튼 hidden 처리
+- 가상 차량에 maintenance / contract / insurance 가짜 데이터 첨가
+- 매칭 / 계약 / 정비 catalog 탭에 가상 노출
+- PR-C: OSRM 도로 polyline 보간


### PR DESCRIPTION
## Summary

가상 플릿 데모 시리즈 PR-B + PR-C: 차량 시뮬레이션 데이터를 테이블/KPI/검색에 통합하고, EN_ROUTE 이동을 실제 도로 경로로 교체하며, 배송 상태 배지를 마커에 추가.

### PR-B — Virtual fleet tables / KPI / search (#307)
- 차량·라이더 관리 테이블에 가상 차량 20대 + 라이더 행 추가 (데모 실행 중)
- KPI 카드에 가상 시동 온 차량 수 반영
- 지도 검색에 가상 차량·라이더 포함

### PR-C — OSRM road routing + delivery badges (#308)
- EN_ROUTE 이동이 직선 lerp → OSRM 실제 서울 도로 경로로 교체
- 지도 마커에 배송 상태 배지: 배정됨(노랑) → 배송 중(파랑) → 배송 완료(초록)
- OSRM 실패 시 직선 fallback (graceful degradation)
- unmount-safe async fetch 패턴 적용

## Architecture
- `lib/services/osrm.ts`: OSRM fetch 순수 함수 (5초 timeout)
- `SimulatedBikeState.routeWaypoints`: 경유점 배열 | null
- `FleetSimulationContext`: ASSIGNED 감지 → async OSRM fetch → state 주입
- `useSimulatedBikePins`: `SimulatedBikePin` 타입, `deliveryPhase` overlay
- `MapShell`: `deliveryBadgeMarkup` + `bikeMarkerHtml` 확장

## Test plan
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [ ] 데모 시작 → OSRM API 호출 확인 (Network 탭)
- [ ] 차량이 서울 도로를 따라 이동
- [ ] 배정됨 → 배송 중 → 배송 완료 배지 순서 확인
- [ ] OSRM 차단 시 직선 fallback 정상 작동
- [ ] 데모 정지 → 배지 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)