### PR TITLE
fix: IMEI=-1 multi-vehicle simulation — deviceUid=-1 차량별 독립 device 생성

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -264,14 +264,25 @@ export async function updateVehicleFromOverviewAction(
         // 새 IMEI → 기존 device 가 있으면 재사용, 없으면 생성 후 부착.
         // backend 는 새 installation 생성 시 같은 bike 의 이전 active row 를
         // 자동으로 close 하므로 별도로 detach 호출할 필요 없음.
+        //
+        // 예외: deviceUid="-1" (가상 시뮬레이션 단말기) 는 여러 차량이 같은
+        // device 를 공유하면 backend 가 이전 차량의 installation 을 닫아버려
+        // 한 번에 한 대만 시뮬레이션되는 문제가 생긴다. 따라서 "-1" 은
+        // 항상 차량별 전용 device 를 새로 생성한다.
         let deviceId: string | null = null;
-        const devicePage = await client.listDevices({ page: 0, size: 200 });
-        const existing = devicePage.items.find((row) => row.deviceUid === nextDeviceUid);
-        if (existing) {
-          deviceId = existing.id;
-        } else {
+        if (nextDeviceUid === "-1") {
+          // 가상 시뮬레이션 단말기 — 차량마다 독립 device 생성 (공유 금지).
           const created = await client.createDevice({ deviceUid: nextDeviceUid, enabled: true });
           deviceId = created.id;
+        } else {
+          const devicePage = await client.listDevices({ page: 0, size: 200 });
+          const existing = devicePage.items.find((row) => row.deviceUid === nextDeviceUid);
+          if (existing) {
+            deviceId = existing.id;
+          } else {
+            const created = await client.createDevice({ deviceUid: nextDeviceUid, enabled: true });
+            deviceId = created.id;
+          }
         }
         await client.createBikeDeviceInstallation({
           bikeId: vehicleId,


### PR DESCRIPTION
## Summary

- IMEI=-1 차량에 단말기를 부착할 때 기존에 공유 device를 재사용하던 버그 수정
- 이전에는 deviceUid="-1"인 device를 모든 차량이 공유 → 백엔드가 이전 차량의 installation을 종료시킴 → 한 번에 1대만 IMEI=-1 활성화 가능했음
- 수정 후: deviceUid="-1"일 때는 항상 새 device 생성 → 각 차량이 독립적인 가상 단말기 보유
- 결과: 다수의 IMEI=-1 차량이 동시에 EN_ROUTE 시뮬레이션 가능

## Fleet simulation feature (PR #312 포함)

- FleetSimulationContext: props 기반 자동 트리거, 250ms tick
- fleet-simulation: 2-state machine (IDLE/EN_ROUTE)
- OSRM 경로 반영, KPI 시동 차량 카운트 연동

## Test plan

- [ ] 10대 차량에 IMEI=-1 설정
- [ ] 7대 라이더 매칭 → 지도에서 동시 "배송 중" 뱃지 + 이동 확인
- [ ] 비매칭 3대 → 정적 상태 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)