### PR TITLE
feat: CLEANING 시뮬레이션 전체 + 알림/UX 개선

### DIFF
--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -912,16 +912,20 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     return () => { cancelled = true; };
   }, [bikeId]);
 
-  // 시뮬레이션 WORKING→MOVING 전환 감지 — 작업 완료 시 폼 즉시 초기화.
+  // MOVING→WORKING(도착) 감지 — 도착 후 대기 중 진입 시 폼 초기화.
+  // 이동 중에는 고객 정보가 그대로 표시되고, 도착해야 지워짐.
   // updatePinNextCustomer: 저장 성공 시 pinsRef 를 즉시 갱신해 tick 루프가
   // 새 nextCustomerDestination 을 page revalidation 없이도 감지하게 함.
   const { simulated, updatePinNextCustomer } = useFleetSimulation();
   const ignitionOnAt = simulated.get(bikeId)?.ignitionOnAt ?? null;
   const prevIgnitionOnAtRef = useRef(ignitionOnAt);
   useEffect(() => {
-    if (ignitionOnAt === null) return;
     if (prevIgnitionOnAtRef.current === ignitionOnAt) return;
+    const prev = prevIgnitionOnAtRef.current;
     prevIgnitionOnAtRef.current = ignitionOnAt;
+    // MOVING→WORKING(도착): prev 가 non-null 이고 현재가 null 일 때만 초기화.
+    // WORKING→MOVING(출발) 시에는 폼을 유지해 이동 중에도 고객 정보가 보임.
+    if (prev === null || ignitionOnAt !== null) return;
     setCustomerName("");
     setCustomerPhone("");
     setAddress("");

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -7,6 +7,7 @@ import {
   makeInitialState,
   TICK_INTERVAL_MS,
   MOVING_DURATION_MAX_MS,
+  CLEANING_MOVING_DURATION_MAX_MS,
   type SimulatedBikeState,
   type ServicePhase
 } from "@/lib/services/fleet-simulation";
@@ -142,7 +143,9 @@ export function FleetSimulationProvider({
             ? "WORKING"
             : "MOVING";
         // MOVING 시작 시에만 오프셋으로 사이클 분산. WORKING 은 어차피 대기이므로 불필요.
-        const offsetMs = initialPhase === "MOVING" ? Math.random() * MOVING_DURATION_MAX_MS : 0;
+        // CLEANING 은 최대 이동 시간이 5분이므로 그 범위 안에서만 오프셋을 줌.
+        const maxOffsetMs = pin?.serviceType === "CLEANING" ? CLEANING_MOVING_DURATION_MAX_MS : MOVING_DURATION_MAX_MS;
+        const offsetMs = initialPhase === "MOVING" ? Math.random() * maxOffsetMs : 0;
         next.set(
           bikeId,
           makeInitialState({

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -63,6 +63,8 @@ export function FleetSimulationProvider({
   const { addNotification } = useNotifications();
   /** bikeId → last ignitionOnAt that was notified. Prevents duplicate notifications. */
   const lastNotifiedIgnitionOnAtRef = useRef<Map<string, number>>(new Map());
+  /** bikeId → last deliveryCount seen. MOVING→WORKING(도착) 감지용. */
+  const lastDeliveryCountRef = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
     mountedRef.current = true;
@@ -166,6 +168,8 @@ export function FleetSimulationProvider({
   }, [matchedImeiSet]);
 
   // Detect WORKING→MOVING transitions → send ignition notification.
+  // pinsRef 정리/DB 삭제는 하지 않음 — 이동 중에도 고객 정보를 유지해야 하므로.
+  // 도착(MOVING→WORKING) 시 정리는 아래 deliveryCount effect 에서 처리.
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
       if (state.ignitionOnAt == null) continue;
@@ -182,15 +186,6 @@ export function FleetSimulationProvider({
         customerName: pin?.nextCustomerName ?? undefined,
         customerPhone: pin?.nextCustomerPhone ?? undefined
       });
-      // 작업 완료 후 다음 고객 정보를 DB에서 제거 (fire-and-forget)
-      clearNextCustomerAction(bikeId).catch(() => undefined);
-      // pinsRef에서도 즉시 제거해 다음 MOVING 페이즈가 랜덤 좌표를 쓰도록
-      pinsRef.current = pinsRef.current.map((p) =>
-        p.bikeId === bikeId
-          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
-                nextCustomerName: null, nextCustomerPhone: null }
-          : p
-      );
     }
     // Clean up ref entries for bikes that left simulation
     for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
@@ -199,6 +194,31 @@ export function FleetSimulationProvider({
       }
     }
   }, [simulated, addNotification]);
+
+  // Detect MOVING→WORKING transitions (deliveryCount 증가) → DB 삭제 + pinsRef 정리.
+  // 도착 후 대기 중 진입 시점에 고객 정보를 지우므로, 이동 중에는 정보가 유지됨.
+  useEffect(() => {
+    for (const [bikeId, state] of simulated) {
+      if (state.serviceType !== "CLEANING") continue;
+      const last = lastDeliveryCountRef.current.get(bikeId) ?? 0;
+      if (state.deliveryCount <= last) continue;
+      // deliveryCount 증가 = 도착 완료 (MOVING→WORKING)
+      lastDeliveryCountRef.current.set(bikeId, state.deliveryCount);
+      // 다음 고객 정보를 DB에서 제거 (fire-and-forget)
+      clearNextCustomerAction(bikeId).catch(() => undefined);
+      // pinsRef 초기화 — 다음 MOVING 페이즈가 새 주소 입력 전까지 대기하도록
+      pinsRef.current = pinsRef.current.map((p) =>
+        p.bikeId === bikeId
+          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
+                nextCustomerName: null, nextCustomerPhone: null }
+          : p
+      );
+    }
+    // Clean up ref entries for bikes that left simulation
+    for (const bikeId of lastDeliveryCountRef.current.keys()) {
+      if (!simulated.has(bikeId)) lastDeliveryCountRef.current.delete(bikeId);
+    }
+  }, [simulated]);
 
   // 250ms tick loop — mount 시 한 번만 interval 을 생성. simulated.size 를
   // dep 으로 두면 size 변화 시점에 효과가 재실행되면서 stale closure 가 발생해

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -139,9 +139,9 @@ function FullscreenMapOverlay({
   const [stationFilters, setStationFilters] = useState<StationFilterState>(DEFAULT_STATION_FILTERS);
   const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
-  // 필터 바 펼침/접힘. 기본 펼침 — 운영자가 들어오자마자 필터들이 보이게.
+  // 필터 바 펼침/접힘. 기본 접힘 — 전체화면 진입 시 지도가 최대한 넓게 보이도록.
   // 닫으면 11개 select 가 숨겨지고 토글 버튼만 작은 pill 로 남는다.
-  const [filtersOpen, setFiltersOpen] = useState(true);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const { seedBikePins } = useFleetSimulation();
 

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -47,10 +47,14 @@ export type SimulatedBikeState = {
 
 /** tick 간격 (ms) */
 export const TICK_INTERVAL_MS = 250;
-/** MOVING 한 주기 최소 길이 (15분) */
+/** MOVING 한 주기 최소 길이 — DELIVERY/OTHER (15분) */
 export const MOVING_DURATION_MIN_MS = 15 * 60 * 1_000;
-/** MOVING 한 주기 최대 길이 (40분) */
+/** MOVING 한 주기 최대 길이 — DELIVERY/OTHER (40분) */
 export const MOVING_DURATION_MAX_MS = 40 * 60 * 1_000;
+/** CLEANING 차량 MOVING 최소 길이 (2분) */
+export const CLEANING_MOVING_DURATION_MIN_MS = 2 * 60 * 1_000;
+/** CLEANING 차량 MOVING 최대 길이 (5분) */
+export const CLEANING_MOVING_DURATION_MAX_MS = 5 * 60 * 1_000;
 /** 완료 후 다음 사이클까지 최소 대기 (ms) */
 export const WORKING_BETWEEN_MIN_MS = 5_000;
 /** 완료 후 다음 사이클까지 최대 대기 (ms) */
@@ -65,11 +69,11 @@ const SEOUL_LAT_MAX = 37.65;
 const SEOUL_LNG_MIN = 126.87;
 const SEOUL_LNG_MAX = 127.10;
 
-function randomMovingDurationMs(random: () => number): number {
-  return (
-    MOVING_DURATION_MIN_MS +
-    random() * (MOVING_DURATION_MAX_MS - MOVING_DURATION_MIN_MS)
-  );
+function randomMovingDurationMs(random: () => number, serviceType: ServiceType = "DELIVERY"): number {
+  if (serviceType === "CLEANING") {
+    return CLEANING_MOVING_DURATION_MIN_MS + random() * (CLEANING_MOVING_DURATION_MAX_MS - CLEANING_MOVING_DURATION_MIN_MS);
+  }
+  return MOVING_DURATION_MIN_MS + random() * (MOVING_DURATION_MAX_MS - MOVING_DURATION_MIN_MS);
 }
 
 function randomSeoulPoint(random: () => number = Math.random): { lat: number; lng: number } {
@@ -132,7 +136,7 @@ export function advanceBikeState(
       progress: 0,
       position: prev.origin,
       phaseStartedAt: nowMs,
-      phaseEndsAt: nowMs + randomMovingDurationMs(random),
+      phaseEndsAt: nowMs + randomMovingDurationMs(random, prev.serviceType),
       speedKph: MOVING_SPEED_KPH,
       ignitionStatus: "ON",
       ignitionOnAt: nowMs,
@@ -181,7 +185,7 @@ export function advanceBikeState(
         progress: 0,
         position: prev.origin,
         phaseStartedAt: nowMs,
-        phaseEndsAt: nowMs + randomMovingDurationMs(random),
+        phaseEndsAt: nowMs + randomMovingDurationMs(random, prev.serviceType),
         speedKph: MOVING_SPEED_KPH,
         ignitionStatus: "ON",
         ignitionOnAt: nowMs,
@@ -249,7 +253,7 @@ export function makeInitialState(input: {
       progress: 0,
       position: origin,
       phaseStartedAt: nowMs,
-      phaseEndsAt: nowMs + randomMovingDurationMs(random),
+      phaseEndsAt: nowMs + randomMovingDurationMs(random, serviceType),
       speedKph: MOVING_SPEED_KPH,
       ignitionStatus: "ON",
       ignitionOnAt: nowMs,

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -209,6 +209,8 @@ export function advanceBikeState(
         position: finalPosition,
         origin: finalPosition,
         destination: null,
+        // CLEANING: 도착 즉시 초기화 — pinsRef 정리 전 다음 tick 이 재트리거하지 않도록.
+        nextCustomerDestination: null,
         phaseStartedAt: nowMs,
         phaseEndsAt: workingPhaseEndsAt,
         speedKph: 0,


### PR DESCRIPTION
## Summary

CLEANING 서비스 타입 차량의 시뮬레이션 흐름 완성 및 다수 버그 수정.

---

## 주요 변경사항

### CLEANING 시뮬레이션 흐름
- **대기 중 시작**: 시뮬레이션 진입 시 목적지 없으면 무단 이동 없이 대기 중으로 시작
- **즉시 출발**: 관리자가 다음 고객 주소 저장 → 250ms tick 내 이동 중으로 즉시 전환
- **이동 시간 단축**: CLEANING 차량 2~5분 (기존 15~40분), DELIVERY/OTHER는 유지
- **이동 중 고객 정보 유지**: 저장 후 이동 중에도 이름·전화·주소 표시
- **도착 시 자동 정리**: 대기 중 진입 시 폼 초기화 + DB 삭제

### 알림
- 이동 시작 시 알림벨에 고객 이름·전화번호 포함 (`📞 번호 → 이름 전화`)
- 저장 시 이름·전화를 pinsRef에도 즉시 반영해 알림에 정확히 표시

### UX
- 전체화면 진입 시 필터 바 기본 접힘 (지도 최대 면적)
- 알림·폼 초기화 타이밍 개선

### 버그 수정
- CLEANING 차량 WORKING→MOVING 시 랜덤 좌표 이동 방지
- pinsRef 정리 전 다음 tick race condition 방지 (`nextCustomerDestination: null` 즉시 설정)
- `clearNextCustomerAction` 호출 시점을 도착 후로 이동

## Test plan
- [ ] CLEANING 차량 라이더 매칭 시 "대기 중" 배지 확인 (무단 이동 없음)
- [ ] 다음 고객 저장 후 즉시 "이동 중" 전환 확인
- [ ] 이동 중 고객 이름·전화·주소 폼에 유지 확인
- [ ] 도착 후 "대기 중" 진입 시 폼 초기화 확인
- [ ] 알림벨에 고객 이름·전화 포함 확인
- [ ] 전체화면 진입 시 필터 바 접힌 상태 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)