### PR TITLE
feat: /management page — Excel bulk import/export + UI redesign

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -204,6 +204,16 @@ button, input, select, textarea { font: inherit; }
 
 .management-page { display: flex; flex-direction: column; gap: 40px; }
 .management-section-title { margin: 0 0 12px; font-size: 13px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--color-text-muted); }
+.mgmt-panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; gap: 12px; }
+.mgmt-panel-header-left { display: flex; align-items: center; gap: 8px; }
+.mgmt-panel-title { font-size: 14px; font-weight: 700; color: var(--color-text-primary); }
+.mgmt-panel-count { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 20px; padding: 0 6px; border-radius: 999px; background: var(--color-bg-muted); color: var(--color-text-muted); font-size: 12px; font-weight: 600; }
+.mgmt-panel-header-actions { display: flex; align-items: center; gap: 8px; }
+.status-badge { display: inline-flex; align-items: center; height: 22px; padding: 0 8px; border-radius: 999px; font-size: 12px; font-weight: 600; white-space: nowrap; }
+.status-badge-green { background: color-mix(in srgb, #22c55e 12%, transparent); color: #16a34a; }
+.status-badge-gray { background: var(--color-bg-muted); color: var(--color-text-muted); }
+.status-badge-orange { background: color-mix(in srgb, #f97316 12%, transparent); color: #c2410c; }
+.status-badge-red { background: color-mix(in srgb, #ef4444 12%, transparent); color: #dc2626; }
 .management-subnav { display: flex; flex-wrap: wrap; gap: 8px; margin: -8px 0 20px; }
 .management-subnav-link { display: inline-flex; align-items: center; min-height: 34px; padding: 0 12px; border-radius: 999px; background: var(--color-surface); color: var(--color-text-secondary); box-shadow: 0 0 0 1px var(--color-border); font-size: 13px; font-weight: 800; }
 .management-subnav-link:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -7,18 +7,9 @@ export const dynamic = "force-dynamic";
 export default function ManagementPage() {
   return (
     <div className="management-page">
-      <section>
-        <h2 className="management-section-title">차량</h2>
-        <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
-      </section>
-      <section>
-        <h2 className="management-section-title">라이더</h2>
-        <RidersManagementPanel exportUrl="/api/management/riders/export" />
-      </section>
-      <section>
-        <h2 className="management-section-title">매칭</h2>
-        <MatchingManagementPanel exportUrl="/api/management/matching/export" />
-      </section>
+      <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
+      <RidersManagementPanel exportUrl="/api/management/riders/export" />
+      <MatchingManagementPanel exportUrl="/api/management/matching/export" />
     </div>
   );
 }

--- a/development/front-admin-web/components/management/ExcelImportButton.tsx
+++ b/development/front-admin-web/components/management/ExcelImportButton.tsx
@@ -9,9 +9,10 @@ interface ExcelImportButtonProps {
   onApply: (formData: FormData) => Promise<unknown>;
   onSuccess?: () => void;
   label?: string;
+  className?: string;
 }
 
-export function ExcelImportButton({ onPreview, onApply, onSuccess, label = 'Excel 업로드' }: ExcelImportButtonProps) {
+export function ExcelImportButton({ onPreview, onApply, onSuccess, label = 'Excel 업로드', className }: ExcelImportButtonProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<BulkPreviewResponse | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -70,7 +71,7 @@ export function ExcelImportButton({ onPreview, onApply, onSuccess, label = 'Exce
         style={{ display: 'none' }}
         onChange={handleFileChange}
       />
-      <button onClick={() => fileInputRef.current?.click()} disabled={loading}>
+      <button className={className} onClick={() => fileInputRef.current?.click()} disabled={loading}>
         {loading ? '처리 중...' : label}
       </button>
       {error && <span style={{ color: 'red', marginLeft: 8 }}>{error}</span>}

--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -11,10 +11,13 @@ import {
 } from "@/app/management/matching/actions";
 import type { ServiceOpsRiderBikeContract } from "@/lib/services/service-ops-api";
 
-/**
- * 매칭(계약) 관리 페이지 패널.
- * DB 라이더-차량 계약 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
- */
+function ContractStatusBadge({ contract }: { contract: ServiceOpsRiderBikeContract }) {
+  if (contract.terminatedAt) {
+    return <span className="status-badge status-badge-gray">종료</span>;
+  }
+  return <span className="status-badge status-badge-green">진행 중</span>;
+}
+
 export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [contracts, setContracts] = useState<ServiceOpsRiderBikeContract[]>([]);
@@ -38,20 +41,27 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
 
   return (
     <div className="management-panel">
-      <div style={{ display: "flex", gap: "8px", marginBottom: "12px", alignItems: "center" }}>
-        <a href={exportUrl} target="_blank" rel="noreferrer">
-          <button type="button">Excel 내려받기</button>
-        </a>
-        <ExcelImportButton
-          onPreview={bulkPreviewMatchingAction}
-          onApply={bulkApplyMatchingAction}
-          onSuccess={handleSuccess}
-          label="Excel 업로드"
-        />
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">매칭</span>
+          <span className="mgmt-panel-count">{loading ? "…" : contracts.length}</span>
+        </div>
+        <div className="mgmt-panel-header-actions">
+          <a href={exportUrl} target="_blank" rel="noreferrer">
+            <button type="button" className="button-secondary">내려받기</button>
+          </a>
+          <ExcelImportButton
+            onPreview={bulkPreviewMatchingAction}
+            onApply={bulkApplyMatchingAction}
+            onSuccess={handleSuccess}
+            label="업로드"
+            className="button-primary"
+          />
+        </div>
       </div>
 
       {error ? (
-        <p role="alert" style={{ color: "red" }}>
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
           {error}
         </p>
       ) : null}
@@ -60,9 +70,9 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
-              <th>라이더 ID</th>
-              <th>차량 ID</th>
-              <th>템플릿 ID</th>
+              <th>차량번호</th>
+              <th>라이더명</th>
+              <th>연락처</th>
               <th>시작일</th>
               <th>종료일</th>
               <th>상태</th>
@@ -71,31 +81,21 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  불러오는 중…
-                </td>
+                <td colSpan={6} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : contracts.length === 0 ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  계약 없음
-                </td>
+                <td colSpan={6} className="table-empty-cell">계약 없음</td>
               </tr>
             ) : (
               contracts.map((c) => (
                 <tr key={c.id}>
-                  <td>{c.riderId}</td>
-                  <td>{c.bikeId}</td>
-                  <td>{c.contractTemplateId}</td>
+                  <td>{c.plateNumber ?? <span className="muted">—</span>}</td>
+                  <td>{c.riderName ?? <span className="muted">—</span>}</td>
+                  <td>{c.riderPhoneNumber ?? <span className="muted">—</span>}</td>
                   <td>{c.startAt.slice(0, 10)}</td>
                   <td>{c.endAt ? c.endAt.slice(0, 10) : <span className="muted">—</span>}</td>
-                  <td>
-                    {c.terminatedAt ? (
-                      <span className="muted">종료</span>
-                    ) : (
-                      <span>진행 중</span>
-                    )}
-                  </td>
+                  <td><ContractStatusBadge contract={c} /></td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -9,12 +9,15 @@ import {
   bulkApplyRidersAction,
   listRidersAction
 } from "@/app/management/riders/actions";
-import type { FrontendRider } from "@/lib/services/service-ops-api";
+import type { FrontendRider, ServiceOpsRiderTrainingStatus } from "@/lib/services/service-ops-api";
 
-/**
- * 라이더 관리 페이지 패널.
- * DB 라이더 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
- */
+function TrainingStatusBadge({ status }: { status?: ServiceOpsRiderTrainingStatus | null }) {
+  if (!status) return <span className="muted">—</span>;
+  if (status === "ONLINE") return <span className="status-badge status-badge-green">온라인</span>;
+  if (status === "OFFLINE") return <span className="status-badge status-badge-gray">오프라인</span>;
+  return <span className="status-badge status-badge-orange">미완료</span>;
+}
+
 export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [riders, setRiders] = useState<FrontendRider[]>([]);
@@ -38,20 +41,27 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
 
   return (
     <div className="management-panel">
-      <div style={{ display: "flex", gap: "8px", marginBottom: "12px", alignItems: "center" }}>
-        <a href={exportUrl} target="_blank" rel="noreferrer">
-          <button type="button">Excel 내려받기</button>
-        </a>
-        <ExcelImportButton
-          onPreview={bulkPreviewRidersAction}
-          onApply={bulkApplyRidersAction}
-          onSuccess={handleSuccess}
-          label="Excel 업로드"
-        />
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">라이더</span>
+          <span className="mgmt-panel-count">{loading ? "…" : riders.length}</span>
+        </div>
+        <div className="mgmt-panel-header-actions">
+          <a href={exportUrl} target="_blank" rel="noreferrer">
+            <button type="button" className="button-secondary">내려받기</button>
+          </a>
+          <ExcelImportButton
+            onPreview={bulkPreviewRidersAction}
+            onApply={bulkApplyRidersAction}
+            onSuccess={handleSuccess}
+            label="업로드"
+            className="button-primary"
+          />
+        </div>
       </div>
 
       {error ? (
-        <p role="alert" style={{ color: "red" }}>
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
           {error}
         </p>
       ) : null}
@@ -62,34 +72,26 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
             <tr>
               <th>이름</th>
               <th>연락처</th>
-              <th>팀</th>
-              <th>지역</th>
-              <th>상태</th>
-              <th>가입일</th>
+              <th>훈련 상태</th>
+              <th>팀명</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  불러오는 중…
-                </td>
+                <td colSpan={4} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : riders.length === 0 ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  라이더 없음
-                </td>
+                <td colSpan={4} className="table-empty-cell">라이더 없음</td>
               </tr>
             ) : (
               riders.map((r) => (
                 <tr key={r.slug}>
                   <td>{r.name}</td>
                   <td>{r.phone}</td>
+                  <td><TrainingStatusBadge status={r.trainingStatus} /></td>
                   <td>{r.team}</td>
-                  <td>{r.area}</td>
-                  <td>{r.status}</td>
-                  <td>{r.joinedAt}</td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -11,10 +11,21 @@ import {
 } from "@/app/management/vehicles/actions";
 import type { FrontendVehicle } from "@/lib/services/service-ops-api";
 
-/**
- * 차량 관리 페이지 패널.
- * DB 차량 목록 테이블 + Excel 내려받기 / 업로드 버튼을 제공한다.
- */
+function WheelTypeBadge({ value }: { value?: string | null }) {
+  if (!value) return <span className="muted">—</span>;
+  return <span>{value === "TWO_WHEEL" ? "2륜" : "4륜"}</span>;
+}
+
+function EngineTypeBadge({ value }: { value?: string | null }) {
+  if (!value) return <span className="muted">—</span>;
+  return <span>{value === "ELECTRIC" ? "전기" : "내연"}</span>;
+}
+
+function OperationStatusBadge({ status }: { status: FrontendVehicle["status"] }) {
+  const cls = status === "운행" ? "status-badge status-badge-green" : "status-badge status-badge-gray";
+  return <span className={cls}>{status}</span>;
+}
+
 export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [vehicles, setVehicles] = useState<FrontendVehicle[]>([]);
@@ -38,20 +49,27 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
 
   return (
     <div className="management-panel">
-      <div style={{ display: "flex", gap: "8px", marginBottom: "12px", alignItems: "center" }}>
-        <a href={exportUrl} target="_blank" rel="noreferrer">
-          <button type="button">Excel 내려받기</button>
-        </a>
-        <ExcelImportButton
-          onPreview={bulkPreviewVehiclesAction}
-          onApply={bulkApplyVehiclesAction}
-          onSuccess={handleSuccess}
-          label="Excel 업로드"
-        />
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">차량</span>
+          <span className="mgmt-panel-count">{loading ? "…" : vehicles.length}</span>
+        </div>
+        <div className="mgmt-panel-header-actions">
+          <a href={exportUrl} target="_blank" rel="noreferrer">
+            <button type="button" className="button-secondary">내려받기</button>
+          </a>
+          <ExcelImportButton
+            onPreview={bulkPreviewVehiclesAction}
+            onApply={bulkApplyVehiclesAction}
+            onSuccess={handleSuccess}
+            label="업로드"
+            className="button-primary"
+          />
+        </div>
       </div>
 
       {error ? (
-        <p role="alert" style={{ color: "red" }}>
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
           {error}
         </p>
       ) : null}
@@ -61,35 +79,29 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
           <thead>
             <tr>
               <th>차량번호</th>
-              <th>모델</th>
-              <th>구분</th>
+              <th>휠타입</th>
+              <th>동력</th>
+              <th>IMEI</th>
               <th>운영 상태</th>
-              <th>메모</th>
-              <th>생성일</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  불러오는 중…
-                </td>
+                <td colSpan={5} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : vehicles.length === 0 ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">
-                  차량 없음
-                </td>
+                <td colSpan={5} className="table-empty-cell">차량 없음</td>
               </tr>
             ) : (
               vehicles.map((v) => (
                 <tr key={v.slug}>
                   <td>{v.plateNumber}</td>
-                  <td>{v.model}</td>
-                  <td>{v.engineType ?? "—"}</td>
-                  <td>{v.status}</td>
-                  <td>{v.memo ?? <span className="muted">—</span>}</td>
-                  <td>{v.createdAt ? v.createdAt.slice(0, 10) : <span className="muted">—</span>}</td>
+                  <td><WheelTypeBadge value={v.wheelType} /></td>
+                  <td><EngineTypeBadge value={v.engineType} /></td>
+                  <td>{v.imei ?? <span className="muted">—</span>}</td>
+                  <td><OperationStatusBadge status={v.status} /></td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -31,6 +31,8 @@ export type ServiceOpsAuthResponse = {
   admin: ServiceOpsAdminIdentity;
 };
 
+export type ServiceOpsRiderTrainingStatus = "ONLINE" | "OFFLINE" | "INCOMPLETE";
+
 export type ServiceOpsRider = {
   id: string;
   idx: number | null;
@@ -43,6 +45,7 @@ export type ServiceOpsRider = {
   appLinkedAt: string | null;
   appLinkStatus: string;
   memo: string | null;
+  trainingStatus?: ServiceOpsRiderTrainingStatus | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -57,6 +60,7 @@ export type FrontendRider = {
   area: string;
   status: "활동" | "대기" | "휴면";
   joinedAt: string;
+  trainingStatus?: ServiceOpsRiderTrainingStatus | null;
   appAccountLinked?: boolean;
   appAccountId?: string | null;
   appLinkedAt?: string | null;
@@ -119,6 +123,7 @@ export type RiderEducationRecordUpdateInput = {
 };
 
 export type ServiceOpsBikeOperationStatus = "READY" | "IN_SERVICE";
+export type ServiceOpsBikeWheelType = "TWO_WHEEL" | "FOUR_WHEEL";
 
 /**
  * 차량 동력 종류. 정비 카탈로그 매칭과 운영자 필터의 1차 분류 키. backend
@@ -140,6 +145,8 @@ export type ServiceOpsBike = {
   operationStatus: ServiceOpsBikeOperationStatus;
   /** "시동 방지" 플래그. 라이더 상세 다이얼로그의 토글이 이 값을 PATCH 한다. */
   ignitionBlocked?: boolean;
+  wheelType?: ServiceOpsBikeWheelType | null;
+  imei?: string | null;
   memo: string | null;
   createdAt: string;
   updatedAt: string;
@@ -159,6 +166,8 @@ export type FrontendVehicle = {
   /** 정비 카탈로그 매칭에 쓰이는 동력 종류. 옛 backend 호환 위해 optional. */
   engineType?: ServiceOpsBikeEngineType;
   serviceType?: ServiceOpsBikeServiceType;
+  wheelType?: ServiceOpsBikeWheelType | null;
+  imei?: string | null;
   status: "운행" | "대기";
   operationStatus?: ServiceOpsBikeOperationStatus;
   /** 시동 방지 토글의 현재 상태. 백엔드가 응답에 포함; 없으면 false 로 간주. */
@@ -353,6 +362,11 @@ export type ServiceOpsRiderBikeContract = {
   autoIssuedRiderInsuranceId?: string | null;
   /** Slice D: short SKIP token explaining why automatic issuance did not run. */
   autoInsuranceSkipReason?: ServiceOpsAutoInsuranceSkipReason | null;
+  /** Denormalized from Bike — populated in list responses. */
+  plateNumber?: string | null;
+  /** Denormalized from Rider — populated in list responses. */
+  riderName?: string | null;
+  riderPhoneNumber?: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -1728,6 +1742,8 @@ export function toFrontendVehicle(bike: ServiceOpsBike): FrontendVehicle {
     model: normalizeDisplayText(bike.modelName, "모델 미지정"),
     engineType: bike.engineType,
     serviceType: bike.serviceType,
+    wheelType: bike.wheelType,
+    imei: bike.imei,
     status: toFrontendVehicleStatus(bike.operationStatus),
     operationStatus: bike.operationStatus,
     ignitionBlocked: bike.ignitionBlocked ?? false,
@@ -1766,6 +1782,7 @@ export function toFrontendRider(rider: ServiceOpsRider): FrontendRider {
     area: normalizeDisplayText(rider.areaName, "미지정"),
     status: rider.appAccountLinked ? "활동" : "대기",
     joinedAt: toDateOnly(rider.createdAt),
+    trainingStatus: rider.trainingStatus,
     appAccountLinked: rider.appAccountLinked,
     appAccountId: rider.appAccountId,
     appLinkedAt: rider.appLinkedAt,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/dto/BikeReadResponse.java
@@ -4,6 +4,7 @@ import com.thundercrew.opsapi.bike.domain.Bike;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.domain.BikeWheelType;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -18,6 +19,8 @@ public record BikeReadResponse(
         BikeOperationStatus operationStatus,
         boolean ignitionBlocked,
         String memo,
+        BikeWheelType wheelType,
+        String imei,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -33,6 +36,8 @@ public record BikeReadResponse(
                 bike.getOperationStatus(),
                 bike.isIgnitionBlocked(),
                 bike.getMemo(),
+                bike.getWheelType(),
+                bike.getImei(),
                 bike.getCreatedAt(),
                 bike.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
@@ -17,6 +17,9 @@ public record RiderBikeContractReadResponse(
         String memo,
         UUID autoIssuedRiderInsuranceId,
         String autoInsuranceSkipReason,
+        String plateNumber,
+        String riderName,
+        String riderPhoneNumber,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -26,14 +29,7 @@ public record RiderBikeContractReadResponse(
 
     /**
      * Used by {@code create} when the service has just attempted automatic
-     * insurance issuance off the matching contract template:
-     * <ul>
-     *   <li>{@code autoIssuedRiderInsuranceId} carries the new RiderInsurance id when it succeeded.</li>
-     *   <li>{@code autoInsuranceSkipReason} carries a short SKIP token when the
-     *       service intentionally did not issue (already linked, item disabled,
-     *       etc.). Both fields stay {@code null} when the template did not opt
-     *       in to automatic issuance.</li>
-     * </ul>
+     * insurance issuance off the matching contract template.
      */
     public static RiderBikeContractReadResponse from(
             RiderBikeContract contract,
@@ -53,6 +49,37 @@ public record RiderBikeContractReadResponse(
                 contract.getMemo(),
                 autoIssuedRiderInsuranceId,
                 autoInsuranceSkipReason,
+                null,
+                null,
+                null,
+                contract.getCreatedAt(),
+                contract.getUpdatedAt()
+        );
+    }
+
+    /** Used by the list endpoint to include denormalized bike/rider fields. */
+    public static RiderBikeContractReadResponse from(
+            RiderBikeContract contract,
+            String plateNumber,
+            String riderName,
+            String riderPhoneNumber
+    ) {
+        return new RiderBikeContractReadResponse(
+                contract.getId(),
+                contract.getIdx(),
+                contract.getRiderId(),
+                contract.getBikeId(),
+                contract.getContractTemplateId(),
+                contract.getStartAt(),
+                contract.getEndAt(),
+                contract.getTerminatedAt(),
+                contract.getTerminatedReason(),
+                contract.getMemo(),
+                null,
+                null,
+                plateNumber,
+                riderName,
+                riderPhoneNumber,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
@@ -1,12 +1,20 @@
 package com.thundercrew.opsapi.contract.service;
 
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
 import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
 import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
 import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,10 +25,19 @@ public class ContractReadService {
 
     private final ContractTemplateRepository contractTemplateRepository;
     private final RiderBikeContractRepository riderBikeContractRepository;
+    private final BikeRepository bikeRepository;
+    private final RiderRepository riderRepository;
 
-    public ContractReadService(ContractTemplateRepository contractTemplateRepository, RiderBikeContractRepository riderBikeContractRepository) {
+    public ContractReadService(
+            ContractTemplateRepository contractTemplateRepository,
+            RiderBikeContractRepository riderBikeContractRepository,
+            BikeRepository bikeRepository,
+            RiderRepository riderRepository
+    ) {
         this.contractTemplateRepository = contractTemplateRepository;
         this.riderBikeContractRepository = riderBikeContractRepository;
+        this.bikeRepository = bikeRepository;
+        this.riderRepository = riderRepository;
     }
 
     public PageResponse<ContractTemplateReadResponse> listTemplates(Pageable pageable) {
@@ -34,7 +51,31 @@ public class ContractReadService {
     }
 
     public PageResponse<RiderBikeContractReadResponse> listRiderBikeContracts(Pageable pageable) {
-        return PageResponse.of(riderBikeContractRepository.findByDeletedAtIsNull(pageable).map(RiderBikeContractReadResponse::from));
+        Page<com.thundercrew.opsapi.contract.domain.RiderBikeContract> page =
+                riderBikeContractRepository.findByDeletedAtIsNull(pageable);
+
+        Set<UUID> bikeIds = page.getContent().stream()
+                .map(com.thundercrew.opsapi.contract.domain.RiderBikeContract::getBikeId)
+                .collect(Collectors.toSet());
+        Set<UUID> riderIds = page.getContent().stream()
+                .map(com.thundercrew.opsapi.contract.domain.RiderBikeContract::getRiderId)
+                .collect(Collectors.toSet());
+
+        Map<UUID, Bike> bikeMap = bikeRepository.findAllById(bikeIds).stream()
+                .collect(Collectors.toMap(Bike::getId, b -> b));
+        Map<UUID, Rider> riderMap = riderRepository.findAllById(riderIds).stream()
+                .collect(Collectors.toMap(Rider::getId, r -> r));
+
+        return PageResponse.of(page.map(contract -> {
+            Bike bike = bikeMap.get(contract.getBikeId());
+            Rider rider = riderMap.get(contract.getRiderId());
+            return RiderBikeContractReadResponse.from(
+                    contract,
+                    bike != null ? bike.getPlateNumber() : null,
+                    rider != null ? rider.getName() : null,
+                    rider != null ? rider.getPhoneNumber() : null
+            );
+        }));
     }
 
     public RiderBikeContractReadResponse getRiderBikeContract(UUID id) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderReadResponse.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.rider.dto;
 import com.thundercrew.opsapi.rider.domain.Rider;
 import com.thundercrew.opsapi.rider.domain.RiderEducationRecord;
 import com.thundercrew.opsapi.rider.domain.RiderEducationType;
+import com.thundercrew.opsapi.rider.domain.RiderTrainingStatus;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -22,6 +23,7 @@ public record RiderReadResponse(
         RiderEducationType latestEducationType,
         Instant latestEducationCompletedAt,
         boolean educationExpired,
+        RiderTrainingStatus trainingStatus,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -47,6 +49,7 @@ public record RiderReadResponse(
                 null,
                 null,
                 false,
+                rider.getTrainingStatus(),
                 rider.getCreatedAt(),
                 rider.getUpdatedAt()
         );
@@ -81,6 +84,7 @@ public record RiderReadResponse(
                 type,
                 completedAt,
                 expired,
+                rider.getTrainingStatus(),
                 rider.getCreatedAt(),
                 rider.getUpdatedAt()
         );


### PR DESCRIPTION
## Summary

- `/management` 페이지 신설 — 차량/라이더/매칭 세 섹션을 한 페이지에 스크롤로 통합
- Excel 내려받기/업로드(bulk preview → apply) 기능 전체 구현
- 관리 테이블 컬럼을 Excel 템플릿 컬럼과 일치시킴
- Linear 스타일 패널 헤더 + 상태 배지 UI 적용

## Changes

**Backend**
- V30/V31 DB migration: `BikeWheelType` enum, `RiderTrainingStatus` 3-way enum
- `BikeReadResponse`: `wheelType`, `imei` 필드 추가
- `RiderReadResponse`: `trainingStatus` 필드 추가
- `RiderBikeContractReadResponse`: 비정규화 `plateNumber`, `riderName`, `riderPhoneNumber` 추가
- `ContractReadService`: list 엔드포인트에서 bike/rider 배치 조회로 비정규화 필드 채움 (N+1 없음)
- Bike/Rider/Contract 벌크 서비스+컨트롤러 (bulk-preview, bulk-apply, export)
- Next.js API proxy routes: `/api/management/*/export` (내부 서비스 URL 노출 방지)
- Flyway 충돌 수정 (V30 중복 → V31 리네임)

**Frontend**
- 차량 테이블: 차량번호 / 휠타입(2륜/4륜) / 동력(전기/내연) / IMEI / 운영상태
- 라이더 테이블: 이름 / 연락처 / 훈련상태(배지) / 팀명
- 매칭 테이블: 차량번호 / 라이더명 / 연락처 / 시작일 / 종료일 / 상태(배지) ← UUID 컬럼 제거
- BulkPreviewModal: 변경없음/업데이트/신규/오류 요약 후 적용 확인
- Linear 스타일 패널 헤더: 제목 + 건수 배지 + ghost 내려받기 + primary 업로드

## Test plan
- [ ] `/management` 접속 → 차량/라이더/매칭 세 섹션 모두 표시
- [ ] 각 섹션 내려받기 클릭 → xlsx 다운로드 정상 동작
- [ ] xlsx 수정 후 업로드 → 미리보기 모달 표시 → 적용 확인
- [ ] 차량 테이블: 휠타입(2륜/4륜), 동력(전기/내연), IMEI 컬럼 확인
- [ ] 라이더 테이블: 훈련상태 배지(온라인/오프라인/미완료) 확인
- [ ] 매칭 테이블: UUID 대신 차량번호/라이더명 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)