### PR TITLE
fix: 다음 고객 저장 후 pinsRef 즉시 갱신 (MOVING 전환 즉시 발동)

### DIFF
--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -912,8 +912,10 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     return () => { cancelled = true; };
   }, [bikeId]);
 
-  // 시뮬레이션 WORKING→MOVING 전환 감지 — 작업 완료 시 폼 즉시 초기화
-  const { simulated } = useFleetSimulation();
+  // 시뮬레이션 WORKING→MOVING 전환 감지 — 작업 완료 시 폼 즉시 초기화.
+  // updatePinNextCustomer: 저장 성공 시 pinsRef 를 즉시 갱신해 tick 루프가
+  // 새 nextCustomerDestination 을 page revalidation 없이도 감지하게 함.
+  const { simulated, updatePinNextCustomer } = useFleetSimulation();
   const ignitionOnAt = simulated.get(bikeId)?.ignitionOnAt ?? null;
   const prevIgnitionOnAtRef = useRef(ignitionOnAt);
   useEffect(() => {
@@ -939,6 +941,9 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     setSaving(false);
     if (result.ok) {
       setSavedCoords({ lat: result.lat, lng: result.lng });
+      // pinsRef 즉시 갱신 — tick 루프가 새 nextCustomerDestination 을 감지해
+      // WORKING→MOVING 전환을 page revalidation 없이도 즉시 발동시킨다.
+      updatePinNextCustomer(bikeId, result.lat, result.lng);
     } else {
       setError(result.error);
     }

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -31,6 +31,12 @@ type FleetSimulationContextValue = {
   simulated: ReadonlyMap<string, SimulatedBikeState>;
   /** OverviewMapBanner / FullscreenMapHost 가 호출 — origin 좌표 조회용. */
   seedBikePins: (pins: ReadonlyArray<FrontendDashboardBikePin>) => void;
+  /**
+   * 운영자가 다음 고객 저장 후 즉시 호출 — pinsRef 를 갱신해 tick 루프가
+   * 새 nextCustomerDestination 을 즉시 감지하도록 한다.
+   * page revalidation 없이도 시뮬레이션이 MOVING 으로 전환된다.
+   */
+  updatePinNextCustomer: (bikeId: string, lat: number, lng: number) => void;
 };
 
 const FleetSimulationContext = createContext<FleetSimulationContextValue | null>(null);
@@ -65,6 +71,14 @@ export function FleetSimulationProvider({
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
+  }, []);
+
+  const updatePinNextCustomer = useCallback((bikeId: string, lat: number, lng: number) => {
+    pinsRef.current = pinsRef.current.map((p) =>
+      p.bikeId === bikeId
+        ? { ...p, nextCustomerLat: lat, nextCustomerLng: lng }
+        : p
+    );
   }, []);
 
   // 직렬화된 배열 → Set/Map (useMemo 로 참조 안정화).
@@ -253,8 +267,8 @@ export function FleetSimulationProvider({
   }, [simulated]);
 
   const value = useMemo<FleetSimulationContextValue>(
-    () => ({ simulated, seedBikePins }),
-    [simulated, seedBikePins]
+    () => ({ simulated, seedBikePins, updatePinNextCustomer }),
+    [simulated, seedBikePins, updatePinNextCustomer]
   );
 
   return <FleetSimulationContext.Provider value={value}>{children}</FleetSimulationContext.Provider>;
@@ -263,6 +277,7 @@ export function FleetSimulationProvider({
 // 모듈 스코프 상수 — fallback 에서 호출마다 새 참조를 만들지 않도록.
 const EMPTY_SIMULATED: ReadonlyMap<string, SimulatedBikeState> = new Map();
 const NOOP_SEED = () => {};
+const NOOP_UPDATE = () => {};
 
 /**
  * Provider 없는 환경에서도 안전하게 호출되도록 noop fallback 반환.
@@ -270,7 +285,7 @@ const NOOP_SEED = () => {};
 export function useFleetSimulation(): FleetSimulationContextValue {
   const ctx = useContext(FleetSimulationContext);
   if (!ctx) {
-    return { simulated: EMPTY_SIMULATED, seedBikePins: NOOP_SEED };
+    return { simulated: EMPTY_SIMULATED, seedBikePins: NOOP_SEED, updatePinNextCustomer: NOOP_UPDATE };
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary

- **버그**: `setNextCustomerAction` 저장 성공 후 `pinsRef`(시뮬레이션 좌표 캐시)가 업데이트되지 않아, CLEANING 차량이 새 목적지를 받아도 MOVING으로 전환되지 않는 문제
- **원인**: `pinsRef`는 `seedBikePins`(맵 컴포넌트가 SSR 데이터로 초기화)로만 갱신되며, `setNextCustomerAction`은 `revalidatePath`를 호출하지 않아 SSR 캐시가 무효화되지 않음
- **수정**: `FleetSimulationContext`에 `updatePinNextCustomer(bikeId, lat, lng)` 메서드 추가 → 저장 성공 시 `VehicleDetailDialog`가 즉시 호출해 `pinsRef`를 갱신, 다음 tick(250ms)에서 `advanceBikeState`가 새 좌표를 감지해 WORKING→MOVING 전환 발동

## Changes

- `FleetSimulationContext.tsx`: `updatePinNextCustomer` 메서드 추가 (타입 + 구현 + fallback)
- `VehicleDetailDialog.tsx`: 저장 성공 후 `updatePinNextCustomer` 호출

## Test plan

- [ ] 배포 후 CLEANING 차량 패널 → 다음 고객 정보 저장 → 250ms 이내 지도에서 "이동 중"으로 전환 확인
- [ ] 저장 실패(주소 오류) 시 상태 변경 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)