### PR TITLE
release: 차량 필터 단일화 (지도 필터가 차량 탭 구동)

### DIFF
--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
@@ -8,15 +8,7 @@ import { IgnitionControlButton } from "@/components/management/IgnitionControlBu
 import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
 import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
-import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
-import {
-  applyVehicleFilters,
-  DEFAULT_VEHICLE_FILTERS,
-  statusToOperation,
-  type VehicleFilterState
-} from "@/components/overview/filter-compute";
-import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
-import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
+import { statusToOperation } from "@/components/overview/filter-compute";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
@@ -73,7 +65,6 @@ export function VehiclesPanel({
   riderActiveInsuranceByRiderId,
   insuranceOptions,
   ignitionBlockedByBikeId,
-  maintenanceSummaryByBike,
   statusParam
 }: {
   data: VehicleDataResult;
@@ -93,14 +84,10 @@ export function VehiclesPanel({
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
   /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
   ignitionBlockedByBikeId?: Map<string, boolean>;
-  /** bikeId → 정비 상태 요약. "정비 상태" 필터가 임박/지연 차량을 골라낼 때 사용. */
-  maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
   /** server action 결과 status. "delete-error" 이면 삭제 실패 배너 표시. */
   statusParam?: string | null;
 }) {
-  const [filters, setFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
-  const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
-  const { setFilteredBikeIds, setSelectedBikeId } = useVehicleFilter();
+  const { setSelectedBikeId } = useVehicleFilter();
 
   // IMEI=-1 시뮬 차량의 ignitionStatus / 속도 / 배터리 등을 지도와 동일하게 overlay.
   const overlaidBikePins = useSimulatedBikePins(bikePins ?? []);
@@ -123,47 +110,11 @@ export function VehiclesPanel({
     return map;
   }, [insuranceOptions]);
 
-  const effectiveVehicles = data.vehicles;
-
-  const serviceTypeFilteredVehicles = useMemo(
-    () =>
-      serviceTypeFilter === "ALL"
-        ? effectiveVehicles
-        : effectiveVehicles.filter((v) => (v.serviceType ?? "DELIVERY") === serviceTypeFilter),
-    [effectiveVehicles, serviceTypeFilter]
-  );
-
-  const visibleVehicles = useMemo(
-    () =>
-      applyVehicleFilters({
-        vehicles: serviceTypeFilteredVehicles,
-        filters,
-        bikePinById,
-        deviceUidByBikeId,
-        maintenanceSummaryByBike
-      }),
-    [serviceTypeFilteredVehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
-  );
-
-  // 필터링 결과를 공유 컨텍스트에 publish — 같은 페이지에 마운트된
-  // OverviewMapBanner 가 이 부분 집합만 핀으로 노출한다. rAF 한 프레임 양보로
-  // `react-hooks/set-state-in-effect` 규칙도 자연스럽게 피한다 (지도 마커
-  // 갱신이 한 프레임 늦는 건 시각적으로 거의 안 보임). 언마운트 시 cleanup
-  // 에서 null 로 되돌려 다른 탭 활성 시 필터가 잔존하지 않게 한다.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const ids = new Set<string>();
-    for (const vehicle of visibleVehicles) {
-      const key = vehicle.id ?? vehicle.slug;
-      if (key) ids.add(key);
-    }
-    const handle = window.requestAnimationFrame(() => setFilteredBikeIds(ids));
-    return () => window.cancelAnimationFrame(handle);
-  }, [visibleVehicles, setFilteredBikeIds]);
-
-  useEffect(() => {
-    return () => setFilteredBikeIds(null);
-  }, [setFilteredBikeIds]);
+  // 지도 헤더 필터가 차량 필터의 단일 소스다. FullscreenMapHost 가 이미
+  // 필터링한 `visibleVehicles` 를 `data.vehicles` 로 받아 그대로 렌더한다.
+  // (예전엔 이 패널이 자체 필터 UI + applyVehicleFilters 를 들고 있었으나
+  // 지도 필터와 이원화되는 문제가 있어 지도 필터로 통일했다.)
+  const visibleVehicles = data.vehicles;
 
   // 탭 언마운트(다른 탭으로 전환) 시 선택 상태도 해제. 마커 클릭 / 행 클릭
   // 으로 잡힌 selectedBikeId 가 다른 탭에서 잔존하지 않게.
@@ -182,16 +133,6 @@ export function VehiclesPanel({
               : `차량 삭제에 실패했습니다. (${statusParam}) 잠시 후 다시 시도해 주세요.`}
         </p>
       )}
-      {/* 서비스 유형 필터 탭 — VehicleFilterControls 바로 위 */}
-      <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
-      {/* 필터 한 줄 — 좁은 폭에선 flex-wrap 으로 자연스럽게 두 줄로 떨어진다. */}
-      <VehicleFilterControls
-        filters={filters}
-        onChange={setFilters}
-        layout="horizontal"
-        count={{ visible: visibleVehicles.length, total: serviceTypeFilteredVehicles.length }}
-      />
-
       <div className="table-card vehicles-table-scroll">
         <table className="table vehicles-table">
           <thead>

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -6,9 +6,9 @@ import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
 import { ContractMatchingForm, type ContractMatchingOption } from "@/components/management/ContractMatchingForm";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
-import type { VehicleMaintenanceSummary } from "@/components/management/vehicle-maintenance-derive";
 import type {
   FrontendDashboardBikePin,
+  FrontendVehicle,
   ServiceOpsRiderEducationType,
   ServiceOpsRiderInsurance
 } from "@/lib/services/service-ops-api";
@@ -22,6 +22,9 @@ export interface BottomMapPanelProps {
   // vehicles tab — VehiclesPanel 은 `data: VehicleDataResult` 전체를 받는다
   // (notice 뿐 아니라 source 필드까지 필요).
   vehicleData: VehicleDataResult;
+  // 지도 헤더 필터로 이미 필터링된 차량 목록. 테이블은 이 목록만 렌더한다
+  // (지도 필터 = 단일 소스). notice/source 는 vehicleData 에서 가져온다.
+  visibleVehicles: ReadonlyArray<FrontendVehicle>;
   bikeActiveRiderById: Map<string, string>;
   riderInfoById: Map<string, { name: string; phone: string }>;
   bikePins: ReadonlyArray<FrontendDashboardBikePin>;
@@ -31,7 +34,6 @@ export interface BottomMapPanelProps {
   riderActiveInsuranceByRiderId: Map<string, ServiceOpsRiderInsurance>;
   insuranceOptions: ReadonlyArray<InsuranceOption>;
   ignitionBlockedByBikeId: Map<string, boolean>;
-  maintenanceSummaryByBike: Map<string, VehicleMaintenanceSummary>;
   statusParam: string | null;
   // contract matching form
   riderOptions: ContractMatchingOption[];
@@ -96,7 +98,7 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
                 <p className="notice" role="status">{props.vehicleData.notice}</p>
               )}
               <VehiclesPanel
-                data={props.vehicleData}
+                data={{ ...props.vehicleData, vehicles: [...props.visibleVehicles] }}
                 bikeActiveRiderById={props.bikeActiveRiderById}
                 riderInfoById={props.riderInfoById}
                 bikePins={props.bikePins}
@@ -106,7 +108,6 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
                 riderActiveInsuranceByRiderId={props.riderActiveInsuranceByRiderId}
                 insuranceOptions={props.insuranceOptions}
                 ignitionBlockedByBikeId={props.ignitionBlockedByBikeId}
-                maintenanceSummaryByBike={props.maintenanceSummaryByBike}
                 statusParam={props.statusParam}
               />
               <ContractMatchingForm

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -344,6 +344,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
             onChange={setVehicleFilters}
             layout="horizontal"
             hideSearch
+            count={{ visible: visibleVehicles.length, total: serviceTypeFilteredVehicles.length }}
           />
           <RiderFilterControls
             filters={riderFilters}
@@ -387,6 +388,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
         />
         <BottomMapPanel
           vehicleData={vehicleData}
+          visibleVehicles={visibleVehicles}
           bikeActiveRiderById={bikeActiveRiderById ?? new Map()}
           riderInfoById={riderInfoById ?? new Map()}
           bikePins={bikePins}
@@ -396,7 +398,6 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId ?? new Map()}
           insuranceOptions={insuranceOptions ?? []}
           ignitionBlockedByBikeId={ignitionBlockedByBikeId ?? new Map()}
-          maintenanceSummaryByBike={maintenanceSummaryByBike ?? new Map()}
           statusParam={statusParam}
           stationData={stationData}
           riderOptions={riderOptions}

--- a/development/front-admin-web/components/overview/VehicleFilterContext.tsx
+++ b/development/front-admin-web/components/overview/VehicleFilterContext.tsx
@@ -3,22 +3,19 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 /**
- * 차량 탭과 지도가 공유하는 두 가지 채널:
+ * 차량 탭과 지도가 공유하는 선택 차량 채널:
  *
- * 1. **필터 동기화** — `filteredBikeIds === null` 이면 필터 미적용(전체 핀
- *    노출), Set 이면 그 부분 집합만 마커로. VehiclesPanel 이 publish, Map
- *    Banner 가 consume.
+ * **선택 차량 동기화** — `selectedBikeId` 가 있으면 지도가 그 차량 위치로 pan
+ * 하고 지도 위 floating panel(차량 상세) 이 열린다. 행 클릭 / 마커 클릭이
+ * 같은 채널을 통해 서로를 비춘다.
  *
- * 2. **선택 차량 동기화** — `selectedBikeId` 가 있으면 지도가 자동으로 켜지고
- *    그 차량의 위치로 pan. 행 클릭이 modal 모달 대신 지도 위 floating panel
- *    을 띄우는 채널이기도 하다.
+ * (예전엔 `filteredBikeIds` 로 필터도 공유했지만, 차량 필터를 지도 헤더
+ * 필터로 단일화하면서 제거했다 — 지도 필터가 곧 테이블 필터다.)
  *
  * Provider 는 page 의 client subtree 를 한 번만 감싸는 `OverviewClientShell`
  * 에서 마운트되어 모든 탭 컨텐츠가 같은 인스턴스를 본다.
  */
 type FilterContextValue = {
-  filteredBikeIds: ReadonlySet<string> | null;
-  setFilteredBikeIds: (ids: ReadonlySet<string> | null) => void;
   selectedBikeId: string | null;
   setSelectedBikeId: (id: string | null) => void;
 };
@@ -26,22 +23,16 @@ type FilterContextValue = {
 const VehicleFilterContext = createContext<FilterContextValue | null>(null);
 
 export function VehicleFilterProvider({ children }: { children: ReactNode }) {
-  const [filteredBikeIds, setFilteredRaw] = useState<ReadonlySet<string> | null>(null);
   const [selectedBikeId, setSelectedRaw] = useState<string | null>(null);
-  const setFilteredBikeIds = useCallback((ids: ReadonlySet<string> | null) => {
-    setFilteredRaw(ids);
-  }, []);
   const setSelectedBikeId = useCallback((id: string | null) => {
     setSelectedRaw(id);
   }, []);
   const value = useMemo<FilterContextValue>(
     () => ({
-      filteredBikeIds,
-      setFilteredBikeIds,
       selectedBikeId,
       setSelectedBikeId
     }),
-    [filteredBikeIds, setFilteredBikeIds, selectedBikeId, setSelectedBikeId]
+    [selectedBikeId, setSelectedBikeId]
   );
   return <VehicleFilterContext.Provider value={value}>{children}</VehicleFilterContext.Provider>;
 }
@@ -54,8 +45,6 @@ export function useVehicleFilter(): FilterContextValue {
   const ctx = useContext(VehicleFilterContext);
   if (!ctx) {
     return {
-      filteredBikeIds: null,
-      setFilteredBikeIds: () => {},
       selectedBikeId: null,
       setSelectedBikeId: () => {}
     };


### PR DESCRIPTION
프로덕션 릴리스 (`dev` → `main`). 머지 시 `aws-ec2-deploy.yml`이 EC2 프로덕션 배포를 트리거합니다.

## 포함 내용 (프론트 전용, 1개 PR)
- **[#364](https://github.com/EVNSolution/thundercrew-domain/pull/364) 차량 필터 단일화:** 차량 탭의 자체 필터(서비스유형 탭 + VehicleFilterControls) 제거 → **지도 헤더 필터가 단일 소스**로 차량 탭 테이블까지 구동. 죽은 `filteredBikeIds`/`maintenanceSummaryByBike` 채널 정리.

## 배포 영향
- ✅ **마이그레이션 없음**, **백엔드 변경 없음** — 프론트 4파일 (−90/+22)
- 배포: `npm ci → lint → typecheck → build` 후 프론트 재기동만

## Verification
- ✅ `npm run typecheck` / `npm run lint` / `npm run build` (루트) 모두 green

## 배포 후 확인
- [ ] 지도 헤더 "필터" 바 + 서비스유형 탭으로 거르면 차량 탭 테이블도 동일하게 필터됨
- [ ] 차량 탭 안에 별도 필터 UI가 사라졌는지
- [ ] 필터 바에 표시/전체 카운트 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)