### PR TITLE
fix: trail 현재까지 이동한 구간만 표시 + EN_ROUTE 15~40분 랜덤 사이클

### DIFF
--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/overview/filter-compute";
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
+import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 import type {
@@ -96,14 +97,17 @@ export function VehiclesPanel({
   const [filters, setFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
   const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
+  // IMEI=-1 시뮬 차량의 ignitionStatus / 속도 / 배터리 등을 지도와 동일하게 overlay.
+  const overlaidBikePins = useSimulatedBikePins(bikePins ?? []);
+
   // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
-    for (const pin of bikePins ?? []) {
+    for (const pin of overlaidBikePins) {
       map.set(pin.bikeId, pin);
     }
     return map;
-  }, [bikePins]);
+  }, [overlaidBikePins]);
 
   // insurance_item id → 표시 라벨 사전. 보험 컬럼이 매 행마다 lookup 1회.
   const insuranceLabelById = useMemo(() => {

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -6,7 +6,7 @@ import {
   advanceBikeState,
   makeInitialState,
   TICK_INTERVAL_MS,
-  EN_ROUTE_DURATION_MS,
+  EN_ROUTE_DURATION_MAX_MS,
   type SimulatedBikeState
 } from "@/lib/services/fleet-simulation";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
@@ -104,7 +104,7 @@ export function FleetSimulationProvider({
           : { lat: 37.5665, lng: 126.978 }; // 서울 중심 fallback
         // 차량마다 0~5분 사이 랜덤 진행률로 시작 — phaseStartedAt 을 과거로 당겨
         // advanceBikeState 가 첫 tick 에 올바른 progress / position 을 계산.
-        const offsetMs = Math.random() * EN_ROUTE_DURATION_MS;
+        const offsetMs = Math.random() * EN_ROUTE_DURATION_MAX_MS;
         next.set(
           bikeId,
           makeInitialState({

--- a/development/front-admin-web/components/overview/use-trail-waypoints.ts
+++ b/development/front-admin-web/components/overview/use-trail-waypoints.ts
@@ -7,16 +7,50 @@ import { useFleetSimulation } from "@/components/overview/FleetSimulationContext
 export type TrailWaypoint = { lat: number; lng: number };
 
 /**
- * 선택된 차량의 이동 경로 waypoints 반환.
+ * progress(0~1) 기준으로 전체 polyline waypoints 중 이미 이동한 구간만 반환.
  *
- * - IMEI=-1 시뮬 차량: FleetSimulationContext 의 routeWaypoints (OSRM fetch 완료분).
- *   EN_ROUTE + routeWaypoints !== null + length >= 2 일 때만 반환.
- *   IDLE 이거나 OSRM fetch 아직 진행 중(routeWaypoints === null)이면 null.
+ * walkPolyline 과 동일한 세그먼트 분할 방식을 사용:
+ *   totalSegs = waypoints.length - 1
+ *   pos = progress * totalSegs → segIndex(정수) + segT(소수)
+ *
+ * 반환값: [wp[0] .. wp[segIndex]] + 보간된 현재 위치
+ * progress ≈ 0 이면 waypoints 1개 → MapShell 이 length < 2 guard 로 선 미표시.
+ */
+function traveledWaypoints(
+  waypoints: ReadonlyArray<TrailWaypoint>,
+  progress: number
+): ReadonlyArray<TrailWaypoint> {
+  if (waypoints.length < 2) return waypoints;
+  const clamped = Math.max(0, Math.min(1, progress));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+
+  const traveled: TrailWaypoint[] = waypoints.slice(0, segIndex + 1) as TrailWaypoint[];
+
+  // 세그먼트 중간 지점이면 보간 좌표를 끝점으로 추가
+  if (segT > 0) {
+    const from = waypoints[segIndex];
+    const to = waypoints[segIndex + 1];
+    traveled.push({
+      lat: from.lat + (to.lat - from.lat) * segT,
+      lng: from.lng + (to.lng - from.lng) * segT
+    });
+  }
+
+  return traveled;
+}
+
+/**
+ * 선택된 차량의 **현재까지 이동한** 경로 waypoints 반환.
+ *
+ * - IMEI=-1 시뮬 차량: OSRM routeWaypoints 를 progress 로 슬라이스.
+ *   EN_ROUTE + routeWaypoints 있을 때만 반환. IDLE / fetch 중이면 null.
  * - 실제 차량: null (백엔드 API 완성 후 fetchBikeLocationHistory 로 교체).
  * - selectedBikeId === null → null.
  *
- * OSRM fetch 가 완료되면 simulated Map 이 갱신 → 이 훅이 재계산 → MapShell 이
- * Polyline 을 자동으로 표시한다. 별도 polling 불필요.
+ * 250ms tick 마다 simulated 가 갱신 → 훅 재계산 → MapShell Polyline 자동 연장.
  */
 export function useTrailWaypoints(
   selectedBikeId: string | null
@@ -34,7 +68,7 @@ export function useTrailWaypoints(
         sim.routeWaypoints !== null &&
         sim.routeWaypoints.length >= 2
       ) {
-        return sim.routeWaypoints;
+        return traveledWaypoints(sim.routeWaypoints, sim.progress);
       }
       return null;
     }

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -45,8 +45,10 @@ export type SimulatedBikeState = {
 
 /** tick 간격 (ms). 250ms = 초당 4회 업데이트. */
 export const TICK_INTERVAL_MS = 250;
-/** 배송 한 주기 길이 (5분). */
-export const EN_ROUTE_DURATION_MS = 5 * 60 * 1_000;
+/** 배송 한 주기 최소 길이 (15분). */
+export const EN_ROUTE_DURATION_MIN_MS = 15 * 60 * 1_000;
+/** 배송 한 주기 최대 길이 (40분). */
+export const EN_ROUTE_DURATION_MAX_MS = 40 * 60 * 1_000;
 /** 배송 완료 후 다음 사이클까지 최소 대기 (ms). */
 export const IDLE_BETWEEN_DELIVERIES_MIN_MS = 5_000;
 /** 배송 완료 후 다음 사이클까지 최대 대기 (ms). */
@@ -60,6 +62,17 @@ const SEOUL_LAT_MIN = 37.44;
 const SEOUL_LAT_MAX = 37.65;
 const SEOUL_LNG_MIN = 126.87;
 const SEOUL_LNG_MAX = 127.10;
+
+/**
+ * 15~40분 사이 랜덤 EN_ROUTE 주기 길이(ms).
+ * 차량마다 매 사이클 독립적으로 뽑아 실제 배송처럼 각자 다른 시간 소요.
+ */
+function randomEnRouteDurationMs(random: () => number): number {
+  return (
+    EN_ROUTE_DURATION_MIN_MS +
+    random() * (EN_ROUTE_DURATION_MAX_MS - EN_ROUTE_DURATION_MIN_MS)
+  );
+}
 
 /**
  * 서울 박스 안 random 좌표. EN_ROUTE 의 destination 으로 사용.
@@ -135,7 +148,7 @@ export function advanceBikeState(
       ? walkPolyline(prev.routeWaypoints, progress)
       : lerpPosition(prev.origin, prev.destination, progress);
     const distanceKm = approxDistanceKm(prev.origin, prev.destination);
-    const totalSeconds = EN_ROUTE_DURATION_MS / 1_000;
+    const totalSeconds = total / 1_000; // 차량마다 다른 실제 phase 길이 사용
     // 250ms tick 기준 delta: (초당 변화량) × (tick_ms / 1000)
     const tickFactor = TICK_INTERVAL_MS / 1_000;
     const odometerDelta = totalSeconds > 0 ? (distanceKm / totalSeconds) * tickFactor : 0;
@@ -164,7 +177,7 @@ export function advanceBikeState(
         progress: 0,
         position: prev.origin,
         phaseStartedAt: nowMs,
-        phaseEndsAt: nowMs + EN_ROUTE_DURATION_MS,
+        phaseEndsAt: nowMs + randomEnRouteDurationMs(random),
         speedKph: EN_ROUTE_SPEED_KPH,
         ignitionStatus: "ON",
         routeWaypoints: null
@@ -229,7 +242,7 @@ export function makeInitialState(input: {
       progress: 0,
       position: origin,
       phaseStartedAt: nowMs,
-      phaseEndsAt: nowMs + EN_ROUTE_DURATION_MS,
+      phaseEndsAt: nowMs + randomEnRouteDurationMs(random),
       speedKph: EN_ROUTE_SPEED_KPH,
       ignitionStatus: "ON",
       odometerKm: initialOdometerKm,


### PR DESCRIPTION
## Summary

- **Trail progress 슬라이스**: PR #320 배포 후 발견된 버그 수정 — 전체 경로(미래 구간 포함) 대신 `sim.progress` 기준 현재까지 이동한 구간만 polyline으로 표시. `traveledWaypoints()` 함수가 `walkPolyline`과 동일한 세그먼트 분할 방식으로 슬라이스 + 현재 위치를 끝점에 보간 추가.
- **EN_ROUTE 사이클 길이**: 고정 5분 → 15~40분 사이 랜덤으로 변경. 차량마다 매 사이클 독립적으로 duration을 뽑아 실제 배송처럼 각자 다른 시간 소요.

## Test plan

- [ ] IMEI=-1 매칭 차량 클릭 → trail이 마커 현재 위치까지만 표시되는지 확인 (목적지까지 전체 선이 아님)
- [ ] 250ms tick마다 trail 끝점이 마커 위치와 함께 점진적으로 연장되는지 확인
- [ ] EN_ROUTE 사이클이 15분 이상 지속되는지 확인 (이전 5분 고정 대비)
- [ ] 패널 닫기 → trail 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)