### PR TITLE
chore/fix: fleet-simulation export 정리 + 시뮬레이션 사이클 분산

### DIFF
--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -6,6 +6,7 @@ import {
   advanceBikeState,
   makeInitialState,
   TICK_INTERVAL_MS,
+  EN_ROUTE_DURATION_MS,
   type SimulatedBikeState
 } from "@/lib/services/fleet-simulation";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
@@ -87,6 +88,9 @@ export function FleetSimulationProvider({
   });
 
   // 자동 트리거: matchedImeiSet 이 변경되면 새로 매칭된 bike 를 EN_ROUTE 로 시작.
+  // 여러 차량이 동시에 초기화될 때 모두 같은 nowMs 를 쓰면 5분 후 동시에 사이클이
+  // 끝나 "대기" 가 동시에 표시된다. 차량별로 0~5분 랜덤 오프셋을 주어 사이클을
+  // 처음부터 분산시킨다 — 마치 이미 서로 다른 시점에 출발한 것처럼 보임.
   useEffect(() => {
     const nowMs = Date.now();
     setSimulated((prev) => {
@@ -98,12 +102,15 @@ export function FleetSimulationProvider({
         const origin = pin
           ? { lat: pin.latitude, lng: pin.longitude }
           : { lat: 37.5665, lng: 126.978 }; // 서울 중심 fallback
+        // 차량마다 0~5분 사이 랜덤 진행률로 시작 — phaseStartedAt 을 과거로 당겨
+        // advanceBikeState 가 첫 tick 에 올바른 progress / position 을 계산.
+        const offsetMs = Math.random() * EN_ROUTE_DURATION_MS;
         next.set(
           bikeId,
           makeInitialState({
             bikeId,
             origin,
-            nowMs,
+            nowMs: nowMs - offsetMs,
             phase: "EN_ROUTE",
             initialBatteryPercent:
               typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -64,7 +64,7 @@ const SEOUL_LNG_MAX = 127.10;
 /**
  * 서울 박스 안 random 좌표. EN_ROUTE 의 destination 으로 사용.
  */
-export function randomSeoulPoint(random: () => number = Math.random): { lat: number; lng: number } {
+function randomSeoulPoint(random: () => number = Math.random): { lat: number; lng: number } {
   return {
     lat: SEOUL_LAT_MIN + random() * (SEOUL_LAT_MAX - SEOUL_LAT_MIN),
     lng: SEOUL_LNG_MIN + random() * (SEOUL_LNG_MAX - SEOUL_LNG_MIN)
@@ -72,14 +72,14 @@ export function randomSeoulPoint(random: () => number = Math.random): { lat: num
 }
 
 /** Haversine 대신 단순 평면 근사 — 데모 표시용, km 단위 오차 무방. */
-export function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
   const dLat = (b.lat - a.lat) * 111;
   const dLng = (b.lng - a.lng) * 88;
   return Math.sqrt(dLat * dLat + dLng * dLng);
 }
 
 /** lerp 보간 — t=0..1, from → to. clamp 포함. */
-export function lerpPosition(
+function lerpPosition(
   from: { lat: number; lng: number },
   to: { lat: number; lng: number },
   t: number


### PR DESCRIPTION
## Summary
- `fleet-simulation.ts` 내부 유틸 함수(`randomSeoulPoint`, `approxDistanceKm`, `lerpPosition`) 불필요한 `export` 제거 — 모듈 외부 노출 없음
- 여러 IMEI=-1 차량 초기화 시 동일 `nowMs` 를 쓰던 문제 수정: 차량마다 0~5분 랜덤 오프셋(`nowMs - Math.random() * EN_ROUTE_DURATION_MS`)을 적용해 사이클 분산 — 운영자 화면에서 여러 차량이 동시에 "배송 완료 → 대기" 로 전환되는 현상 해결

## Test plan
- [ ] IMEI=-1 + 라이더 매칭 차량 2대 이상 → 마커가 서로 다른 시점에 `배송 중` ↔ `대기` 전환되는지 확인
- [ ] `fleet-simulation` 내보내기 변경이 빌드를 깨지 않는지 확인 (`randomSeoulPoint` 등 외부 참조 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)