### PR TITLE
release: 지도 검색·헤더 용어 정리 (BSS→충전소 + 라이더 카테고리 제거)

### DIFF
--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -282,7 +282,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
 
   const handleSearchSelect = (match: OverviewMapSearchMatch) => {
     setSearchOverride({ lat: match.latitude, lng: match.longitude });
-    if (match.kind === "bike" || match.kind === "rider") {
+    if (match.kind === "bike") {
       setSelectedBikeId(match.bikeId);
     }
   };
@@ -329,8 +329,6 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
         <OverviewMapSearch
           bikePins={overlaidBikePins}
           stationPins={stationPins}
-          bikeActiveRiderById={bikeActiveRiderById ?? new Map()}
-          riderInfoById={riderInfoById ?? new Map()}
           onSelect={handleSearchSelect}
         />
         <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -335,7 +335,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
         />
         <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
         <span className="fullscreen-map-counts">
-          {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 BSS
+          {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 충전소
         </span>
         <NotificationBell />
       </header>

--- a/development/front-admin-web/components/overview/OverviewMapSearch.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapSearch.tsx
@@ -8,27 +8,22 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * 차량 / BSS / 라이더 통합 검색 인풋. 옛 `/monitoring` 의 `MonitoringSearch` 를
- * 모델로 하되 결과 종류를 셋으로 늘리고, 인라인(토글 행 안) 배치로 바뀐 새
- * placement 에 맞춰 새 CSS 클래스(`overview-map-search-*`) 를 쓴다.
+ * 차량 / 충전소 통합 검색 인풋. 옛 `/monitoring` 의 `MonitoringSearch` 를
+ * 모델로 하되, 인라인(토글 행 안) 배치로 바뀐 새 placement 에 맞춰 새 CSS
+ * 클래스(`overview-map-search-*`) 를 쓴다.
  *
- * 라이더 항목은 지도 위에 마커가 없으므로, 라이더가 현재 타고 있는 bike 의
- * 좌표를 사용해 같은 "지도 팬 + 차량 상세 패널 열기" 흐름으로 연결한다.
+ * 라이더는 검색에서 별도 카테고리로 두지 않는다 — 차량에 매칭된 라이더는
+ * 차량 탭 테이블에서 차량에 귀속돼 표기되므로 그걸로 충분하다. 여기서는
+ * 차량(번호) / 충전소(이름·주소) 두 종류만 찾는다.
  */
 
 export type OverviewMapSearchMatch =
   | { kind: "bike"; bikeId: string; latitude: number; longitude: number; label: string; sublabel?: string }
-  | { kind: "station"; stationId: string; latitude: number; longitude: number; label: string; sublabel?: string }
-  | { kind: "rider"; bikeId: string; latitude: number; longitude: number; label: string; sublabel?: string };
+  | { kind: "station"; stationId: string; latitude: number; longitude: number; label: string; sublabel?: string };
 
 export interface OverviewMapSearchProps {
   bikePins: ReadonlyArray<FrontendDashboardBikePin>;
   stationPins: ReadonlyArray<FrontendDashboardStationPin>;
-  /** bike → rider 인덱스. 라이더 검색 후보를 "할당된 라이더" 로 좁히고
-   *  결과 클릭 시 그 라이더가 타는 bike 의 좌표로 점프하는 데 쓴다. */
-  bikeActiveRiderById?: Map<string, string>;
-  /** rider id → { name, phone } */
-  riderInfoById?: Map<string, { name: string; phone: string }>;
   onSelect: (match: OverviewMapSearchMatch) => void;
 }
 
@@ -37,30 +32,10 @@ const MAX_RESULTS = 8;
 export function OverviewMapSearch({
   bikePins,
   stationPins,
-  bikeActiveRiderById,
-  riderInfoById,
   onSelect
 }: OverviewMapSearchProps) {
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(false);
-
-  // rider → bike 역방향 인덱스. 라이더 매칭이 잡힌 결과를 한 번에 좌표로
-  // 매핑하기 위해 매 키스트로크가 아니라 deps 변경 시에만 다시 만든다.
-  const bikeIdByRiderId = useMemo(() => {
-    const map = new Map<string, string>();
-    if (!bikeActiveRiderById) return map;
-    for (const [bikeId, riderId] of bikeActiveRiderById) {
-      map.set(riderId, bikeId);
-    }
-    return map;
-  }, [bikeActiveRiderById]);
-
-  // bikeId → pin 빠른 lookup. 라이더 매칭 결과에서 좌표를 채울 때 사용.
-  const bikePinById = useMemo(() => {
-    const map = new Map<string, FrontendDashboardBikePin>();
-    for (const pin of bikePins) map.set(pin.bikeId, pin);
-    return map;
-  }, [bikePins]);
 
   const matches = useMemo<OverviewMapSearchMatch[]>(() => {
     const q = query.trim().toLowerCase();
@@ -76,28 +51,6 @@ export function OverviewMapSearch({
         label: pin.plateNumber,
         sublabel: pin.modelName || undefined
       }));
-
-    const riderMatches: OverviewMapSearchMatch[] = [];
-    if (riderInfoById) {
-      for (const [riderId, info] of riderInfoById) {
-        const bikeId = bikeIdByRiderId.get(riderId);
-        if (!bikeId) continue; // 할당된 차량이 없으면 화면에 표시할 의미가 없다
-        const pin = bikePinById.get(bikeId);
-        if (!pin) continue; // 차량이 핀에 없으면 (예: 폴링 누락) 스킵
-        if (!info.name) continue; // 라벨로 쓸 이름이 없으면 행을 만들 수 없다
-        const name = info.name?.toLowerCase() ?? "";
-        const phone = info.phone?.toLowerCase() ?? "";
-        if (!name.includes(q) && !phone.includes(q)) continue;
-        riderMatches.push({
-          kind: "rider",
-          bikeId,
-          latitude: pin.latitude,
-          longitude: pin.longitude,
-          label: info.name,
-          sublabel: `${info.phone} · ${pin.plateNumber}`
-        });
-      }
-    }
 
     const stationMatches: OverviewMapSearchMatch[] = stationPins
       .filter((pin) => {
@@ -115,10 +68,10 @@ export function OverviewMapSearch({
         sublabel: pin.address || undefined
       }));
 
-    // 운영자의 가장 흔한 task (특정 차량 찾기) 가 위에 노출되도록 bike → rider
-    // → station 순서로 채워서 8개에서 절단. 스펙의 "고정 순서" 결정 그대로.
-    return [...bikeMatches, ...riderMatches, ...stationMatches].slice(0, MAX_RESULTS);
-  }, [query, bikePins, stationPins, riderInfoById, bikeIdByRiderId, bikePinById]);
+    // 운영자의 가장 흔한 task (특정 차량 찾기) 가 위에 노출되도록 bike →
+    // station 순서로 채워서 8개에서 절단.
+    return [...bikeMatches, ...stationMatches].slice(0, MAX_RESULTS);
+  }, [query, bikePins, stationPins]);
 
   const handleSelect = (match: OverviewMapSearchMatch) => {
     onSelect(match);
@@ -133,7 +86,7 @@ export function OverviewMapSearch({
       <input
         className="overview-map-search-input"
         type="search"
-        placeholder="차량 번호 / 충전소 / 라이더 검색"
+        placeholder="차량 번호 / 충전소 검색"
         value={query}
         onChange={(event) => setQuery(event.target.value)}
         onFocus={() => setFocused(true)}
@@ -146,7 +99,7 @@ export function OverviewMapSearch({
             const key =
               match.kind === "station"
                 ? `station-${match.stationId}`
-                : `${match.kind}-${match.bikeId}`;
+                : `bike-${match.bikeId}`;
             return (
               <li
                 key={key}
@@ -161,7 +114,7 @@ export function OverviewMapSearch({
                 }}
               >
                 <span className={`overview-map-search-item-chip overview-map-search-item-chip--${match.kind}`}>
-                  {match.kind === "bike" ? "차량" : match.kind === "station" ? "충전소" : "라이더"}
+                  {match.kind === "bike" ? "차량" : "충전소"}
                 </span>
                 <span className="overview-map-search-item-label">{match.label}</span>
                 {match.sublabel ? (

--- a/development/front-admin-web/components/overview/OverviewMapSearch.tsx
+++ b/development/front-admin-web/components/overview/OverviewMapSearch.tsx
@@ -133,7 +133,7 @@ export function OverviewMapSearch({
       <input
         className="overview-map-search-input"
         type="search"
-        placeholder="차량 번호 / BSS / 라이더 검색"
+        placeholder="차량 번호 / 충전소 / 라이더 검색"
         value={query}
         onChange={(event) => setQuery(event.target.value)}
         onFocus={() => setFocused(true)}
@@ -161,7 +161,7 @@ export function OverviewMapSearch({
                 }}
               >
                 <span className={`overview-map-search-item-chip overview-map-search-item-chip--${match.kind}`}>
-                  {match.kind === "bike" ? "차량" : match.kind === "station" ? "BSS" : "라이더"}
+                  {match.kind === "bike" ? "차량" : match.kind === "station" ? "충전소" : "라이더"}
                 </span>
                 <span className="overview-map-search-item-label">{match.label}</span>
                 {match.sublabel ? (


### PR DESCRIPTION
프로덕션 릴리스 (`dev` → `main`). 머지 시 `aws-ec2-deploy.yml`이 EC2 프로덕션 배포를 트리거합니다.

## 포함 내용 (프론트 전용, 2개 PR)
프로덕션 QA에서 발견된 지도 헤더/검색 용어 정리 — Group A([#360](https://github.com/EVNSolution/thundercrew-domain/pull/360)) 후속.

- **[#361](https://github.com/EVNSolution/thundercrew-domain/pull/361) BSS → 충전소:** 풀스크린 지도 헤더 카운트 배지 + 검색 placeholder/결과 칩 (하단 탭과 용어 통일)
- **[#362](https://github.com/EVNSolution/thundercrew-domain/pull/362) 라이더 검색 카테고리 제거:** 차량에 매칭된 라이더는 차량 탭 테이블에 차량 귀속으로 표기되므로 검색에서 라이더를 별도 종류로 두지 않음 (이제 차량/충전소 2종). `bikeActiveRiderById`/`riderInfoById` 맵은 차량 상세·하단 패널에서 계속 사용해 유지.

## 배포 영향
- ✅ **마이그레이션 없음** — 프론트 전용 (`FullscreenMapHost.tsx`, `OverviewMapSearch.tsx` 2파일)
- ✅ 백엔드 변경 없음
- 배포: `npm ci → lint → typecheck → build` 후 프론트 재기동만

## Verification
- ✅ `npm run typecheck` (루트) green
- ✅ `npm run lint` (루트, eslint . 전체) green

## 배포 후 확인
- [ ] 지도 헤더 카운트 "N개 충전소" 표시
- [ ] 검색 placeholder "차량 번호 / 충전소 검색", 결과 칩 차량/충전소
- [ ] 차량 번호·충전소 검색 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)