### PR TITLE
feat: CLEANING 시뮬레이션 3단계 phase (이동 중 → 작업 중 → 대기 중)

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -665,19 +665,23 @@ function labelMarkup(text: string): string {
  * 서비스 상태 배지 HTML.
  * position:absolute 로 내장하고 wrapper 에 overflow:visible 을 준다.
  *
- * - DELIVERY (undefined 포함) MOVING: 파랑 "배송 중 · N건"
- * - DELIVERY (undefined 포함) WORKING: 회색 "대기 · N건"
- * - CLEANING / OTHER MOVING: 파랑 "이동 중 · N건"
- * - CLEANING / OTHER WORKING: 회색 "작업 · N건"
+ * DELIVERY (undefined 포함): MOVING=파랑 "배송 중", WORKING/IDLE=회색 "대기"
+ * CLEANING / OTHER:           MOVING=파랑 "이동 중", WORKING=앰버 "작업 중", IDLE=회색 "대기 중"
  * servicePhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
  */
 function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceType?: ServiceType): string {
-  const isMoving = phase === "MOVING";
-  const bg = isMoving ? "#3b82f6" : "#6b7280";
-  const label = (() => {
-    if (!serviceType || serviceType === "DELIVERY") return isMoving ? "배송 중" : "대기";
-    return isMoving ? "이동 중" : "대기 중";
-  })();
+  let bg: string;
+  let label: string;
+  if (!serviceType || serviceType === "DELIVERY") {
+    const isMoving = phase === "MOVING";
+    bg = isMoving ? "#3b82f6" : "#6b7280";
+    label = isMoving ? "배송 중" : "대기";
+  } else {
+    // CLEANING / OTHER
+    if (phase === "MOVING")       { bg = "#3b82f6"; label = "이동 중"; }
+    else if (phase === "WORKING") { bg = "#f59e0b"; label = "작업 중"; }
+    else                          { bg = "#6b7280"; label = "대기 중"; } // IDLE
+  }
   const text = `${label} · ${deliveryCount}건`;
   return (
     `<div style="position:absolute;top:${BADGE_TOP_OFFSET}px;left:50%;` +

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -853,6 +853,12 @@ function DeliverySection({
             </div>
           </>
         ) : null}
+        {state.phase === "WORKING" && state.phaseEndsAt !== Number.POSITIVE_INFINITY ? (
+          <div className="delivery-meta-row">
+            <dt>남은 시간</dt>
+            <dd>{renderRemainingLabel(state.phaseEndsAt)}</dd>
+          </div>
+        ) : null}
       </dl>
     </section>
   );
@@ -863,7 +869,9 @@ function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: Servi
     return phase === "MOVING" ? "배송 중" : "대기";
   }
   // CLEANING or OTHER
