### PR TITLE
feat: CLEANING 다음 고객 주소 입력 BSS 방식 통일 + 작업 완료 시 자동 삭제

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -907,3 +907,14 @@ export async function setNextCustomerAction(
     return { ok: false, error: "저장 중 오류가 발생했습니다. 다시 시도해주세요." };
   }
 }
+
+export async function clearNextCustomerAction(bikeId: string): Promise<{ ok: boolean }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return { ok: false };
+  try {
+    await client.clearBikeNextCustomer(bikeId);
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
 
+import { AddressSearchButton } from "@/components/management/AddressSearchButton";
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import {
   deriveMaintenanceRows,
@@ -959,13 +960,17 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
           <div className="delivery-meta-row">
             <dt>주소</dt>
             <dd>
-              <input
-                type="text"
-                value={address}
-                onChange={(e) => setAddress(e.target.value)}
-                placeholder="서울 강남구 역삼동 123"
-                className="next-customer-input"
-              />
+              <div className="station-address-field">
+                <input
+                  type="text"
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
+                  placeholder="주소 검색 버튼을 눌러 주소를 선택하세요"
+                  className="next-customer-input"
+                  readOnly
+                />
+                <AddressSearchButton onSelect={setAddress} />
+              </div>
             </dd>
           </div>
           {savedCoords && (

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -891,6 +891,7 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
+  // 초기 데이터 로드
   useEffect(() => {
     let cancelled = false;
     getNextCustomerAction(bikeId).then((data) => {
@@ -910,6 +911,21 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     });
     return () => { cancelled = true; };
   }, [bikeId]);
+
+  // 시뮬레이션 WORKING→MOVING 전환 감지 — 작업 완료 시 폼 즉시 초기화
+  const { simulated } = useFleetSimulation();
+  const ignitionOnAt = simulated.get(bikeId)?.ignitionOnAt ?? null;
+  const prevIgnitionOnAtRef = useRef(ignitionOnAt);
+  useEffect(() => {
+    if (ignitionOnAt === null) return;
+    if (prevIgnitionOnAtRef.current === ignitionOnAt) return;
+    prevIgnitionOnAtRef.current = ignitionOnAt;
+    setCustomerName("");
+    setCustomerPhone("");
+    setAddress("");
+    setSavedCoords(null);
+    setError(null);
+  }, [ignitionOnAt]);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -11,6 +11,7 @@ import {
   type ServicePhase
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
+import { clearNextCustomerAction } from "@/app/actions";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
@@ -151,6 +152,15 @@ export function FleetSimulationProvider({
         customerName: pin?.nextCustomerName ?? undefined,
         customerPhone: pin?.nextCustomerPhone ?? undefined
       });
+      // 작업 완료 후 다음 고객 정보를 DB에서 제거 (fire-and-forget)
+      clearNextCustomerAction(bikeId).catch(() => undefined);
+      // pinsRef에서도 즉시 제거해 다음 MOVING 페이즈가 랜덤 좌표를 쓰도록
+      pinsRef.current = pinsRef.current.map((p) =>
+        p.bikeId === bikeId
+          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
+                nextCustomerName: null, nextCustomerPhone: null }
+          : p
+      );
     }
     // Clean up ref entries for bikes that left simulation
     for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -888,6 +888,7 @@ export type ServiceOpsApiClient = {
   getBikeSnapshot: (bikeId: string) => Promise<ServiceOpsBikeSnapshot>;
   getBikeNextCustomer: (bikeId: string) => Promise<ServiceOpsBikeNextCustomer | null>;
   setBikeNextCustomer: (bikeId: string, input: BikeNextCustomerUpsertInput) => Promise<ServiceOpsBikeNextCustomer>;
+  clearBikeNextCustomer: (bikeId: string) => Promise<void>;
   getIntegrityReferenceChecks: () => Promise<ServiceOpsIntegrityScan>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
@@ -1132,6 +1133,11 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       request<ServiceOpsBikeNextCustomer>(
         `/bikes/${encodeURIComponent(bikeId)}/next-customer`,
         { body: JSON.stringify(input), method: "PUT" }
+      ),
+    clearBikeNextCustomer: (bikeId) =>
+      request<void>(
+        `/bikes/${encodeURIComponent(bikeId)}/next-customer`,
+        { method: "DELETE" }
       ),
     getIntegrityReferenceChecks: () =>
       request<ServiceOpsIntegrityScan>("/integrity/reference-checks", { method: "GET" }),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeNextCustomerController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeNextCustomerController.java
@@ -6,6 +6,7 @@ import com.thundercrew.opsapi.bike.service.BikeNextCustomerService;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,5 +35,11 @@ public class BikeNextCustomerController {
     BikeNextCustomerResponse put(@PathVariable UUID bikeId,
                                   @Valid @RequestBody BikeNextCustomerRequest request) {
         return bikeNextCustomerService.upsert(bikeId, request);
+    }
+
+    @DeleteMapping
+    ResponseEntity<Void> delete(@PathVariable UUID bikeId) {
+        bikeNextCustomerService.clear(bikeId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeNextCustomerRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeNextCustomerRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.repository.Repository;
 public interface BikeNextCustomerRepository extends Repository<BikeNextCustomer, UUID> {
     Optional<BikeNextCustomer> findById(UUID bikeId);
     BikeNextCustomer save(BikeNextCustomer entity);
+    void deleteById(UUID id);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
@@ -33,6 +33,12 @@ public class BikeNextCustomerService {
     }
 
     @Transactional
+    public void clear(UUID bikeId) {
+        requireCleaningBike(bikeId);
+        nextCustomerRepository.deleteById(bikeId);
+    }
+
+    @Transactional
     public BikeNextCustomerResponse upsert(UUID bikeId, BikeNextCustomerRequest request) {
         requireCleaningBike(bikeId);
         BikeNextCustomer entity = nextCustomerRepository.findById(bikeId)


### PR DESCRIPTION
## Summary

- CLEANING 다음 고객 주소 입력을 BSS 방식으로 통일 (readOnly + 카카오 우편번호 팝업)
- 작업 완료(WORKING→MOVING 전환) 시 다음 고객 정보 DB 자동 삭제
- 삭제 시 차량 상세 다이얼로그 폼 즉시 초기화 (다이얼로그 열린 채로도 반영)

## Changes

### Backend
- BikeNextCustomerRepository — deleteById(UUID) 선언
- BikeNextCustomerService — clear(UUID) 메서드 (CLEANING 타입 검증 후 삭제)
- BikeNextCustomerController — DELETE /api/v1/bikes/{bikeId}/next-customer → 204 No Content

### Frontend
- service-ops-api.ts — clearBikeNextCustomer (DELETE) 메서드 추가
- ctions.ts — clearNextCustomerAction 서버 액션 추가
- FleetSimulationContext.tsx — WORKING→MOVING 전환 시 clearNextCustomerAction fire-and-forget + pinsRef 즉시 초기화
- VehicleDetailDialog.tsx — NextCustomerSection에서 ignitionOnAt 변화 감지 → 폼 즉시 초기화
- VehicleDetailDialog.tsx — 주소 필드 eadOnly + AddressSearchButton (BSS 방식 통일)

## Test plan

- [ ] CLEANING 차량 다음 고객 설정 — 주소 검색 팝업으로만 입력됨 (자유 타이핑 차단)
- [ ] CLEANING 차량 IMEI=-1 시뮬레이션 WORKING 페이즈 완료 → DB에서 ike_next_customer 행 삭제됨
- [ ] 다이얼로그 열린 상태에서 작업 완료 → 폼 자동 초기화 (이름/전화/주소/좌표 비워짐)
- [ ] 다이얼로그 재오픈 시 빈 폼 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)