### PR TITLE
fix: 알림에 고객 이름·전화번호 누락 수정

### DIFF
--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -943,7 +943,7 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
       setSavedCoords({ lat: result.lat, lng: result.lng });
       // pinsRef 즉시 갱신 — tick 루프가 새 nextCustomerDestination 을 감지해
       // WORKING→MOVING 전환을 page revalidation 없이도 즉시 발동시킨다.
-      updatePinNextCustomer(bikeId, result.lat, result.lng);
+      updatePinNextCustomer(bikeId, result.lat, result.lng, customerName, customerPhone);
     } else {
       setError(result.error);
     }

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -34,9 +34,10 @@ type FleetSimulationContextValue = {
   /**
    * 운영자가 다음 고객 저장 후 즉시 호출 — pinsRef 를 갱신해 tick 루프가
    * 새 nextCustomerDestination 을 즉시 감지하도록 한다.
-   * page revalidation 없이도 시뮬레이션이 MOVING 으로 전환된다.
+   * page revalidation 없이도 시뮬레이션이 MOVING 으로 전환되며,
+   * 알림 발송 시 고객 이름·전화번호도 함께 포함된다.
    */
-  updatePinNextCustomer: (bikeId: string, lat: number, lng: number) => void;
+  updatePinNextCustomer: (bikeId: string, lat: number, lng: number, name?: string, phone?: string) => void;
 };
 
 const FleetSimulationContext = createContext<FleetSimulationContextValue | null>(null);
@@ -73,10 +74,16 @@ export function FleetSimulationProvider({
     pinsRef.current = pins;
   }, []);
 
-  const updatePinNextCustomer = useCallback((bikeId: string, lat: number, lng: number) => {
+  const updatePinNextCustomer = useCallback((bikeId: string, lat: number, lng: number, name?: string, phone?: string) => {
     pinsRef.current = pinsRef.current.map((p) =>
       p.bikeId === bikeId
-        ? { ...p, nextCustomerLat: lat, nextCustomerLng: lng }
+        ? {
+            ...p,
+            nextCustomerLat: lat,
+            nextCustomerLng: lng,
+            nextCustomerName: name ?? p.nextCustomerName,
+            nextCustomerPhone: phone ?? p.nextCustomerPhone,
+          }
         : p
     );
   }, []);


### PR DESCRIPTION
## Summary
- `updatePinNextCustomer`가 lat/lng만 `pinsRef`에 반영해 ignition 알림 발송 시 `nextCustomerName`/`nextCustomerPhone`이 null로 남아 있던 버그 수정
- 저장 성공 시 이름·전화도 함께 pinsRef에 반영 → 알림에 `📞 22나2222 → QA고객 010-5555-9999` 형식으로 표시됨

## Root Cause
`VehicleDetailDialog.tsx`의 `handleSave`에서 `updatePinNextCustomer(bikeId, lat, lng)`만 호출, 이름·전화 미전달 → `pinsRef`의 `nextCustomerName/Phone`이 null 유지 → 알림 발송 시 `🔑 {plateNumber} 이동 시작` fallback 포맷으로 표시

## Fix
```typescript
// 수정 전
updatePinNextCustomer(bikeId, result.lat, result.lng);

// 수정 후
updatePinNextCustomer(bikeId, result.lat, result.lng, customerName, customerPhone);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)