-  return phase === "MOVING" ? "이동 중" : "대기 중";
+  if (phase === "MOVING")  return "이동 중";
+  if (phase === "WORKING") return "작업 중";
+  return "대기 중"; // IDLE
 }
 
 function renderRemainingLabel(phaseEndsAt: number): string {

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -139,10 +139,10 @@ export function FleetSimulationProvider({
           pin.nextCustomerLng != null
             ? { lat: pin.nextCustomerLat, lng: pin.nextCustomerLng }
             : null;
-        // CLEANING 차량은 목적지가 없으면 WORKING(대기) 으로 시작 — 랜덤 좌표 이동 방지.
-        const initialPhase: "MOVING" | "WORKING" =
+        // CLEANING 차량은 목적지가 없으면 IDLE(대기 중) 으로 시작 — 랜덤 좌표 이동 방지.
+        const initialPhase: "MOVING" | "IDLE" =
           pin?.serviceType === "CLEANING" && nextCustomerDestination === null
-            ? "WORKING"
+            ? "IDLE"
             : "MOVING";
         // MOVING 시작 시에만 오프셋으로 사이클 분산. WORKING 은 어차피 대기이므로 불필요.
         // CLEANING 은 최대 이동 시간이 5분이므로 그 범위 안에서만 오프셋을 줌.
@@ -256,10 +256,10 @@ export function FleetSimulationProvider({
           const advanced = advanceBikeState(stateForAdvance, nowMs, isMatched);
           if (advanced !== stateForAdvance || destChanged) mutated = true;
 
-          // 비매칭 + WORKING + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
+          // 비매칭 + WORKING/IDLE + phaseEndsAt=Infinity → cleanup (다음 매칭까지 불필요)
           if (
             !isMatched &&
-            advanced.phase === "WORKING" &&
+            (advanced.phase === "WORKING" || advanced.phase === "IDLE") &&
             advanced.phaseEndsAt === Number.POSITIVE_INFINITY
           ) {
             mutated = true;
@@ -293,8 +293,8 @@ export function FleetSimulationProvider({
         if (waypoints.length === 0) return;
         setSimulated((prev) => {
           const current = prev.get(bikeId);
-          // stale guard: bike 가 이미 WORKING 으로 돌아갔으면 주입 무시
-          if (!current || current.phase === "WORKING") return prev;
+          // stale guard: bike 가 이미 WORKING/IDLE 로 돌아갔으면 주입 무시
+          if (!current || current.phase === "WORKING" || current.phase === "IDLE") return prev;
           const next = new Map(prev);
           next.set(bikeId, { ...current, routeWaypoints: waypoints });
           return next;

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -1,11 +1,12 @@
 /**
  * Fleet 서비스 시뮬레이션 순수 데이터 모델 + phase 진행 함수.
  *
- * Phase: WORKING(작업, 시동 OFF) ↔ MOVING(이동 중, 시동 ON)
- * isMatched=true 이면 WORKING → MOVING 자동 전환, false 이면 WORKING 유지.
+ * Phase (CLEANING):  IDLE(대기 중) → MOVING(이동 중) → WORKING(작업 중, ~30초) → IDLE
+ * Phase (DELIVERY):  WORKING(대기) ↔ MOVING(이동 중)
+ * isMatched=true 이면 IDLE → MOVING 자동 전환, false 이면 IDLE 유지.
  */
 
-export type ServicePhase = "WORKING" | "MOVING";
+export type ServicePhase = "MOVING" | "WORKING" | "IDLE";
 
 export type ServiceType = "DELIVERY" | "CLEANING" | "OTHER";
 
@@ -55,10 +56,12 @@ export const MOVING_DURATION_MAX_MS = 40 * 60 * 1_000;
 export const CLEANING_MOVING_DURATION_MIN_MS = 2 * 60 * 1_000;
 /** CLEANING 차량 MOVING 최대 길이 (5분) */
 export const CLEANING_MOVING_DURATION_MAX_MS = 5 * 60 * 1_000;
-/** 완료 후 다음 사이클까지 최소 대기 (ms) */
+/** 완료 후 다음 사이클까지 최소 대기 (ms) — DELIVERY/OTHER */
 export const WORKING_BETWEEN_MIN_MS = 5_000;
-/** 완료 후 다음 사이클까지 최대 대기 (ms) */
+/** 완료 후 다음 사이클까지 최대 대기 (ms) — DELIVERY/OTHER */
 export const WORKING_BETWEEN_MAX_MS = 30_000;
+/** CLEANING 차량 작업 중(WORKING) 지속 시간 (30초) — 이후 IDLE(대기 중)으로 전환 */
+export const CLEANING_WORKING_DURATION_MS = 30_000;
 /** MOVING 시 표시 속도 (km/h) */
 export const MOVING_SPEED_KPH = 30;
 /** 초당 배터리 감소량 */
@@ -121,10 +124,10 @@ export function advanceBikeState(
   isMatched: boolean,
   random: () => number = Math.random
 ): SimulatedBikeState {
-  // CLEANING: WORKING 무한 대기 중 nextCustomerDestination 이 설정되면 즉시 MOVING 전환.
+  // CLEANING: IDLE(대기 중) 무한 대기 중 nextCustomerDestination 이 설정되면 즉시 MOVING 전환.
   // phaseEndsAt 체크보다 먼저 실행해야 Infinity 대기 상태도 처리됨.
   if (
-    prev.phase === "WORKING" &&
+    prev.phase === "IDLE" &&
     isMatched &&
     prev.serviceType === "CLEANING" &&
     prev.nextCustomerDestination !== null
@@ -167,14 +170,23 @@ export function advanceBikeState(
   }
 
   switch (prev.phase) {
+    case "IDLE": {
+      // CLEANING 대기 중 — nextCustomerDestination 설정 시 조기 MOVING 전환(위에서 처리).
+      // 여기까지 오면 목적지 없음 → 계속 무한 대기.
+      return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
+    }
     case "WORKING": {
       if (!isMatched) {
         return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
       }
-      // CLEANING 차량은 위의 조기 전환 로직에서 nextCustomerDestination !== null 케이스를 처리함.
-      // 여기까지 오면 nextCustomerDestination === null → 계속 대기.
       if (prev.serviceType === "CLEANING") {
-        return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
+        // 작업 중 30초 완료 → 대기 중(IDLE)으로 전환
+        return {
+          ...prev,
+          phase: "IDLE",
+          phaseStartedAt: nowMs,
+          phaseEndsAt: Number.POSITIVE_INFINITY
+        };
       }
       // DELIVERY / OTHER: 랜덤 목적지로 이동 시작
       const destination = randomSeoulPoint(random);
@@ -194,14 +206,15 @@ export function advanceBikeState(
     }
     case "MOVING": {
       const finalPosition = prev.destination ?? prev.origin;
-      // CLEANING 차량은 다음 고객 목적지가 입력될 때까지 WORKING 상태를 유지해야 하므로
-      // phaseEndsAt 을 Infinity 로 설정해 타이머 없이 대기.
-      const idleMs =
-        !isMatched || prev.serviceType === "CLEANING"
-          ? Number.POSITIVE_INFINITY
+      // CLEANING: 도착 후 30초 작업 중(WORKING) → 이후 IDLE(대기 중)로 전환.
+      // DELIVERY/OTHER: 5~30초 WORKING 후 다음 사이클 이동.
+      // 비매칭(isMatched=false) 이면 Infinity 대기.
+      const workingDurationMs = !isMatched
+        ? Number.POSITIVE_INFINITY
+        : prev.serviceType === "CLEANING"
+          ? CLEANING_WORKING_DURATION_MS
           : WORKING_BETWEEN_MIN_MS +
             Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS));
-      const workingPhaseEndsAt = idleMs === Number.POSITIVE_INFINITY ? idleMs : nowMs + idleMs;
       return {
         ...prev,
         phase: "WORKING",
@@ -212,7 +225,7 @@ export function advanceBikeState(
         // CLEANING: 도착 즉시 초기화 — pinsRef 정리 전 다음 tick 이 재트리거하지 않도록.
         nextCustomerDestination: null,
         phaseStartedAt: nowMs,
-        phaseEndsAt: workingPhaseEndsAt,
+        phaseEndsAt: workingDurationMs === Number.POSITIVE_INFINITY ? workingDurationMs : nowMs + workingDurationMs,
         speedKph: 0,
         ignitionStatus: "OFF",
         ignitionOnAt: null,
@@ -227,7 +240,7 @@ export function makeInitialState(input: {
   bikeId: string;
   origin: { lat: number; lng: number };
   nowMs: number;
-  phase: "WORKING" | "MOVING";
+  phase: ServicePhase;
   random?: () => number;
   initialOdometerKm?: number;
   initialBatteryPercent?: number;
@@ -268,9 +281,12 @@ export function makeInitialState(input: {
     };
   }
 
+  // CLEANING 차량은 초기 대기 상태를 IDLE(대기 중)로 시작.
+  // DELIVERY/OTHER 는 WORKING(대기) 유지.
+  const idlePhase: ServicePhase = serviceType === "CLEANING" ? "IDLE" : "WORKING";
   return {
     bikeId,
-    phase: "WORKING",
+    phase: idlePhase,
     origin,
     destination: null,
     progress: 0,


### PR DESCRIPTION
## Summary
- `ServicePhase`에 `"IDLE"` 추가 — CLEANING 차량 3단계 흐름 구현
- MOVING → WORKING(작업 중, 30초) → IDLE(대기 중, 다음 고객 대기)
- 지도 배지: WORKING=앰버 "작업 중", IDLE=회색 "대기 중"
- 차량 상세 패널: 작업 중 남은 시간 표시

## Test Plan
- [ ] CLEANING 차량 다음 고객 저장 → 이동 중 전환 확인
- [ ] 도착 후 "작업 중" 배지(앰버) + 패널 상태 표시 확인
- [ ] 30초 후 "대기 중"으로 자동 전환 확인
- [ ] 다음 고객 재입력 시 즉시 출발 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)