### PR TITLE
fix: 시뮬레이션 device uid 고유화 — 다중 차량 동시 시뮬레이션 지원

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -251,7 +251,12 @@ export async function updateVehicleFromOverviewAction(
     // IMEI 변경 처리는 위 두 호출이 성공한 다음에만 진행. 운영자가 IMEI 만
     // 바꾸려고 같은 plateNumber 를 다시 저장해도 멱등 — backend 가 동일 값
     // update 는 no-op 처리한다.
-    if (nextDeviceUid !== currentDeviceUid) {
+    // 시뮬레이션 device 감지: uid 가 "-1" 이거나 "-1-" 으로 시작하는 경우.
+    const currentIsSimDevice = currentDeviceUid === "-1" || currentDeviceUid.startsWith("-1-");
+    const nextIsSimDevice = nextDeviceUid === "-1";
+    // 운영자가 이미 시뮬레이션 device 인 차량에 "-1" 을 다시 입력해 저장하면 no-op.
+    // (currentDeviceUid="-1-abc" / nextDeviceUid="-1" 처럼 문자열이 달라도 동일 의미.)
+    if (!(currentIsSimDevice && nextIsSimDevice) && nextDeviceUid !== currentDeviceUid) {
       if (!nextDeviceUid) {
         // 비움 → 기존 installation 해제
         if (currentInstallationId) {
@@ -268,11 +273,15 @@ export async function updateVehicleFromOverviewAction(
         // 예외: deviceUid="-1" (가상 시뮬레이션 단말기) 는 여러 차량이 같은
         // device 를 공유하면 backend 가 이전 차량의 installation 을 닫아버려
         // 한 번에 한 대만 시뮬레이션되는 문제가 생긴다. 따라서 "-1" 은
-        // 항상 차량별 전용 device 를 새로 생성한다.
+        // vehicleId 를 포함한 고유 uid 로 차량별 독립 device 를 생성한다.
+        // (백엔드 deviceUid unique 제약을 피하면서도 "-1-" 접두사로 시뮬레이션 감지 유지.)
         let deviceId: string | null = null;
         if (nextDeviceUid === "-1") {
           // 가상 시뮬레이션 단말기 — 차량마다 독립 device 생성 (공유 금지).
-          const created = await client.createDevice({ deviceUid: nextDeviceUid, enabled: true });
+          // deviceUid 에 vehicleId prefix 를 붙여 백엔드 unique 제약 회피.
+          // 감지 로직은 "-1" 또는 "-1-" 으로 시작하는 uid 를 모두 시뮬레이션으로 인식.
+          const simUid = `-1-${vehicleId.replace(/-/g, "").slice(0, 8)}`;
+          const created = await client.createDevice({ deviceUid: simUid, enabled: true });
           deviceId = created.id;
         } else {
           const devicePage = await client.listDevices({ page: 0, size: 200 });

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -208,11 +208,12 @@ export default async function RootPage({
     (pin) => pin.ignitionStatus === "ON"
   ).length;
 
-  // IMEI=-1 차량 식별: deviceUid 가 문자열 "-1" 인 bikeId 만 추출.
-  // 실제 IMEI 는 15자리 숫자라서 "-1" 과 절대 겹치지 않음.
+  // IMEI=-1 차량 식별: deviceUid 가 "-1" 이거나 "-1-" 으로 시작하는 bikeId 를 추출.
+  // "-1-{prefix}" 형식은 차량별 독립 가상 단말기를 위해 고유하게 생성된 uid.
+  // 실제 IMEI 는 15자리 숫자라서 "-1" 패턴과 절대 겹치지 않음.
   const imeiMinusOneBikeIds: string[] = [];
   for (const [bikeId, uid] of deviceMap.deviceUidByBikeId) {
-    if (uid === "-1") imeiMinusOneBikeIds.push(bikeId);
+    if (uid === "-1" || uid.startsWith("-1-")) imeiMinusOneBikeIds.push(bikeId);
   }
 
   // 활성 라이더-차량 매칭을 직렬화 가능한 배열로 변환.


### PR DESCRIPTION
## 문제

- IMEI=-1 설정 시 모든 차량이 동일한 device (`deviceUid="-1"`)를 공유
- 백엔드가 deviceUid에 unique 제약 → 두 번째 vehicle부터 `createDevice` 409 에러
- 결과: 두 번째 차량부터 IMEI=-1 저장 실패 (`update-error`)

## 수정

- `actions.ts`: deviceUid="-1" 입력 시 `-1-{vehicleId 앞 8자}` 형식 고유 uid로 device 생성
- `page.tsx`: 시뮬레이션 감지를 `uid === "-1"` → `uid === "-1" || uid.startsWith("-1-")`로 확장
- 이미 시뮬레이션 device인 차량에 "-1" 재입력 시 no-op (불필요한 device 생성 방지)

## 기존 호환성

- 99가9999 (deviceUid="-1" 기존 vehicle) → 그대로 동작
- 신규 차량들 → `-1-abc12345` 형식 uid 생성, 시뮬레이션 감지 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)