### PR TITLE
release: 관리 링크를 지도 헤더로 이동 (가려짐 수정)

### DIFF
--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -26,26 +26,6 @@ export async function AppShell({ children }: { children: ReactNode }) {
         <ThemeToggle />
         {serviceOpsSessionActive ? (
           <>
-            <a className="sidebar-link" href="/management" title="데이터 관리" aria-label="데이터 관리">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                {/* 표(데이터 관리) 아이콘 — 외곽 + 행/열 구분선 */}
-                <rect x="3" y="4" width="18" height="16" rx="1.5" />
-                <path d="M3 9h18" />
-                <path d="M3 14h18" />
-                <path d="M9 4v16" />
-              </svg>
-              <span className="sidebar-label">관리</span>
-            </a>
             <PasswordChangeButton />
             <LogoutButton />
           </>

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -324,6 +324,11 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 충전소
         </span>
         <NotificationBell />
+        {/* 데이터 관리(/management) 진입. top-actions 바는 full-viewport 지도
+            오버레이에 가려지므로, 항상 보이는 지도 헤더(z-index 110) 안에 둔다. */}
+        <a className="fullscreen-map-filter-reopen" href="/management" title="데이터 관리">
+          관리
+        </a>
       </header>
       {filtersOpen ? (
         <div className="fullscreen-map-filter-bar">


### PR DESCRIPTION
프로덕션 릴리스 (`dev` → `main`). 머지 시 `aws-ec2-deploy.yml`이 EC2 프로덕션 배포를 트리거합니다.

## 포함 내용 (프론트 전용, 1개 PR)
- **[#372](https://github.com/EVNSolution/thundercrew-domain/pull/372) 관리 링크 위치 수정:** 직전 릴리스(#371)에서 추가한 "관리" 링크가 우상단 액션바(z80)에 있어 full-viewport 지도 오버레이(z100)에 가려져 클릭 불가였음. **항상 보이는 지도 헤더(z110, 알림벨 옆)로 이동**해 노출/클릭 가능하게 수정. (가려지던 top-actions 버전 원복)

## 배포 영향
- ✅ **마이그레이션 없음**, **백엔드 변경 없음** — 프론트 2파일
- 배포: `npm ci → lint → typecheck → build` 후 프론트 재기동만

## Verification
- ✅ `npm run typecheck` / `lint` / `build` (루트) green
- QA로 가려짐 확인(z80 vs z100) 후 헤더(z110)로 이동

## 배포 후 확인
- [ ] 지도 화면 헤더(알림벨 옆)에 "관리" 버튼 표시 + 클릭 시 /management 이동
- [ ] 차량 상세 패널 열어도 관리 버튼과 안 겹침

🤖 Generated with [Claude Code](https://claude.com/claude-code)