### PR TITLE
fix: trail 깜빡임·토글·KPI 이중카운팅·삭제 버튼 수정

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -132,9 +132,16 @@ export async function deleteVehicleFromOverviewAction(vehicleId: string): Promis
     redirect("/login?status=session-required");
   }
 
+  // redirect() 는 try/catch 블록 안에서 호출하면 Next.js 런타임이 NEXT_REDIRECT
+  // 에러를 올바르게 처리하지 못할 수 있어 flag 패턴으로 분리.
+  let failed = false;
   try {
     await client.deleteVehicle(vehicleId);
   } catch {
+    failed = true;
+  }
+
+  if (failed) {
     redirect("/?tab=vehicles&status=delete-error");
   }
 

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -389,6 +389,7 @@ textarea { padding-top: 10px; min-height: 96px; }
 /* 루트 페이지 vehicles 패널 — 10컬럼 단순 구조. 검색 한 줄 + 운영 상태 select
    하나 + 카운트만. 색 토큰은 우리 `--rm-*` 그대로. */
 .vehicles-panel { display: flex; flex-direction: column; gap: 12px; }
+.panel-error-banner { margin: 0; padding: 10px 14px; border-radius: 8px; background: #fef2f2; border: 1px solid #fca5a5; color: #b91c1c; font-size: 13px; font-weight: 500; }
 .vehicles-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; padding: 10px 0; }
 .vehicles-filter-search-wrap { position: relative; flex: 0 1 280px; min-width: 220px; }
 .vehicles-filter-search { width: 100%; height: 38px; padding: 0 36px 0 12px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-surface); color: var(--color-text-primary); font-size: 13px; font-family: inherit; }

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -214,15 +214,14 @@ export default async function RootPage({
     }
   }
 
-  // 시동 차량 = telemetry ignition_status === "ON". The dashboard summary
-  // does not aggregate this yet, so we count it from the bike pin list
-  // (which carries `ignitionStatus` per pin). UNKNOWN / OFF are excluded.
-  // IMEI=-1 차량은 실제 텔레메트리가 없어 서버가 ON 을 반환해도 신뢰 불가.
-  // OverviewKpiTiles 가 시뮬 EN_ROUTE 를 별도로 더하므로 여기서 제외해야
-  // 이중 카운팅이 발생하지 않는다.
-  const ignitionOnCount = mapState.data.bikePins.filter(
-    (pin) => pin.ignitionStatus === "ON" && !imeiMinusOneSet.has(pin.bikeId)
-  ).length;
+  // 시동 차량(실제 차량분) — API 연동 완료 후 실 텔레메트리 값으로 채움.
+  // 현재는 API 미연동 상태라 실제 차량의 ignitionStatus 신뢰 불가 → 0 고정.
+  // IMEI=-1 차량은 OverviewKpiTiles 가 simulatedIgnitionOn 으로 별도 카운트.
+  // TODO: API 연동 후 아래 값을 실 텔레메트리 기반으로 교체.
+  //   const ignitionOnCount = mapState.data.bikePins.filter(
+  //     (pin) => pin.ignitionStatus === "ON" && !imeiMinusOneSet.has(pin.bikeId)
+  //   ).length;
+  const ignitionOnCount = 0;
 
   // 활성 라이더-차량 매칭을 직렬화 가능한 배열로 변환.
   // RSC → client component JSON boundary 를 넘기 위해 배열로.
