### PR TITLE
fix: 시뮬레이션 tick 루프 stale closure + 지도 배송 중 배지

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -103,6 +103,10 @@ export function MapShell({
   const mapRef = useRef<NaverMapInstance | null>(null);
   const bikeMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
   const stationMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
+  /** bikeId → 마지막으로 마커를 만들 때 사용한 deliveryPhase. phase 가 바뀌면
+   *  marker 를 재생성해 배송 상태 배지 HTML 이 반영되도록 한다.
+   *  NCP setIcon 은 icon.content(HTML) 을 갱신하지 않아 배지 추가/제거가 안 됨. */
+  const prevDeliveryPhaseRef = useRef<Map<string, DeliveryPhase | null>>(new Map());
   const onBikeSelectRef = useRef(onBikeSelect);
   const onStationSelectRef = useRef(onStationSelect);
 
@@ -218,6 +222,7 @@ export function MapShell({
       for (const m of stationMarkerCacheRef.current.values()) m.setMap(null);
       bikeMarkerCacheRef.current.clear();
       stationMarkerCacheRef.current.clear();
+      prevDeliveryPhaseRef.current.clear();
     }
 
     const options: NaverMapOptions = {
@@ -413,6 +418,7 @@ export function MapShell({
     if (!map || !naver?.maps?.Marker) return;
 
     const cache = bikeMarkerCacheRef.current;
+    const prevPhases = prevDeliveryPhaseRef.current;
     const incomingIds = new Set<string>();
 
     const showLabel = currentZoom >= LABEL_VISIBLE_ZOOM;
@@ -426,11 +432,25 @@ export function MapShell({
         size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.bikeId);
-      if (existing) {
+      const currentPhase = pin.deliveryPhase ?? null;
+      const prevPhase = prevPhases.get(pin.bikeId) ?? null;
+
+      // NCP marker.setIcon() 은 icon.content(HTML) 을 실제로 갱신하지 않는다.
+      // deliveryPhase 가 바뀐 경우(배송 중 배지 추가/제거) 에만 마커를 재생성하고
+      // 나머지 tick 에는 setPosition + setIcon(위치·anchor 만 갱신) 으로 처리.
+      if (existing && prevPhase === currentPhase) {
         existing.setPosition?.(position);
         existing.setIcon?.(icon);
         continue;
       }
+
+      // deliveryPhase 변경 → 기존 마커 제거 후 새로 생성
+      if (existing) {
+        existing.setMap(null);
+        cache.delete(pin.bikeId);
+      }
+      prevPhases.set(pin.bikeId, currentPhase);
+
       const marker = new naver.maps.Marker({
         position,
         map,
@@ -450,6 +470,7 @@ export function MapShell({
       if (!incomingIds.has(bikeId)) {
         marker.setMap(null);
         cache.delete(bikeId);
+        prevPhases.delete(bikeId);
       }
     }
   }, [sdkReady, bikePins, mapVersion, currentZoom]);

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -115,13 +115,16 @@ export function FleetSimulationProvider({
     });
   }, [matchedImeiSet]);
 
-  // 250ms tick loop — simulated 에 entry 가 있는 동안만 실행.
+  // 250ms tick loop — mount 시 한 번만 interval 을 생성. simulated.size 를
+  // dep 으로 두면 size 변화 시점에 효과가 재실행되면서 stale closure 가 발생해
+  // "size === 0" 분기를 타는 경우가 있다. updater 패턴(prev) 으로 최신 상태를
+  // 항상 받으므로 closure 문제 없이 deps=[] 로 고정한다.
   useEffect(() => {
-    if (simulated.size === 0) return;
     const interval = window.setInterval(() => {
       const nowMs = Date.now();
       const currentMatched = matchedImeiSetRef.current;
       setSimulated((prev) => {
+        if (prev.size === 0) return prev; // entry 없으면 no-op (re-render 없음)
         let mutated = false;
         const next = new Map<string, SimulatedBikeState>();
         for (const [bikeId, state] of prev) {
@@ -143,7 +146,7 @@ export function FleetSimulationProvider({
       });
     }, TICK_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [simulated.size]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // EN_ROUTE + routeWaypoints 없음 → OSRM 경로 fetch.
   // (기존 ASSIGNED 조건에서 EN_ROUTE 로 변경 — 즉시 이동 시작, 경로 도착 후 반영)


### PR DESCRIPTION
## Summary

- **FleetSimulationContext**: 250ms tick `useEffect` 가 `[simulated.size]` dep 으로 인한 stale closure 경쟁 조건 수정. 효과가 `size===0` 인 시점에 실행되어 `setInterval` 생성 전에 early-return 하는 문제. 수정: deps를 `[]` 로 고정하고 `setSimulated` updater 내부에서 `prev.size===0` 체크 (항상 최신 state 접근).

- **MapShell**: NCP `marker.setIcon()` 이 `icon.content` (HTML) 을 실제로 갱신하지 않아 `deliveryPhase` 변경 시 "배송 중" 배지가 나타나지 않는 문제. 수정: `prevDeliveryPhaseRef` 로 이전 phase 를 추적하고, phase 가 바뀐 경우 마커를 재생성해 배지 HTML 이 처음부터 올바르게 포함되도록.

## Test plan

- [ ] 스테이징에서 IMEI=-1 차량 10대 모두 지도에 표시됨
- [ ] 배송 중인 차량 마커 아래 파란색 "배송 중" 뱃지 표시됨
- [ ] 차량 위치가 250ms 마다 부드럽게 이동함 (tick 루프 정상 동작)
- [ ] 대기 중 전환 시 뱃지 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)