### PR TITLE
fix: proxy Excel export via Next.js API routes (localhost URL bug)

### DIFF
--- a/development/front-admin-web/app/api/management/matching/export/route.ts
+++ b/development/front-admin-web/app/api/management/matching/export/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { serviceOpsApiBaseUrl } from "@/lib/services/service-ops-api";
+import { getServiceOpsAccessToken } from "@/lib/services/service-ops-session";
+
+export async function GET() {
+  const accessToken = await getServiceOpsAccessToken();
+  if (!accessToken) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const baseUrl = serviceOpsApiBaseUrl();
+  if (!baseUrl) {
+    return new NextResponse("Service OPS API not configured", { status: 503 });
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/contracts/export`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    return new NextResponse("Export failed", { status: response.status });
+  }
+
+  const data = await response.arrayBuffer();
+  return new NextResponse(data, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": 'attachment; filename="matching.xlsx"',
+    },
+  });
+}

--- a/development/front-admin-web/app/api/management/riders/export/route.ts
+++ b/development/front-admin-web/app/api/management/riders/export/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { serviceOpsApiBaseUrl } from "@/lib/services/service-ops-api";
+import { getServiceOpsAccessToken } from "@/lib/services/service-ops-session";
+
+export async function GET() {
+  const accessToken = await getServiceOpsAccessToken();
+  if (!accessToken) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const baseUrl = serviceOpsApiBaseUrl();
+  if (!baseUrl) {
+    return new NextResponse("Service OPS API not configured", { status: 503 });
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/riders/export`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    return new NextResponse("Export failed", { status: response.status });
+  }
+
+  const data = await response.arrayBuffer();
+  return new NextResponse(data, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": 'attachment; filename="riders.xlsx"',
+    },
+  });
+}

--- a/development/front-admin-web/app/api/management/vehicles/export/route.ts
+++ b/development/front-admin-web/app/api/management/vehicles/export/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { serviceOpsApiBaseUrl } from "@/lib/services/service-ops-api";
+import { getServiceOpsAccessToken } from "@/lib/services/service-ops-session";
+
+export async function GET() {
+  const accessToken = await getServiceOpsAccessToken();
+  if (!accessToken) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const baseUrl = serviceOpsApiBaseUrl();
+  if (!baseUrl) {
+    return new NextResponse("Service OPS API not configured", { status: 503 });
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/bikes/export`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    return new NextResponse("Export failed", { status: response.status });
+  }
+
+  const data = await response.arrayBuffer();
+  return new NextResponse(data, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": 'attachment; filename="vehicles.xlsx"',
+    },
+  });
+}

--- a/development/front-admin-web/app/management/matching/page.tsx
+++ b/development/front-admin-web/app/management/matching/page.tsx
@@ -1,9 +1,7 @@
-import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function MatchingManagementPage() {
-  const exportUrl = createServiceOpsApiClient().getMatchingExportUrl();
-  return <MatchingManagementPanel exportUrl={exportUrl} />;
+  return <MatchingManagementPanel exportUrl="/api/management/matching/export" />;
 }

--- a/development/front-admin-web/app/management/riders/page.tsx
+++ b/development/front-admin-web/app/management/riders/page.tsx
@@ -1,9 +1,7 @@
-import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function RidersManagementPage() {
-  const exportUrl = createServiceOpsApiClient().getRidersExportUrl();
-  return <RidersManagementPanel exportUrl={exportUrl} />;
+  return <RidersManagementPanel exportUrl="/api/management/riders/export" />;
 }

--- a/development/front-admin-web/app/management/vehicles/page.tsx
+++ b/development/front-admin-web/app/management/vehicles/page.tsx
@@ -1,9 +1,7 @@
-import { createServiceOpsApiClient } from "@/lib/services/service-ops-api";
 import { VehiclesManagementPanel } from "@/components/management/VehiclesManagementPanel";
 
 export const dynamic = "force-dynamic";
 
 export default function VehiclesManagementPage() {
-  const exportUrl = createServiceOpsApiClient().getVehiclesExportUrl();
-  return <VehiclesManagementPanel exportUrl={exportUrl} />;
+  return <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />;
 }


### PR DESCRIPTION
## Summary
- Excel 내려받기 버튼이 `http://127.0.0.1:8080/api/v1/bikes/export` 같은 서버 내부 URL을 브라우저에 노출하여 연결 실패하는 버그 수정
- Next.js API route 3개 추가: `/api/management/{vehicles,riders,matching}/export`
- 각 route는 서버 사이드에서 쿠키의 accessToken으로 인증 후 Spring Boot에 요청, 응답을 클라이언트로 스트리밍
- page.tsx 3개에서 `createServiceOpsApiClient()` 호출 제거, 고정 상대 경로 사용