### PR TITLE
Fix: 데모 정지 후 시동 차량 KPI 즉시 복귀 안 되는 버그

### DIFF
--- a/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
+++ b/development/front-admin-web/components/overview/OverviewKpiTiles.tsx
@@ -40,6 +40,9 @@ export function OverviewKpiTiles({
   const { virtualFleet, simulated } = useFleetSimulation();
 
   const virtualIgnitionOn = useMemo(() => {
+    // virtualFleet 이 null 이면 fleet 정지 — simulated 에 잔류 entry 가 있어도
+    // 즉시 0 으로 복귀. totalBikesEffective / totalRidersEffective 와 같은 패턴.
+    if (!virtualFleet) return 0;
     let n = 0;
     for (const state of simulated.values()) {
       if (state.ignitionStatus === "ON" && state.bikeId.startsWith(VIRTUAL_BIKE_PREFIX)) {
@@ -47,7 +50,7 @@ export function OverviewKpiTiles({
       }
     }
     return n;
-  }, [simulated]);
+  }, [virtualFleet, simulated]);
 
   const totalBikesEffective = totalBikes + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);
   const totalRidersEffective = totalRiders + (virtualFleet ? VIRTUAL_FLEET_COUNT : 0);


### PR DESCRIPTION
## Summary
- 데모 정지 직후 `시동 차량` KPI가 이전 값으로 수초간 잔류하는 버그 수정 (#310)

## 원인 및 수정
`virtualFleet`은 데모 정지 시 즉시 `null`로 청소되지만, `simulated` 맵은 각 bike가 IDLE에 도달할 때까지 entry를 유지한다. `virtualIgnitionOn` useMemo에 `virtualFleet` null-guard를 추가해 데모 정지 즉시 0으로 복귀하도록 수정.

## 변경 파일
- `components/overview/OverviewKpiTiles.tsx` — 3줄

## Test plan
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [ ] 데모 시작 → 시동 차량 증가 → 데모 정지 → 즉시 0으로 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)