### PR TITLE
release: 우상단 액션바에 관리(/management) 링크 추가

### DIFF
--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -26,6 +26,26 @@ export async function AppShell({ children }: { children: ReactNode }) {
         <ThemeToggle />
         {serviceOpsSessionActive ? (
           <>
+            <a className="sidebar-link" href="/management" title="데이터 관리" aria-label="데이터 관리">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {/* 표(데이터 관리) 아이콘 — 외곽 + 행/열 구분선 */}
+                <rect x="3" y="4" width="18" height="16" rx="1.5" />
+                <path d="M3 9h18" />
+                <path d="M3 14h18" />
+                <path d="M9 4v16" />
+              </svg>
+              <span className="sidebar-label">관리</span>
+            </a>
             <PasswordChangeButton />
             <LogoutButton />
           </>


### PR DESCRIPTION
프로덕션 릴리스 (`dev` → `main`). 머지 시 `aws-ec2-deploy.yml`이 EC2 프로덕션 배포를 트리거합니다.

## 포함 내용 (프론트 전용, 1개 PR)
- **[#370](https://github.com/EVNSolution/thundercrew-domain/pull/370) 관리 링크:** 지도 화면 우상단 액션바에 "관리"(/management) 링크 추가 — 로그인 상태일 때만 노출. (기존엔 지도 → management 동선이 없었음)

## 배포 영향
- ✅ **마이그레이션 없음**, **백엔드 변경 없음** — 프론트 1파일 (AppShell.tsx)
- 배포: `npm ci → lint → typecheck → build` 후 프론트 재기동만

## Verification
- ✅ `npm run typecheck` / `lint` / `build` (루트) green

## 배포 후 확인
- [ ] 로그인 상태에서 우상단에 "관리" 링크 표시
- [ ] 클릭 시 /management 이동
- [ ] 로그아웃 상태에선 미노출(관리자 로그인 링크만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)