### PR TITLE
fix: 관리 링크를 지도 헤더로 이동 (액션바가 지도에 가려짐)

### DIFF
--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -26,26 +26,6 @@ export async function AppShell({ children }: { children: ReactNode }) {
         <ThemeToggle />
         {serviceOpsSessionActive ? (
           <>
-            <a className="sidebar-link" href="/management" title="데이터 관리" aria-label="데이터 관리">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                {/* 표(데이터 관리) 아이콘 — 외곽 + 행/열 구분선 */}
-                <rect x="3" y="4" width="18" height="16" rx="1.5" />
-                <path d="M3 9h18" />
-                <path d="M3 14h18" />
-                <path d="M9 4v16" />
-              </svg>
-              <span className="sidebar-label">관리</span>
-            </a>
             <PasswordChangeButton />
             <LogoutButton />
           </>

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -324,6 +324,11 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 충전소
         </span>
         <NotificationBell />
+        {/* 데이터 관리(/management) 진입. top-actions 바는 full-viewport 지도
+            오버레이에 가려지므로, 항상 보이는 지도 헤더(z-index 110) 안에 둔다. */}
+        <a className="fullscreen-map-filter-reopen" href="/management" title="데이터 관리">
+          관리
+        </a>
       </header>
       {filtersOpen ? (
         <div className="fullscreen-map-filter-bar">


### PR DESCRIPTION
## 배경 (QA에서 발견)
#370에서 추가한 "관리" 링크가 지도 화면에서 보이지/클릭되지 않았음:
- `.top-actions` z-index **80**, `.fullscreen-map-overlay`(full viewport) z-index **100** → 액션바 전체(테마/비번/로그아웃/관리)가 지도 캔버스 뒤에 가려짐. 우상단 클릭 시 잡히는 요소 = `mapboxgl-canvas`.

## 수정
- "관리" 링크를 **항상 보이는 지도 헤더**(`.fullscreen-map-header`, z-index 110) 안, 알림벨 뒤에 배치. 좌측 정렬 흐름이라 우측 차량 상세 패널(right:16, 360px)과 겹치지 않음.
- `.top-actions`에 넣었던 링크는 원복.

(테마/로그아웃이 지도에서 가려지는 건 기존부터의 별개 이슈 — 이번 범위 외.)

## Verification
- ✅ `npm run typecheck` / `lint` / `build` (루트) green
- 프론트 2파일, 마이그레이션/백엔드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)