### PR TITLE
feat: 차량 서비스 유형(배송/클리닝/기타) 분류 + 필터

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -299,7 +299,7 @@ export async function updateVehicleFromOverviewAction(
   const nextStatus = String(formData.get("operationStatus") ?? "") as ServiceOpsBikeOperationStatus;
   const currentStatus = String(formData.get("currentOperationStatus") ?? "") as ServiceOpsBikeOperationStatus;
   const engineType = parseEngineType(formData.get("engineType"));
-  const serviceType = String(formData.get("serviceType") ?? "").trim() || undefined;
+  const serviceType = parseServiceType(formData.get("serviceType"));
   // 단말기(IMEI) 변경 의도는 세 가지 값으로 표현:
   //   - 새 IMEI 값 (string) → set / change
   //   - 빈 문자열 + currentInstallationId 가 있음 → 기존 부착 해제
@@ -317,7 +317,7 @@ export async function updateVehicleFromOverviewAction(
       plateNumber: requiredText(formData.get("plateNumber")),
       modelName: optionalText(formData.get("modelName")),
       engineType,
-      serviceType: serviceType as ServiceOpsBikeServiceType | undefined
+      serviceType
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {
@@ -820,6 +820,13 @@ function optionalText(value: FormDataEntryValue | null): string | null {
 function parseEngineType(value: FormDataEntryValue | null): ServiceOpsBikeEngineType | undefined {
   const text = String(value ?? "").trim();
   if (text === "ELECTRIC" || text === "ICE") return text;
+  return undefined;
+}
+
+// formData("serviceType") 가 빈 값이면 undefined 로. 인식 못 하는 값은 잡고 무시.
+function parseServiceType(value: FormDataEntryValue | null): ServiceOpsBikeServiceType | undefined {
+  const text = String(value ?? "").trim();
+  if (text === "DELIVERY" || text === "CLEANING" || text === "OTHER") return text;
   return undefined;
 }
 

--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import {
   type ServiceOpsBikeEngineType,
   type ServiceOpsBikeOperationStatus,
+  type ServiceOpsBikeServiceType,
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
   serviceOpsApiConfigured,
@@ -297,6 +298,8 @@ export async function updateVehicleFromOverviewAction(
 
   const nextStatus = String(formData.get("operationStatus") ?? "") as ServiceOpsBikeOperationStatus;
   const currentStatus = String(formData.get("currentOperationStatus") ?? "") as ServiceOpsBikeOperationStatus;
+  const engineType = parseEngineType(formData.get("engineType"));
+  const serviceType = String(formData.get("serviceType") ?? "").trim() || undefined;
   // 단말기(IMEI) 변경 의도는 세 가지 값으로 표현:
   //   - 새 IMEI 값 (string) → set / change
   //   - 빈 문자열 + currentInstallationId 가 있음 → 기존 부착 해제
@@ -313,7 +316,8 @@ export async function updateVehicleFromOverviewAction(
     await client.updateVehicle(vehicleId, {
       plateNumber: requiredText(formData.get("plateNumber")),
       modelName: optionalText(formData.get("modelName")),
-      engineType: parseEngineType(formData.get("engineType"))
+      engineType,
+      serviceType: serviceType as ServiceOpsBikeServiceType | undefined
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1120,3 +1120,23 @@ textarea { padding-top: 10px; min-height: 96px; }
 .insurance-addon-checkbox input[type="checkbox"] { width: 14px; height: 14px; margin: 0; cursor: pointer; }
 .insurance-form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
 .action-feedback { margin: 16px 0 0; padding: 12px 14px; border-radius: 12px; background: var(--mint-08); color: var(--color-text-primary); box-shadow: 0 0 0 1px var(--mint-20); font-size: 13px; font-weight: 800; line-height: 1.5; }
+
+/* 서비스 유형 필터 탭 — VehiclesPanel 상단 + 지도 필터에서 공유. */
+.service-type-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+.service-type-tab {
+  padding: 4px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid var(--rm-line-subtle);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background .12s ease, color .12s ease, border-color .12s ease;
+}
+.service-type-tab:hover { color: var(--color-text-primary); }
+.service-type-tab.is-active {
+  background: var(--baemin-mint);
+  color: #fff;
+  border-color: var(--baemin-mint);
+}

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -16,7 +16,7 @@ import {
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { useSimulatedCurrentTelemetry } from "@/components/overview/use-simulated-bike-pins";
-import type { FrontendVehicle, ServiceOpsBikeOperationStatus } from "@/lib/services/service-ops-api";
+import type { FrontendVehicle, ServiceOpsBikeOperationStatus, ServiceOpsBikeServiceType } from "@/lib/services/service-ops-api";
 import type { SimulatedBikeState } from "@/lib/services/fleet-simulation";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
@@ -185,6 +185,7 @@ export function VehicleDetailDialog({
           <div className="detail-row-grid">
             <DetailField label="차량번호" value={vehicle.plateNumber} />
             <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
+            <DetailField label="서비스" value={serviceTypeLabel(vehicle.serviceType)} />
             <DetailField label="모델명" value={vehicle.model || "—"} />
             <DetailField label="운영 상태" value={vehicle.status} />
             <DetailField label="이름" value={row.riderName ?? "—"} />
@@ -237,6 +238,14 @@ export function VehicleDetailDialog({
             </select>
           </label>
           <label>
+            서비스 유형
+            <select name="serviceType" defaultValue={vehicle.serviceType ?? "DELIVERY"}>
+              <option value="DELIVERY">배송</option>
+              <option value="CLEANING">클리닝</option>
+              <option value="OTHER">기타</option>
+            </select>
+          </label>
+          <label>
             모델명 (메모)
             <input name="modelName" defaultValue={vehicle.model} maxLength={100} placeholder="예: NIU NQi GTS" />
           </label>
@@ -285,6 +294,12 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
   return "—";
+}
+
+function serviceTypeLabel(t?: ServiceOpsBikeServiceType): string {
+  if (t === "CLEANING") return "클리닝";
+  if (t === "OTHER") return "기타";
+  return "배송";
 }
 
 // ============================================================================

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -15,6 +15,7 @@ import {
   statusToOperation,
   type VehicleFilterState
 } from "@/components/overview/filter-compute";
+import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
@@ -98,6 +99,7 @@ export function VehiclesPanel({
   statusParam?: string | null;
 }) {
   const [filters, setFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
+  const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
 
   // IMEI=-1 시뮬 차량의 ignitionStatus / 속도 / 배터리 등을 지도와 동일하게 overlay.
@@ -123,16 +125,24 @@ export function VehiclesPanel({
 
   const effectiveVehicles = data.vehicles;
 
+  const serviceTypeFilteredVehicles = useMemo(
+    () =>
+      serviceTypeFilter === "ALL"
+        ? effectiveVehicles
+        : effectiveVehicles.filter((v) => (v.serviceType ?? "DELIVERY") === serviceTypeFilter),
+    [effectiveVehicles, serviceTypeFilter]
+  );
+
   const visibleVehicles = useMemo(
     () =>
       applyVehicleFilters({
-        vehicles: effectiveVehicles,
+        vehicles: serviceTypeFilteredVehicles,
         filters,
         bikePinById,
         deviceUidByBikeId,
         maintenanceSummaryByBike
       }),
-    [effectiveVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+    [serviceTypeFilteredVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
   );
 
   // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
@@ -172,12 +182,14 @@ export function VehiclesPanel({
               : `차량 삭제에 실패했습니다. (${statusParam}) 잠시 후 다시 시도해 주세요.`}
         </p>
       )}
+      {/* 서비스 유형 필터 탭 — VehicleFilterControls 바로 위 */}
+      <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
       {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
       <VehicleFilterControls
         filters={filters}
         onChange={setFilters}
         layout="horizontal"
-        count={{ visible: visibleVehicles.length, total: effectiveVehicles.length }}
+        count={{ visible: visibleVehicles.length, total: serviceTypeFilteredVehicles.length }}
       />
 
       <div className="table-card vehicles-table-scroll">

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -22,6 +22,7 @@ import {
 import { RiderFilterControls } from "@/components/overview/RiderFilterControls";
 import { StationFilterControls } from "@/components/overview/StationFilterControls";
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
+import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import { OverviewMapSearch, type OverviewMapSearchMatch } from "@/components/overview/OverviewMapSearch";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
@@ -135,6 +136,7 @@ function FullscreenMapOverlay({
   const [vehicleFilters, setVehicleFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
   const [riderFilters, setRiderFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
   const [stationFilters, setStationFilters] = useState<StationFilterState>(DEFAULT_STATION_FILTERS);
+  const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
   // 필터 바 펼침/접힘. 기본 펼침 — 운영자가 들어오자마자 필터들이 보이게.
   // 닫으면 11개 select 가 숨겨지고 토글 버튼만 작은 pill 로 남는다.
@@ -164,16 +166,24 @@ function FullscreenMapOverlay({
     return map;
   }, [vehicles]);
 
+  const serviceTypeFilteredVehicles = useMemo(
+    () =>
+      serviceTypeFilter === "ALL"
+        ? vehicles
+        : vehicles.filter((v) => (v.serviceType ?? "DELIVERY") === serviceTypeFilter),
+    [vehicles, serviceTypeFilter]
+  );
+
   const visibleVehicles = useMemo(
     () =>
       applyVehicleFilters({
-        vehicles,
+        vehicles: serviceTypeFilteredVehicles,
         filters: vehicleFilters,
         bikePinById,
         deviceUidByBikeId,
         maintenanceSummaryByBike
       }),
-    [vehicles, vehicleFilters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
+    [serviceTypeFilteredVehicles, vehicleFilters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
   );
 
   const visibleRiders = useMemo(
@@ -339,6 +349,7 @@ function FullscreenMapOverlay({
               CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
               컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
               wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
+          <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
           <VehicleFilterControls
             filters={vehicleFilters}
             onChange={setVehicleFilters}

--- a/development/front-admin-web/components/overview/OverviewMapBanner.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapBanner.tsx
@@ -9,6 +9,7 @@ import { OverviewMapSearch, type OverviewMapSearchMatch } from "@/components/ove
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import { useTrailWaypoints } from "@/components/overview/use-trail-waypoints";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
+import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
   FrontendDashboardBikePin,
@@ -62,6 +63,7 @@ export function OverviewMapBanner({
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
 }) {
   const [open, setOpen] = useState(false);
+  const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const { filteredBikeIds, selectedBikeId, setSelectedBikeId, setFullscreenMapOpen } = useVehicleFilter();
   const { seedBikePins } = useFleetSimulation();
 
@@ -92,11 +94,6 @@ export function OverviewMapBanner({
     [setSelectedBikeId]
   );
 
-  const effectiveBikePins = useMemo(() => {
-    if (filteredBikeIds === null) return overlaidBikePins;
-    return overlaidBikePins.filter((pin) => filteredBikeIds.has(pin.bikeId));
-  }, [overlaidBikePins, filteredBikeIds]);
-
   const bikePinById = useMemo(() => {
     const map = new Map<string, FrontendDashboardBikePin>();
     for (const pin of overlaidBikePins) map.set(pin.bikeId, pin);
@@ -111,6 +108,16 @@ export function OverviewMapBanner({
     }
     return map;
   }, [vehicles]);
+
+  const effectiveBikePins = useMemo(() => {
+    let pins = filteredBikeIds === null ? overlaidBikePins : overlaidBikePins.filter((pin) => filteredBikeIds.has(pin.bikeId));
+    if (serviceTypeFilter !== "ALL") {
+      const vehicleServiceType = (bikeId: string) =>
+        vehicleById.get(bikeId)?.serviceType ?? "DELIVERY";
+      pins = pins.filter((pin) => vehicleServiceType(pin.bikeId) === serviceTypeFilter);
+    }
+    return pins;
+  }, [overlaidBikePins, filteredBikeIds, serviceTypeFilter, vehicleById]);
 
   // 행 클릭이든 마커 클릭이든 selectedBikeId 가 새 값으로 바뀌면 지도를 자동으로 연다.
   //
@@ -198,6 +205,7 @@ export function OverviewMapBanner({
           />
           <span>지도 보기</span>
         </label>
+        <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
         <OverviewMapSearch
           bikePins={bikePins}
           stationPins={stationPins}

--- a/development/front-admin-web/components/overview/ServiceTypeFilterTabs.tsx
+++ b/development/front-admin-web/components/overview/ServiceTypeFilterTabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ServiceOpsBikeServiceType } from "@/lib/services/service-ops-api";
+
+export type ServiceTypeFilter = ServiceOpsBikeServiceType | "ALL";
+
+const TABS: { value: ServiceTypeFilter; label: string }[] = [
+  { value: "ALL", label: "전체" },
+  { value: "DELIVERY", label: "배송" },
+  { value: "CLEANING", label: "클리닝" },
+  { value: "OTHER", label: "기타" }
+];
+
+export function ServiceTypeFilterTabs({
+  value,
+  onChange
+}: {
+  value: ServiceTypeFilter;
+  onChange: (value: ServiceTypeFilter) => void;
+}) {
+  return (
+    <div className="service-type-tabs" role="tablist" aria-label="서비스 유형 필터">
+      {TABS.map((tab) => (
+        <button
+          key={tab.value}
+          type="button"
+          role="tab"
+          aria-selected={value === tab.value}
+          className={value === tab.value ? "service-type-tab is-active" : "service-type-tab"}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/development/front-admin-web/docs/superpowers/specs/2026-05-26-vehicle-service-type-design.md
+++ b/development/front-admin-web/docs/superpowers/specs/2026-05-26-vehicle-service-type-design.md
@@ -1,0 +1,279 @@
+# Vehicle Service Type (serviceType) Implementation Design
+
+## Goal
+
+차량에 서비스 유형(`serviceType`)을 추가해 배송(오토바이)과 클리닝(자동차)을 구분하고, 운영자가 차량 목록과 지도에서 유형별로 필터링할 수 있게 한다.
+
+## Architecture
+
+백엔드(`service-ops-api`)에 `BikeServiceType` enum과 DB 컬럼을 추가하고, 프론트엔드(`front-admin-web`)에서 편집 폼·필터 탭·지도 마커 연동까지 일관되게 반영한다. 일정 관리 및 발송 시뮬레이션(스펙 B)은 이 스펙이 완료된 후 별도 진행한다.
+
+## Tech Stack
+
+- Backend: Java 17, Spring Boot, JPA, Flyway (service-ops-api)
+- Frontend: Next.js 14 App Router, TypeScript, React (front-admin-web)
+
+---
+
+## Backend Changes (service-ops-api)
+
+### New: `BikeServiceType.java`
+
+```
+path: src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java
+```
+
+```java
+package com.thundercrew.opsapi.bike.domain;
+
+public enum BikeServiceType {
+    DELIVERY,   // 배송 (오토바이)
+    CLEANING,   // 클리닝 (자동차)
+    OTHER       // 기타
+}
+```
+
+### New: DB Migration
+
+```
+path: src/main/resources/db/migration/V??__add_bike_service_type.sql
+```
+
+버전 번호는 기존 마이그레이션 파일 중 가장 높은 번호 + 1.
+
+```sql
+ALTER TABLE bikes
+    ADD COLUMN service_type VARCHAR(20) NOT NULL DEFAULT 'DELIVERY';
+```
+
+기존 모든 차량은 `DELIVERY`로 초기화된다. 운영자가 클리닝 차량을 등록하거나 기존 차량 유형을 수정할 때 변경.
+
+### Modified: `Bike.java`
+
+`engineType` 필드 바로 아래에 추가:
+
+```java
+@Enumerated(EnumType.STRING)
+@Column(name = "service_type", nullable = false, length = 20)
+private BikeServiceType serviceType;
+```
+
+`create()` 정적 팩토리 메서드에 `BikeServiceType serviceType` 파라미터 추가:
+
+```java
+public static Bike create(
+    String plateNumber, String vin, String modelName,
+    BikeEngineType engineType, BikeServiceType serviceType,
+    BikeOperationStatus operationStatus, String memo
+) {
+    Bike bike = new Bike();
+    // ... 기존 필드
+    bike.serviceType = serviceType;
+    return bike;
+}
+```
+
+`updateBasicProfile()`에 `BikeServiceType serviceType` 파라미터 추가:
+
+```java
+public void updateBasicProfile(
+    String plateNumber, String vin, String modelName,
+    BikeEngineType engineType, BikeServiceType serviceType, String memo
+) {
+    // ... 기존 필드
+    if (serviceType != null) {
+        this.serviceType = serviceType;
+    }
+}
+```
+
+getter 추가:
+
+```java
+public BikeServiceType getServiceType() {
+    return serviceType;
+}
+```
+
+### Modified: `BikeCreateRequest.java`
+
+```java
+private BikeServiceType serviceType = BikeServiceType.DELIVERY; // 기본값
+```
+
+### Modified: `BikeUpdateRequest.java`
+
+```java
+private BikeServiceType serviceType; // null이면 변경 없음
+```
+
+### Modified: `BikeReadResponse.java`
+
+```java
+private BikeServiceType serviceType;
+```
+
+응답 빌더/생성자에서 `bike.getServiceType()` 매핑.
+
+### Modified: `DashboardBikeSnapshotResponse.java`
+
+지도 마커 필터링을 위해 `serviceType` 포함:
+
+```java
+private BikeServiceType serviceType;
+```
+
+### Modified: `BikeCommandService.java`
+
+`create` 및 `update` 메서드에서 `serviceType`을 request에서 읽어 Bike 도메인에 전달.
+
+---
+
+## Frontend Changes (front-admin-web)
+
+### Modified: `lib/services/service-ops-api.ts`
+
+새 타입 추가:
+
+```ts
+export type ServiceOpsBikeServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+```
+
+`ServiceOpsBike` 타입에 추가:
+
+```ts
+serviceType?: ServiceOpsBikeServiceType;
+```
+
+`FrontendVehicle` 타입에 추가:
+
+```ts
+serviceType?: ServiceOpsBikeServiceType;
+```
+
+`toFrontendVehicle()` 변환 함수에서 매핑:
+
+```ts
+serviceType: raw.serviceType,
+```
+
+### Modified: `components/management/VehicleDetailDialog.tsx`
+
+편집 폼에 `serviceType` select 추가 (`engineType` select 바로 아래):
+
+```tsx
+<label>
+  서비스 유형
+  <select name="serviceType" defaultValue={vehicle.serviceType ?? "DELIVERY"}>
+    <option value="DELIVERY">배송</option>
+    <option value="CLEANING">클리닝</option>
+    <option value="OTHER">기타</option>
+  </select>
+</label>
+```
+
+뷰 모드 `DetailField`에도 추가:
+
+```tsx
+<DetailField label="유형" value={serviceTypeLabel(vehicle.serviceType)} />
+```
+
+헬퍼 함수:
+
+```ts
+function serviceTypeLabel(t?: ServiceOpsBikeServiceType): string {
+  if (t === "CLEANING") return "클리닝";
+  if (t === "OTHER") return "기타";
+  return "배송";
+}
+```
+
+### Modified: `app/actions.ts`
+
+`updateVehicleFromOverviewAction`에서 `formData.get("serviceType")`을 읽어 API 요청에 포함.
+
+### Modified: `components/management/VehiclesPanel.tsx`
+
+필터바 위에 서비스 유형 탭 추가:
+
+```tsx
+// serviceType 필터 state
+const [serviceTypeFilter, setServiceTypeFilter] =
+  useState<ServiceOpsBikeServiceType | "ALL">("ALL");
+
+// 탭 UI (기존 RiderFilterControls 위에)
+<div className="service-type-tabs">
+  {(["ALL", "DELIVERY", "CLEANING", "OTHER"] as const).map((t) => (
+    <button
+      key={t}
+      type="button"
+      className={serviceTypeFilter === t ? "service-type-tab is-active" : "service-type-tab"}
+      onClick={() => setServiceTypeFilter(t)}
+    >
+      {t === "ALL" ? "전체" : t === "DELIVERY" ? "배송" : t === "CLEANING" ? "클리닝" : "기타"}
+    </button>
+  ))}
+</div>
+```
+
+`visibleVehicles` 계산에서 필터 적용:
+
+```ts
+const filteredByType = serviceTypeFilter === "ALL"
+  ? vehicles
+  : vehicles.filter((v) => (v.serviceType ?? "DELIVERY") === serviceTypeFilter);
+```
+
+### Modified: `components/overview/OverviewMapBanner.tsx` + `FullscreenMapHost.tsx`
+
+`serviceTypeFilter` state 추가. `effectiveBikePins` 계산 시 serviceType 기준 필터링 추가. 지도 위 필터 탭 UI 추가 (VehiclesPanel과 동일한 탭 컴포넌트 공유).
+
+### New: `components/overview/ServiceTypeFilterTabs.tsx`
+
+VehiclesPanel과 지도 양쪽에서 재사용할 탭 컴포넌트. props:
+
+```ts
+{
+  value: ServiceOpsBikeServiceType | "ALL";
+  onChange: (value: ServiceOpsBikeServiceType | "ALL") => void;
+}
+```
+
+### Modified: `app/globals.css`
+
+```css
+.service-type-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+.service-type-tab {
+  padding: 4px 12px; border-radius: 999px; font-size: 13px;
+  font-weight: 600; border: 1px solid var(--rm-line-subtle);
+  background: transparent; color: var(--color-text-muted); cursor: pointer;
+}
+.service-type-tab.is-active {
+  background: var(--baemin-mint); color: #fff; border-color: var(--baemin-mint);
+}
+```
+
+---
+
+## Data Flow
+
+```
+운영자 차량 수정 (편집 폼 serviceType select)
+  → updateVehicleFromOverviewAction
+  → PATCH /bikes/:id { serviceType: "CLEANING" }
+  → Bike.updateBasicProfile(serviceType)
+  → bikes 테이블 service_type = 'CLEANING'
+
+페이지 로드
+  → GET /bikes → BikeReadResponse.serviceType
+  → toFrontendVehicle() → FrontendVehicle.serviceType
+  → VehiclesPanel 필터 탭 / 지도 마커 필터링
+```
+
+---
+
+## Out of Scope
+
+- 고객 일정 관리 및 시동 ON 발송 시뮬레이션 → 스펙 B에서 별도 진행
+- 실제 SMS/카카오 발송 연동
+- serviceType별 정비 카탈로그 분리

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -126,6 +126,8 @@ export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE";
  */
 export type ServiceOpsBikeEngineType = "ELECTRIC" | "ICE";
 
+export type ServiceOpsBikeServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+
 export type ServiceOpsBike = {
   id: string;
   idx: number | null;
@@ -134,6 +136,7 @@ export type ServiceOpsBike = {
   modelName: string | null;
   /** Backend V21 부터 응답에 포함. 옛 backend 호환 위해 optional. */
   engineType?: ServiceOpsBikeEngineType;
+  serviceType?: ServiceOpsBikeServiceType;
   operationStatus: ServiceOpsBikeOperationStatus;
   /** "시동 방지" 플래그. 라이더 상세 다이얼로그의 토글이 이 값을 PATCH 한다. */
   ignitionBlocked?: boolean;
@@ -155,6 +158,7 @@ export type FrontendVehicle = {
   model: string;
   /** 정비 카탈로그 매칭에 쓰이는 동력 종류. 옛 backend 호환 위해 optional. */
   engineType?: ServiceOpsBikeEngineType;
+  serviceType?: ServiceOpsBikeServiceType;
   status: "운행" | "대기";
   operationStatus?: ServiceOpsBikeOperationStatus;
   /** 시동 방지 토글의 현재 상태. 백엔드가 응답에 포함; 없으면 false 로 간주. */
@@ -1460,6 +1464,7 @@ export function toFrontendVehicle(bike: ServiceOpsBike): FrontendVehicle {
     vin: bike.vin,
     model: normalizeDisplayText(bike.modelName, "모델 미지정"),
     engineType: bike.engineType,
+    serviceType: bike.serviceType,
     status: toFrontendVehicleStatus(bike.operationStatus),
     operationStatus: bike.operationStatus,
     ignitionBlocked: bike.ignitionBlocked ?? false,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -180,6 +180,7 @@ export type VehicleCreateInput = {
   modelName?: string | null;
   /** 미지정 시 backend 가 ELECTRIC 으로 기본값 (V21). */
   engineType?: ServiceOpsBikeEngineType;
+  serviceType?: ServiceOpsBikeServiceType;
   operationStatus: ServiceOpsBikeOperationStatus;
   memo?: string | null;
 };

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/Bike.java
@@ -30,6 +30,10 @@ public class Bike extends DisplaySequencedEntity {
     private BikeEngineType engineType;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "service_type", nullable = false, length = 20)
+    private BikeServiceType serviceType;
+
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 40)
     private BikeOperationStatus operationStatus;
 
@@ -48,6 +52,7 @@ public class Bike extends DisplaySequencedEntity {
             String vin,
             String modelName,
             BikeEngineType engineType,
+            BikeServiceType serviceType,
             BikeOperationStatus operationStatus,
             String memo
     ) {
@@ -56,6 +61,7 @@ public class Bike extends DisplaySequencedEntity {
         bike.vin = vin;
         bike.modelName = modelName;
         bike.engineType = engineType;
+        bike.serviceType = serviceType;
         bike.operationStatus = operationStatus;
         bike.memo = memo;
         return bike;
@@ -66,6 +72,7 @@ public class Bike extends DisplaySequencedEntity {
             String vin,
             String modelName,
             BikeEngineType engineType,
+            BikeServiceType serviceType,
             String memo
     ) {
         if (plateNumber != null) {
@@ -79,6 +86,9 @@ public class Bike extends DisplaySequencedEntity {
         }
         if (engineType != null) {
             this.engineType = engineType;
+        }
+        if (serviceType != null) {
+            this.serviceType = serviceType;
         }
         if (memo != null) {
             this.memo = memo;
@@ -108,6 +118,10 @@ public class Bike extends DisplaySequencedEntity {
 
     public BikeEngineType getEngineType() {
         return engineType;
+    }
+
+    public BikeServiceType getServiceType() {
+        return serviceType;
     }
 
     public BikeOperationStatus getOperationStatus() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.bike.domain;
+
+/**
+ * 차량의 서비스 유형. 배송(오토바이)과 클리닝(자동차)을 운영자 필터·알림 분기의
+ * 기준 축으로 구분한다. engineType(동력 종류)과 직교하는 독립 분류.
+ */
+public enum BikeServiceType {
+    /** 배송 서비스 (오토바이). 기존 차량의 기본값. */
+    DELIVERY,
+    /** 클리닝 서비스 (자동차). 세스코라이프케어 등. */
+    CLEANING,
+    /** 기타 서비스. */
+    OTHER
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeCreateRequest.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.bike.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -10,15 +11,14 @@ import jakarta.validation.constraints.Size;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BikeCreateRequest(
         @NotBlank @Size(max = 50) String plateNumber,
-        /** Optional at register time — operator updates later via the bike edit flow. */
         @Size(max = 100) String vin,
         @Size(max = 100) String modelName,
-        /**
-         * 동력 종류. null 이면 서비스 측에서 ELECTRIC 으로 기본값 잡음 — 현재
-         * 운영 차량이 모두 전기 이륜차라는 도메인 가정과 일치. ICE 차량은
-         * 운영자가 명시적으로 ICE 를 골라야 등록된다.
-         */
         BikeEngineType engineType,
+        /**
+         * 서비스 유형. null 이면 서비스 측에서 DELIVERY 로 기본값 잡음.
+         * 클리닝·기타 차량은 운영자가 명시적으로 선택해야 등록된다.
+         */
+        BikeServiceType serviceType,
         @NotNull BikeOperationStatus operationStatus,
         String memo
 ) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.bike.dto;
 import com.thundercrew.opsapi.bike.domain.Bike;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -13,6 +14,7 @@ public record BikeReadResponse(
         String vin,
         String modelName,
         BikeEngineType engineType,
+        BikeServiceType serviceType,
         BikeOperationStatus operationStatus,
         boolean ignitionBlocked,
         String memo,
@@ -27,6 +29,7 @@ public record BikeReadResponse(
                 bike.getVin(),
                 bike.getModelName(),
                 bike.getEngineType(),
+                bike.getServiceType(),
                 bike.getOperationStatus(),
                 bike.isIgnitionBlocked(),
                 bike.getMemo(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeUpdateRequest.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.bike.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -10,8 +11,9 @@ public record BikeUpdateRequest(
         @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String plateNumber,
         @Size(max = 100) @Pattern(regexp = ".*\\S.*", message = "must not be blank when provided") String vin,
         @Size(max = 100) String modelName,
-        /** null 이면 변경 안 함 (다른 필드와 동일한 partial-update 규약). */
         BikeEngineType engineType,
+        /** null 이면 변경 안 함 (다른 필드와 동일한 partial-update 규약). */
+        BikeServiceType serviceType,
         String memo
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.bike.service;
 import com.thundercrew.opsapi.bike.domain.Bike;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatusHistory;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import com.thundercrew.opsapi.bike.dto.BikeCreateRequest;
 import com.thundercrew.opsapi.bike.dto.BikeOperationStatusChangeRequest;
 import com.thundercrew.opsapi.bike.dto.BikeReadResponse;
@@ -53,11 +54,15 @@ public class BikeCommandService {
         BikeEngineType engineType = request.engineType() != null
                 ? request.engineType()
                 : BikeEngineType.ELECTRIC;
+        BikeServiceType serviceType = request.serviceType() != null
+                ? request.serviceType()
+                : BikeServiceType.DELIVERY;
         Bike bike = Bike.create(
                 request.plateNumber(),
                 vin,
                 request.modelName(),
                 engineType,
+                serviceType,
                 request.operationStatus(),
                 request.memo()
         );
@@ -97,6 +102,7 @@ public class BikeCommandService {
                     request.vin(),
                     request.modelName(),
                     request.engineType(),
+                    request.serviceType(),
                     request.memo()
             );
             entityManager.flush();

--- a/development/service-ops-api/src/main/resources/db/migration/V25__add_bikes_service_type.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V25__add_bikes_service_type.sql
@@ -1,0 +1,14 @@
+-- 차량의 서비스 유형을 저장하는 컬럼. engineType(동력)과 직교하는 분류.
+-- 기존 행은 모두 배송 차량으로 간주해 DELIVERY 기본값으로 초기화.
+alter table bikes
+    add column service_type varchar(20) not null default 'DELIVERY';
+
+update bikes set service_type = 'DELIVERY' where service_type is null;
+
+alter table bikes
+    add constraint ck_bikes_service_type
+        check (service_type in ('DELIVERY', 'CLEANING', 'OTHER'));
+
+create index ix_bikes_service_type_active
+    on bikes(service_type)
+    where deleted_at is null;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
@@ -346,11 +346,56 @@ class BikeCommandApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
     }
 
+    @Test
+    void createBikeWithServiceTypeStoresAndReturnsThatType() throws Exception {
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "plateNumber":"서울B-2001",
+                                  "operationStatus":"READY",
+                                  "serviceType":"CLEANING"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.serviceType").value("CLEANING"));
+    }
+
+    @Test
+    void createBikeWithoutServiceTypeDefaultsToDelivery() throws Exception {
+        mockMvc.perform(post("/api/v1/bikes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "plateNumber":"서울B-2002",
+                                  "operationStatus":"READY"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.serviceType").value("DELIVERY"));
+    }
+
+    @Test
+    void updateBikeServiceTypeChangesStoredValue() throws Exception {
+        seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-001", "READY", null);
+
+        mockMvc.perform(patch("/api/v1/bikes/" + BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"serviceType":"CLEANING"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serviceType").value("CLEANING"));
+    }
+
     private void seedBike(UUID id, String plateNumber, String vin, String operationStatus, String deletedAtSql) {
         String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
         jdbcTemplate.update("""
-                insert into bikes (id, plate_number, vin, model_name, operation_status, memo, deleted_at)
-                values (?, ?, ?, 'Thunder M1', ?, 'fixture bike', %s)
+                insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, memo, deleted_at)
+                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'DELIVERY', ?, 'fixture bike', %s)
                 """.formatted(deletedAtExpression), id, plateNumber, vin, operationStatus);
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
@@ -381,7 +381,7 @@ class BikeCommandApiContractTests extends PostgresContainerSupport {
     void updateBikeServiceTypeChangesStoredValue() throws Exception {
         seedBike(BIKE_ID, "서울A-1001", "VIN-BIKE-001", "READY", null);
 
-        mockMvc.perform(patch("/api/v1/bikes/" + BIKE_ID)
+        mockMvc.perform(patch("/api/v1/bikes/{id}", BIKE_ID)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""


### PR DESCRIPTION
## Summary
- 백엔드: BikeServiceType enum (DELIVERY/CLEANING/OTHER) + V25 마이그레이션 + Bike 엔티티 + DTO/서비스 반영 + 계약 테스트 3개
- 프론트: ServiceTypeFilterTabs 공용 컴포넌트 + VehicleDetailDialog 편집·뷰 + VehiclesPanel 목록 필터 탭 + 지도(OverviewMapBanner + FullscreenMapHost) 마커 필터
- 기존 차량은 기본값 DELIVERY로 유지 (DB 마이그레이션)

## Test plan
- [ ] 차량 수정 → 서비스 유형 변경(클리닝) → 저장 → 뷰에 "클리닝" 표시 확인
- [ ] VehiclesPanel 필터 탭 [배송/클리닝/기타/전체] 동작 확인
- [ ] 지도 및 전체화면 지도 필터 탭 동작 확인
- [ ] 백엔드: BikeCommandService 계약 테스트 통과 확인
- [ ] 신규 등록 차량 기본값 DELIVERY 확인

🤖 Generated with Claude Code