### PR TITLE
feat: 현재 고객 / 다음 고객 분리 (CLEANING 차량)

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -908,17 +908,6 @@ export async function setNextCustomerAction(
   }
 }
 
-export async function clearNextCustomerAction(bikeId: string): Promise<{ ok: boolean }> {
-  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
-  if (!client) return { ok: false };
-  try {
-    await client.clearBikeNextCustomer(bikeId);
-    return { ok: true };
-  } catch {
-    return { ok: false };
-  }
-}
-
 /**
  * CLEANING 차량의 다음 고객 → 현재 고객으로 승격.
  * 시동 ON(WORKING→MOVING) 시점에 FleetSimulationContext 가 호출.

--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -918,3 +918,18 @@ export async function clearNextCustomerAction(bikeId: string): Promise<{ ok: boo
     return { ok: false };
   }
 }
+
+/**
+ * CLEANING 차량의 다음 고객 → 현재 고객으로 승격.
+ * 시동 ON(WORKING→MOVING) 시점에 FleetSimulationContext 가 호출.
+ */
+export async function promoteNextToCurrentAction(bikeId: string): Promise<{ ok: boolean }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return { ok: false };
+  try {
+    await client.promoteNextToCurrentBikeCustomer(bikeId);
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -880,10 +880,16 @@ function formatRemaining(ms: number): string {
 }
 
 // ============================================================================
-// 다음 고객 섹션 (CLEANING 전용)
+// 현재 고객 / 다음 고객 섹션 (CLEANING 전용)
 // ============================================================================
 
 function NextCustomerSection({ bikeId }: { bikeId: string }) {
+  // 현재 고객 (read-only — promote 시 자동 갱신)
+  const [currentCustomerName, setCurrentCustomerName] = useState("");
+  const [currentCustomerPhone, setCurrentCustomerPhone] = useState("");
+  const [currentCustomerAddress, setCurrentCustomerAddress] = useState("");
+
+  // 다음 고객 (editable form)
   const [customerName, setCustomerName] = useState("");
   const [customerPhone, setCustomerPhone] = useState("");
   const [address, setAddress] = useState("");
@@ -891,46 +897,61 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  // 초기 데이터 로드
+  // 초기 데이터 로드 — 서버에서 현재 고객 + 다음 고객 모두 조회
   useEffect(() => {
     let cancelled = false;
     getNextCustomerAction(bikeId).then((data) => {
-      if (cancelled) return;
-      if (data) {
-        setCustomerName(data.customerName ?? "");
-        setCustomerPhone(data.customerPhone ?? "");
-        setAddress(data.address ?? "");
-        setSavedCoords(data.latitude && data.longitude ? { lat: data.latitude, lng: data.longitude } : null);
+      if (cancelled || !data) return;
+      // 현재 고객
+      setCurrentCustomerName(data.currentCustomerName ?? "");
+      setCurrentCustomerPhone(data.currentCustomerPhone ?? "");
+      setCurrentCustomerAddress(data.currentCustomerAddress ?? "");
+      // 다음 고객
+      setCustomerName(data.customerName ?? "");
+      setCustomerPhone(data.customerPhone ?? "");
+      setAddress(data.address ?? "");
+      if (data.latitude != null && data.longitude != null) {
+        setSavedCoords({ lat: data.latitude, lng: data.longitude });
       } else {
-        setCustomerName("");
-        setCustomerPhone("");
-        setAddress("");
         setSavedCoords(null);
-        setError(null);
       }
+      setError(null);
     });
     return () => { cancelled = true; };
   }, [bikeId]);
 
-  // MOVING→WORKING(도착) 감지 — 도착 후 대기 중 진입 시 폼 초기화.
-  // 이동 중에는 고객 정보가 그대로 표시되고, 도착해야 지워짐.
-  // updatePinNextCustomer: 저장 성공 시 pinsRef 를 즉시 갱신해 tick 루프가
-  // 새 nextCustomerDestination 을 page revalidation 없이도 감지하게 함.
+  // ignitionOnAt 변화 감지:
+  //   null → non-null (WORKING→MOVING, 출발): 다음 고객 form 값 → 현재 고객으로 승격; 폼 초기화
+  //   non-null → null (MOVING→WORKING, 도착): 현재 고객 유지 (아무것도 안 함)
   const { simulated, updatePinNextCustomer } = useFleetSimulation();
   const ignitionOnAt = simulated.get(bikeId)?.ignitionOnAt ?? null;
   const prevIgnitionOnAtRef = useRef(ignitionOnAt);
+  // form 값을 ref 에 보관 — ignitionOnAt 이펙트에서 stale closure 없이 읽기 위해
+  const customerNameRef = useRef(customerName);
+  const customerPhoneRef = useRef(customerPhone);
+  const addressRef = useRef(address);
+  useEffect(() => { customerNameRef.current = customerName; }, [customerName]);
+  useEffect(() => { customerPhoneRef.current = customerPhone; }, [customerPhone]);
+  useEffect(() => { addressRef.current = address; }, [address]);
+
   useEffect(() => {
     if (prevIgnitionOnAtRef.current === ignitionOnAt) return;
     const prev = prevIgnitionOnAtRef.current;
     prevIgnitionOnAtRef.current = ignitionOnAt;
-    // MOVING→WORKING(도착): prev 가 non-null 이고 현재가 null 일 때만 초기화.
-    // WORKING→MOVING(출발) 시에는 폼을 유지해 이동 중에도 고객 정보가 보임.
-    if (prev === null || ignitionOnAt !== null) return;
-    setCustomerName("");
-    setCustomerPhone("");
-    setAddress("");
-    setSavedCoords(null);
-    setError(null);
+
+    if (prev === null && ignitionOnAt !== null) {
+      // 출발: 다음 고객 → 현재 고객으로 승격 (로컬 상태)
+      setCurrentCustomerName(customerNameRef.current);
+      setCurrentCustomerPhone(customerPhoneRef.current);
+      setCurrentCustomerAddress(addressRef.current);
+      // 다음 고객 폼 초기화
+      setCustomerName("");
+      setCustomerPhone("");
+      setAddress("");
+      setSavedCoords(null);
+      setError(null);
+    }
+    // 도착(non-null → null): 현재 고객은 그대로 유지 — 아무것도 안 함
   }, [ignitionOnAt]);
 
   async function handleSave(e: React.FormEvent) {
@@ -945,8 +966,6 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     setSaving(false);
     if (result.ok) {
       setSavedCoords({ lat: result.lat, lng: result.lng });
-      // pinsRef 즉시 갱신 — tick 루프가 새 nextCustomerDestination 을 감지해
-      // WORKING→MOVING 전환을 page revalidation 없이도 즉시 발동시킨다.
       updatePinNextCustomer(bikeId, result.lat, result.lng, customerName, customerPhone);
     } else {
       setError(result.error);
@@ -955,7 +974,31 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
 
   return (
     <section className="delivery-section">
-      <h4>🧹 다음 고객 <span className="muted" style={{ fontSize: "0.8em" }}>(CLEANING 전용)</span></h4>
+      {/* ── 현재 고객 (read-only) ── */}
+      <h4>📍 현재 고객 <span className="muted" style={{ fontSize: "0.8em" }}>(이동 중)</span></h4>
+      {currentCustomerName ? (
+        <dl className="delivery-meta">
+          <div className="delivery-meta-row">
+            <dt>고객 이름</dt>
+            <dd>{currentCustomerName}</dd>
+          </div>
+          <div className="delivery-meta-row">
+            <dt>전화번호</dt>
+            <dd>{currentCustomerPhone}</dd>
+          </div>
+          {currentCustomerAddress && (
+            <div className="delivery-meta-row">
+              <dt>주소</dt>
+              <dd>{currentCustomerAddress}</dd>
+            </div>
+          )}
+        </dl>
+      ) : (
+        <p className="muted" style={{ fontSize: "0.85em", margin: "4px 0 12px" }}>아직 이동 이력 없음</p>
+      )}
+
+      {/* ── 다음 고객 (editable) ── */}
+      <h4 style={{ marginTop: "14px" }}>🧹 다음 고객 <span className="muted" style={{ fontSize: "0.8em" }}>(CLEANING 전용)</span></h4>
       <form onSubmit={handleSave}>
         <dl className="delivery-meta">
           <div className="delivery-meta-row">

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -897,10 +897,10 @@ function NextCustomerSection({ bikeId }: { bikeId: string }) {
     getNextCustomerAction(bikeId).then((data) => {
       if (cancelled) return;
       if (data) {
-        setCustomerName(data.customerName);
-        setCustomerPhone(data.customerPhone);
-        setAddress(data.address);
-        setSavedCoords({ lat: data.latitude, lng: data.longitude });
+        setCustomerName(data.customerName ?? "");
+        setCustomerPhone(data.customerPhone ?? "");
+        setAddress(data.address ?? "");
+        setSavedCoords(data.latitude && data.longitude ? { lat: data.latitude, lng: data.longitude } : null);
       } else {
         setCustomerName("");
         setCustomerPhone("");

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -12,7 +12,7 @@ import {
   type ServicePhase
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
-import { clearNextCustomerAction } from "@/app/actions";
+import { promoteNextToCurrentAction } from "@/app/actions";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
@@ -167,25 +167,36 @@ export function FleetSimulationProvider({
     });
   }, [matchedImeiSet]);
 
-  // Detect WORKING→MOVING transitions → send ignition notification.
-  // pinsRef 정리/DB 삭제는 하지 않음 — 이동 중에도 고객 정보를 유지해야 하므로.
-  // 도착(MOVING→WORKING) 시 정리는 아래 deliveryCount effect 에서 처리.
+  // Detect WORKING→MOVING transitions (ignitionOnAt null → non-null).
+  // 클리닝 차량에 한해:
+  //   1. 알림 발송 (기존 로직 유지)
+  //   2. promote 호출 (fire-and-forget): DB에서 next→current 복사 후 next 초기화
+  //   3. pinsRef nextCustomer 필드 초기화 — tick 루프가 이전 목적지로 재트리거하지 않도록
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
       if (state.ignitionOnAt == null) continue;
       const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
       if (last === state.ignitionOnAt) continue;
-      // 클리닝 차량에만 알림 발송
       if (state.serviceType !== "CLEANING") continue;
       lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
       const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
       const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
+      // 1. 알림
       addNotification({
         plateNumber,
         startedAt: state.ignitionOnAt,
         customerName: pin?.nextCustomerName ?? undefined,
         customerPhone: pin?.nextCustomerPhone ?? undefined
       });
+      // 2. DB promote (fire-and-forget)
+      promoteNextToCurrentAction(bikeId).catch(() => undefined);
+      // 3. pinsRef nextCustomer 초기화 — 다음 입력 전까지 새 이동 트리거 방지
+      pinsRef.current = pinsRef.current.map((p) =>
+        p.bikeId === bikeId
+          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
+                nextCustomerName: null, nextCustomerPhone: null }
+          : p
+      );
     }
     // Clean up ref entries for bikes that left simulation
     for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
@@ -195,26 +206,16 @@ export function FleetSimulationProvider({
     }
   }, [simulated, addNotification]);
 
-  // Detect MOVING→WORKING transitions (deliveryCount 증가) → DB 삭제 + pinsRef 정리.
-  // 도착 후 대기 중 진입 시점에 고객 정보를 지우므로, 이동 중에는 정보가 유지됨.
+  // Detect MOVING→WORKING transitions (deliveryCount 증가) → ref 정리만.
+  // 고객 정보는 도착 시 초기화하지 않음 — 현재 고객은 다음 출발 전까지 유지.
+  // pinsRef nextCustomer 정리는 이제 ignitionOnAt 이펙트(출발 시)에서 수행.
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
       if (state.serviceType !== "CLEANING") continue;
       const last = lastDeliveryCountRef.current.get(bikeId) ?? 0;
       if (state.deliveryCount <= last) continue;
-      // deliveryCount 증가 = 도착 완료 (MOVING→WORKING)
       lastDeliveryCountRef.current.set(bikeId, state.deliveryCount);
-      // 다음 고객 정보를 DB에서 제거 (fire-and-forget)
-      clearNextCustomerAction(bikeId).catch(() => undefined);
-      // pinsRef 초기화 — 다음 MOVING 페이즈가 새 주소 입력 전까지 대기하도록
-      pinsRef.current = pinsRef.current.map((p) =>
-        p.bikeId === bikeId
-          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
-                nextCustomerName: null, nextCustomerPhone: null }
-          : p
-      );
     }
-    // Clean up ref entries for bikes that left simulation
     for (const bikeId of lastDeliveryCountRef.current.keys()) {
       if (!simulated.has(bikeId)) lastDeliveryCountRef.current.delete(bikeId);
     }

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -675,15 +675,24 @@ export type ServiceOpsDashboardBikePin = {
   nextCustomerPhone?: string | null;
   nextCustomerLat?: number | string | null;
   nextCustomerLng?: number | string | null;
+  currentCustomerName?: string | null;
+  currentCustomerPhone?: string | null;
 };
 
 export type ServiceOpsBikeNextCustomer = {
   bikeId: string;
-  customerName: string;
-  customerPhone: string;
-  address: string;
-  latitude: number;
-  longitude: number;
+  /** 다음 고객. promote() 후 null. */
+  customerName: string | null;
+  customerPhone: string | null;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  /** 현재 고객. 아직 한 번도 이동 안 했으면 null. */
+  currentCustomerName: string | null;
+  currentCustomerPhone: string | null;
+  currentCustomerAddress: string | null;
+  currentCustomerLat: number | null;
+  currentCustomerLng: number | null;
 };
 
 export type BikeNextCustomerUpsertInput = {
@@ -889,6 +898,7 @@ export type ServiceOpsApiClient = {
   getBikeNextCustomer: (bikeId: string) => Promise<ServiceOpsBikeNextCustomer | null>;
   setBikeNextCustomer: (bikeId: string, input: BikeNextCustomerUpsertInput) => Promise<ServiceOpsBikeNextCustomer>;
   clearBikeNextCustomer: (bikeId: string) => Promise<void>;
+  promoteNextToCurrentBikeCustomer: (bikeId: string) => Promise<void>;
   getIntegrityReferenceChecks: () => Promise<ServiceOpsIntegrityScan>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
@@ -1139,6 +1149,12 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/bikes/${encodeURIComponent(bikeId)}/next-customer`,
         { method: "DELETE" }
       ),
+    promoteNextToCurrentBikeCustomer: async (bikeId) => {
+      await request<void>(
+        `/bikes/${encodeURIComponent(bikeId)}/next-customer/promote`,
+        { method: "POST" }
+      );
+    },
     getIntegrityReferenceChecks: () =>
       request<ServiceOpsIntegrityScan>("/integrity/reference-checks", { method: "GET" }),
     listVehicles: async ({ page = 0, size = 20, sort } = {}) => {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeNextCustomerController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/controller/BikeNextCustomerController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +41,12 @@ public class BikeNextCustomerController {
     @DeleteMapping
     ResponseEntity<Void> delete(@PathVariable UUID bikeId) {
         bikeNextCustomerService.clear(bikeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/promote")
+    ResponseEntity<Void> promote(@PathVariable UUID bikeId) {
+        bikeNextCustomerService.promote(bikeId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeNextCustomer.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeNextCustomer.java
@@ -15,20 +15,38 @@ public class BikeNextCustomer {
     @Column(name = "bike_id", nullable = false, updatable = false)
     private UUID bikeId;
 
-    @Column(name = "customer_name", nullable = false, length = 100)
+    /** 다음 고객 이름. promote() 후 null. */
+    @Column(name = "customer_name", length = 100)
     private String customerName;
 
-    @Column(name = "customer_phone", nullable = false, length = 20)
+    @Column(name = "customer_phone", length = 20)
     private String customerPhone;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String address;
 
-    @Column(nullable = false)
-    private double latitude;
+    /** Double (nullable) — promote() 후 null 허용. */
+    @Column
+    private Double latitude;
 
-    @Column(nullable = false)
-    private double longitude;
+    @Column
+    private Double longitude;
+
+    /** 현재 고객 이름 (promote 시 next → current 복사). */
+    @Column(name = "current_customer_name", length = 100)
+    private String currentCustomerName;
+
+    @Column(name = "current_customer_phone", length = 20)
+    private String currentCustomerPhone;
+
+    @Column(name = "current_customer_address", length = 500)
+    private String currentCustomerAddress;
+
+    @Column(name = "current_customer_lat")
+    private Double currentCustomerLat;
+
+    @Column(name = "current_customer_lng")
+    private Double currentCustomerLng;
 
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
@@ -58,11 +76,34 @@ public class BikeNextCustomer {
         this.updatedAt = Instant.now();
     }
 
-    public UUID getBikeId()          { return bikeId; }
-    public String getCustomerName()  { return customerName; }
-    public String getCustomerPhone() { return customerPhone; }
-    public String getAddress()       { return address; }
-    public double getLatitude()      { return latitude; }
-    public double getLongitude()     { return longitude; }
-    public Instant getUpdatedAt()    { return updatedAt; }
+    /**
+     * 다음 고객 → 현재 고객으로 승격.
+     * next 필드를 null 로 초기화해 이후 PUT 이 들어올 때까지 다음 고객 없음 상태를 유지.
+     */
+    public void promote() {
+        this.currentCustomerName    = this.customerName;
+        this.currentCustomerPhone   = this.customerPhone;
+        this.currentCustomerAddress = this.address;
+        this.currentCustomerLat     = this.latitude;
+        this.currentCustomerLng     = this.longitude;
+        this.customerName    = null;
+        this.customerPhone   = null;
+        this.address         = null;
+        this.latitude        = null;
+        this.longitude       = null;
+        this.updatedAt       = Instant.now();
+    }
+
+    public UUID   getBikeId()                { return bikeId; }
+    public String getCustomerName()          { return customerName; }
+    public String getCustomerPhone()         { return customerPhone; }
+    public String getAddress()               { return address; }
+    public Double getLatitude()              { return latitude; }
+    public Double getLongitude()             { return longitude; }
+    public String getCurrentCustomerName()   { return currentCustomerName; }
+    public String getCurrentCustomerPhone()  { return currentCustomerPhone; }
+    public String getCurrentCustomerAddress(){ return currentCustomerAddress; }
+    public Double getCurrentCustomerLat()    { return currentCustomerLat; }
+    public Double getCurrentCustomerLng()    { return currentCustomerLng; }
+    public Instant getUpdatedAt()            { return updatedAt; }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeNextCustomer.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeNextCustomer.java
@@ -79,8 +79,10 @@ public class BikeNextCustomer {
     /**
      * 다음 고객 → 현재 고객으로 승격.
      * next 필드를 null 로 초기화해 이후 PUT 이 들어올 때까지 다음 고객 없음 상태를 유지.
+     * customerName 이 null 인 상태(이미 promote 완료)에서 재호출하면 no-op — 멱등성 보장.
      */
     public void promote() {
+        if (this.customerName == null) return;
         this.currentCustomerName    = this.customerName;
         this.currentCustomerPhone   = this.customerPhone;
         this.currentCustomerAddress = this.address;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeNextCustomerResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeNextCustomerResponse.java
@@ -5,11 +5,18 @@ import java.util.UUID;
 
 public record BikeNextCustomerResponse(
         UUID   bikeId,
+        // 다음 고객 (null = 설정 안 됨 또는 이미 promote 됨)
         String customerName,
         String customerPhone,
         String address,
-        double latitude,
-        double longitude
+        Double latitude,
+        Double longitude,
+        // 현재 고객 (null = 아직 한 번도 이동한 적 없음)
+        String currentCustomerName,
+        String currentCustomerPhone,
+        String currentCustomerAddress,
+        Double currentCustomerLat,
+        Double currentCustomerLng
 ) {
     public static BikeNextCustomerResponse from(BikeNextCustomer entity) {
         return new BikeNextCustomerResponse(
@@ -18,7 +25,12 @@ public record BikeNextCustomerResponse(
                 entity.getCustomerPhone(),
                 entity.getAddress(),
                 entity.getLatitude(),
-                entity.getLongitude()
+                entity.getLongitude(),
+                entity.getCurrentCustomerName(),
+                entity.getCurrentCustomerPhone(),
+                entity.getCurrentCustomerAddress(),
+                entity.getCurrentCustomerLat(),
+                entity.getCurrentCustomerLng()
         );
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
@@ -56,6 +56,7 @@ public class BikeNextCustomerService {
     @Transactional
     public void promote(UUID bikeId) {
         requireCleaningBike(bikeId);
+        // No-op if no next-customer row exists — idempotent by design.
         nextCustomerRepository.findById(bikeId).ifPresent(entity -> {
             entity.promote();
             nextCustomerRepository.save(entity);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
@@ -53,6 +53,15 @@ public class BikeNextCustomerService {
         return BikeNextCustomerResponse.from(nextCustomerRepository.save(entity));
     }
 
+    @Transactional
+    public void promote(UUID bikeId) {
+        requireCleaningBike(bikeId);
+        nextCustomerRepository.findById(bikeId).ifPresent(entity -> {
+            entity.promote();
+            nextCustomerRepository.save(entity);
+        });
+    }
+
     private void requireCleaningBike(UUID bikeId) {
         Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
@@ -51,7 +51,9 @@ public record DashboardMapStateResponse(
             String nextCustomerName,
             String nextCustomerPhone,
             BigDecimal nextCustomerLat,
-            BigDecimal nextCustomerLng
+            BigDecimal nextCustomerLng,
+            String currentCustomerName,
+            String currentCustomerPhone
     ) {
     }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
@@ -52,7 +52,9 @@ public class DashboardMapQueryRepository {
                     bnc.customer_name  as next_customer_name,
                     bnc.customer_phone as next_customer_phone,
                     bnc.latitude       as next_customer_lat,
-                    bnc.longitude      as next_customer_lng
+                    bnc.longitude      as next_customer_lng,
+                    bnc.current_customer_name  as current_customer_name,
+                    bnc.current_customer_phone as current_customer_phone
                 from bike_current_states cs
                 join bikes b
                   on b.id = cs.bike_id
@@ -115,7 +117,9 @@ public class DashboardMapQueryRepository {
                 rs.getString("next_customer_name"),
                 rs.getString("next_customer_phone"),
                 rs.getBigDecimal("next_customer_lat"),
-                rs.getBigDecimal("next_customer_lng")
+                rs.getBigDecimal("next_customer_lng"),
+                rs.getString("current_customer_name"),
+                rs.getString("current_customer_phone")
         );
     }
 
@@ -153,7 +157,9 @@ public class DashboardMapQueryRepository {
             String nextCustomerName,
             String nextCustomerPhone,
             BigDecimal nextCustomerLat,
-            BigDecimal nextCustomerLng
+            BigDecimal nextCustomerLng,
+            String currentCustomerName,
+            String currentCustomerPhone
     ) {
     }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
@@ -85,7 +85,9 @@ public class DashboardMapStateService {
                 row.nextCustomerName(),
                 row.nextCustomerPhone(),
                 row.nextCustomerLat(),
-                row.nextCustomerLng()
+                row.nextCustomerLng(),
+                row.currentCustomerName(),
+                row.currentCustomerPhone()
         );
     }
 

--- a/development/service-ops-api/src/main/resources/db/migration/V28__promote_current_customer.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V28__promote_current_customer.sql
@@ -1,0 +1,15 @@
+-- bike_next_customer 테이블에 현재 고객 컬럼 추가.
+-- 기존 next 컬럼들은 promote() 후 null 이 될 수 있으므로 NOT NULL 제약을 제거.
+ALTER TABLE bike_next_customer
+  ADD COLUMN current_customer_name    VARCHAR(100)     NULL,
+  ADD COLUMN current_customer_phone   VARCHAR(20)      NULL,
+  ADD COLUMN current_customer_address VARCHAR(500)     NULL,
+  ADD COLUMN current_customer_lat     DOUBLE PRECISION NULL,
+  ADD COLUMN current_customer_lng     DOUBLE PRECISION NULL;
+
+ALTER TABLE bike_next_customer
+  ALTER COLUMN customer_name  DROP NOT NULL,
+  ALTER COLUMN customer_phone DROP NOT NULL,
+  ALTER COLUMN address        DROP NOT NULL,
+  ALTER COLUMN latitude       DROP NOT NULL,
+  ALTER COLUMN longitude      DROP NOT NULL;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
@@ -195,6 +195,35 @@ class BikeNextCustomerApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isNoContent());
     }
 
+    @Test
+    void promote_calledTwice_doesNotCorruptCurrentCustomer() throws Exception {
+        // 1회차 promote: next → current 승격
+        mockMvc.perform(put("/api/v1/bikes/{id}/next-customer", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"customerName":"이순신","customerPhone":"010-1111-2222",
+                                 "address":"서울 종로구","latitude":37.5762,"longitude":126.9769}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/bikes/{id}/next-customer/promote", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        // 2회차 promote: next 필드 이미 null → currentCustomer 를 덮어쓰면 안 됨
+        mockMvc.perform(post("/api/v1/bikes/{id}/next-customer/promote", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        // 현재 고객이 여전히 "이순신" 이어야 함 (null 로 덮어쓰지 않음)
+        mockMvc.perform(get("/api/v1/bikes/{id}/next-customer", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentCustomerName").value("이순신"))
+                .andExpect(jsonPath("$.customerName").value(null));
+    }
+
     private String loginAndExtractToken() throws Exception {
         MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
@@ -160,6 +160,41 @@ class BikeNextCustomerApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    void promote_movesNextToCurrentAndClearsNext() throws Exception {
+        // Arrange: next customer 저장
+        mockMvc.perform(put("/api/v1/bikes/{id}/next-customer", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"customerName":"이순신","customerPhone":"010-1111-2222",
+                                 "address":"서울 종로구 세종대로 175",
+                                 "latitude":37.5762,"longitude":126.9769}
+                                """))
+                .andExpect(status().isOk());
+
+        // Act: promote
+        mockMvc.perform(post("/api/v1/bikes/{id}/next-customer/promote", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        // Assert: GET 응답에서 current=이순신, next=null
+        mockMvc.perform(get("/api/v1/bikes/{id}/next-customer", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerName").value(null))
+                .andExpect(jsonPath("$.currentCustomerName").value("이순신"))
+                .andExpect(jsonPath("$.currentCustomerPhone").value("010-1111-2222"));
+    }
+
+    @Test
+    void promote_withNoNextCustomer_isIdempotent() throws Exception {
+        // next-customer 가 없는 상태에서 promote → 204 (no-op, bike_next_customer 행 없음)
+        mockMvc.perform(post("/api/v1/bikes/{id}/next-customer/promote", CLEANING_BIKE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+    }
+
     private String loginAndExtractToken() throws Exception {
         MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## Summary

- **V28 Flyway migration** — adds 5 `current_customer_*` columns to `bike_next_customer`; makes existing next-customer columns nullable
- **`POST /bikes/{id}/next-customer/promote`** — atomically copies next→current fields and clears next fields (idempotent: no-op when next is already null); adds dashboard `BikePin.currentCustomerName/Phone`
- **UI split in `VehicleDetailDialog`** — 📍 현재 고객 (read-only) + 🧹 다음 고객 (editable form); departure (WORKING→MOVING) promotes via fire-and-forget API call and immediately reflects in local state; arrival (MOVING→WORKING) intentionally keeps current customer

## Test Plan

- [ ] Backend: `BikeNextCustomerApiContractTests` — `promote_movesNextToCurrentAndClearsNext`, `promote_withNoNextCustomer_isIdempotent`, `promote_calledTwice_doesNotCorruptCurrentCustomer`
- [ ] Run `./gradlew compileTestJava` to verify all contract tests compile
- [ ] Frontend: `npx tsc --noEmit` → 0 errors (verified locally)
- [ ] Manually: open a CLEANING vehicle detail, enter a next customer, simulate departure → confirm UI shows 현재 고객 and 다음 고객 form clears
- [ ] Manually: simulate arrival → confirm 현재 고객 remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)