### PR TITLE
fix: 삭제 실패 원인 진단 — HTTP 상태 코드 URL 인코딩 + 원인별 메시지

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -8,7 +8,8 @@ import {
   type ServiceOpsBikeOperationStatus,
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
-  serviceOpsApiConfigured
+  serviceOpsApiConfigured,
+  ServiceOpsApiError
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 import { geocodeAddress } from "@/lib/services/ncp-geocoder";
@@ -134,15 +135,17 @@ export async function deleteVehicleFromOverviewAction(vehicleId: string): Promis
 
   // redirect() 는 try/catch 블록 안에서 호출하면 Next.js 런타임이 NEXT_REDIRECT
   // 에러를 올바르게 처리하지 못할 수 있어 flag 패턴으로 분리.
-  let failed = false;
+  // httpStatus 를 URL 에 실어 운영자/개발자가 원인을 즉시 파악할 수 있게 함.
+  let deleteErrorStatus: number | null = null;
   try {
     await client.deleteVehicle(vehicleId);
-  } catch {
-    failed = true;
+  } catch (err) {
+    deleteErrorStatus = err instanceof ServiceOpsApiError ? err.status : -1;
   }
 
-  if (failed) {
-    redirect("/?tab=vehicles&status=delete-error");
+  if (deleteErrorStatus !== null) {
+    // status 값에 HTTP 상태 코드를 인코딩 — 원인 진단용 (409=활성 매칭 등).
+    redirect(`/?tab=vehicles&status=delete-error-${deleteErrorStatus}`);
   }
 
   revalidatePath("/");

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -163,9 +163,13 @@ export function VehiclesPanel({
 
   return (
     <div className="vehicles-panel">
-      {statusParam === "delete-error" && (
+      {statusParam?.startsWith("delete-error") && (
         <p role="alert" className="panel-error-banner">
-          차량 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.
+          {statusParam === "delete-error-409"
+            ? "차량 삭제에 실패했습니다. 활성 라이더 매칭이 있는 차량은 먼저 매칭을 해제해 주세요."
+            : statusParam === "delete-error-403"
+              ? "차량 삭제 권한이 없습니다."
+              : `차량 삭제에 실패했습니다. (${statusParam}) 잠시 후 다시 시도해 주세요.`}
         </p>
       )}
       {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}


### PR DESCRIPTION
## Summary

- 삭제 실패 시 백엔드 HTTP 상태 코드를 `status=delete-error-{code}` 형태로 URL에 포함해 원인 즉시 파악 가능
- VehiclesPanel에서 코드별 메시지 표시:
  - `409` → "활성 라이더 매칭이 있는 차량은 먼저 매칭을 해제해 주세요"
  - `403` → "차량 삭제 권한이 없습니다"
  - 그 외 → HTTP 코드 포함한 일반 오류 메시지

## Test plan

- [ ] 차량 삭제 시도 → URL에 `status=delete-error-{코드}` 확인
- [ ] 409 응답 시 매칭 해제 안내 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)