### PR TITLE
feat: CLEANING 차량 다음 고객 설정 + 시뮬레이션 연동

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -676,7 +676,7 @@ function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceT
   const bg = isMoving ? "#3b82f6" : "#6b7280";
   const label = (() => {
     if (!serviceType || serviceType === "DELIVERY") return isMoving ? "배송 중" : "대기";
-    return isMoving ? "이동 중" : "작업";
+    return isMoving ? "이동 중" : "대기 중";
   })();
   const text = `${label} · ${deliveryCount}건`;
   return (

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -832,7 +832,7 @@ function DeliverySection({
           <dt>상태</dt>
           <dd>{phaseLabel}</dd>
         </div>
-        {state.destination ? (
+        {state.phase === "MOVING" && state.destination ? (
           <div className="delivery-meta-row">
             <dt>목적지</dt>
             <dd>
@@ -862,7 +862,7 @@ function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: Servi
     return phase === "MOVING" ? "배송 중" : "대기";
   }
   // CLEANING or OTHER
-  return phase === "MOVING" ? "이동 중" : "작업";
+  return phase === "MOVING" ? "이동 중" : "대기 중";
 }
 
 function renderRemainingLabel(phaseEndsAt: number): string {

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -24,6 +24,7 @@ import { StationFilterControls } from "@/components/overview/StationFilterContro
 import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import { OverviewMapSearch, type OverviewMapSearchMatch } from "@/components/overview/OverviewMapSearch";
+import { NotificationBell } from "@/components/layout/NotificationBell";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
   FrontendDashboardBikePin,
@@ -343,6 +344,7 @@ function FullscreenMapOverlay({
         <span className="fullscreen-map-counts">
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
         </span>
+        <NotificationBell />
       </header>
       {filtersOpen ? (
         <div className="fullscreen-map-filter-bar">


### PR DESCRIPTION
## Summary

### 핵심 기능 (PR #329)
- V27 DB 마이그레이션 -- bike_next_customer 테이블 추가 (bike_id PK, 고객명/전화/주소/좌표)
- 백엔드 API -- GET/PUT /api/v1/bikes/{id}/next-customer (CLEANING 차량 전용 guard)
- 대시보드 API 확장 -- getDashboardMapState 응답에 serviceType + nextCustomerLat/Lng/Name/Phone 포함
- 차량 상세 패널 -- CLEANING 차량에만 NextCustomerSection 표시 (고객명/전화/주소 저장 폼)
- 시뮬레이션 연동 -- IMEI=-1 CLEANING 차량이 저장된 고객 좌표를 MOVING 목적지로 사용
- 알림 벨 -- CLEANING 차량 WORKING->MOVING 전환 시 '📞 {번호판} -> {고객명} {전화}' 형식 알림

### 시동 알림 시스템
- NotificationContext + NotificationBell 컴포넌트
- 시동 켜짐 말풍선 ('🔑 이동 시작') 4초 자동 소멸 애니메이션
- ServicePhase-aware 시뮬레이션 배지 (이동 중/대기 중)

### Followup fixes (QA 후 수정)
- 13786b1 -- 미추적 CLEANING 차량에도 serviceType + nextCustomer 좌표 주입
- 31993dd -- CLEANING WORKING 페이즈 표기 '작업' -> '대기 중', WORKING 중 목적지 숨김
- de008b5 -- 전체화면 지도 헤더에 알림 벨 추가

## Test plan

- [x] QA-1: 서비스 유형 필터 탭 (배송 8대 / 클리닝 5대)
- [x] QA-2: NextCustomerSection -- CLEANING 차량에만 표시
- [x] QA-3: 저장된 고객 정보 (이순신, 010-9999-8888, 37.5793/126.8898) 표시
- [x] QA-4: 알림 벨 렌더링 및 드롭다운
- [x] QA-5: 시뮬레이션 목적지 = 저장된 고객 좌표 (37.5793, 126.8898)
- [x] QA-6: 벨 알림 형식 '📞 22나2222 -> 이순신 010-9999-8888'
- [x] CLEANING WORKING 배지 '대기 중' 표시
- [x] 전체화면 벨 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)