### PR TITLE
feat: CLEANING 차량 다음 고객 설정 + 시뮬레이션 연동 (PR #329 배포)

### DIFF
--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -121,6 +121,7 @@ export function generatePinsForUntrackedVehicles(
         connectionStatus: "ONLINE" as const,
         batteryStatus: sim.batteryStatus === "HEALTHY" ? "NORMAL" : sim.batteryStatus,
         pinLabel: vehicle.plateNumber,
+        serviceType: vehicle.serviceType ?? "DELIVERY",
         nextCustomerLat: null,
         nextCustomerLng: null
       };

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -47,7 +47,25 @@ async function withSimulatedPins(
     const vehiclePage = await client.listVehicles({ page: 0, size: 200 });
     const totalRegistered = vehiclePage.page.totalItems;
     const existingBikeIds = new Set(state.bikePins.map((p) => p.bikeId));
-    const simulated = generatePinsForUntrackedVehicles(vehiclePage.items, existingBikeIds);
+    const rawSimulated = generatePinsForUntrackedVehicles(vehiclePage.items, existingBikeIds);
+
+    // CLEANING 차량의 다음 고객 좌표를 주입한다. 텔레메트리가 없는 차량도
+    // bike_next_customer 에 데이터가 있을 수 있으므로 개별 조회 후 병합.
+    const simulated = await Promise.all(
+      rawSimulated.map(async (pin) => {
+        if (pin.serviceType !== "CLEANING") return pin;
+        try {
+          const nc = await client.getBikeNextCustomer(pin.bikeId);
+          if (nc) {
+            return { ...pin, nextCustomerLat: nc.latitude, nextCustomerLng: nc.longitude,
+                     nextCustomerName: nc.customerName, nextCustomerPhone: nc.customerPhone };
+          }
+        } catch {
+          // 조회 실패 시 원본 pin 사용
+        }
+        return pin;
+      })
+    );
 
     const bikePins = [...state.bikePins, ...simulated];
     const lowBatteryDelta = simulated.filter(


### PR DESCRIPTION
## Summary

- **bike_next_customer 테이블 + API**: V27 마이그레이션, BikeNextCustomer 엔티티/레포지토리/DTO, GET/PUT `/api/v1/bikes/{id}/next-customer` 엔드포인트 (CLEANING 차량 전용 guard)
- **대시보드 API 확장**: `DashboardMapStateResponse.BikePin`에 `serviceType`, `nextCustomerName/Phone/Lat/Lng` 필드 추가 (QA-5/QA-6 블로커 해소)
- **프론트엔드 — NextCustomerSection**: VehicleDetailDialog에 CLEANING 전용 다음 고객 설정 폼 추가 (getNextCustomerAction / setNextCustomerAction 서버 액션)
- **프론트엔드 — 시뮬레이션 연동**: `fleet-simulation.ts` `nextCustomerDestination` 지원, `FleetSimulationContext` tick sync + 알림 발송, 고객 좌표를 MOVING 목적지로 사용
- **프론트엔드 — 알림**: `NotificationContext` + `NotificationBell` 컴포넌트 (CLEANING 차량 시동 ON 시 `📞 차량번호 → 고객명 전화번호` / `🔑 차량번호 이동 시작` 형식)
- **서비스 유형 필터**: 지도 뷰 + 차량 목록 탭 필터 연결 (전체/배송/클리닝/기타)
- **버그 수정**: untracked CLEANING 차량 serviceType 전파 + nextCustomer 좌표 주입

## Test plan

- [ ] Java 서비스 재빌드 후 `/api/v1/dashboard/map-state` 응답에 `serviceType: "CLEANING"` + `nextCustomerLat/Lng` 포함 확인
- [ ] CLEANING 차량(22나2222, IMEI=-1-b)에 라이더 배정 → 시뮬레이션 목적지가 저장된 고객 좌표(37.5793/126.8898)로 설정되는지 확인 (QA-5)
- [ ] WORKING→MOVING 전환 시 알림 벨에 `📞 22나2222 → 이순신 010-9999-8888` 형식으로 표시되는지 확인 (QA-6)
- [ ] VehicleDetailDialog — CLEANING 차량에만 "다음 고객 (CLEANING 전용)" 섹션 표시 확인
- [ ] 서비스 유형 필터 탭 (배송/클리닝) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)