### PR TITLE
fix: ESLint set-state-in-effect in management panels

### DIFF
--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
@@ -21,27 +21,20 @@ export function MatchingManagementPanel() {
   const [contracts, setContracts] = useState<ServiceOpsRiderBikeContract[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const items = await listMatchingAction();
-      setContracts(items);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "계약 목록 조회 실패");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let active = true;
+    listMatchingAction()
+      .then(items => { if (active) { setContracts(items); setError(null); setLoading(false); } })
+      .catch(err => { if (active) { setError(err instanceof Error ? err.message : "계약 목록 조회 실패"); setLoading(false); } });
+    return () => { active = false; };
+  }, [refreshKey]);
 
   const handleSuccess = () => {
     router.refresh();
-    void load();
+    setLoading(true);
+    setRefreshKey(k => k + 1);
   };
 
   const exportUrl = getMatchingExportUrl();

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
@@ -21,27 +21,20 @@ export function RidersManagementPanel() {
   const [riders, setRiders] = useState<FrontendRider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const items = await listRidersAction();
-      setRiders(items);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "라이더 목록 조회 실패");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let active = true;
+    listRidersAction()
+      .then(items => { if (active) { setRiders(items); setError(null); setLoading(false); } })
+      .catch(err => { if (active) { setError(err instanceof Error ? err.message : "라이더 목록 조회 실패"); setLoading(false); } });
+    return () => { active = false; };
+  }, [refreshKey]);
 
   const handleSuccess = () => {
     router.refresh();
-    void load();
+    setLoading(true);
+    setRefreshKey(k => k + 1);
   };
 
   const exportUrl = getRidersExportUrl();

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
@@ -21,27 +21,20 @@ export function VehiclesManagementPanel() {
   const [vehicles, setVehicles] = useState<FrontendVehicle[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const items = await listVehiclesAction();
-      setVehicles(items);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "차량 목록 조회 실패");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let active = true;
+    listVehiclesAction()
+      .then(items => { if (active) { setVehicles(items); setError(null); setLoading(false); } })
+      .catch(err => { if (active) { setError(err instanceof Error ? err.message : "차량 목록 조회 실패"); setLoading(false); } });
+    return () => { active = false; };
+  }, [refreshKey]);
 
   const handleSuccess = () => {
     router.refresh();
-    void load();
+    setLoading(true);
+    setRefreshKey(k => k + 1);
   };
 
   const exportUrl = getVehiclesExportUrl();


### PR DESCRIPTION
## Summary

- Replace `useCallback` + `void load()` pattern with promise chain in all three management panels
- Fixes `react-hooks/set-state-in-effect` ESLint errors on VehiclesManagementPanel, RidersManagementPanel, MatchingManagementPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)