### PR TITLE
feat: 차량 탭을 읽기 전용 (엑셀 차량정보 + 매칭정보) 테이블로 슬림화

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 
-import { type ContractMatchingOption } from "@/components/management/ContractMatchingForm";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import { FullscreenMapHost } from "@/components/overview/FullscreenMapHost";
 import { OverviewClientShell } from "@/components/overview/OverviewClientShell";
@@ -57,7 +56,7 @@ export default async function RootPage({
   // batch lookup. installations + devices 두 list 를 조인해 bikeId → deviceUid
   // 사전 한 장으로 내려준다.
   const [
-    { tab: tabParam, status: statusParam },
+    { tab: tabParam },
     mapState,
     riderData,
     vehicleData,
@@ -130,20 +129,6 @@ export default async function RootPage({
     insuranceItemById.set(item.id, item);
   }
 
-  // 신규 매칭 다이얼로그의 select 옵션. id 와 사용자에게 보일 라벨만 노출.
-  const riderOptions: ContractMatchingOption[] = riderData.riders
-    .filter((rider) => Boolean(rider.id))
-    .map((rider) => ({ id: rider.id ?? rider.slug, label: `${rider.name} (${rider.phone})` }));
-  const vehicleOptions: ContractMatchingOption[] = vehicleData.vehicles
-    .filter((vehicle) => Boolean(vehicle.id))
-    .map((vehicle) => ({
-      id: vehicle.id ?? vehicle.slug,
-      label: `${vehicle.plateNumber}${vehicle.model ? ` · ${vehicle.model}` : ""}`
-    }));
-  const templateOptions: ContractMatchingOption[] = opsExtra.templates.map((template) => ({
-    id: template.id,
-    label: template.name
-  }));
   // 라이더 수정 다이얼로그 + 차량 상세 패널 보험 편집에 쓰는 옵션 목록 (active 항목만).
   // category 포함 → PRIMARY(기본보험) / ADDON(추가보험) 분리 표시.
   const insuranceOptions: InsuranceOption[] = opsExtra.insuranceItems.map((item) => ({
@@ -158,13 +143,6 @@ export default async function RootPage({
   for (const pin of mapState.data.bikePins) {
     ignitionStatusByBikeId.set(pin.bikeId, pin.ignitionStatus);
   }
-  // 라이더 상세 다이얼로그의 "시동 방지" 토글이 현재 상태를 보여주는 데
-  // 쓰는 맵. ServiceOpsBike 응답에 `ignitionBlocked` 가 있으면 그걸 그대로.
-  const ignitionBlockedByBikeId = new Map<string, boolean>();
-  for (const vehicle of vehicleData.vehicles) {
-    if (vehicle.id) ignitionBlockedByBikeId.set(vehicle.id, vehicle.ignitionBlocked ?? false);
-  }
-
   // 차량 탭 "정비 상태" 필터가 임박/지연 차량을 골라낼 때 참조. bikeId →
   // {hasOverdue, hasDueSoon, overallStatus}. 차량별 engineType 으로 적용
   // catalog 를 분기해 catalog × records 의 매트릭스를 한 번에 derive.
@@ -224,14 +202,9 @@ export default async function RootPage({
           riderAllInsurancesByRiderId={riderAllInsurancesByRiderId}
           insuranceItemById={insuranceItemById}
           insuranceOptions={insuranceOptions}
-          ignitionBlockedByBikeId={ignitionBlockedByBikeId}
           vehicleData={vehicleData}
           stationData={stationData}
           riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId}
-          riderOptions={riderOptions}
-          vehicleOptions={vehicleOptions}
-          templateOptions={templateOptions}
-          statusParam={statusParam ?? null}
         />
       </OverviewClientShell>
     </div>

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -3,48 +3,38 @@
 import { useEffect, useMemo, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
-import { DeleteVehicleButton } from "@/components/management/DeleteVehicleButton";
-import { IgnitionControlButton } from "@/components/management/IgnitionControlButton";
-import { OperationStatusToggle } from "@/components/management/OperationStatusToggle";
-import { VEHICLE_DRAG_TYPE } from "@/components/management/ContractMatchingForm";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import { statusToOperation } from "@/components/overview/filter-compute";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
-import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 import type {
-  FrontendDashboardBikePin,
   FrontendVehicle,
   ServiceOpsBikeOperationStatus,
   ServiceOpsRiderInsurance
 } from "@/lib/services/service-ops-api";
 
 /**
- * `/?tab=vehicles` 의 차량 현황 패널. 한 행에서 차량 자체 + 매칭된 라이더 +
- * 라이더의 계약·보험·교육 + 텔레메트리 + 단말기 + 시동 제어까지 한 번에
- * 훑을 수 있도록 라이더 탭과 동일한 라이더-측 컬럼들을 함께 노출한다.
+ * 지도 하단 패널의 차량 현황 탭. 읽기 전용 표로, 차량 자체 정보(엑셀 스타일)
+ * 와 매칭된 라이더·계약·보험 정보만 한 줄에서 훑을 수 있게 한다. 매칭/등록·
+ * 삭제 등 관리 동작은 모두 `/management` 페이지에서 처리하므로 이 패널에는
+ * 어떤 관리 affordance 도 두지 않는다.
  *
- * 컬럼 (총 16):
- *   차량번호 / 구분 / 운영 상태 / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 /
- *   기간 / 보험 / IMEI / 연결 상태 / 시동 상태 / 시동 제어 / 속도 / 잔량
+ * 컬럼 (총 11):
+ *   차량번호 / 구분 / 운영 상태 / IMEI / 이름 / 연락처 / 교육 / 구독·렌탈 /
+ *   형태 / 기간 / 보험
  *
  * 데이터 매핑:
  * - 차량번호 / 구분(engineType) / 운영 상태 ← FrontendVehicle (이 패널 데이터)
+ * - IMEI ← deviceUidByBikeId (페이지 진입 시 batch-load)
  * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
  * - 교육 / 구독·렌탈 / 형태 / 기간 / 보험 ← bikeActiveRiderById 로 riderId 를
  *   먼저 찾고, 라이더 탭과 동일한 4 종 map (educationTypeByRiderId,
- *   riderActiveContractById, insuredRiderIds) 으로 lookup
- * - IMEI ← deviceUidByBikeId (페이지 진입 시 batch-load)
- * - 연결 상태 / 시동 상태 / 속도 / 잔량 ← bikePinById (텔레메트리 핀)
- * - 시동 제어 ← ignitionBlockedByBikeId + IgnitionControlButton (라이더 탭과
- *   같은 컴포넌트 재사용)
+ *   riderActiveContractById, riderActiveInsuranceByRiderId, insuranceOptions)
+ *   으로 lookup
  *
  * 행 클릭은 차량 상세 다이얼로그 — 라이더 정보는 단순 조회용이고 편집은
- * 라이더 탭에서 처리하도록 책임 분리. 시동 제어 토글만 행 안에서 직접 동작.
- *
- * 지도 보기 토글은 페이지 최상단의 글로벌 토글로 이동했으므로 이 패널에서는
- * 다루지 않는다. 필터는 차량번호/모델명/IMEI 검색 한 줄만.
+ * 라이더 탭/관리 페이지에서 처리하도록 책임 분리.
  */
 
 const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
@@ -52,26 +42,19 @@ const STATUS_LABEL: Record<ServiceOpsBikeOperationStatus, string> = {
   IN_SERVICE: "운행"
 };
 
-const LOW_BATTERY_THRESHOLD = 20;
-
 export function VehiclesPanel({
   data,
   bikeActiveRiderById,
   riderInfoById,
-  bikePins,
   deviceUidByBikeId,
   educationTypeByRiderId,
   riderActiveContractById,
   riderActiveInsuranceByRiderId,
-  insuranceOptions,
-  ignitionBlockedByBikeId,
-  statusParam
+  insuranceOptions
 }: {
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
-  /** 텔레메트리 핀 — 연결 상태 / 시동 / 속도 / 잔량 컬럼이 참조. */
-  bikePins?: ReadonlyArray<FrontendDashboardBikePin>;
   /** 차량 → 부착된 단말기 IMEI 사전. 루트 페이지가 batch loader 로 받아서 내려준다. */
   deviceUidByBikeId?: Map<string, string>;
   /** riderId → ONLINE/OFFLINE 교육 type. */
@@ -82,24 +65,8 @@ export function VehiclesPanel({
   riderActiveInsuranceByRiderId?: Map<string, ServiceOpsRiderInsurance>;
   /** insurance_item id → 표시 라벨 사전. 라이더 탭과 동일. */
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
-  /** bikeId → 시동 방지 토글 현재 상태. 시동 제어 인라인 토글의 초기값. */
-  ignitionBlockedByBikeId?: Map<string, boolean>;
-  /** server action 결과 status. "delete-error" 이면 삭제 실패 배너 표시. */
-  statusParam?: string | null;
 }) {
   const { setSelectedBikeId } = useVehicleFilter();
-
-  // IMEI=-1 시뮬 차량의 ignitionStatus / 속도 / 배터리 등을 지도와 동일하게 overlay.
-  const overlaidBikePins = useSimulatedBikePins(bikePins ?? []);
-
-  // bikeId → 텔레메트리 핀 1:1 인덱스. 표 렌더링이 매 행마다 lookup 1회.
-  const bikePinById = useMemo(() => {
-    const map = new Map<string, FrontendDashboardBikePin>();
-    for (const pin of overlaidBikePins) {
-      map.set(pin.bikeId, pin);
-    }
-    return map;
-  }, [overlaidBikePins]);
 
   // insurance_item id → 표시 라벨 사전. 보험 컬럼이 매 행마다 lookup 1회.
   const insuranceLabelById = useMemo(() => {
@@ -112,8 +79,6 @@ export function VehiclesPanel({
 
   // 지도 헤더 필터가 차량 필터의 단일 소스다. FullscreenMapHost 가 이미
   // 필터링한 `visibleVehicles` 를 `data.vehicles` 로 받아 그대로 렌더한다.
-  // (예전엔 이 패널이 자체 필터 UI + applyVehicleFilters 를 들고 있었으나
-  // 지도 필터와 이원화되는 문제가 있어 지도 필터로 통일했다.)
   const visibleVehicles = data.vehicles;
 
   // 탭 언마운트(다른 탭으로 전환) 시 선택 상태도 해제. 마커 클릭 / 행 클릭
@@ -124,23 +89,14 @@ export function VehiclesPanel({
 
   return (
     <div className="vehicles-panel">
-      {statusParam?.startsWith("delete-error") && (
-        <p role="alert" className="panel-error-banner">
-          {statusParam === "delete-error-409"
-            ? "차량 삭제에 실패했습니다. 활성 라이더 매칭이 있는 차량은 먼저 매칭을 해제해 주세요."
-            : statusParam === "delete-error-403"
-              ? "차량 삭제 권한이 없습니다."
-              : `차량 삭제에 실패했습니다. (${statusParam}) 잠시 후 다시 시도해 주세요.`}
-        </p>
-      )}
       <div className="table-card vehicles-table-scroll">
         <table className="table vehicles-table">
           <thead>
             <tr>
-              <th aria-label="삭제" />
               <th>차량번호</th>
               <th>구분</th>
               <th>운영 상태</th>
+              <th>IMEI</th>
               <th>이름</th>
               <th>연락처</th>
               <th>교육</th>
@@ -148,18 +104,12 @@ export function VehiclesPanel({
               <th>형태</th>
               <th>기간</th>
               <th>보험</th>
-              <th>IMEI</th>
-              <th>연결 상태</th>
-              <th>시동 상태</th>
-              <th>시동 제어</th>
-              <th>속도</th>
-              <th>잔량</th>
             </tr>
           </thead>
           <tbody>
             {visibleVehicles.length === 0 ? (
               <tr>
-                <td colSpan={17} className="table-empty-cell">
+                <td colSpan={11} className="table-empty-cell">
                   조건에 맞는 차량 없음
                 </td>
               </tr>
@@ -168,7 +118,6 @@ export function VehiclesPanel({
               const vehicleKey = vehicle.id ?? vehicle.slug;
               const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
               const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
-              const pin = bikePinById.get(vehicleKey);
               const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
               const imei = deviceUidByBikeId?.get(vehicleKey) ?? null;
               // 라이더-측 lookup. 매칭이 없으면 모두 null → "—" 폴백.
@@ -178,17 +127,10 @@ export function VehiclesPanel({
               const insuranceLabel = activeInsurance
                 ? insuranceLabelById.get(activeInsurance.insuranceItemId) ?? null
                 : null;
-              const ignitionBlocked = ignitionBlockedByBikeId?.get(vehicleKey) ?? false;
               return (
                 <tr
                   key={vehicle.slug}
                   className="table-row-clickable"
-                  draggable={Boolean(vehicle.id)}
-                  onDragStart={(event) => {
-                    if (!vehicle.id) return;
-                    event.dataTransfer.setData(VEHICLE_DRAG_TYPE, vehicle.id);
-                    event.dataTransfer.effectAllowed = "copy";
-                  }}
                   onClick={() => {
                     // selectedBikeId 만 publish — 지도 위 floating panel 이
                     // 컨텍스트를 읽어 자동으로 열린다. rider 정보 lookup 은
@@ -196,20 +138,10 @@ export function VehiclesPanel({
                     if (vehicle.id) setSelectedBikeId(vehicle.id);
                   }}
                 >
-                  <td onClick={(event) => event.stopPropagation()}>
-                    {vehicle.id ? (
-                      <DeleteVehicleButton vehicleId={vehicle.id} plateNumber={vehicle.plateNumber} />
-                    ) : null}
-                  </td>
                   <td>{vehicle.plateNumber}</td>
                   <td>{renderEngineTypeBadge(vehicle.engineType)}</td>
-                  <td onClick={(event) => event.stopPropagation()}>
-                    {vehicle.id ? (
-                      <OperationStatusToggle bikeId={vehicle.id} initialStatus={op} />
-                    ) : (
-                      renderOperationBadge(op)
-                    )}
-                  </td>
+                  <td>{renderOperationBadge(op)}</td>
+                  <td className="vehicles-cell-mono">{imei || <span className="muted">—</span>}</td>
                   <td>{riderInfo ? riderInfo.name : <span className="muted">미배정</span>}</td>
                   <td>{riderInfo ? riderInfo.phone : <span className="muted">—</span>}</td>
                   <td>{renderEducationType(educationType)}</td>
@@ -217,18 +149,6 @@ export function VehiclesPanel({
                   <td>{renderReturnType(contract?.returnType ?? null)}</td>
                   <td>{renderDuration(contract?.durationLabel ?? null)}</td>
                   <td>{renderInsuranceProduct(insuranceLabel)}</td>
-                  <td className="vehicles-cell-mono">{imei || <span className="muted">—</span>}</td>
-                  <td>{renderConnection(pin?.connectionStatus)}</td>
-                  <td>{renderIgnition(pin?.ignitionStatus)}</td>
-                  <td onClick={(event) => event.stopPropagation()}>
-                    {vehicle.id ? (
-                      <IgnitionControlButton bikeId={vehicle.id} initialBlocked={ignitionBlocked} />
-                    ) : (
-                      <span className="muted">—</span>
-                    )}
-                  </td>
-                  <td>{renderSpeed(pin?.speedKph)}</td>
-                  <td>{renderBattery(pin?.batteryPercent)}</td>
                 </tr>
               );
             })}
@@ -261,43 +181,6 @@ function renderOperationBadge(op: ServiceOpsBikeOperationStatus): ReactNode {
   return (
     <span className={`vehicles-pill vehicles-pill--${isOperating ? "operating" : "idle"}`}>
       {STATUS_LABEL[op]}
-    </span>
-  );
-}
-
-// 연결 상태: telemetry 의 connectionStatus 그대로 사람 친화 라벨로. 핀이 없는
-// 차량(텔레메트리 한 번도 못 받음) 은 "—" — 단말기를 부착하지 않은 경우와
-// 단말기는 있는데 통신 끊긴 경우 둘 다 핀이 없을 수 있어 한 톤으로 표시.
-function renderConnection(status: string | undefined): ReactNode {
-  if (!status) return <span className="muted">—</span>;
-  if (status === "ONLINE") {
-    return <span className="vehicles-pill vehicles-pill--operating">온라인</span>;
-  }
-  if (status === "SIGNAL_LOST") {
-    return <span className="vehicles-pill vehicles-pill--unknown">신호 끊김</span>;
-  }
-  // 그 외(OFFLINE / PARKED_OFFLINE 등) 는 회색 톤으로 통일.
-  return <span className="vehicles-pill vehicles-pill--idle">오프라인</span>;
-}
-
-function renderIgnition(status: string | undefined): ReactNode {
-  // ON 은 명시적 ON 만. 그 외(OFF / UNKNOWN / 핀 없음) 는 모두 OFF — 운영자
-  // 멘탈 모델 ("상태없음 = 사실상 OFF") 과 필터 의미와 동일하게 통일.
-  if (status === "ON") return <span className="vehicles-pill vehicles-pill--ignition-on">ON</span>;
-  return <span className="vehicles-pill vehicles-pill--ignition-off">OFF</span>;
-}
-
-function renderSpeed(speedKph: number | null | undefined): ReactNode {
-  if (speedKph === null || speedKph === undefined) return <span className="muted">—</span>;
-  return <span className="vehicles-cell-mono">{Math.round(speedKph)} km/h</span>;
-}
-
-function renderBattery(percent: number | null | undefined): ReactNode {
-  if (percent === null || percent === undefined) return <span className="muted">—</span>;
-  const tone = percent <= LOW_BATTERY_THRESHOLD ? "low" : percent <= 50 ? "mid" : "high";
-  return (
-    <span className={`vehicles-soc vehicles-soc--${tone}`}>
-      {percent.toFixed(0)}%
     </span>
   );
 }

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -4,10 +4,8 @@ import { useState } from "react";
 
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
-import { ContractMatchingForm, type ContractMatchingOption } from "@/components/management/ContractMatchingForm";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
-  FrontendDashboardBikePin,
   FrontendVehicle,
   ServiceOpsRiderEducationType,
   ServiceOpsRiderInsurance
@@ -27,18 +25,11 @@ export interface BottomMapPanelProps {
   visibleVehicles: ReadonlyArray<FrontendVehicle>;
   bikeActiveRiderById: Map<string, string>;
   riderInfoById: Map<string, { name: string; phone: string }>;
-  bikePins: ReadonlyArray<FrontendDashboardBikePin>;
   deviceUidByBikeId: Map<string, string>;
   educationTypeByRiderId: Map<string, ServiceOpsRiderEducationType>;
   riderActiveContractById: Map<string, RiderActiveContractSummary>;
   riderActiveInsuranceByRiderId: Map<string, ServiceOpsRiderInsurance>;
   insuranceOptions: ReadonlyArray<InsuranceOption>;
-  ignitionBlockedByBikeId: Map<string, boolean>;
-  statusParam: string | null;
-  // contract matching form
-  riderOptions: ContractMatchingOption[];
-  vehicleOptions: ContractMatchingOption[];
-  templateOptions: ContractMatchingOption[];
   // stations tab
   stationData: StationDataResult;
   // tips tab — placeholder for Task 8
@@ -49,8 +40,8 @@ export interface BottomMapPanelProps {
  * 전체화면 지도 하단에 고정되는 접이식 패널. 탭(차량/충전소/팁)을 누르면
  * 30vh 높이로 펼쳐지고, 같은 탭을 다시 누르거나 ▼ 버튼을 누르면 접힌다.
  *
- * 차량 탭은 기존 VehiclesPanel + ContractMatchingForm 을 그대로 재사용하고,
- * 충전소 탭은 StationsPanel 을 재사용한다. 팁 탭은 Task 8 에서 TipsPanel 이
+ * 차량 탭은 읽기 전용 VehiclesPanel 만 재사용하고, 충전소 탭은 StationsPanel
+ * 을 재사용한다. 팁 탭은 Task 8 에서 TipsPanel 이
  * `tipContent` 로 주입되기 전까지 placeholder 만 표시한다.
  */
 export function BottomMapPanel(props: BottomMapPanelProps) {
@@ -101,20 +92,11 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
                 data={{ ...props.vehicleData, vehicles: [...props.visibleVehicles] }}
                 bikeActiveRiderById={props.bikeActiveRiderById}
                 riderInfoById={props.riderInfoById}
-                bikePins={props.bikePins}
                 deviceUidByBikeId={props.deviceUidByBikeId}
                 educationTypeByRiderId={props.educationTypeByRiderId}
                 riderActiveContractById={props.riderActiveContractById}
                 riderActiveInsuranceByRiderId={props.riderActiveInsuranceByRiderId}
                 insuranceOptions={props.insuranceOptions}
-                ignitionBlockedByBikeId={props.ignitionBlockedByBikeId}
-                statusParam={props.statusParam}
-              />
-              <ContractMatchingForm
-                riderOptions={props.riderOptions}
-                vehicleOptions={props.vehicleOptions}
-                templateOptions={props.templateOptions}
-                statusParam={props.statusParam}
               />
             </>
           )}

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -6,7 +6,6 @@ import { MapShell } from "@/components/dashboard/MapShell";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import { BottomMapPanel } from "@/components/overview/BottomMapPanel";
 import { TipsPanel } from "@/components/overview/TipsPanel";
-import type { ContractMatchingOption } from "@/components/management/ContractMatchingForm";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import { useTrailWaypoints } from "@/components/overview/use-trail-waypoints";
@@ -88,17 +87,11 @@ export interface FullscreenMapHostProps {
   insuranceItemById?: Map<string, ServiceOpsInsuranceItem>;
   /** 보험 상품 선택지. VehicleDetailDialog + 하단 차량 패널에 사용. */
   insuranceOptions?: ReadonlyArray<InsuranceOption>;
-  /** bikeId → 시동 방지 토글 현재 상태. 하단 차량 패널의 인라인 토글 초기값. */
-  ignitionBlockedByBikeId?: Map<string, boolean>;
   // bottom panel
   /** VehiclesPanel 이 그대로 받는 차량 데이터 결과 (notice / source 포함). */
   vehicleData: VehicleDataResult;
   stationData: StationDataResult;
   riderActiveInsuranceByRiderId?: Map<string, ServiceOpsRiderInsurance>;
-  riderOptions: ContractMatchingOption[];
-  vehicleOptions: ContractMatchingOption[];
-  templateOptions: ContractMatchingOption[];
-  statusParam: string | null;
 }
 
 export function FullscreenMapHost(props: FullscreenMapHostProps) {
@@ -122,14 +115,9 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     riderAllInsurancesByRiderId,
     insuranceItemById,
     insuranceOptions,
-    ignitionBlockedByBikeId,
     vehicleData,
     stationData,
-    riderActiveInsuranceByRiderId,
-    riderOptions,
-    vehicleOptions,
-    templateOptions,
-    statusParam
+    riderActiveInsuranceByRiderId
   } = props;
 
   const { selectedBikeId, setSelectedBikeId } = useVehicleFilter();
@@ -392,18 +380,12 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           visibleVehicles={visibleVehicles}
           bikeActiveRiderById={bikeActiveRiderById ?? new Map()}
           riderInfoById={riderInfoById ?? new Map()}
-          bikePins={bikePins}
           deviceUidByBikeId={deviceUidByBikeId ?? new Map()}
           educationTypeByRiderId={educationTypeByRiderId ?? new Map()}
           riderActiveContractById={riderActiveContractById ?? new Map()}
           riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId ?? new Map()}
           insuranceOptions={insuranceOptions ?? []}
-          ignitionBlockedByBikeId={ignitionBlockedByBikeId ?? new Map()}
-          statusParam={statusParam}
           stationData={stationData}
-          riderOptions={riderOptions}
-          vehicleOptions={vehicleOptions}
-          templateOptions={templateOptions}
           tipContent={<TipsPanel selectedTipId={selectedTipId} onTipSelect={setSelectedTipId} />}
         />
       </main>


### PR DESCRIPTION
## Summary
지도 하단 차량 탭을 **읽기 전용 테이블**로 정리. 매칭/등록은 /management에서 하므로 지도 탭에서는 관리 기능을 제거.

- **컬럼 11개(읽기 전용)**: 차량번호 / 구분 / 운영상태 / IMEI / 이름 / 연락처 / 교육 / 구독·렌탈 / 형태 / 기간 / 보험
- **제거**: 삭제 버튼, 운영상태 토글, 시동제어 토글, 텔레메트리(연결/시동/속도/잔량), "신규 매칭" 폼(ContractMatchingForm)
- **유지**: 행 클릭 → 차량 상세 다이얼로그(텔레메트리 등은 여기서 확인)
- 죽은 prop 체인 정리: VehiclesPanel → BottomMapPanel → FullscreenMapHost → page.tsx (riderOptions/vehicleOptions/templateOptions/ignitionBlockedByBikeId/statusParam 등 미사용 계산 제거)

`ContractMatchingForm`은 RidersPanel에서 계속 쓰여 그대로 두고, `VehiclesManagementPanel`(관리 페이지)도 손대지 않음.

## Verification
- ✅ `npm run typecheck` / `lint` / `build` (루트) green
- 코드 리뷰: spec 일치 + 캐스케이드 안전(detailRow·bikePins가 제거 입력과 독립) + 보험 컬럼 체인 무손상 확인
- 프론트 전용 4파일, 마이그레이션/백엔드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)