@@ -284,6 +283,7 @@ export default async function RootPage({
                 insuranceOptions={insuranceOptions}
                 ignitionBlockedByBikeId={ignitionBlockedByBikeId}
                 maintenanceSummaryByBike={maintenanceSummaryByBike}
+                statusParam={statusParam}
               />
             ),
             notice: vehicleData.notice

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -201,20 +201,28 @@ export default async function RootPage({
     bikeEngineTypeById
   );
 
-  // 시동 차량 = telemetry ignition_status === "ON". The dashboard summary
-  // does not aggregate this yet, so we count it from the bike pin list
-  // (which carries `ignitionStatus` per pin). UNKNOWN / OFF are excluded.
-  const ignitionOnCount = mapState.data.bikePins.filter(
-    (pin) => pin.ignitionStatus === "ON"
-  ).length;
-
   // IMEI=-1 차량 식별: deviceUid 가 "-1" 이거나 "-1-" 으로 시작하는 bikeId 를 추출.
   // "-1-{prefix}" 형식은 차량별 독립 가상 단말기를 위해 고유하게 생성된 uid.
   // 실제 IMEI 는 15자리 숫자라서 "-1" 패턴과 절대 겹치지 않음.
+  // ▶ ignitionOnCount 보다 먼저 계산 — 이중 카운팅 방지를 위한 필터에 사용.
   const imeiMinusOneBikeIds: string[] = [];
+  const imeiMinusOneSet = new Set<string>();
   for (const [bikeId, uid] of deviceMap.deviceUidByBikeId) {
-    if (uid === "-1" || uid.startsWith("-1-")) imeiMinusOneBikeIds.push(bikeId);
+    if (uid === "-1" || uid.startsWith("-1-")) {
+      imeiMinusOneBikeIds.push(bikeId);
+      imeiMinusOneSet.add(bikeId);
+    }
   }
+
+  // 시동 차량 = telemetry ignition_status === "ON". The dashboard summary
+  // does not aggregate this yet, so we count it from the bike pin list
+  // (which carries `ignitionStatus` per pin). UNKNOWN / OFF are excluded.
+  // IMEI=-1 차량은 실제 텔레메트리가 없어 서버가 ON 을 반환해도 신뢰 불가.
+  // OverviewKpiTiles 가 시뮬 EN_ROUTE 를 별도로 더하므로 여기서 제외해야
+  // 이중 카운팅이 발생하지 않는다.
+  const ignitionOnCount = mapState.data.bikePins.filter(
+    (pin) => pin.ignitionStatus === "ON" && !imeiMinusOneSet.has(pin.bikeId)
+  ).length;
 
   // 활성 라이더-차량 매칭을 직렬화 가능한 배열로 변환.
   // RSC → client component JSON boundary 를 넘기 위해 배열로.

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -539,24 +539,20 @@ export function MapShell({
     }
   }, [sdkReady, stationPins, mapVersion, currentZoom]);
 
-  // 경로 trail Polyline — trailWaypoints 가 바뀔 때마다 재생성.
-  // mapVersion dep 으로 테마 토글(NCP map 재생성) 시 새 map 에 재부착.
+  // 경로 trail Polyline — 두 effect 로 분리해 깜빡임 방지.
+  //
+  // [Lifecycle effect] Polyline 인스턴스 생성/삭제.
+  //   sdkReady / mapVersion 변경 시에만 실행 → 250ms tick 에는 반응 안 함.
+  //   path / map 첨부는 아래 path-update effect 에서 담당.
   useEffect(() => {
     if (!sdkReady) return;
     const map = mapRef.current;
     const naver = typeof window !== "undefined" ? window.naver : undefined;
     if (!map || !naver?.maps?.Polyline) return;
 
-    // 이전 Polyline 제거 — waypoints 변경 시 항상 먼저 정리
-    trailPolylineRef.current?.setMap(null);
-    trailPolylineRef.current = null;
-
-    if (!trailWaypoints || trailWaypoints.length < 2) return;
-
-    const path = trailWaypoints.map((wp) => new naver.maps.LatLng(wp.lat, wp.lng));
     const polyline = new naver.maps.Polyline({
-      map,
-      path,
+      map: null, // path-update effect 가 조건부로 attach
+      path: [],
       strokeColor: "#3b82f6",
       strokeWeight: 4,
       strokeOpacity: 0.85,
@@ -570,6 +566,26 @@ export function MapShell({
         trailPolylineRef.current = null;
       }
     };
+  }, [sdkReady, mapVersion]);
+
+  // [Path-update effect] setPath() 만 호출 — Polyline 재생성 없음.
+  //   trailWaypoints 가 250ms tick 마다 새 참조로 바뀌어도 깜빡이지 않는다.
+  //   lifecycle effect 가 먼저 실행되므로 같은 render cycle 내에서도
+  //   trailPolylineRef.current 는 항상 최신 인스턴스를 가리킨다.
+  useEffect(() => {
+    const polyline = trailPolylineRef.current;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!polyline || !map || !naver?.maps?.LatLng) return;
+
+    if (!trailWaypoints || trailWaypoints.length < 2) {
+      polyline.setMap(null);
+      return;
+    }
+
+    const path = trailWaypoints.map((wp) => new naver.maps.LatLng(wp.lat, wp.lng));
+    polyline.setPath?.(path);
+    polyline.setMap(map);
   }, [sdkReady, trailWaypoints, mapVersion]);
 
   if (!NCP_CLIENT_ID) {

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -72,7 +72,8 @@ export function VehiclesPanel({
   riderActiveInsuranceByRiderId,
   insuranceOptions,
   ignitionBlockedByBikeId,
-  maintenanceSummaryByBike
+  maintenanceSummaryByBike,
+  statusParam
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
@@ -93,6 +94,8 @@ export function VehiclesPanel({
   ignitionBlockedByBikeId?: Map<string, boolean>;
   /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
   maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
+  /** server action 결과 status. "delete-error" 이면 삭제 실패 배너 표시. */
+  statusParam?: string | null;
 }) {
   const [filters, setFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
   const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
@@ -160,6 +163,11 @@ export function VehiclesPanel({
 
   return (
     <div className="vehicles-panel">
+      {statusParam === "delete-error" && (
+        <p role="alert" className="panel-error-banner">
+          차량 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      )}
       {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <VehicleFilterControls
         filters={filters}


### PR DESCRIPTION
## Summary

- **Trail Polyline 깜빡임 + 지도 보기 토글 불가** (`35a6e09`): Polyline effect를 lifecycle / path-update 두 개로 분리. 250ms tick마다 `setMap(null)` + 재생성하던 것을 `setPath()` in-place 갱신으로 변경해 깜빡임 제거 및 NCP 맵 상태 충돌 해소.
- **KPI 시동 차량 이중 카운팅** (`097ac62`): `ignitionOnCount`(SSR)와 `simulatedIgnitionOn`(클라이언트)이 같은 IMEI=-1 차량을 중복 카운트하던 문제 수정. IMEI=-1을 SSR 카운트에서 제외.
- **KPI 시동 차량 + 삭제 버튼** (`0bb4f4a`):
  - API 미연동 상태에서 실 차량 `ignitionOnCount=0` 고정 (IMEI=-1 시뮬만 카운트).
  - `redirect()`를 try/catch 밖으로 이동 (Next.js 권고) → 삭제 요청이 묵살되던 문제 수정.
  - 삭제 실패 시 오류 배너 표시.

## Test plan

- [ ] 시뮬 차량 클릭 → trail 선이 깜빡이지 않고 부드럽게 연장되는지 확인
- [ ] trail 표시 상태에서 지도 보기 토글이 정상 동작하는지 확인
- [ ] KPI "시동 차량" ≤ "전체 차량" 항상 성립하는지 확인
- [ ] 차량 삭제 버튼 → 확인 → 삭제 처리 또는 오류 배너 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)