### PR TITLE
feat: 우상단 액션바에 관리(/management) 링크 추가

### DIFF
--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -26,6 +26,26 @@ export async function AppShell({ children }: { children: ReactNode }) {
         <ThemeToggle />
         {serviceOpsSessionActive ? (
           <>
+            <a className="sidebar-link" href="/management" title="데이터 관리" aria-label="데이터 관리">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {/* 표(데이터 관리) 아이콘 — 외곽 + 행/열 구분선 */}
+                <rect x="3" y="4" width="18" height="16" rx="1.5" />
+                <path d="M3 9h18" />
+                <path d="M3 14h18" />
+                <path d="M9 4v16" />
+              </svg>
+              <span className="sidebar-label">관리</span>
+            </a>
             <PasswordChangeButton />
             <LogoutButton />
           </>


### PR DESCRIPTION
## Summary
지도 화면에서 `/management`로 가는 동선이 없던 문제(단일 화면 통합 때 좌측 메뉴 레일 제거됨) 해결. 우상단 floating 액션바(테마/비번변경/로그아웃)에 **"관리" 링크**를 추가 — ops 세션 활성일 때만 노출.

- `AppShell.tsx`: 로그인 상태 블록에 `<a href="/management">` (표 아이콘 + "관리" 라벨, 기존 sidebar-link 스타일 재사용)

## Verification
- ✅ `npm run typecheck` / `lint` / `build` (루트) green
- 프론트 1파일, 마이그레이션/백엔드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)