### PR TITLE
fix: CLEANING 차량 대기 중 → 목적지 입력 시 출발 (무한 대기 + 즉시 전환)

### DIFF
--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -184,8 +184,27 @@ export function FleetSimulationProvider({
         const next = new Map<string, SimulatedBikeState>();
         for (const [bikeId, state] of prev) {
           const isMatched = currentMatched.has(bikeId);
-          const advanced = advanceBikeState(state, nowMs, isMatched);
-          if (advanced !== state) mutated = true;
+
+          // nextCustomerDestination 을 advanceBikeState 호출 전에 최신 pin 데이터로 동기화.
+          // 순서가 중요: CLEANING 차량이 대기 중(phaseEndsAt=Infinity)일 때 목적지가 새로
+          // 설정되면 advance 함수가 그 값을 보고 즉시 MOVING 으로 전환해야 하기 때문.
+          const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+          const newDest =
+            pin?.serviceType === "CLEANING" &&
+            pin.nextCustomerLat != null &&
+            pin.nextCustomerLng != null
+              ? { lat: pin.nextCustomerLat, lng: pin.nextCustomerLng }
+              : null;
+          const prevDest = state.nextCustomerDestination;
+          const destChanged =
+            prevDest?.lat !== newDest?.lat || prevDest?.lng !== newDest?.lng;
+          const stateForAdvance: SimulatedBikeState = destChanged
+            ? { ...state, nextCustomerDestination: newDest }
+            : state;
+
+          const advanced = advanceBikeState(stateForAdvance, nowMs, isMatched);
+          if (advanced !== stateForAdvance || destChanged) mutated = true;
+
           // 비매칭 + WORKING + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
           if (
             !isMatched &&
@@ -195,22 +214,7 @@ export function FleetSimulationProvider({
             mutated = true;
             continue;
           }
-          // Sync nextCustomerDestination from latest pin data (every 250ms)
-          const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
-          const newDest =
-            pin?.serviceType === "CLEANING" &&
-            pin.nextCustomerLat != null &&
-            pin.nextCustomerLng != null
-              ? { lat: pin.nextCustomerLat, lng: pin.nextCustomerLng }
-              : null;
-          const prevDest = advanced.nextCustomerDestination;
-          const destUnchanged =
-            prevDest?.lat === newDest?.lat && prevDest?.lng === newDest?.lng;
-          const entry: SimulatedBikeState = destUnchanged
-            ? advanced
-            : { ...advanced, nextCustomerDestination: newDest };
-          if (!destUnchanged) mutated = true;
-          next.set(bikeId, entry);
+          next.set(bikeId, advanced);
         }
         return mutated ? next : prev;
       });

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -117,6 +117,29 @@ export function advanceBikeState(
   isMatched: boolean,
   random: () => number = Math.random
 ): SimulatedBikeState {
+  // CLEANING: WORKING 무한 대기 중 nextCustomerDestination 이 설정되면 즉시 MOVING 전환.
+  // phaseEndsAt 체크보다 먼저 실행해야 Infinity 대기 상태도 처리됨.
+  if (
+    prev.phase === "WORKING" &&
+    isMatched &&
+    prev.serviceType === "CLEANING" &&
+    prev.nextCustomerDestination !== null
+  ) {
+    return {
+      ...prev,
+      phase: "MOVING",
+      destination: prev.nextCustomerDestination,
+      progress: 0,
+      position: prev.origin,
+      phaseStartedAt: nowMs,
+      phaseEndsAt: nowMs + randomMovingDurationMs(random),
+      speedKph: MOVING_SPEED_KPH,
+      ignitionStatus: "ON",
+      ignitionOnAt: nowMs,
+      routeWaypoints: null
+    };
+  }
+
   if (nowMs < prev.phaseEndsAt) {
     if (prev.phase !== "MOVING" || !prev.destination) return prev;
     const total = prev.phaseEndsAt - prev.phaseStartedAt;
@@ -144,7 +167,13 @@ export function advanceBikeState(
       if (!isMatched) {
         return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
       }
-      const destination = prev.nextCustomerDestination ?? randomSeoulPoint(random);
+      // CLEANING 차량은 위의 조기 전환 로직에서 nextCustomerDestination !== null 케이스를 처리함.
+      // 여기까지 오면 nextCustomerDestination === null → 계속 대기.
+      if (prev.serviceType === "CLEANING") {
+        return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
+      }
+      // DELIVERY / OTHER: 랜덤 목적지로 이동 시작
+      const destination = randomSeoulPoint(random);
       return {
         ...prev,
         phase: "MOVING",
@@ -161,10 +190,13 @@ export function advanceBikeState(
     }
     case "MOVING": {
       const finalPosition = prev.destination ?? prev.origin;
-      const idleMs = isMatched
-        ? WORKING_BETWEEN_MIN_MS +
-          Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS))
-        : Number.POSITIVE_INFINITY;
+      // CLEANING 차량은 다음 고객 목적지가 입력될 때까지 WORKING 상태를 유지해야 하므로
+      // phaseEndsAt 을 Infinity 로 설정해 타이머 없이 대기.
+      const idleMs =
+        !isMatched || prev.serviceType === "CLEANING"
+          ? Number.POSITIVE_INFINITY
+          : WORKING_BETWEEN_MIN_MS +
+            Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS));
       const workingPhaseEndsAt = idleMs === Number.POSITIVE_INFINITY ? idleMs : nowMs + idleMs;
       return {
         ...prev,


### PR DESCRIPTION
## Summary

- CLEANING 차량이 작업 완료 후 **대기 중 상태를 다음 고객 목적지가 입력될 때까지 유지**하도록 수정
- 관리자가 다음 고객 정보를 저장하면 다음 250ms tick에 **즉시 MOVING 전환**
- DELIVERY/OTHER 차량의 기존 랜덤 이동 동작은 그대로 유지

## Changes

### `fleet-simulation.ts`
- CLEANING 차량 `MOVING→WORKING` 전환 시 `phaseEndsAt = Infinity` (타이머 없이 무한 대기)
- `WORKING` 상태 최상단: `nextCustomerDestination !== null` 이면 `phaseEndsAt` 무관하게 즉시 MOVING 전환
- `WORKING` case: CLEANING + `nextCustomerDestination === null` → Infinity 유지, 랜덤 목적지 이동 제거

### `FleetSimulationContext.tsx`
- tick 루프에서 `nextCustomerDestination` pin 동기화를 `advanceBikeState` 호출 **전**으로 이동
- 관리자 저장 → 다음 250ms tick에 최신 목적지 반영 → 즉시 전환 트리거

## Flow

```
이동 중 (고객 목적지로 이동)
    ↓ 도착
대기 중 ← 무한 대기 (타이머 없음)
    ↓ 관리자가 차량 상세에서 다음 고객 정보 저장
이동 중 (새 고객 목적지로 즉시 출발)
```

## Test plan

- [ ] CLEANING 차량이 도착 후 대기 중 상태로 전환되는지 확인
- [ ] 대기 중에서 랜덤 목적지로 자동 이동하지 않는지 확인
- [ ] 다음 고객 정보 저장 후 즉시 이동 중으로 전환되는지 확인
- [ ] DELIVERY 차량은 기존처럼 대기 후 랜덤 목적지로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)