### PR TITLE
fix: use findAllByIdIn in ContractReadService (compile error)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/repository/BikeRepository.java
@@ -64,4 +64,6 @@ public interface BikeRepository extends Repository<Bike, UUID> {
     Optional<Bike> findByPlateNumberAndDeletedAtIsNull(String plateNumber);
 
     List<Bike> findAllByDeletedAtIsNull();
+
+    List<Bike> findAllByIdIn(Iterable<UUID> ids);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
@@ -61,9 +61,9 @@ public class ContractReadService {
                 .map(com.thundercrew.opsapi.contract.domain.RiderBikeContract::getRiderId)
                 .collect(Collectors.toSet());
 
-        Map<UUID, Bike> bikeMap = bikeRepository.findAllById(bikeIds).stream()
+        Map<UUID, Bike> bikeMap = bikeRepository.findAllByIdIn(bikeIds).stream()
                 .collect(Collectors.toMap(Bike::getId, b -> b));
-        Map<UUID, Rider> riderMap = riderRepository.findAllById(riderIds).stream()
+        Map<UUID, Rider> riderMap = riderRepository.findAllByIdIn(riderIds).stream()
                 .collect(Collectors.toMap(Rider::getId, r -> r));
 
         return PageResponse.of(page.map(contract -> {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
@@ -53,4 +53,6 @@ public interface RiderRepository extends Repository<Rider, UUID> {
     Optional<Rider> findByPhoneNumberAndDeletedAtIsNull(String phoneNumber);
 
     List<Rider> findAllByDeletedAtIsNull();
+
+    List<Rider> findAllByIdIn(Iterable<UUID> ids);
 }


### PR DESCRIPTION
## Summary

- `BikeRepository`와 `RiderRepository`는 `JpaRepository`가 아닌 최소 `Repository<T, UUID>` 인터페이스를 상속하므로 `findAllById`가 없음
- 두 레포지토리에 `findAllByIdIn(Iterable<UUID>)` 메서드 추가 (Spring Data 파생 쿼리 → `WHERE id IN (...)`)
- `ContractReadService`에서 `findAllById` → `findAllByIdIn` 으로 교체

## Test plan
- [ ] EC2 Gradle 빌드 성공 확인
- [ ] `/management` 매칭 섹션에서 차량번호/라이더명 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)