### PR TITLE
fix: move export URL to server components, remove sync exports from use-server

### DIFF
--- a/development/front-admin-web/app/management/matching/actions.ts
+++ b/development/front-admin-web/app/management/matching/actions.ts
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
-  createServiceOpsApiClient,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type ServiceOpsRiderBikeContract
@@ -39,9 +38,6 @@ export async function bulkApplyMatchingAction(formData: FormData): Promise<BulkA
   return client.bulkApplyMatching(file);
 }
 
-export function getMatchingExportUrl(): string {
-  return createServiceOpsApiClient().getMatchingExportUrl();
-}
 
 export async function listMatchingAction(): Promise<ServiceOpsRiderBikeContract[]> {
   if (!serviceOpsApiConfigured()) {

--- a/development/front-admin-web/app/management/matching/page.tsx
+++ b/development/front-admin-web/app/management/matching/page.tsx
@@ -1,7 +1,9 @@
+import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function MatchingManagementPage() {
-  return <MatchingManagementPanel />;
+  const exportUrl = createServiceOpsApiClient().getMatchingExportUrl();
+  return <MatchingManagementPanel exportUrl={exportUrl} />;
 }

--- a/development/front-admin-web/app/management/riders/actions.ts
+++ b/development/front-admin-web/app/management/riders/actions.ts
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
-  createServiceOpsApiClient,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type FrontendRider
@@ -39,9 +38,6 @@ export async function bulkApplyRidersAction(formData: FormData): Promise<BulkApp
   return client.bulkApplyRiders(file);
 }
 
-export function getRidersExportUrl(): string {
-  return createServiceOpsApiClient().getRidersExportUrl();
-}
 
 export async function listRidersAction(): Promise<FrontendRider[]> {
   if (!serviceOpsApiConfigured()) {

--- a/development/front-admin-web/app/management/riders/page.tsx
+++ b/development/front-admin-web/app/management/riders/page.tsx
@@ -1,7 +1,9 @@
+import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function RidersManagementPage() {
-  return <RidersManagementPanel />;
+  const exportUrl = createServiceOpsApiClient().getRidersExportUrl();
+  return <RidersManagementPanel exportUrl={exportUrl} />;
 }

--- a/development/front-admin-web/app/management/vehicles/actions.ts
+++ b/development/front-admin-web/app/management/vehicles/actions.ts
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
-  createServiceOpsApiClient,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type FrontendVehicle
@@ -39,9 +38,6 @@ export async function bulkApplyVehiclesAction(formData: FormData): Promise<BulkA
   return client.bulkApplyVehicles(file);
 }
 
-export function getVehiclesExportUrl(): string {
-  return createServiceOpsApiClient().getVehiclesExportUrl();
-}
 
 export async function listVehiclesAction(): Promise<FrontendVehicle[]> {
   if (!serviceOpsApiConfigured()) {

--- a/development/front-admin-web/app/management/vehicles/page.tsx
+++ b/development/front-admin-web/app/management/vehicles/page.tsx
@@ -1,7 +1,9 @@
+import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { VehiclesManagementPanel } from "@/components/management/VehiclesManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function VehiclesManagementPage() {
-  return <VehiclesManagementPanel />;
+  const exportUrl = createServiceOpsApiClient().getVehiclesExportUrl();
+  return <VehiclesManagementPanel exportUrl={exportUrl} />;
 }

--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -7,7 +7,6 @@ import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewMatchingAction,
   bulkApplyMatchingAction,
-  getMatchingExportUrl,
   listMatchingAction
 } from "@/app/management/matching/actions";
 import type { ServiceOpsRiderBikeContract } from "@/lib/services/service-ops-api";
@@ -16,7 +15,7 @@ import type { ServiceOpsRiderBikeContract } from "@/lib/services/service-ops-api
  * 매칭(계약) 관리 페이지 패널.
  * DB 라이더-차량 계약 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
  */
-export function MatchingManagementPanel() {
+export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [contracts, setContracts] = useState<ServiceOpsRiderBikeContract[]>([]);
   const [loading, setLoading] = useState(true);
@@ -36,8 +35,6 @@ export function MatchingManagementPanel() {
     setLoading(true);
     setRefreshKey(k => k + 1);
   };
-
-  const exportUrl = getMatchingExportUrl();
 
   return (
     <div className="management-panel">

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -7,7 +7,6 @@ import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewRidersAction,
   bulkApplyRidersAction,
-  getRidersExportUrl,
   listRidersAction
 } from "@/app/management/riders/actions";
 import type { FrontendRider } from "@/lib/services/service-ops-api";
@@ -16,7 +15,7 @@ import type { FrontendRider } from "@/lib/services/service-ops-api";
  * 라이더 관리 페이지 패널.
  * DB 라이더 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
  */
-export function RidersManagementPanel() {
+export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [riders, setRiders] = useState<FrontendRider[]>([]);
   const [loading, setLoading] = useState(true);
@@ -36,8 +35,6 @@ export function RidersManagementPanel() {
     setLoading(true);
     setRefreshKey(k => k + 1);
   };
-
-  const exportUrl = getRidersExportUrl();
 
   return (
     <div className="management-panel">

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -7,7 +7,6 @@ import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewVehiclesAction,
   bulkApplyVehiclesAction,
-  getVehiclesExportUrl,
   listVehiclesAction
 } from "@/app/management/vehicles/actions";
 import type { FrontendVehicle } from "@/lib/services/service-ops-api";
@@ -16,7 +15,7 @@ import type { FrontendVehicle } from "@/lib/services/service-ops-api";
  * 차량 관리 페이지 패널.
  * DB 차량 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
  */
-export function VehiclesManagementPanel() {
+export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [vehicles, setVehicles] = useState<FrontendVehicle[]>([]);
   const [loading, setLoading] = useState(true);
@@ -36,8 +35,6 @@ export function VehiclesManagementPanel() {
     setLoading(true);
     setRefreshKey(k => k + 1);
   };
-
-  const exportUrl = getVehiclesExportUrl();
 
   return (
     <div className="management-panel">


### PR DESCRIPTION
## Summary

- Remove synchronous `get*ExportUrl` functions from `'use server'` action files (Next.js only allows async exports from server action files)
- Move URL computation to server page components (`page.tsx`) and pass as `exportUrl` prop to panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)