### PR TITLE
Consolidate /management into single page

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -202,6 +202,8 @@ button, input, select, textarea { font: inherit; }
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
 }
 
+.management-page { display: flex; flex-direction: column; gap: 40px; }
+.management-section-title { margin: 0 0 12px; font-size: 13px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--color-text-muted); }
 .management-subnav { display: flex; flex-wrap: wrap; gap: 8px; margin: -8px 0 20px; }
 .management-subnav-link { display: inline-flex; align-items: center; min-height: 34px; padding: 0 12px; border-radius: 999px; background: var(--color-surface); color: var(--color-text-secondary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-weight: 800; }
 .management-subnav-link:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }

--- a/development/front-admin-web/app/management/matching/page.tsx
+++ b/development/front-admin-web/app/management/matching/page.tsx
@@ -1,7 +1,0 @@
-import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
-
-export const dynamic = "force-dynamic";
-
-export default function MatchingManagementPage() {
-  return <MatchingManagementPanel exportUrl="/api/management/matching/export" />;
-}

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -1,0 +1,24 @@
+import { VehiclesManagementPanel } from "@/components/management/VehiclesManagementPanel";
+import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
+import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
+
+export const dynamic = "force-dynamic";
+
+export default function ManagementPage() {
+  return (
+    <div className="management-page">
+      <section>
+        <h2 className="management-section-title">차량</h2>
+        <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
+      </section>
+      <section>
+        <h2 className="management-section-title">라이더</h2>
+        <RidersManagementPanel exportUrl="/api/management/riders/export" />
+      </section>
+      <section>
+        <h2 className="management-section-title">매칭</h2>
+        <MatchingManagementPanel exportUrl="/api/management/matching/export" />
+      </section>
+    </div>
+  );
+}

--- a/development/front-admin-web/app/management/riders/page.tsx
+++ b/development/front-admin-web/app/management/riders/page.tsx
@@ -1,7 +1,0 @@
-import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
-
-export const dynamic = "force-dynamic";
-
-export default function RidersManagementPage() {
-  return <RidersManagementPanel exportUrl="/api/management/riders/export" />;
-}

--- a/development/front-admin-web/app/management/vehicles/page.tsx
+++ b/development/front-admin-web/app/management/vehicles/page.tsx
@@ -1,7 +1,0 @@
-import { VehiclesManagementPanel } from "@/components/management/VehiclesManagementPanel";
-
-export const dynamic = "force-dynamic";
-
-export default function VehiclesManagementPage() {
-  return <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />;
-}


### PR DESCRIPTION
## Summary

- Merged three separate pages (`/management/vehicles`, `/management/riders`, `/management/matching`) into a single `/management` page that displays all three sections (vehicles, riders, matching) together on one screen

## Why

The three entities — vehicles, riders, and matching — are used together for bulk Excel import/export workflows. Having them on separate pages breaks workflow coherence: operators need to switch back and forth between pages during a bulk import/export cycle. Consolidating into one page keeps all three sections visible and accessible simultaneously, matching the actual usage pattern.

## What changed

- `/management` now renders vehicles, riders, and matching sections as a unified single-page layout
- Previous separate page routes are consolidated under this single entry point
- Excel bulk import/export (added in prior PRs) benefits directly from this layout since all three entity types appear together

🤖 Generated with [Claude Code](https://claude.com/claude-code)