### PR TITLE
feat: 시동 ON 말풍선 + 벨 알림 (IMEI=-1 시뮬레이션)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1144,3 +1144,92 @@ textarea { padding-top: 10px; min-height: 96px; }
   color: #fff;
   border-color: var(--baemin-mint);
 }
+
+/* ── Notification Bell ──────────────────────────────────────────── */
+.notif-bell-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.notif-bell-btn {
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  line-height: 1;
+  color: var(--rm-text, #374151);
+}
+
+.notif-bell-btn:hover {
+  background: var(--rm-hover, rgba(0, 0, 0, 0.06));
+}
+
+.notif-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #ef4444;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.notif-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--rm-card-bg, #fff);
+  border: 1px solid var(--rm-border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+}
+
+.notif-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--rm-text-muted, #9ca3af);
+}
+
+.notif-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--rm-border, #e5e7eb);
+  font-size: 12px;
+}
+
+.notif-item:last-child {
+  border-bottom: none;
+}
+
+.notif-item-text {
+  color: var(--rm-text, #374151);
+  font-weight: 500;
+  flex: 1;
+}
+
+.notif-item-time {
+  color: var(--rm-text-muted, #9ca3af);
+  white-space: nowrap;
+  flex-shrink: 0;
+}

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1233,3 +1233,36 @@ textarea { padding-top: 10px; min-height: 96px; }
   white-space: nowrap;
   flex-shrink: 0;
 }
+
+/* ── Map Ignition Bubble ────────────────────────────────────────── */
+.map-ignition-bubble {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1d4ed8;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 10px;
+  pointer-events: none;
+  animation: ignition-bubble-fade 4s ease forwards;
+}
+
+.map-ignition-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #1d4ed8;
+}
+
+@keyframes ignition-bubble-fade {
+  0%   { opacity: 1; }
+  70%  { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -11,6 +11,7 @@ import { MaintenancePanel } from "@/components/management/MaintenancePanel";
 import { RidersPanel, type InsuranceOption } from "@/components/management/RidersPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
+import { NotificationBell } from "@/components/layout/NotificationBell";
 import { FullscreenMapHost } from "@/components/overview/FullscreenMapHost";
 import { OverviewClientShell } from "@/components/overview/OverviewClientShell";
 import { OverviewKpiTiles } from "@/components/overview/OverviewKpiTiles";
@@ -390,6 +391,7 @@ export default async function RootPage({
           })}
         </nav>
         <div className="overview-tab-action">
+          <NotificationBell />
           {activeTab === "riders" ? <CreateRiderDialog /> : null}
           {activeTab === "vehicles" ? <CreateVehicleDialog /> : null}
           {activeTab === "stations" ? <CreateStationDialog /> : null}

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -12,7 +12,7 @@ import type {
   NaverMarkerInstance,
   NaverPolylineInstance
 } from "@/types/naver-maps";
-import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+import type { ServicePhase } from "@/lib/services/fleet-simulation";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
 const NCP_STYLE_ID_LIGHT = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT;
@@ -71,7 +71,7 @@ export interface MapShellProps {
   children?: ReactNode;
   initialCenter?: { lat: number; lng: number };
   initialZoom?: number;
-  bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null; deliveryCount?: number }>;
+  bikePins?: Array<FrontendDashboardBikePin & { servicePhase?: ServicePhase | null; deliveryCount?: number; ignitionOnAt?: number | null }>;
   stationPins?: FrontendDashboardStationPin[];
   onBikeSelect?: (bikeId: string) => void;
   onStationSelect?: (stationId: string) => void;
@@ -115,7 +115,7 @@ export function MapShell({
   /** bikeId → 마지막으로 마커를 만들 때 사용한 deliveryPhase. phase 가 바뀌면
    *  marker 를 재생성해 배송 상태 배지 HTML 이 반영되도록 한다.
    *  NCP setIcon 은 icon.content(HTML) 을 갱신하지 않아 배지 추가/제거가 안 됨. */
-  const prevDeliveryPhaseRef = useRef<Map<string, DeliveryPhase | null>>(new Map());
+  const prevServicePhaseRef = useRef<Map<string, ServicePhase | null>>(new Map());
   const onBikeSelectRef = useRef(onBikeSelect);
   const onStationSelectRef = useRef(onStationSelect);
   const trailPolylineRef = useRef<NaverPolylineInstance | null>(null);
@@ -236,7 +236,7 @@ export function MapShell({
       for (const m of stationMarkerCacheRef.current.values()) m.setMap(null);
       bikeMarkerCacheRef.current.clear();
       stationMarkerCacheRef.current.clear();
-      prevDeliveryPhaseRef.current.clear();
+      prevServicePhaseRef.current.clear();
       trailPolylineRef.current?.setMap(null);
       trailPolylineRef.current = null;
     }
@@ -434,14 +434,14 @@ export function MapShell({
     if (!map || !naver?.maps?.Marker) return;
 
     const cache = bikeMarkerCacheRef.current;
-    const prevPhases = prevDeliveryPhaseRef.current;
+    const prevPhases = prevServicePhaseRef.current;
     const incomingIds = new Set<string>();
 
     const showLabel = currentZoom >= LABEL_VISIBLE_ZOOM;
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase, pin.deliveryCount);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt);
       // 배지는 icon wrapper(overflow:visible) 안에 position:absolute 로 내장되므로
       // icon.size 는 아이콘 자체 크기(28×28) 고정. 배지는 visually 아래로 넘침.
       const icon = {
@@ -450,11 +450,11 @@ export function MapShell({
         size: new naver.maps.Size(ICON_PX, ICON_PX)
       };
       const existing = cache.get(pin.bikeId);
-      const currentPhase = pin.deliveryPhase ?? null;
+      const currentPhase = pin.servicePhase ?? null;
       const prevPhase = prevPhases.get(pin.bikeId) ?? null;
 
       // NCP marker.setIcon() 은 icon.content(HTML) 을 실제로 갱신하지 않는다.
-      // deliveryPhase 가 바뀐 경우(배송 중 배지 추가/제거) 에만 마커를 재생성하고
+      // servicePhase 가 바뀐 경우(이동 중 배지 추가/제거) 에만 마커를 재생성하고
       // 나머지 tick 에는 setPosition + setIcon(위치·anchor 만 갱신) 으로 처리.
       if (existing && prevPhase === currentPhase) {
         existing.setPosition?.(position);
@@ -462,7 +462,7 @@ export function MapShell({
         continue;
       }
 
-      // deliveryPhase 변경 → 기존 마커 제거 후 새로 생성
+      // servicePhase 변경 → 기존 마커 제거 후 새로 생성
       if (existing) {
         existing.setMap(null);
         cache.delete(pin.bikeId);
@@ -662,24 +662,18 @@ function labelMarkup(text: string): string {
 }
 
 /**
- * 배송 상태 + 건수 배지 HTML.
- *
- * NCP 는 icon.content HTML 을 처리할 때 outer container 의 firstChild 만
- * 실제 DOM 에 삽입한다. 배지를 outer container 의 형제(sibling)로 두면
- * NCP 가 무시하는 문제가 있어, 배지를 icon wrapper(= firstChild) 안에
+ * 서비스 상태 배지 HTML.
  * position:absolute 로 내장하고 wrapper 에 overflow:visible 을 준다.
  *
- * - EN_ROUTE: 파랑(#3b82f6) "배송 중 · N건"
- * - IDLE: 회색(#6b7280) "대기 · N건"
- * deliveryPhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
+ * - MOVING: 파랑(#3b82f6) "이동 중 · N건"
+ * - WORKING: 회색(#6b7280) "작업 · N건"
+ * servicePhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
  */
-function deliveryBadgeMarkup(phase: DeliveryPhase, deliveryCount: number): string {
-  const isEnRoute = phase === "EN_ROUTE";
-  const bg = isEnRoute ? "#3b82f6" : "#6b7280";
-  const label = isEnRoute ? "배송 중" : "대기";
+function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number): string {
+  const isMoving = phase === "MOVING";
+  const bg = isMoving ? "#3b82f6" : "#6b7280";
+  const label = isMoving ? "이동 중" : "작업";
   const text = `${label} · ${deliveryCount}건`;
-  // position:absolute + top:BADGE_TOP_OFFSET → icon wrapper(28px) 바로 아래
-  // icon wrapper 는 overflow:visible 이므로 28px 경계 밖으로 노출됨
   return (
     `<div style="position:absolute;top:${BADGE_TOP_OFFSET}px;left:50%;` +
     `transform:translateX(-50%);display:flex;align-items:center;` +
@@ -687,6 +681,15 @@ function deliveryBadgeMarkup(phase: DeliveryPhase, deliveryCount: number): strin
     `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
     `${text}</div>`
   );
+}
+
+/**
+ * 시동 켜짐 말풍선 HTML.
+ * CSS animation (.map-ignition-bubble) 으로 4초 후 자동 소멸.
+ * NCP firstChild-only 제약상 markerWrapper 안에 badge 와 함께 삽입.
+ */
+function ignitionBubbleMarkup(): string {
+  return `<div class="map-ignition-bubble">🔑 이동 시작</div>`;
 }
 
 // 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
@@ -746,25 +749,27 @@ function stationMarkerHtml(name: string, showLabel: boolean): string {
 }
 
 /**
- * 차량 마커 — 배달 스쿠터 아이콘 + (옵션) 번호판 라벨 + (옵션) 배송 상태 배지.
+ * 차량 마커 — 스쿠터 아이콘 + (옵션) 번호판 라벨 + (옵션) 서비스 상태 배지 + (옵션) 시동 말풍선.
  *
- * deliveryPhase != null 이면 "배송 중 · N건" 또는 "대기 · N건" 배지를 아이콘
- * wrapper 내부에 삽입한다 (overflow:visible + position:absolute 방식).
- * NCP 의 firstChild-only 삽입 문제를 우회하기 위해 배지는 반드시 wrapper 안에.
+ * servicePhase != null 이면 배지 포함. ignitionOnAt 이 4초 이내이면 말풍선 포함.
+ * 배지·말풍선은 markerWrapper(overflow:visible + position:relative) 안 position:absolute 자식.
  */
 function bikeMarkerHtml(
   plateNumber: string,
   showLabel: boolean,
-  deliveryPhase?: DeliveryPhase | null,
-  deliveryCount?: number
+  servicePhase?: ServicePhase | null,
+  deliveryCount?: number,
+  ignitionOnAt?: number | null
 ): string {
   const badge =
-    deliveryPhase != null
-      ? deliveryBadgeMarkup(deliveryPhase, deliveryCount ?? 0)
-      : undefined;
-  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", badge);
+    servicePhase != null
+      ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0)
+      : "";
+  const showBubble = ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
+  const bubble = showBubble ? ignitionBubbleMarkup() : "";
+  const extras = badge || bubble ? badge + bubble : undefined;
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras);
   if (!showLabel) return wrapped;
-  // 라벨은 .map-marker-label CSS 에서 position:absolute;bottom:100% 로 올라간다.
   return (
     `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
     `${labelMarkup(plateNumber)}${wrapped}` +

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -12,7 +12,7 @@ import type {
   NaverMarkerInstance,
   NaverPolylineInstance
 } from "@/types/naver-maps";
-import type { ServicePhase } from "@/lib/services/fleet-simulation";
+import type { ServicePhase, ServiceType } from "@/lib/services/fleet-simulation";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
 const NCP_STYLE_ID_LIGHT = process.env.NEXT_PUBLIC_NCP_MAP_STYLE_ID_LIGHT;
@@ -665,16 +665,19 @@ function labelMarkup(text: string): string {
  * 서비스 상태 배지 HTML.
  * position:absolute 로 내장하고 wrapper 에 overflow:visible 을 준다.
  *
- * - MOVING: 파랑(#3b82f6) "이동 중 · N건"
- * - WORKING: 회색(#6b7280) "작업 · N건"
+ * - DELIVERY (undefined 포함) MOVING: 파랑 "배송 중 · N건"
+ * - DELIVERY (undefined 포함) WORKING: 회색 "대기 · N건"
+ * - CLEANING / OTHER MOVING: 파랑 "이동 중 · N건"
+ * - CLEANING / OTHER WORKING: 회색 "작업 · N건"
  * servicePhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
  */
-function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceType?: string): string {
+function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceType?: ServiceType): string {
   const isMoving = phase === "MOVING";
   const bg = isMoving ? "#3b82f6" : "#6b7280";
-  const label = isMoving
-    ? (serviceType === "CLEANING" ? "이동 중" : "배송 중")
-    : (serviceType === "CLEANING" ? "작업" : "대기");
+  const label = (() => {
+    if (!serviceType || serviceType === "DELIVERY") return isMoving ? "배송 중" : "대기";
+    return isMoving ? "이동 중" : "작업";
+  })();
   const text = `${label} · ${deliveryCount}건`;
   return (
     `<div style="position:absolute;top:${BADGE_TOP_OFFSET}px;left:50%;` +
@@ -762,7 +765,7 @@ function bikeMarkerHtml(
   servicePhase?: ServicePhase | null,
   deliveryCount?: number,
   ignitionOnAt?: number | null,
-  serviceType?: string
+  serviceType?: ServiceType
 ): string {
   const badge =
     servicePhase != null

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -112,8 +112,8 @@ export function MapShell({
   const mapRef = useRef<NaverMapInstance | null>(null);
   const bikeMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
   const stationMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
-  /** bikeId → 마지막으로 마커를 만들 때 사용한 deliveryPhase. phase 가 바뀌면
-   *  marker 를 재생성해 배송 상태 배지 HTML 이 반영되도록 한다.
+  /** bikeId → 마지막으로 마커를 만들 때 사용한 servicePhase. phase 가 바뀌면
+   *  marker 를 재생성해 서비스 상태 배지 + 시동 말풍선 HTML 이 반영되도록 한다.
    *  NCP setIcon 은 icon.content(HTML) 을 갱신하지 않아 배지 추가/제거가 안 됨. */
   const prevServicePhaseRef = useRef<Map<string, ServicePhase | null>>(new Map());
   const onBikeSelectRef = useRef(onBikeSelect);
@@ -724,7 +724,7 @@ function stationIconSvg(): string {
  * 은 SVG 가 inline-element 라 기본적으로 baseline 여백을 만드는 걸 잘라 — 그
  * 여백이 anchor 계산과 어긋나면 마커가 lat/lng 점 위에서 미세하게 떠 보임.
  *
- * badge 를 넘기면 wrapper 내부 position:absolute 자식으로 삽입하고
+ * extras(badge + bubble HTML) 를 넘기면 wrapper 내부 position:absolute 자식으로 삽입하고
  * wrapper 에 overflow:visible + position:relative 를 추가한다.
  * NCP 는 icon.content 의 firstChild 만 DOM 에 삽입하므로 배지는 반드시
  * wrapper(= firstChild) 안에 있어야 잘리지 않는다.

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -441,7 +441,7 @@ export function MapShell({
     for (const pin of bikePins) {
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType);
       // 배지는 icon wrapper(overflow:visible) 안에 position:absolute 로 내장되므로
       // icon.size 는 아이콘 자체 크기(28×28) 고정. 배지는 visually 아래로 넘침.
       const icon = {
@@ -669,10 +669,12 @@ function labelMarkup(text: string): string {
  * - WORKING: 회색(#6b7280) "작업 · N건"
  * servicePhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
  */
-function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number): string {
+function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceType?: string): string {
   const isMoving = phase === "MOVING";
   const bg = isMoving ? "#3b82f6" : "#6b7280";
-  const label = isMoving ? "이동 중" : "작업";
+  const label = isMoving
+    ? (serviceType === "CLEANING" ? "이동 중" : "배송 중")
+    : (serviceType === "CLEANING" ? "작업" : "대기");
   const text = `${label} · ${deliveryCount}건`;
   return (
     `<div style="position:absolute;top:${BADGE_TOP_OFFSET}px;left:50%;` +
@@ -759,13 +761,14 @@ function bikeMarkerHtml(
   showLabel: boolean,
   servicePhase?: ServicePhase | null,
   deliveryCount?: number,
-  ignitionOnAt?: number | null
+  ignitionOnAt?: number | null,
+  serviceType?: string
 ): string {
   const badge =
     servicePhase != null
-      ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0)
+      ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0, serviceType)
       : "";
-  const showBubble = ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
+  const showBubble = serviceType === "CLEANING" && ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
   const bubble = showBubble ? ignitionBubbleMarkup() : "";
   const extras = badge || bubble ? badge + bubble : undefined;
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras);

--- a/development/front-admin-web/components/layout/NotificationBell.tsx
+++ b/development/front-admin-web/components/layout/NotificationBell.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useNotifications } from "@/components/layout/NotificationContext";
+
+function formatRelativeTime(startedAt: number): string {
+  const diffMs = Date.now() - startedAt;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "방금";
+  if (diffMin < 60) return `${diffMin}분 전`;
+  return `${Math.floor(diffMin / 60)}시간 전`;
+}
+
+export function NotificationBell() {
+  const { notifications, unreadCount, markAllRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function handleToggle() {
+    const next = !open;
+    setOpen(next);
+    if (next) markAllRead();
+  }
+
+  return (
+    <div className="notif-bell-wrapper" ref={wrapperRef}>
+      <button
+        type="button"
+        className="notif-bell-btn"
+        onClick={handleToggle}
+        aria-label={`알림${unreadCount > 0 ? ` (읽지 않은 알림 ${unreadCount}건)` : ""}`}
+      >
+        🔔
+        {unreadCount > 0 && (
+          <span className="notif-badge" aria-hidden="true">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="notif-dropdown" role="list" aria-label="이동 알림 이력">
+          {notifications.length === 0 ? (
+            <div className="notif-empty">알림 없음</div>
+          ) : (
+            [...notifications].reverse().map((n) => (
+              <div key={n.id} className="notif-item" role="listitem">
+                <span className="notif-item-text">🔑 {n.plateNumber} 이동 시작</span>
+                <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -28,11 +28,9 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   const [readCount, setReadCount] = useState(0);
 
   const addNotification = useCallback((n: Omit<IgnitionNotification, "id">) => {
+    const id = `${n.plateNumber}-${n.startedAt}-${Math.random().toString(36).slice(2, 7)}`;
     setNotifications((prev) => {
-      const next = [
-        ...prev,
-        { ...n, id: `${n.plateNumber}-${n.startedAt}-${Math.random().toString(36).slice(2, 7)}` },
-      ];
+      const next = [...prev, { ...n, id }];
       return next.length > 20 ? next.slice(-20) : next;
     });
   }, []);

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type IgnitionNotification = {
+  id: string;
+  plateNumber: string;
+  startedAt: number;
+};
+
+type NotificationContextValue = {
+  notifications: IgnitionNotification[];
+  unreadCount: number;
+  addNotification: (n: Omit<IgnitionNotification, "id">) => void;
+  markAllRead: () => void;
+};
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<IgnitionNotification[]>([]);
+  const [readCount, setReadCount] = useState(0);
+
+  const addNotification = useCallback((n: Omit<IgnitionNotification, "id">) => {
+    setNotifications((prev) => {
+      const next = [
+        ...prev,
+        { ...n, id: `${n.plateNumber}-${n.startedAt}` },
+      ];
+      return next.length > 20 ? next.slice(-20) : next;
+    });
+  }, []);
+
+  const markAllRead = useCallback((total: number) => {
+    setReadCount(total);
+  }, []);
+
+  const unreadCount = Math.max(0, notifications.length - readCount);
+
+  return (
+    <NotificationContext.Provider
+      value={{ notifications, unreadCount, addNotification, markAllRead: () => markAllRead(notifications.length) }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error("useNotifications must be used within NotificationProvider");
+  return ctx;
+}

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -31,21 +31,24 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     setNotifications((prev) => {
       const next = [
         ...prev,
-        { ...n, id: `${n.plateNumber}-${n.startedAt}` },
+        { ...n, id: `${n.plateNumber}-${n.startedAt}-${Math.random().toString(36).slice(2, 7)}` },
       ];
       return next.length > 20 ? next.slice(-20) : next;
     });
   }, []);
 
-  const markAllRead = useCallback((total: number) => {
-    setReadCount(total);
+  const markAllRead = useCallback(() => {
+    setNotifications((notifs) => {
+      setReadCount(notifs.length);
+      return notifs;
+    });
   }, []);
 
   const unreadCount = Math.max(0, notifications.length - readCount);
 
   return (
     <NotificationContext.Provider
-      value={{ notifications, unreadCount, addNotification, markAllRead: () => markAllRead(notifications.length) }}
+      value={{ notifications, unreadCount, addNotification, markAllRead }}
     >
       {children}
     </NotificationContext.Provider>

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -835,7 +835,7 @@ function DeliverySection({
             </dd>
           </div>
         ) : null}
-        {state.phase === "EN_ROUTE" ? (
+        {state.phase === "MOVING" ? (
           <>
             <div className="delivery-meta-row">
               <dt>남은 시간</dt>
@@ -854,8 +854,8 @@ function DeliverySection({
 
 function renderPhaseLabel(phase: SimulatedBikeState["phase"]): string {
   switch (phase) {
-    case "IDLE": return "대기";
-    case "EN_ROUTE": return "배송 중";
+    case "WORKING": return "작업";
+    case "MOVING": return "이동 중";
   }
 }
 

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -818,7 +818,7 @@ function DeliverySection({
       </section>
     );
   }
-  const phaseLabel = renderPhaseLabel(state.phase);
+  const phaseLabel = renderPhaseLabel(state.phase, state.serviceType);
   return (
     <section className="delivery-section">
       <h4>배송</h4>
@@ -852,11 +852,11 @@ function DeliverySection({
   );
 }
 
-function renderPhaseLabel(phase: SimulatedBikeState["phase"]): string {
-  switch (phase) {
-    case "WORKING": return "작업";
-    case "MOVING": return "이동 중";
+function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: string): string {
+  if (serviceType === "CLEANING") {
+    return phase === "MOVING" ? "이동 중" : "작업";
   }
+  return phase === "MOVING" ? "배송 중" : "대기";
 }
 
 function renderRemainingLabel(phaseEndsAt: number): string {

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -17,7 +17,7 @@ import type { InsuranceOption } from "@/components/management/RidersPanel";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { useSimulatedCurrentTelemetry } from "@/components/overview/use-simulated-bike-pins";
 import type { FrontendVehicle, ServiceOpsBikeOperationStatus, ServiceOpsBikeServiceType } from "@/lib/services/service-ops-api";
-import type { SimulatedBikeState } from "@/lib/services/fleet-simulation";
+import type { SimulatedBikeState, ServiceType } from "@/lib/services/fleet-simulation";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
 
@@ -852,11 +852,12 @@ function DeliverySection({
   );
 }
 
-function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: string): string {
-  if (serviceType === "CLEANING") {
-    return phase === "MOVING" ? "이동 중" : "작업";
+function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: ServiceType): string {
+  if (serviceType === "DELIVERY") {
+    return phase === "MOVING" ? "배송 중" : "대기";
   }
-  return phase === "MOVING" ? "배송 중" : "대기";
+  // CLEANING or OTHER
+  return phase === "MOVING" ? "이동 중" : "작업";
 }
 
 function renderRemainingLabel(phaseEndsAt: number): string {

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -6,9 +6,10 @@ import {
   advanceBikeState,
   makeInitialState,
   TICK_INTERVAL_MS,
-  EN_ROUTE_DURATION_MAX_MS,
+  MOVING_DURATION_MAX_MS,
   type SimulatedBikeState
 } from "@/lib/services/fleet-simulation";
+import { useNotifications } from "@/components/layout/NotificationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
@@ -49,6 +50,9 @@ export function FleetSimulationProvider({
   const pinsRef = useRef<ReadonlyArray<FrontendDashboardBikePin>>([]);
   const pendingFetchesRef = useRef<Set<string>>(new Set());
   const mountedRef = useRef(true);
+  const { addNotification } = useNotifications();
+  /** bikeId → last ignitionOnAt that was notified. Prevents duplicate notifications. */
+  const lastNotifiedIgnitionOnAtRef = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
     mountedRef.current = true;
@@ -104,14 +108,14 @@ export function FleetSimulationProvider({
           : { lat: 37.5665, lng: 126.978 }; // 서울 중심 fallback
         // 차량마다 0~5분 사이 랜덤 진행률로 시작 — phaseStartedAt 을 과거로 당겨
         // advanceBikeState 가 첫 tick 에 올바른 progress / position 을 계산.
-        const offsetMs = Math.random() * EN_ROUTE_DURATION_MAX_MS;
+        const offsetMs = Math.random() * MOVING_DURATION_MAX_MS;
         next.set(
           bikeId,
           makeInitialState({
             bikeId,
             origin,
             nowMs: nowMs - offsetMs,
-            phase: "EN_ROUTE",
+            phase: "MOVING",
             initialBatteryPercent:
               typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90
           })
@@ -121,6 +125,25 @@ export function FleetSimulationProvider({
       return mutated ? next : prev;
     });
   }, [matchedImeiSet]);
+
+  // Detect WORKING→MOVING transitions → send ignition notification.
+  useEffect(() => {
+    for (const [bikeId, state] of simulated) {
+      if (state.ignitionOnAt == null) continue;
+      const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
+      if (last === state.ignitionOnAt) continue;
+      lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
+      const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+      const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
+      addNotification({ plateNumber, startedAt: state.ignitionOnAt });
+    }
+    // Clean up ref entries for bikes that left simulation
+    for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
+      if (!simulated.has(bikeId)) {
+        lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
+      }
+    }
+  }, [simulated, addNotification]);
 
   // 250ms tick loop — mount 시 한 번만 interval 을 생성. simulated.size 를
   // dep 으로 두면 size 변화 시점에 효과가 재실행되면서 stale closure 가 발생해
@@ -141,7 +164,7 @@ export function FleetSimulationProvider({
           // 비매칭 + IDLE + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
           if (
             !isMatched &&
-            advanced.phase === "IDLE" &&
+            advanced.phase === "WORKING" &&
             advanced.phaseEndsAt === Number.POSITIVE_INFINITY
           ) {
             mutated = true;
@@ -160,7 +183,7 @@ export function FleetSimulationProvider({
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
       if (
-        state.phase !== "EN_ROUTE" ||
+        state.phase !== "MOVING" ||
         state.routeWaypoints !== null ||
         pendingFetchesRef.current.has(bikeId)
       ) {
@@ -175,8 +198,8 @@ export function FleetSimulationProvider({
         if (waypoints.length === 0) return;
         setSimulated((prev) => {
           const current = prev.get(bikeId);
-          // stale guard: bike 가 이미 IDLE 로 돌아갔으면 주입 무시
-          if (!current || current.phase === "IDLE") return prev;
+          // stale guard: bike 가 이미 WORKING 으로 돌아갔으면 주입 무시
+          if (!current || current.phase === "WORKING") return prev;
           const next = new Map(prev);
           next.set(bikeId, { ...current, routeWaypoints: waypoints });
           return next;

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -177,7 +177,7 @@ export function FleetSimulationProvider({
       });
     }, TICK_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   // MOVING + routeWaypoints 없음 → OSRM 경로 fetch.
   // (즉시 이동 시작, 경로 도착 후 반영)

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -118,7 +118,8 @@ export function FleetSimulationProvider({
             nowMs: nowMs - offsetMs,
             phase: "MOVING",
             initialBatteryPercent:
-              typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90
+              typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90,
+            serviceType: pin?.serviceType ?? "DELIVERY"
           })
         );
         mutated = true;
@@ -133,6 +134,8 @@ export function FleetSimulationProvider({
       if (state.ignitionOnAt == null) continue;
       const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
       if (last === state.ignitionOnAt) continue;
+      // 클리닝 차량에만 알림 발송
+      if (state.serviceType !== "CLEANING") continue;
       lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
       const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
       const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -7,7 +7,8 @@ import {
   makeInitialState,
   TICK_INTERVAL_MS,
   MOVING_DURATION_MAX_MS,
-  type SimulatedBikeState
+  type SimulatedBikeState,
+  type ServicePhase
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
@@ -91,7 +92,7 @@ export function FleetSimulationProvider({
     matchedImeiSetRef.current = matchedImeiSet;
   });
 
-  // 자동 트리거: matchedImeiSet 이 변경되면 새로 매칭된 bike 를 EN_ROUTE 로 시작.
+  // 자동 트리거: matchedImeiSet 이 변경되면 새로 매칭된 bike 를 MOVING 으로 시작.
   // 여러 차량이 동시에 초기화될 때 모두 같은 nowMs 를 쓰면 5분 후 동시에 사이클이
   // 끝나 "대기" 가 동시에 표시된다. 차량별로 0~5분 랜덤 오프셋을 주어 사이클을
   // 처음부터 분산시킨다 — 마치 이미 서로 다른 시점에 출발한 것처럼 보임.
@@ -161,7 +162,7 @@ export function FleetSimulationProvider({
           const isMatched = currentMatched.has(bikeId);
           const advanced = advanceBikeState(state, nowMs, isMatched);
           if (advanced !== state) mutated = true;
-          // 비매칭 + IDLE + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
+          // 비매칭 + WORKING + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
           if (
             !isMatched &&
             advanced.phase === "WORKING" &&
@@ -178,8 +179,8 @@ export function FleetSimulationProvider({
     return () => window.clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // EN_ROUTE + routeWaypoints 없음 → OSRM 경로 fetch.
-  // (기존 ASSIGNED 조건에서 EN_ROUTE 로 변경 — 즉시 이동 시작, 경로 도착 후 반영)
+  // MOVING + routeWaypoints 없음 → OSRM 경로 fetch.
+  // (즉시 이동 시작, 경로 도착 후 반영)
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
       if (

--- a/development/front-admin-web/components/overview/OverviewClientShell.tsx
+++ b/development/front-admin-web/components/overview/OverviewClientShell.tsx
@@ -2,11 +2,15 @@
 
 import type { ReactNode } from "react";
 
+import { NotificationProvider } from "@/components/layout/NotificationContext";
 import { FleetSimulationProvider } from "@/components/overview/FleetSimulationContext";
 import { VehicleFilterProvider } from "@/components/overview/VehicleFilterContext";
 
 /**
  * 루트 페이지의 클라이언트 전용 Provider 래퍼.
+ *
+ * NotificationProvider — 최외곽. FleetSimulationProvider 가
+ * useNotifications() 를 호출하므로 반드시 그 바깥에 있어야 한다.
  *
  * `imeiMinusOneBikeIds` + `bikeRiderPairs` 는 RSC(page.tsx) 가 SSR 에서
  * 계산한 직렬화 가능한 값이다. JSON boundary 를 넘기 위해 배열로 내려받고
@@ -22,13 +26,15 @@ export function OverviewClientShell({
   bikeRiderPairs: [string, string][];
 }) {
   return (
-    <VehicleFilterProvider>
-      <FleetSimulationProvider
-        imeiMinusOneBikeIds={imeiMinusOneBikeIds}
-        bikeRiderPairs={bikeRiderPairs}
-      >
-        {children}
-      </FleetSimulationProvider>
-    </VehicleFilterProvider>
+    <NotificationProvider>
+      <VehicleFilterProvider>
+        <FleetSimulationProvider
+          imeiMinusOneBikeIds={imeiMinusOneBikeIds}
+          bikeRiderPairs={bikeRiderPairs}
+        >
+          {children}
+        </FleetSimulationProvider>
+      </VehicleFilterProvider>
+    </NotificationProvider>
   );
 }

--- a/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+++ b/development/front-admin-web/components/overview/use-simulated-bike-pins.ts
@@ -5,23 +5,22 @@ import { useMemo } from "react";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-maintenance-data";
-import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+import type { ServicePhase } from "@/lib/services/fleet-simulation";
 
 /**
  * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
- * FrontendDashboardBikePin 위에 deliveryPhase 를 overlay 한다.
+ * FrontendDashboardBikePin 위에 servicePhase / ignitionOnAt 을 overlay 한다.
  */
 export type SimulatedBikePin = FrontendDashboardBikePin & {
-  deliveryPhase: DeliveryPhase | null;
-  /** 누적 배송 완료 건수. 시뮬레이션 대상이 아니면 undefined. */
+  servicePhase: ServicePhase | null;
+  /** 누적 완료 건수. 시뮬레이션 대상이 아니면 undefined. */
   deliveryCount?: number;
+  /** WORKING→MOVING 전환 시점 ms. 말풍선 표시 여부 판단에 사용. null 이면 미표시. */
+  ignitionOnAt?: number | null;
 };
 
 /**
  * 지도 마커용 — raw bikePins 배열 위에 fleet 시뮬레이션 상태를 overlay 한다.
- * simulated 가 비어 있으면 raw 가 그대로 반환되어 비용 없음. 시뮬레이트
- * 되는 차량의 lat/lng / 시동 / 속도 / 배터리 / 연결 상태 / 마지막 수신 만
- * 갈아끼우고 다른 필드 (plateNumber, modelName 등) 는 raw 그대로.
  */
 export function useSimulatedBikePins(
   rawPins: ReadonlyArray<FrontendDashboardBikePin>
@@ -29,12 +28,12 @@ export function useSimulatedBikePins(
   const { simulated } = useFleetSimulation();
   return useMemo(() => {
     if (simulated.size === 0) {
-      return rawPins.map((pin) => ({ ...pin, deliveryPhase: null }));
+      return rawPins.map((pin) => ({ ...pin, servicePhase: null }));
     }
     const nowIso = new Date().toISOString();
     return rawPins.map((pin) => {
       const sim = simulated.get(pin.bikeId);
-      if (!sim) return { ...pin, deliveryPhase: null };
+      if (!sim) return { ...pin, servicePhase: null };
       const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
         sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
       const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
@@ -50,17 +49,16 @@ export function useSimulatedBikePins(
         drivingStatus,
         batteryStatus,
         lastReceivedAt: nowIso,
-        deliveryPhase: sim.phase,
-        deliveryCount: sim.deliveryCount
+        servicePhase: sim.phase,
+        deliveryCount: sim.deliveryCount,
+        ignitionOnAt: sim.ignitionOnAt
       };
     });
   }, [rawPins, simulated]);
 }
 
 /**
- * 차량 상세 패널 텔레메트리 섹션용 — bundle.currentState 위에 simulated
- * overlay. raw 가 null 이고 simulated 에도 entry 없으면 null. simulated 가
- * 있으면 거기서 합성한 summary 를 돌려준다.
+ * 차량 상세 패널 텔레메트리 섹션용.
  */
 export function useSimulatedCurrentTelemetry(
   rawCurrent: VehicleCurrentTelemetrySummary | null,

--- a/development/front-admin-web/components/overview/use-trail-waypoints.ts
+++ b/development/front-admin-web/components/overview/use-trail-waypoints.ts
@@ -46,7 +46,7 @@ function traveledWaypoints(
  * 선택된 차량의 **현재까지 이동한** 경로 waypoints 반환.
  *
  * - IMEI=-1 시뮬 차량: OSRM routeWaypoints 를 progress 로 슬라이스.
- *   EN_ROUTE + routeWaypoints 있을 때만 반환. IDLE / fetch 중이면 null.
+ *   MOVING + routeWaypoints 있을 때만 반환. WORKING / fetch 중이면 null.
  * - 실제 차량: null (백엔드 API 완성 후 fetchBikeLocationHistory 로 교체).
  * - selectedBikeId === null → null.
  *

--- a/development/front-admin-web/components/overview/use-trail-waypoints.ts
+++ b/development/front-admin-web/components/overview/use-trail-waypoints.ts
@@ -64,7 +64,7 @@ export function useTrailWaypoints(
     const sim = simulated.get(selectedBikeId);
     if (sim) {
       if (
-        sim.phase === "EN_ROUTE" &&
+        sim.phase === "MOVING" &&
         sim.routeWaypoints !== null &&
         sim.routeWaypoints.length >= 2
       ) {

--- a/development/front-admin-web/docs/superpowers/plans/2026-05-26-ignition-alarm.md
+++ b/development/front-admin-web/docs/superpowers/plans/2026-05-26-ignition-alarm.md
@@ -1,0 +1,1178 @@
+# Ignition Alarm Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** IMEI=-1 시뮬레이션 차량이 WORKING→MOVING 전환(시동 ON) 시 지도 마커 위에 CSS 말풍선을 표시하고 헤더 벨 아이콘 + 드롭다운 이력에 기록한다.
+
+**Architecture:** `fleet-simulation.ts`의 상태명을 IDLE/EN_ROUTE → WORKING/MOVING으로 바꾸고 `ignitionOnAt` 필드를 추가한다. `FleetSimulationContext`가 상태 변화를 감지해 `NotificationContext`에 이벤트를 push하고, `MapShell`이 `ignitionOnAt` 기준으로 마커 HTML에 CSS 말풍선을 포함시킨다.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, React "use client", NCP Maps SDK (HTML marker), CSS animation
+
+---
+
+## 변경 파일 목록
+
+| 파일 | 신규/수정 |
+|------|----------|
+| `development/front-admin-web/lib/services/fleet-simulation.ts` | 수정 |
+| `development/front-admin-web/components/layout/NotificationContext.tsx` | **신규** |
+| `development/front-admin-web/components/layout/NotificationBell.tsx` | **신규** |
+| `development/front-admin-web/components/overview/FleetSimulationContext.tsx` | 수정 |
+| `development/front-admin-web/components/overview/use-simulated-bike-pins.ts` | 수정 |
+| `development/front-admin-web/components/dashboard/MapShell.tsx` | 수정 |
+| `development/front-admin-web/components/overview/OverviewClientShell.tsx` | 수정 |
+| `development/front-admin-web/app/page.tsx` | 수정 |
+| `development/front-admin-web/app/globals.css` | 수정 |
+
+---
+
+### Task 1: fleet-simulation.ts — ServicePhase + ignitionOnAt
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/fleet-simulation.ts`
+
+현재 파일 전체를 아래 내용으로 교체한다. 변경점:
+- `DeliveryPhase` → `ServicePhase`, `"IDLE"` → `"WORKING"`, `"EN_ROUTE"` → `"MOVING"`
+- `SimulatedBikeState`에 `ignitionOnAt: number | null` 추가
+- `advanceBikeState` WORKING→MOVING 전환 시 `ignitionOnAt: nowMs`, MOVING→WORKING 시 `ignitionOnAt: null`
+- `makeInitialState` 양쪽 `ignitionOnAt: null`
+- 상수명 `EN_ROUTE_*` → `MOVING_*`, `IDLE_BETWEEN_*` → `WORKING_BETWEEN_*`
+
+- [ ] **Step 1: fleet-simulation.ts 전체 교체**
+
+```ts
+/**
+ * Fleet 서비스 시뮬레이션 순수 데이터 모델 + phase 진행 함수.
+ *
+ * Phase: WORKING(작업, 시동 OFF) ↔ MOVING(이동 중, 시동 ON)
+ * isMatched=true 이면 WORKING → MOVING 자동 전환, false 이면 WORKING 유지.
+ */
+
+export type ServicePhase = "WORKING" | "MOVING";
+
+export type SimulatedBikeState = {
+  bikeId: string;
+  phase: ServicePhase;
+  origin: { lat: number; lng: number };
+  destination: { lat: number; lng: number } | null;
+  /** MOVING 진행률 0..1. WORKING 에선 0. */
+  progress: number;
+  /** 누적 완료 건수. MOVING → WORKING 전환 시마다 +1. */
+  deliveryCount: number;
+  /** 현재 표시 위치 */
+  position: { lat: number; lng: number };
+  /** 이 phase 의 시작 ms */
+  phaseStartedAt: number;
+  /** 이 phase 의 종료 예정 ms */
+  phaseEndsAt: number;
+  /** 현재 표시 속도 km/h */
+  speedKph: number;
+  /** 현재 시동. MOVING 만 ON. */
+  ignitionStatus: "ON" | "OFF";
+  /**
+   * WORKING→MOVING 전환 시점 ms. 말풍선 표시 여부 판단에 사용.
+   * MOVING→WORKING 전환 시 null 로 초기화.
+   */
+  ignitionOnAt: number | null;
+  /** 누적 km */
+  odometerKm: number;
+  /** 배터리 % */
+  batteryPercent: number;
+  /** OSRM 경로 waypoints */
+  routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
+};
+
+/** tick 간격 (ms) */
+export const TICK_INTERVAL_MS = 250;
+/** MOVING 한 주기 최소 길이 (15분) */
+export const MOVING_DURATION_MIN_MS = 15 * 60 * 1_000;
+/** MOVING 한 주기 최대 길이 (40분) */
+export const MOVING_DURATION_MAX_MS = 40 * 60 * 1_000;
+/** 완료 후 다음 사이클까지 최소 대기 (ms) */
+export const WORKING_BETWEEN_MIN_MS = 5_000;
+/** 완료 후 다음 사이클까지 최대 대기 (ms) */
+export const WORKING_BETWEEN_MAX_MS = 30_000;
+/** MOVING 시 표시 속도 (km/h) */
+export const MOVING_SPEED_KPH = 30;
+/** 초당 배터리 감소량 */
+export const BATTERY_DROP_PER_SECOND = 0.05;
+
+const SEOUL_LAT_MIN = 37.44;
+const SEOUL_LAT_MAX = 37.65;
+const SEOUL_LNG_MIN = 126.87;
+const SEOUL_LNG_MAX = 127.10;
+
+function randomMovingDurationMs(random: () => number): number {
+  return (
+    MOVING_DURATION_MIN_MS +
+    random() * (MOVING_DURATION_MAX_MS - MOVING_DURATION_MIN_MS)
+  );
+}
+
+function randomSeoulPoint(random: () => number = Math.random): { lat: number; lng: number } {
+  return {
+    lat: SEOUL_LAT_MIN + random() * (SEOUL_LAT_MAX - SEOUL_LAT_MIN),
+    lng: SEOUL_LNG_MIN + random() * (SEOUL_LNG_MAX - SEOUL_LNG_MIN)
+  };
+}
+
+function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+  const dLat = (b.lat - a.lat) * 111;
+  const dLng = (b.lng - a.lng) * 88;
+  return Math.sqrt(dLat * dLat + dLng * dLng);
+}
+
+function lerpPosition(
+  from: { lat: number; lng: number },
+  to: { lat: number; lng: number },
+  t: number
+): { lat: number; lng: number } {
+  const clamped = Math.max(0, Math.min(1, t));
+  return {
+    lat: from.lat + (to.lat - from.lat) * clamped,
+    lng: from.lng + (to.lng - from.lng) * clamped
+  };
+}
+
+function walkPolyline(
+  waypoints: ReadonlyArray<{ lat: number; lng: number }>,
+  t: number
+): { lat: number; lng: number } {
+  if (waypoints.length === 0) return { lat: 37.5665, lng: 126.978 };
+  if (waypoints.length === 1) return waypoints[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const totalSegs = waypoints.length - 1;
+  const pos = clamped * totalSegs;
+  const segIndex = Math.min(Math.floor(pos), totalSegs - 1);
+  const segT = pos - segIndex;
+  return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
+}
+
+export function advanceBikeState(
+  prev: SimulatedBikeState,
+  nowMs: number,
+  isMatched: boolean,
+  random: () => number = Math.random
+): SimulatedBikeState {
+  if (nowMs < prev.phaseEndsAt) {
+    if (prev.phase !== "MOVING" || !prev.destination) return prev;
+    const total = prev.phaseEndsAt - prev.phaseStartedAt;
+    const elapsed = nowMs - prev.phaseStartedAt;
+    const progress = total > 0 ? elapsed / total : 1;
+    const position = prev.routeWaypoints
+      ? walkPolyline(prev.routeWaypoints, progress)
+      : lerpPosition(prev.origin, prev.destination, progress);
+    const distanceKm = approxDistanceKm(prev.origin, prev.destination);
+    const totalSeconds = total / 1_000;
+    const tickFactor = TICK_INTERVAL_MS / 1_000;
+    const odometerDelta = totalSeconds > 0 ? (distanceKm / totalSeconds) * tickFactor : 0;
+    const batteryDelta = BATTERY_DROP_PER_SECOND * tickFactor;
+    return {
+      ...prev,
+      progress,
+      position,
+      odometerKm: prev.odometerKm + odometerDelta,
+      batteryPercent: Math.max(0, prev.batteryPercent - batteryDelta)
+    };
+  }
+
+  switch (prev.phase) {
+    case "WORKING": {
+      if (!isMatched) {
+        return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
+      }
+      const destination = randomSeoulPoint(random);
+      return {
+        ...prev,
+        phase: "MOVING",
+        destination,
+        progress: 0,
+        position: prev.origin,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: nowMs + randomMovingDurationMs(random),
+        speedKph: MOVING_SPEED_KPH,
+        ignitionStatus: "ON",
+        ignitionOnAt: nowMs,
+        routeWaypoints: null
+      };
+    }
+    case "MOVING": {
+      const finalPosition = prev.destination ?? prev.origin;
+      const idleMs = isMatched
+        ? WORKING_BETWEEN_MIN_MS +
+          Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS))
+        : Number.POSITIVE_INFINITY;
+      const workingPhaseEndsAt = idleMs === Number.POSITIVE_INFINITY ? idleMs : nowMs + idleMs;
+      return {
+        ...prev,
+        phase: "WORKING",
+        progress: 0,
+        position: finalPosition,
+        origin: finalPosition,
+        destination: null,
+        phaseStartedAt: nowMs,
+        phaseEndsAt: workingPhaseEndsAt,
+        speedKph: 0,
+        ignitionStatus: "OFF",
+        ignitionOnAt: null,
+        routeWaypoints: null,
+        deliveryCount: prev.deliveryCount + 1
+      };
+    }
+  }
+}
+
+export function makeInitialState(input: {
+  bikeId: string;
+  origin: { lat: number; lng: number };
+  nowMs: number;
+  phase: "WORKING" | "MOVING";
+  random?: () => number;
+  initialOdometerKm?: number;
+  initialBatteryPercent?: number;
+}): SimulatedBikeState {
+  const {
+    bikeId,
+    origin,
+    nowMs,
+    phase,
+    random = Math.random,
+    initialOdometerKm = 0,
+    initialBatteryPercent = 90
+  } = input;
+
+  if (phase === "MOVING") {
+    return {
+      bikeId,
+      phase: "MOVING",
+      origin,
+      destination: randomSeoulPoint(random),
+      progress: 0,
+      position: origin,
+      phaseStartedAt: nowMs,
+      phaseEndsAt: nowMs + randomMovingDurationMs(random),
+      speedKph: MOVING_SPEED_KPH,
+      ignitionStatus: "ON",
+      ignitionOnAt: nowMs,
+      odometerKm: initialOdometerKm,
+      batteryPercent: initialBatteryPercent,
+      routeWaypoints: null,
+      deliveryCount: 0
+    };
+  }
+
+  return {
+    bikeId,
+    phase: "WORKING",
+    origin,
+    destination: null,
+    progress: 0,
+    position: origin,
+    phaseStartedAt: nowMs,
+    phaseEndsAt: Number.POSITIVE_INFINITY,
+    speedKph: 0,
+    ignitionStatus: "OFF",
+    ignitionOnAt: null,
+    odometerKm: initialOdometerKm,
+    batteryPercent: initialBatteryPercent,
+    routeWaypoints: null,
+    deliveryCount: 0
+  };
+}
+```
+
+- [ ] **Step 2: 타입 체크 확인**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: `fleet-simulation.ts` 관련 에러가 다른 파일에서 나올 수 있음 (아직 참조 업데이트 전). `fleet-simulation.ts` 자체 에러는 0.
+
+- [ ] **Step 3: commit**
+
+```bash
+git add development/front-admin-web/lib/services/fleet-simulation.ts
+git commit -m "refactor(sim): rename DeliveryPhase→ServicePhase, IDLE→WORKING, EN_ROUTE→MOVING, add ignitionOnAt"
+```
+
+---
+
+### Task 2: NotificationContext.tsx 신규 + CSS
+
+**Files:**
+- Create: `development/front-admin-web/components/layout/NotificationContext.tsx`
+- Modify: `development/front-admin-web/app/globals.css` (append)
+
+- [ ] **Step 1: NotificationContext.tsx 작성**
+
+`development/front-admin-web/components/layout/NotificationContext.tsx` 파일을 새로 만든다:
+
+```tsx
+// development/front-admin-web/components/layout/NotificationContext.tsx
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type IgnitionNotification = {
+  id: string;
+  plateNumber: string;
+  startedAt: number;
+};
+
+type NotificationContextValue = {
+  notifications: IgnitionNotification[];
+  unreadCount: number;
+  addNotification: (n: Omit<IgnitionNotification, "id">) => void;
+  markAllRead: () => void;
+};
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<IgnitionNotification[]>([]);
+  const [readCount, setReadCount] = useState(0);
+
+  const addNotification = useCallback((n: Omit<IgnitionNotification, "id">) => {
+    setNotifications((prev) => {
+      const next = [
+        ...prev,
+        { ...n, id: `${n.plateNumber}-${n.startedAt}` },
+      ];
+      return next.length > 20 ? next.slice(-20) : next;
+    });
+  }, []);
+
+  const markAllRead = useCallback((total: number) => {
+    setReadCount(total);
+  }, []);
+
+  const unreadCount = Math.max(0, notifications.length - readCount);
+
+  return (
+    <NotificationContext.Provider
+      value={{ notifications, unreadCount, addNotification, markAllRead: () => markAllRead(notifications.length) }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error("useNotifications must be used within NotificationProvider");
+  return ctx;
+}
+```
+
+- [ ] **Step 2: globals.css에 벨 CSS 추가 (파일 끝에 append)**
+
+`development/front-admin-web/app/globals.css` 파일 맨 끝에 추가:
+
+```css
+/* ── Notification Bell ──────────────────────────────────────────── */
+.notif-bell-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.notif-bell-btn {
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  line-height: 1;
+  color: var(--rm-text, #374151);
+}
+
+.notif-bell-btn:hover {
+  background: var(--rm-hover, rgba(0, 0, 0, 0.06));
+}
+
+.notif-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #ef4444;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.notif-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--rm-card-bg, #fff);
+  border: 1px solid var(--rm-border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+}
+
+.notif-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--rm-text-muted, #9ca3af);
+}
+
+.notif-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--rm-border, #e5e7eb);
+  font-size: 12px;
+}
+
+.notif-item:last-child {
+  border-bottom: none;
+}
+
+.notif-item-text {
+  color: var(--rm-text, #374151);
+  font-weight: 500;
+  flex: 1;
+}
+
+.notif-item-time {
+  color: var(--rm-text-muted, #9ca3af);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+```
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | grep "NotificationContext" | head -10
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add development/front-admin-web/components/layout/NotificationContext.tsx \
+        development/front-admin-web/app/globals.css
+git commit -m "feat(notif): add NotificationContext + bell CSS"
+```
+
+---
+
+### Task 3: NotificationBell.tsx 신규 + 말풍선 CSS
+
+**Files:**
+- Create: `development/front-admin-web/components/layout/NotificationBell.tsx`
+- Modify: `development/front-admin-web/app/globals.css` (append)
+
+- [ ] **Step 1: NotificationBell.tsx 작성**
+
+```tsx
+// development/front-admin-web/components/layout/NotificationBell.tsx
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useNotifications } from "@/components/layout/NotificationContext";
+
+function formatRelativeTime(startedAt: number): string {
+  const diffMs = Date.now() - startedAt;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "방금";
+  if (diffMin < 60) return `${diffMin}분 전`;
+  return `${Math.floor(diffMin / 60)}시간 전`;
+}
+
+export function NotificationBell() {
+  const { notifications, unreadCount, markAllRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function handleToggle() {
+    const next = !open;
+    setOpen(next);
+    if (next) markAllRead();
+  }
+
+  return (
+    <div className="notif-bell-wrapper" ref={wrapperRef}>
+      <button
+        type="button"
+        className="notif-bell-btn"
+        onClick={handleToggle}
+        aria-label={`알림${unreadCount > 0 ? ` (읽지 않은 알림 ${unreadCount}건)` : ""}`}
+      >
+        🔔
+        {unreadCount > 0 && (
+          <span className="notif-badge" aria-hidden="true">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="notif-dropdown" role="list" aria-label="이동 알림 이력">
+          {notifications.length === 0 ? (
+            <div className="notif-empty">알림 없음</div>
+          ) : (
+            [...notifications].reverse().map((n) => (
+              <div key={n.id} className="notif-item" role="listitem">
+                <span className="notif-item-text">🔑 {n.plateNumber} 이동 시작</span>
+                <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: globals.css에 말풍선 CSS 추가 (파일 끝에 append)**
+
+```css
+/* ── Map Ignition Bubble ────────────────────────────────────────── */
+.map-ignition-bubble {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1d4ed8;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 10px;
+  pointer-events: none;
+  animation: ignition-bubble-fade 4s ease forwards;
+}
+
+.map-ignition-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #1d4ed8;
+}
+
+@keyframes ignition-bubble-fade {
+  0%   { opacity: 1; }
+  70%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+```
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | grep "NotificationBell" | head -10
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add development/front-admin-web/components/layout/NotificationBell.tsx \
+        development/front-admin-web/app/globals.css
+git commit -m "feat(notif): add NotificationBell component + ignition bubble CSS"
+```
+
+---
+
+### Task 4: FleetSimulationContext.tsx — ignitionOnAt 감지 + addNotification 연동
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/FleetSimulationContext.tsx`
+
+현재 파일에서 다음 변경 적용:
+
+1. import `ServicePhase` (기존 `DeliveryPhase` 제거), `MOVING_DURATION_MAX_MS` (기존 `EN_ROUTE_DURATION_MAX_MS`)
+2. `useNotifications` import 추가
+3. `lastNotifiedIgnitionOnAtRef` ref 추가 — 중복 알림 방지용 (bikeId → 마지막 통보한 ignitionOnAt)
+4. ignition 감지 `useEffect` 추가 — `simulated` 변화 감지 시 새 `ignitionOnAt` 비교
+5. 기존 `"EN_ROUTE"` 문자열 → `"MOVING"`, `"IDLE"` → `"WORKING"` 변경
+6. `EN_ROUTE_DURATION_MAX_MS` → `MOVING_DURATION_MAX_MS`
+
+- [ ] **Step 1: import 블록 + useNotifications 호출 변경**
+
+파일 상단 import를 다음으로 교체:
+
+```ts
+import {
+  advanceBikeState,
+  makeInitialState,
+  TICK_INTERVAL_MS,
+  MOVING_DURATION_MAX_MS,
+  type SimulatedBikeState,
+  type ServicePhase
+} from "@/lib/services/fleet-simulation";
+import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+import { fetchOsrmRoute } from "@/lib/services/osrm";
+import { useNotifications } from "@/components/layout/NotificationContext";
+```
+
+- [ ] **Step 2: Provider 함수 안에 useNotifications + ref 추가**
+
+`FleetSimulationProvider` 함수 내부, `useState` 선언들 바로 아래에 추가:
+
+```ts
+const { addNotification } = useNotifications();
+/** bikeId → 마지막으로 알림 발송한 ignitionOnAt ms. 중복 발송 방지. */
+const lastNotifiedIgnitionOnAtRef = useRef<Map<string, number>>(new Map());
+```
+
+- [ ] **Step 3: ignition 감지 useEffect 추가**
+
+`useEffect(() => { ... }, [matchedImeiSet]);` (자동 트리거 useEffect) 바로 뒤에 추가:
+
+```ts
+// WORKING→MOVING 전환 감지 → 알림 발송.
+// simulated 변화를 감지해 ignitionOnAt 이 새로 설정된 bike 를 찾아낸다.
+// lastNotifiedIgnitionOnAtRef 로 같은 ignitionOnAt 에 대해 중복 발송하지 않는다.
+useEffect(() => {
+  for (const [bikeId, state] of simulated) {
+    if (state.ignitionOnAt == null) continue;
+    const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
+    if (last === state.ignitionOnAt) continue;
+    lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
+    const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+    const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
+    addNotification({ plateNumber, startedAt: state.ignitionOnAt });
+  }
+  // cleanup: 시뮬에서 제거된 bikeId 는 ref 에서도 정리
+  for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
+    if (!simulated.has(bikeId)) {
+      lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
+    }
+  }
+}, [simulated, addNotification]);
+```
+
+- [ ] **Step 4: 나머지 문자열 치환**
+
+파일 내 나머지 변경:
+
+| 변경 전 | 변경 후 |
+|---------|---------|
+| `EN_ROUTE_DURATION_MAX_MS` | `MOVING_DURATION_MAX_MS` |
+| `phase: "EN_ROUTE"` | `phase: "MOVING"` |
+| `phase === "IDLE"` | `phase === "WORKING"` |
+| `DeliveryPhase` (타입 참조) | `ServicePhase` |
+
+자동 트리거 useEffect 내 `makeInitialState` 호출의 `phase: "EN_ROUTE"` → `phase: "MOVING"`.
+
+tick loop 내 cleanup 조건 `advanced.phase === "IDLE"` → `advanced.phase === "WORKING"`.
+
+OSRM fetch useEffect 내 `state.phase !== "EN_ROUTE"` → `state.phase !== "MOVING"`, `current.phase === "IDLE"` → `current.phase === "WORKING"`.
+
+- [ ] **Step 5: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | grep "FleetSimulationContext" | head -10
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add development/front-admin-web/components/overview/FleetSimulationContext.tsx
+git commit -m "feat(sim): connect FleetSimulationContext to NotificationContext on ignitionOnAt change"
+```
+
+---
+
+### Task 5: use-simulated-bike-pins.ts — servicePhase + ignitionOnAt 전달
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/use-simulated-bike-pins.ts`
+
+- [ ] **Step 1: 파일 전체를 아래 내용으로 교체**
+
+```ts
+"use client";
+
+import { useMemo } from "react";
+
+import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
+import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+import type { VehicleCurrentTelemetrySummary } from "@/lib/services/vehicle-maintenance-data";
+import type { ServicePhase } from "@/lib/services/fleet-simulation";
+
+/**
+ * MapShell / OverviewMapSearch 에 전달하는 클라이언트 전용 확장 타입.
+ * FrontendDashboardBikePin 위에 servicePhase / ignitionOnAt 을 overlay 한다.
+ */
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  servicePhase: ServicePhase | null;
+  /** 누적 완료 건수. 시뮬레이션 대상이 아니면 undefined. */
+  deliveryCount?: number;
+  /** WORKING→MOVING 전환 시점 ms. 말풍선 표시 여부 판단에 사용. null 이면 미표시. */
+  ignitionOnAt?: number | null;
+};
+
+/**
+ * 지도 마커용 — raw bikePins 배열 위에 fleet 시뮬레이션 상태를 overlay 한다.
+ */
+export function useSimulatedBikePins(
+  rawPins: ReadonlyArray<FrontendDashboardBikePin>
+): SimulatedBikePin[] {
+  const { simulated } = useFleetSimulation();
+  return useMemo(() => {
+    if (simulated.size === 0) {
+      return rawPins.map((pin) => ({ ...pin, servicePhase: null }));
+    }
+    const nowIso = new Date().toISOString();
+    return rawPins.map((pin) => {
+      const sim = simulated.get(pin.bikeId);
+      if (!sim) return { ...pin, servicePhase: null };
+      const batteryStatus: FrontendDashboardBikePin["batteryStatus"] =
+        sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
+      const drivingStatus: FrontendDashboardBikePin["drivingStatus"] =
+        sim.ignitionStatus === "ON" ? (sim.speedKph >= 3 ? "DRIVING" : "STOPPED") : "PARKED";
+      return {
+        ...pin,
+        latitude: sim.position.lat,
+        longitude: sim.position.lng,
+        speedKph: sim.speedKph,
+        batteryPercent: Math.round(sim.batteryPercent),
+        ignitionStatus: sim.ignitionStatus,
+        connectionStatus: "ONLINE",
+        drivingStatus,
+        batteryStatus,
+        lastReceivedAt: nowIso,
+        servicePhase: sim.phase,
+        deliveryCount: sim.deliveryCount,
+        ignitionOnAt: sim.ignitionOnAt
+      };
+    });
+  }, [rawPins, simulated]);
+}
+
+/**
+ * 차량 상세 패널 텔레메트리 섹션용.
+ */
+export function useSimulatedCurrentTelemetry(
+  rawCurrent: VehicleCurrentTelemetrySummary | null,
+  bikeId: string | null
+): VehicleCurrentTelemetrySummary | null {
+  const { simulated } = useFleetSimulation();
+  return useMemo(() => {
+    if (!bikeId) return rawCurrent;
+    const sim = simulated.get(bikeId);
+    if (!sim) return rawCurrent;
+    const batteryStatus: VehicleCurrentTelemetrySummary["batteryStatus"] =
+      sim.batteryPercent < 20 ? "CRITICAL" : sim.batteryPercent <= 50 ? "LOW" : "NORMAL";
+    const drivingStatus: VehicleCurrentTelemetrySummary["drivingStatus"] =
+      sim.ignitionStatus === "ON" ? (sim.speedKph >= 3 ? "DRIVING" : "STOPPED") : "PARKED";
+    return {
+      odometerKm: Math.round(sim.odometerKm),
+      connectionStatus: "ONLINE",
+      ignitionStatus: sim.ignitionStatus,
+      batteryPercent: Math.round(sim.batteryPercent),
+      batteryStatus,
+      speedKph: sim.speedKph,
+      drivingStatus,
+      lastReceivedAt: new Date().toISOString()
+    };
+  }, [rawCurrent, bikeId, simulated]);
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | grep "use-simulated-bike-pins" | head -10
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 3: commit**
+
+```bash
+git add development/front-admin-web/components/overview/use-simulated-bike-pins.ts
+git commit -m "refactor(sim): rename deliveryPhase→servicePhase, add ignitionOnAt in SimulatedBikePin"
+```
+
+---
+
+### Task 6: MapShell.tsx — servicePhase 배지 + 말풍선
+
+**Files:**
+- Modify: `development/front-admin-web/components/dashboard/MapShell.tsx`
+
+아래 변경을 순서대로 적용한다.
+
+- [ ] **Step 1: import 변경**
+
+파일 상단에서:
+```ts
+import type { DeliveryPhase } from "@/lib/services/fleet-simulation";
+```
+를 다음으로 교체:
+```ts
+import type { ServicePhase } from "@/lib/services/fleet-simulation";
+```
+
+- [ ] **Step 2: bikePins prop 타입 변경**
+
+`MapShellProps` 인터페이스에서:
+```ts
+bikePins?: Array<FrontendDashboardBikePin & { deliveryPhase?: DeliveryPhase | null; deliveryCount?: number }>;
+```
+를 다음으로 교체:
+```ts
+bikePins?: Array<FrontendDashboardBikePin & { servicePhase?: ServicePhase | null; deliveryCount?: number; ignitionOnAt?: number | null }>;
+```
+
+- [ ] **Step 3: prevDeliveryPhaseRef → prevServicePhaseRef**
+
+```ts
+const prevDeliveryPhaseRef = useRef<Map<string, DeliveryPhase | null>>(new Map());
+```
+를 다음으로 교체:
+```ts
+const prevServicePhaseRef = useRef<Map<string, ServicePhase | null>>(new Map());
+```
+
+- [ ] **Step 4: bike markers useEffect 내부 변경**
+
+`useEffect` (bike markers, line ~430-494) 내부:
+
+```ts
+const prevPhases = prevDeliveryPhaseRef.current;
+```
+→
+```ts
+const prevPhases = prevServicePhaseRef.current;
+```
+
+```ts
+const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.deliveryPhase, pin.deliveryCount);
+```
+→
+```ts
+const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt);
+```
+
+```ts
+const currentPhase = pin.deliveryPhase ?? null;
+```
+→
+```ts
+const currentPhase = pin.servicePhase ?? null;
+```
+
+- [ ] **Step 5: deliveryBadgeMarkup → serviceBadgeMarkup 함수 교체**
+
+기존 `deliveryBadgeMarkup` 함수 (line ~676-690) 전체를 다음으로 교체:
+
+```ts
+/**
+ * 서비스 상태 배지 HTML.
+ * - MOVING: 파랑(#3b82f6) "이동 중 · N건"
+ * - WORKING: 회색(#6b7280) "작업 · N건"
+ */
+function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number): string {
+  const isMoving = phase === "MOVING";
+  const bg = isMoving ? "#3b82f6" : "#6b7280";
+  const label = isMoving ? "이동 중" : "작업";
+  const text = `${label} · ${deliveryCount}건`;
+  return (
+    `<div style="position:absolute;top:${BADGE_TOP_OFFSET}px;left:50%;` +
+    `transform:translateX(-50%);display:flex;align-items:center;` +
+    `height:14px;padding:0 5px;border-radius:3px;font-size:9px;font-weight:600;` +
+    `color:#fff;white-space:nowrap;background:${bg};pointer-events:none;">` +
+    `${text}</div>`
+  );
+}
+```
+
+그리고 아래에 말풍선 생성 함수 추가:
+
+```ts
+/**
+ * 시동 켜짐 말풍선 HTML.
+ * CSS animation (.map-ignition-bubble) 으로 4초 후 자동 소멸.
+ * NCP firstChild-only 제약상 markerWrapper 안에 badge 와 함께 삽입.
+ */
+function ignitionBubbleMarkup(): string {
+  return `<div class="map-ignition-bubble">🔑 이동 시작</div>`;
+}
+```
+
+- [ ] **Step 6: bikeMarkerHtml 함수 교체**
+
+기존 `bikeMarkerHtml` 함수 (line ~755-773) 전체를 다음으로 교체:
+
+```ts
+/**
+ * 차량 마커 — 스쿠터 아이콘 + (옵션) 번호판 라벨 + (옵션) 서비스 상태 배지 + (옵션) 시동 말풍선.
+ *
+ * servicePhase != null 이면 배지 포함. ignitionOnAt 이 4초 이내이면 말풍선 포함.
+ * 배지·말풍선은 markerWrapper(overflow:visible + position:relative) 안 position:absolute 자식.
+ */
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  servicePhase?: ServicePhase | null,
+  deliveryCount?: number,
+  ignitionOnAt?: number | null
+): string {
+  const badge =
+    servicePhase != null
+      ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0)
+      : "";
+  const showBubble = ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
+  const bubble = showBubble ? ignitionBubbleMarkup() : "";
+  const extras = badge || bubble ? badge + bubble : undefined;
+  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras);
+  if (!showLabel) return wrapped;
+  return (
+    `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +
+    `${labelMarkup(plateNumber)}${wrapped}` +
+    `</div>`
+  );
+}
+```
+
+- [ ] **Step 7: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | grep "MapShell" | head -10
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 8: commit**
+
+```bash
+git add development/front-admin-web/components/dashboard/MapShell.tsx
+git commit -m "feat(map): servicePhase 배지 (이동 중/작업) + 시동 켜짐 말풍선"
+```
+
+---
+
+### Task 7: OverviewClientShell.tsx + page.tsx — Provider 래핑 + Bell 연결
+
+**Files:**
+- Modify: `development/front-admin-web/components/overview/OverviewClientShell.tsx`
+- Modify: `development/front-admin-web/app/page.tsx`
+
+- [ ] **Step 1: OverviewClientShell.tsx — NotificationProvider 래핑**
+
+현재 내용:
+
+```tsx
+"use client";
+
+import type { ReactNode } from "react";
+
+import { FleetSimulationProvider } from "@/components/overview/FleetSimulationContext";
+import { VehicleFilterProvider } from "@/components/overview/VehicleFilterContext";
+
+export function OverviewClientShell({
+  children,
+  imeiMinusOneBikeIds,
+  bikeRiderPairs
+}: {
+  children: ReactNode;
+  imeiMinusOneBikeIds: string[];
+  bikeRiderPairs: [string, string][];
+}) {
+  return (
+    <VehicleFilterProvider>
+      <FleetSimulationProvider
+        imeiMinusOneBikeIds={imeiMinusOneBikeIds}
+        bikeRiderPairs={bikeRiderPairs}
+      >
+        {children}
+      </FleetSimulationProvider>
+    </VehicleFilterProvider>
+  );
+}
+```
+
+다음으로 교체:
+
+```tsx
+"use client";
+
+import type { ReactNode } from "react";
+
+import { NotificationProvider } from "@/components/layout/NotificationContext";
+import { FleetSimulationProvider } from "@/components/overview/FleetSimulationContext";
+import { VehicleFilterProvider } from "@/components/overview/VehicleFilterContext";
+
+/**
+ * 루트 페이지의 클라이언트 전용 Provider 래퍼.
+ *
+ * NotificationProvider — 최외곽. FleetSimulationProvider 가
+ * useNotifications() 를 호출하므로 반드시 그 바깥에 있어야 한다.
+ */
+export function OverviewClientShell({
+  children,
+  imeiMinusOneBikeIds,
+  bikeRiderPairs
+}: {
+  children: ReactNode;
+  imeiMinusOneBikeIds: string[];
+  bikeRiderPairs: [string, string][];
+}) {
+  return (
+    <NotificationProvider>
+      <VehicleFilterProvider>
+        <FleetSimulationProvider
+          imeiMinusOneBikeIds={imeiMinusOneBikeIds}
+          bikeRiderPairs={bikeRiderPairs}
+        >
+          {children}
+        </FleetSimulationProvider>
+      </VehicleFilterProvider>
+    </NotificationProvider>
+  );
+}
+```
+
+- [ ] **Step 2: page.tsx — NotificationBell import 추가**
+
+`page.tsx` 상단 import 목록에 추가 (다른 import 사이 아무 위치):
+
+```ts
+import { NotificationBell } from "@/components/layout/NotificationBell";
+```
+
+- [ ] **Step 3: page.tsx — NotificationBell을 overview-tab-action에 추가**
+
+`page.tsx`에서 `overview-tab-action` div를 찾아 `NotificationBell`을 추가한다.
+
+현재:
+```tsx
+<div className="overview-tab-action">
+  {activeTab === "riders" ? <CreateRiderDialog /> : null}
+  {activeTab === "vehicles" ? <CreateVehicleDialog /> : null}
+  {activeTab === "stations" ? <CreateStationDialog /> : null}
+  {activeTab === "maintenance" ? <CreateMaintenanceItemDialog parentOptions={maintenanceData.items} /> : null}
+</div>
+```
+
+다음으로 교체:
+```tsx
+<div className="overview-tab-action">
+  <NotificationBell />
+  {activeTab === "riders" ? <CreateRiderDialog /> : null}
+  {activeTab === "vehicles" ? <CreateVehicleDialog /> : null}
+  {activeTab === "stations" ? <CreateStationDialog /> : null}
+  {activeTab === "maintenance" ? <CreateMaintenanceItemDialog parentOptions={maintenanceData.items} /> : null}
+</div>
+```
+
+- [ ] **Step 4: 타입 체크**
+
+```bash
+cd development/front-admin-web && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 에러 없음 (또는 이전부터 있던 무관한 에러만).
+
+- [ ] **Step 5: commit**
+
+```bash
+git add development/front-admin-web/components/overview/OverviewClientShell.tsx \
+        development/front-admin-web/app/page.tsx
+git commit -m "feat(notif): wire NotificationProvider + NotificationBell into page layout"
+```
+
+---
+
+### Task 8: 최종 검증 + PR
+
+**Files:** 없음 (빌드 검증 + PR 생성)
+
+- [ ] **Step 1: 전체 빌드 확인**
+
+```bash
+cd development/front-admin-web && npm run build 2>&1 | tail -30
+```
+
+Expected: `✓ Compiled successfully` — TypeScript 에러 0, 빌드 에러 0.
+
+- [ ] **Step 2: lint 확인**
+
+```bash
+cd development/front-admin-web && npm run lint 2>&1 | tail -20
+```
+
+Expected: 에러 0, warning은 pre-existing 1건 허용.
+
+- [ ] **Step 3: PR 생성**
+
+```bash
+git push origin dev
+
+gh pr create \
+  --base main \
+  --head dev \
+  --title "feat: 시동 ON 말풍선 + 벨 알림 (IMEI=-1 시뮬레이션)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- fleet-simulation: DeliveryPhase → ServicePhase (WORKING/MOVING), ignitionOnAt 필드 추가
+- NotificationContext: ignition 이벤트 배열 + unreadCount + markAllRead
+- NotificationBell: 헤더 벨 버튼 + 드롭다운 이력 (최신순 20건)
+- FleetSimulationContext: WORKING→MOVING 전환 감지 → addNotification
+- MapShell: 배지 라벨 작업/이동 중, WORKING→MOVING 전환 시 CSS 말풍선 (4초 animation)
+
+## Test plan
+
+- [ ] npm run build → compiled successfully
+- [ ] npm run lint → 0 errors
+- [ ] IMEI=-1 차량이 이동 시작할 때 지도 마커 위 🔑 말풍선 표시 후 4초 소멸 확인
+- [ ] 헤더 벨 배지 숫자 증가 확인
+- [ ] 벨 클릭 → 드롭다운에 "🔑 {번호판} 이동 시작 · 방금" 이력 표시
+- [ ] 드롭다운 열면 배지 초기화 확인
+- [ ] 지도 마커 배지 "이동 중 · N건" / "작업 · N건" 표시 확인
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/development/front-admin-web/docs/superpowers/specs/2026-05-26-ignition-alarm-design.md
+++ b/development/front-admin-web/docs/superpowers/specs/2026-05-26-ignition-alarm-design.md
@@ -1,0 +1,234 @@
+# Ignition Alarm — 시동 ON 말풍선 + 벨 알림 설계
+
+## Goal
+
+IMEI=-1 시뮬레이션 차량이 WORKING(작업) → MOVING(이동 중) 상태로 전환될 때(= 시동 켜짐),
+지도 마커 위에 CSS 말풍선을 표시하고, 헤더 벨 아이콘 + 드롭다운 이력에 이벤트를 기록한다.
+백엔드 변경 없음. 프론트엔드 전용.
+
+## Architecture
+
+```
+fleet-simulation.ts        — ServicePhase 타입, ignitionOnAt 필드
+FleetSimulationContext.tsx — tick loop에서 OFF→ON 감지 → addNotification()
+NotificationContext.tsx    — ignition 이벤트 배열 + unreadCount + markAllRead
+NotificationBell.tsx       — 헤더 벨 버튼 + 드롭다운 이력
+use-simulated-bike-pins.ts — ignitionOnAt 필드 포함해 MapShell로 전달
+MapShell.tsx               — 말풍선 HTML(CSS animation 자동 소멸)
+app/page.tsx               — NotificationProvider 래핑, NotificationBell 헤더 추가
+app/globals.css            — 말풍선 + 벨 CSS
+```
+
+## 파일별 상세
+
+### 1. `lib/services/fleet-simulation.ts`
+
+**타입 변경:**
+
+```ts
+// Before
+export type DeliveryPhase = "IDLE" | "EN_ROUTE";
+
+// After
+export type ServicePhase = "WORKING" | "MOVING";
+```
+
+`SimulatedBikeState` 필드 변경:
+- `phase: DeliveryPhase` → `phase: ServicePhase`
+- 기존 `ignitionStatus: "ON" | "OFF"` 유지
+- **신규 추가:** `ignitionOnAt: number | null`
+  - WORKING→MOVING 전환 시 `nowMs` 로 설정
+  - MOVING→WORKING 전환 시 `null` 로 초기화
+  - `makeInitialState` 양쪽 다 `null` 로 초기화
+
+`advanceBikeState` 내부 case 이름 `"IDLE"` → `"WORKING"`, `"EN_ROUTE"` → `"MOVING"` 변경.
+WORKING→MOVING 전환 시: `ignitionOnAt: nowMs` 추가.
+MOVING→WORKING 전환 시: `ignitionOnAt: null` 추가.
+
+상수명 변경:
+- `EN_ROUTE_DURATION_*` → `MOVING_DURATION_*`
+- `IDLE_BETWEEN_*` → `WORKING_BETWEEN_*`
+
+### 2. `components/layout/NotificationContext.tsx` (신규)
+
+```ts
+type IgnitionNotification = {
+  id: string;           // crypto.randomUUID() 또는 `${bikeId}-${startedAt}`
+  plateNumber: string;  // 번호판 (없으면 bikeId 앞 8자리)
+  startedAt: number;    // ms timestamp
+};
+
+type NotificationContextValue = {
+  notifications: IgnitionNotification[];
+  unreadCount: number;
+  addNotification: (n: Omit<IgnitionNotification, "id">) => void;
+  markAllRead: () => void;
+};
+```
+
+- `notifications`: 최대 20건 유지 (초과 시 오래된 것부터 제거)
+- `unreadCount = Math.max(0, notifications.length - readCount)`
+- `markAllRead`: `setReadCount(notifications.length)`
+- Provider: `"use client"`, Context API
+
+### 3. `components/layout/NotificationBell.tsx` (신규)
+
+- `"use client"`, `useNotifications()` 사용
+- 벨 버튼(🔔) + 읽지 않은 수 배지
+- 클릭 시 드롭다운 토글
+- 드롭다운: `role="list"`, 항목마다 `role="listitem"`
+- 항목 내용: `"🔑 {plateNumber} 이동 시작"` + 상대 시간 (`방금`, `N분 전`)
+- 드롭다운 열릴 때 `markAllRead()` 호출 → 배지 초기화
+- 외부 클릭(backdrop) 시 닫힘
+
+### 4. `components/overview/FleetSimulationContext.tsx`
+
+- 상단 import: `ServicePhase` (기존 `DeliveryPhase` 제거)
+- `useNotifications()` import 추가 — Provider 안에 있으므로 안전
+- tick loop (`setSimulated` 내부):
+  ```ts
+  const prevIgnition = state.ignitionStatus;
+  const advanced = advanceBikeState(state, nowMs, isMatched);
+  if (prevIgnition === "OFF" && advanced.ignitionStatus === "ON") {
+    const pin = pinsRef.current.find(p => p.bikeId === bikeId);
+    const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
+    addNotification({ plateNumber, startedAt: nowMs });
+  }
+  ```
+  주의: `addNotification`은 setState 외부에서 호출해야 함 (setState 안에서 다른 setState 호출 금지). 전환 이벤트 수집 후 setSimulated 완료 후 별도 호출.
+
+  구체적 패턴:
+  ```ts
+  const events: { plateNumber: string; startedAt: number }[] = [];
+  setSimulated(prev => {
+    ...
+    if (prevIgnition === "OFF" && advanced.ignitionStatus === "ON") {
+      events.push({ plateNumber, startedAt: nowMs });
+    }
+    ...
+  });
+  // setSimulated 후
+  events.forEach(e => addNotification(e));
+  ```
+  단, `setInterval` 콜백 안에서 `addNotification`이 stale 되지 않도록 ref로 안정화.
+
+### 5. `components/overview/use-simulated-bike-pins.ts`
+
+`SimulatedBikePin` 타입 확장:
+```ts
+export type SimulatedBikePin = FrontendDashboardBikePin & {
+  servicePhase: ServicePhase | null;   // deliveryPhase → servicePhase
+  deliveryCount?: number;
+  ignitionOnAt?: number | null;        // 신규
+};
+```
+
+`useSimulatedBikePins` 반환 시:
+- `deliveryPhase: sim.phase` → `servicePhase: sim.phase`
+- `ignitionOnAt: sim.ignitionOnAt` 추가
+
+### 6. `components/dashboard/MapShell.tsx`
+
+**props 타입 변경:**
+```ts
+bikePins?: Array<
+  FrontendDashboardBikePin & {
+    servicePhase?: ServicePhase | null;
+    deliveryCount?: number;
+    ignitionOnAt?: number | null;  // 신규
+  }
+>
+```
+
+`prevDeliveryPhaseRef` → `prevServicePhaseRef` (타입도 `ServicePhase | null`).
+
+`bikeMarkerHtml` 시그니처:
+```ts
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  servicePhase?: ServicePhase | null,
+  deliveryCount?: number,
+  ignitionOnAt?: number | null   // 신규
+): string
+```
+
+**말풍선 포함 조건:**
+```ts
+const showBubble = ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
+```
+`showBubble` 이 true 이면 `markerWrapper` 에 말풍선 HTML 추가.
+
+**말풍선 HTML 예시:**
+```html
+<div class="map-ignition-bubble">🔑 이동 시작</div>
+```
+CSS `animation: ignition-bubble-fade 4s forwards` 으로 자동 소멸.
+
+**`deliveryBadgeMarkup` → `serviceBadgeMarkup` 이름 변경:**
+- `"EN_ROUTE"` / `"배송 중"` → `"MOVING"` / `"이동 중"`
+- `"IDLE"` / `"대기"` → `"WORKING"` / `"작업"`
+
+**마커 재생성 트리거 추가:**
+현재 `prevDeliveryPhaseRef` 비교만으로 재생성 여부 결정. 말풍선은 CSS animation으로 자동 소멸하므로 추가 재생성 트리거 불필요. 단, phase가 WORKING→MOVING으로 바뀔 때 자연스럽게 마커가 재생성되어 말풍선 HTML이 포함됨.
+
+### 7. `app/page.tsx`
+
+- `NotificationProvider`로 전체 반환을 래핑
+- `NotificationBell`을 헤더 내 적절한 위치에 추가 (overview-tab-action 영역 등)
+- `FleetSimulationProvider`는 `NotificationProvider` 안에 위치
+
+### 8. `app/globals.css`
+
+말풍선 CSS:
+```css
+.map-ignition-bubble {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1d4ed8;
+  color: #fff;
+  font-size: 11px;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 10px;
+  pointer-events: none;
+  animation: ignition-bubble-fade 4s ease forwards;
+}
+.map-ignition-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #1d4ed8;
+}
+@keyframes ignition-bubble-fade {
+  0%   { opacity: 1; }
+  70%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+```
+
+벨 + 드롭다운 CSS: `.notif-bell-btn`, `.notif-badge`, `.notif-dropdown`, `.notif-item` 등.
+
+## 렌더 트리
+
+```
+NotificationProvider
+  FleetSimulationProvider       ← useNotifications() 사용 가능
+    OverviewClientShell
+      ...
+      NotificationBell          ← 헤더
+      OverviewMapBanner / FullscreenMapHost
+        MapShell (bikePins with servicePhase + ignitionOnAt)
+```
+
+## 엣지 케이스
+
+- **페이지 재방문 시 말풍선 재노출 방지:** `ignitionOnAt`이 4초를 초과하면 `showBubble = false` → 마커 재생성 시 말풍선 HTML 미포함.
+- **addNotification stale closure:** `addNotificationRef`로 최신 함수 참조 유지.
+- **notifications 최대 20건:** 초과 항목은 `slice(-20)` 또는 최신 20건 유지.
+- **plateNumber 없는 경우:** `bikeId.slice(0, 8)` fallback.

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -1,61 +1,57 @@
 /**
- * Fleet 배송 시뮬레이션의 순수 데이터 모델 + phase 진행 함수.
+ * Fleet 서비스 시뮬레이션 순수 데이터 모델 + phase 진행 함수.
  *
- * Provider 가 250ms tick interval 안에서 모든 `simulated` entry 를
- * `advanceBikeState` 로 진행시킨다. React / DOM / window 접근 없음.
- *
- * Phase: IDLE(대기) ↔ EN_ROUTE(배송 중) 2개만. ASSIGNED / ARRIVED 없음.
- * isMatched=true 이면 IDLE → EN_ROUTE 자동 전환, false 이면 IDLE 유지.
+ * Phase: WORKING(작업, 시동 OFF) ↔ MOVING(이동 중, 시동 ON)
+ * isMatched=true 이면 WORKING → MOVING 자동 전환, false 이면 WORKING 유지.
  */
 
-export type DeliveryPhase = "IDLE" | "EN_ROUTE";
+export type ServicePhase = "WORKING" | "MOVING";
 
 export type SimulatedBikeState = {
   bikeId: string;
-  phase: DeliveryPhase;
+  phase: ServicePhase;
   origin: { lat: number; lng: number };
   destination: { lat: number; lng: number } | null;
-  /** EN_ROUTE 진행률 0..1. IDLE 에선 0. */
+  /** MOVING 진행률 0..1. WORKING 에선 0. */
   progress: number;
-  /** 누적 배송 완료 건수. EN_ROUTE → IDLE 전환 시마다 +1. */
+  /** 누적 완료 건수. MOVING → WORKING 전환 시마다 +1. */
   deliveryCount: number;
-  /** 현재 표시 위치 — origin → destination 보간 결과 또는 phase 별 고정. */
+  /** 현재 표시 위치 */
   position: { lat: number; lng: number };
   /** 이 phase 의 시작 ms */
   phaseStartedAt: number;
-  /**
-   * 이 phase 의 종료 예정 ms.
-   * IDLE + 비매칭이면 Number.POSITIVE_INFINITY (cleanup trigger).
-   */
+  /** 이 phase 의 종료 예정 ms */
   phaseEndsAt: number;
   /** 현재 표시 속도 km/h */
   speedKph: number;
-  /** 현재 시동. EN_ROUTE 만 ON. */
+  /** 현재 시동. MOVING 만 ON. */
   ignitionStatus: "ON" | "OFF";
-  /** 누적 km. EN_ROUTE 중 점진 증가. */
-  odometerKm: number;
-  /** 배터리 %. EN_ROUTE 중 감소. */
-  batteryPercent: number;
   /**
-   * OSRM 경로 waypoints. EN_ROUTE 진입 시 비동기 fetch, 도착 전까지
-   * null → 직선 lerp fallback.
+   * WORKING→MOVING 전환 시점 ms. 말풍선 표시 여부 판단에 사용.
+   * MOVING→WORKING 전환 시 null 로 초기화.
    */
+  ignitionOnAt: number | null;
+  /** 누적 km */
+  odometerKm: number;
+  /** 배터리 % */
+  batteryPercent: number;
+  /** OSRM 경로 waypoints */
   routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
 };
 
-/** tick 간격 (ms). 250ms = 초당 4회 업데이트. */
+/** tick 간격 (ms) */
 export const TICK_INTERVAL_MS = 250;
-/** 배송 한 주기 최소 길이 (15분). */
-export const EN_ROUTE_DURATION_MIN_MS = 15 * 60 * 1_000;
-/** 배송 한 주기 최대 길이 (40분). */
-export const EN_ROUTE_DURATION_MAX_MS = 40 * 60 * 1_000;
-/** 배송 완료 후 다음 사이클까지 최소 대기 (ms). */
-export const IDLE_BETWEEN_DELIVERIES_MIN_MS = 5_000;
-/** 배송 완료 후 다음 사이클까지 최대 대기 (ms). */
-export const IDLE_BETWEEN_DELIVERIES_MAX_MS = 30_000;
-/** EN_ROUTE 시 표시 속도 (km/h). */
-export const EN_ROUTE_SPEED_KPH = 30;
-/** 초당 배터리 감소량. tick delta = 이 값 × (TICK_INTERVAL_MS / 1000). */
+/** MOVING 한 주기 최소 길이 (15분) */
+export const MOVING_DURATION_MIN_MS = 15 * 60 * 1_000;
+/** MOVING 한 주기 최대 길이 (40분) */
+export const MOVING_DURATION_MAX_MS = 40 * 60 * 1_000;
+/** 완료 후 다음 사이클까지 최소 대기 (ms) */
+export const WORKING_BETWEEN_MIN_MS = 5_000;
+/** 완료 후 다음 사이클까지 최대 대기 (ms) */
+export const WORKING_BETWEEN_MAX_MS = 30_000;
+/** MOVING 시 표시 속도 (km/h) */
+export const MOVING_SPEED_KPH = 30;
+/** 초당 배터리 감소량 */
 export const BATTERY_DROP_PER_SECOND = 0.05;
 
 const SEOUL_LAT_MIN = 37.44;
@@ -63,20 +59,13 @@ const SEOUL_LAT_MAX = 37.65;
 const SEOUL_LNG_MIN = 126.87;
 const SEOUL_LNG_MAX = 127.10;
 
-/**
- * 15~40분 사이 랜덤 EN_ROUTE 주기 길이(ms).
- * 차량마다 매 사이클 독립적으로 뽑아 실제 배송처럼 각자 다른 시간 소요.
- */
-function randomEnRouteDurationMs(random: () => number): number {
+function randomMovingDurationMs(random: () => number): number {
   return (
-    EN_ROUTE_DURATION_MIN_MS +
-    random() * (EN_ROUTE_DURATION_MAX_MS - EN_ROUTE_DURATION_MIN_MS)
+    MOVING_DURATION_MIN_MS +
+    random() * (MOVING_DURATION_MAX_MS - MOVING_DURATION_MIN_MS)
   );
 }
 
-/**
- * 서울 박스 안 random 좌표. EN_ROUTE 의 destination 으로 사용.
- */
 function randomSeoulPoint(random: () => number = Math.random): { lat: number; lng: number } {
   return {
     lat: SEOUL_LAT_MIN + random() * (SEOUL_LAT_MAX - SEOUL_LAT_MIN),
@@ -84,14 +73,12 @@ function randomSeoulPoint(random: () => number = Math.random): { lat: number; ln
   };
 }
 
-/** Haversine 대신 단순 평면 근사 — 데모 표시용, km 단위 오차 무방. */
 function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
   const dLat = (b.lat - a.lat) * 111;
   const dLng = (b.lng - a.lng) * 88;
   return Math.sqrt(dLat * dLat + dLng * dLng);
 }
 
-/** lerp 보간 — t=0..1, from → to. clamp 포함. */
 function lerpPosition(
   from: { lat: number; lng: number },
   to: { lat: number; lng: number },
@@ -104,10 +91,6 @@ function lerpPosition(
   };
 }
 
-/**
- * progress t (0..1) 로 polyline 위 좌표 계산.
- * N 개 waypoint → N-1 세그먼트를 시간 균등 분배.
- */
 function walkPolyline(
   waypoints: ReadonlyArray<{ lat: number; lng: number }>,
   t: number
@@ -122,16 +105,6 @@ function walkPolyline(
   return lerpPosition(waypoints[segIndex], waypoints[segIndex + 1], segT);
 }
 
-/**
- * 250ms tick 마다 호출되어 prev 의 phase / position / 부속 값을 advance.
- *
- * `isMatched`: 이 bike 에 현재 라이더가 매칭되어 있는지.
- *   - IDLE + isMatched + phaseEndsAt 도달 → EN_ROUTE 전환
- *   - IDLE + !isMatched + phaseEndsAt 도달 → phaseEndsAt=Infinity 로 갱신
- *     (Provider 의 tick loop 이 이 조건을 감지해 entry 제거)
- *   - EN_ROUTE 완료 → IDLE. isMatched=true 면 5~30초 후 재시작;
- *     false 면 phaseEndsAt=Infinity (멈춤)
- */
 export function advanceBikeState(
   prev: SimulatedBikeState,
   nowMs: number,
@@ -139,8 +112,7 @@ export function advanceBikeState(
   random: () => number = Math.random
 ): SimulatedBikeState {
   if (nowMs < prev.phaseEndsAt) {
-    // 같은 phase 안 — EN_ROUTE 면 위치 / odometer / battery 만 advance.
-    if (prev.phase !== "EN_ROUTE" || !prev.destination) return prev;
+    if (prev.phase !== "MOVING" || !prev.destination) return prev;
     const total = prev.phaseEndsAt - prev.phaseStartedAt;
     const elapsed = nowMs - prev.phaseStartedAt;
     const progress = total > 0 ? elapsed / total : 1;
@@ -148,8 +120,7 @@ export function advanceBikeState(
       ? walkPolyline(prev.routeWaypoints, progress)
       : lerpPosition(prev.origin, prev.destination, progress);
     const distanceKm = approxDistanceKm(prev.origin, prev.destination);
-    const totalSeconds = total / 1_000; // 차량마다 다른 실제 phase 길이 사용
-    // 250ms tick 기준 delta: (초당 변화량) × (tick_ms / 1000)
+    const totalSeconds = total / 1_000;
     const tickFactor = TICK_INTERVAL_MS / 1_000;
     const odometerDelta = totalSeconds > 0 ? (distanceKm / totalSeconds) * tickFactor : 0;
     const batteryDelta = BATTERY_DROP_PER_SECOND * tickFactor;
@@ -162,45 +133,45 @@ export function advanceBikeState(
     };
   }
 
-  // phaseEndsAt 도달 — 다음 phase 로 전환.
   switch (prev.phase) {
-    case "IDLE": {
+    case "WORKING": {
       if (!isMatched) {
-        // 매칭 없음 → 영원히 IDLE. cleanup 로직이 이 entry 를 제거.
         return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
       }
       const destination = randomSeoulPoint(random);
       return {
         ...prev,
-        phase: "EN_ROUTE",
+        phase: "MOVING",
         destination,
         progress: 0,
         position: prev.origin,
         phaseStartedAt: nowMs,
-        phaseEndsAt: nowMs + randomEnRouteDurationMs(random),
-        speedKph: EN_ROUTE_SPEED_KPH,
+        phaseEndsAt: nowMs + randomMovingDurationMs(random),
+        speedKph: MOVING_SPEED_KPH,
         ignitionStatus: "ON",
+        ignitionOnAt: nowMs,
         routeWaypoints: null
       };
     }
-    case "EN_ROUTE": {
+    case "MOVING": {
       const finalPosition = prev.destination ?? prev.origin;
       const idleMs = isMatched
-        ? IDLE_BETWEEN_DELIVERIES_MIN_MS +
-          Math.floor(random() * (IDLE_BETWEEN_DELIVERIES_MAX_MS - IDLE_BETWEEN_DELIVERIES_MIN_MS))
+        ? WORKING_BETWEEN_MIN_MS +
+          Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS))
         : Number.POSITIVE_INFINITY;
-      const idlePhaseEndsAt = idleMs === Number.POSITIVE_INFINITY ? idleMs : nowMs + idleMs;
+      const workingPhaseEndsAt = idleMs === Number.POSITIVE_INFINITY ? idleMs : nowMs + idleMs;
       return {
         ...prev,
-        phase: "IDLE",
+        phase: "WORKING",
         progress: 0,
         position: finalPosition,
         origin: finalPosition,
         destination: null,
         phaseStartedAt: nowMs,
-        phaseEndsAt: idlePhaseEndsAt,
+        phaseEndsAt: workingPhaseEndsAt,
         speedKph: 0,
         ignitionStatus: "OFF",
+        ignitionOnAt: null,
         routeWaypoints: null,
         deliveryCount: prev.deliveryCount + 1
       };
@@ -208,17 +179,11 @@ export function advanceBikeState(
   }
 }
 
-/**
- * 새로운 시뮬레이션 entry 초기값. Provider 의 자동 트리거가 이 함수를 호출.
- *
- * `phase: "EN_ROUTE"` — 매칭 직후 즉시 배송 시작.
- * `phase: "IDLE"` — phaseEndsAt=Infinity 로 초기화 (비매칭 대기).
- */
 export function makeInitialState(input: {
   bikeId: string;
   origin: { lat: number; lng: number };
   nowMs: number;
-  phase: "IDLE" | "EN_ROUTE";
+  phase: "WORKING" | "MOVING";
   random?: () => number;
   initialOdometerKm?: number;
   initialBatteryPercent?: number;
@@ -233,18 +198,19 @@ export function makeInitialState(input: {
     initialBatteryPercent = 90
   } = input;
 
-  if (phase === "EN_ROUTE") {
+  if (phase === "MOVING") {
     return {
       bikeId,
-      phase: "EN_ROUTE",
+      phase: "MOVING",
       origin,
       destination: randomSeoulPoint(random),
       progress: 0,
       position: origin,
       phaseStartedAt: nowMs,
-      phaseEndsAt: nowMs + randomEnRouteDurationMs(random),
-      speedKph: EN_ROUTE_SPEED_KPH,
+      phaseEndsAt: nowMs + randomMovingDurationMs(random),
+      speedKph: MOVING_SPEED_KPH,
       ignitionStatus: "ON",
+      ignitionOnAt: nowMs,
       odometerKm: initialOdometerKm,
       batteryPercent: initialBatteryPercent,
       routeWaypoints: null,
@@ -252,10 +218,9 @@ export function makeInitialState(input: {
     };
   }
 
-  // IDLE — phaseEndsAt=Infinity, isMatched 가 true 가 될 때 EN_ROUTE 로 전환.
   return {
     bikeId,
-    phase: "IDLE",
+    phase: "WORKING",
     origin,
     destination: null,
     progress: 0,
@@ -264,6 +229,7 @@ export function makeInitialState(input: {
     phaseEndsAt: Number.POSITIVE_INFINITY,
     speedKph: 0,
     ignitionStatus: "OFF",
+    ignitionOnAt: null,
     odometerKm: initialOdometerKm,
     batteryPercent: initialBatteryPercent,
     routeWaypoints: null,

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -31,6 +31,8 @@ export type SimulatedBikeState = {
    * MOVING→WORKING 전환 시 null 로 초기화.
    */
   ignitionOnAt: number | null;
+  /** 서비스 유형. "CLEANING" 이면 알림 + 말풍선 활성. */
+  serviceType: string;
   /** 누적 km */
   odometerKm: number;
   /** 배터리 % */
@@ -187,6 +189,7 @@ export function makeInitialState(input: {
   random?: () => number;
   initialOdometerKm?: number;
   initialBatteryPercent?: number;
+  serviceType?: string;
 }): SimulatedBikeState {
   const {
     bikeId,
@@ -195,7 +198,8 @@ export function makeInitialState(input: {
     phase,
     random = Math.random,
     initialOdometerKm = 0,
-    initialBatteryPercent = 90
+    initialBatteryPercent = 90,
+    serviceType = "DELIVERY"
   } = input;
 
   if (phase === "MOVING") {
@@ -214,7 +218,8 @@ export function makeInitialState(input: {
       odometerKm: initialOdometerKm,
       batteryPercent: initialBatteryPercent,
       routeWaypoints: null,
-      deliveryCount: 0
+      deliveryCount: 0,
+      serviceType
     };
   }
 
@@ -233,6 +238,7 @@ export function makeInitialState(input: {
     odometerKm: initialOdometerKm,
     batteryPercent: initialBatteryPercent,
     routeWaypoints: null,
-    deliveryCount: 0
+    deliveryCount: 0,
+    serviceType
   };
 }

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -7,6 +7,8 @@
 
 export type ServicePhase = "WORKING" | "MOVING";
 
+export type ServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+
 export type SimulatedBikeState = {
   bikeId: string;
   phase: ServicePhase;
@@ -32,7 +34,7 @@ export type SimulatedBikeState = {
    */
   ignitionOnAt: number | null;
   /** 서비스 유형. "CLEANING" 이면 알림 + 말풍선 활성. */
-  serviceType: string;
+  serviceType: ServiceType;
   /** 누적 km */
   odometerKm: number;
   /** 배터리 % */
@@ -189,7 +191,7 @@ export function makeInitialState(input: {
   random?: () => number;
   initialOdometerKm?: number;
   initialBatteryPercent?: number;
-  serviceType?: string;
+  serviceType?: ServiceType;
 }): SimulatedBikeState {
   const {
     bikeId,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -670,6 +670,7 @@ export type ServiceOpsDashboardBikePin = {
   connectionStatus: string;
   batteryStatus: string;
   pinLabel: string;
+  serviceType?: ServiceOpsBikeServiceType;
 };
 
 export type ServiceOpsDashboardStationPin = {


### PR DESCRIPTION
## Summary

- fleet-simulation: DeliveryPhase → ServicePhase (WORKING/MOVING), ignitionOnAt 필드 추가
- NotificationContext: ignition 이벤트 배열 + unreadCount + markAllRead
- NotificationBell: 헤더 벨 버튼 + 드롭다운 이력 (최신순 20건)
- FleetSimulationContext: WORKING→MOVING 전환 감지 → addNotification
- MapShell: 배지 라벨 작업/이동 중, WORKING→MOVING 전환 시 CSS 말풍선 (4초 animation)

## Test plan

- [ ] npm run build → compiled successfully
- [ ] npm run lint → 0 errors, 0 warnings
- [ ] IMEI=-1 차량이 이동 시작할 때 지도 마커 위 🔑 말풍선 표시 후 4초 소멸 확인
- [ ] 헤더 벨 배지 숫자 증가 확인
- [ ] 벨 클릭 → 드롭다운에 "🔑 {번호판} 이동 시작 · 방금" 이력 표시
- [ ] 드롭다운 열면 배지 초기화 확인
- [ ] 지도 마커 배지 "이동 중 · N건" / "작업 · N건" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)