### PR TITLE
feat: move service-type filter tabs to fullscreen map header

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -566,6 +566,10 @@ textarea { padding-top: 10px; min-height: 96px; }
   /* header 안의 search 인풋은 본인 width 를 가지되 양쪽으로 자라지는 않게. */
   flex: 0 1 360px;
 }
+.fullscreen-map-header .service-type-tabs {
+  /* 헤더 가로 행 안에서는 하단 margin 불필요. */
+  margin-bottom: 0;
+}
 
 .fullscreen-map-close {
   height: 36px;

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -339,6 +339,7 @@ function FullscreenMapOverlay({
           riderInfoById={riderInfoById ?? new Map()}
           onSelect={handleSearchSelect}
         />
+        <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
         <span className="fullscreen-map-counts">
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
@@ -349,7 +350,6 @@ function FullscreenMapOverlay({
               CSS `display: contents` 로 사라지고, 11개 select 가 같은 flex
               컨테이너의 자식이 되어 단일 가로 행으로 자라난다. 좁은 폭에선
               wrap 으로 자연스럽게 다음 줄로 떨어진다. */}
-          <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
           <VehicleFilterControls
             filters={vehicleFilters}
             onChange={setVehicleFilters}


### PR DESCRIPTION
## Summary
- ServiceTypeFilterTabs가 전체화면 지도 필터 바 내부에서 헤더 row로 이동 (차량·BSS 카운트 뱃지 옆)
- `.fullscreen-map-header .service-type-tabs { margin-bottom: 0 }` CSS 오버라이드 추가

## Test plan
- [ ] 전체화면 지도 열기 → 헤더에 전체/배송/클리닝/기타 탭 표시 확인
- [ ] 탭 클릭 시 지도 마커 필터링 동작 확인
- [ ] 필터 바 열기/닫기와 무관하게 탭이 항상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)