### PR TITLE
Release: Group C3 — CLEANING 배차 통합 (시동 알림 → dispatch 큐)

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -731,13 +731,16 @@ export function MapShell({
  * 토큰에 정의되어 있어 light/dark + 타이포그래피가 거기서 통일된다. 마커의
  * `pointer-events: auto` 와 충돌하지 않게 라벨 자체는 `pointer-events: none`.
  */
+function escapeMarkerText(value: string): string {
+  return value.replace(/[<>&"]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === "&" ? "&amp;" : "&quot;"
+  );
+}
+
 function labelMarkup(text: string): string {
   // 텍스트는 안전하게 inner text 만 노출 — operator-입력 plate / station name
   // 이 HTML 을 포함할 가능성은 거의 없지만 escape 처리해서 안전망.
-  const safe = text.replace(/[&<>"]/g, (ch) =>
-    ch === "&" ? "&amp;" : ch === "<" ? "&lt;" : ch === ">" ? "&gt;" : "&quot;"
-  );
-  return `<span class="map-marker-label">${safe}</span>`;
+  return `<span class="map-marker-label">${escapeMarkerText(text)}</span>`;
 }
 
 /**
@@ -776,12 +779,6 @@ function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceT
  * CSS animation (.map-ignition-bubble) 으로 4초 후 자동 소멸.
  * NCP firstChild-only 제약상 markerWrapper 안에 badge 와 함께 삽입.
  */
-function escapeMarkerText(value: string): string {
-  return value.replace(/[<>&"]/g, (c) =>
-    c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === "&" ? "&amp;" : "&quot;"
-  );
-}
-
 function ignitionBubbleMarkup(customerName?: string | null): string {
   const who = customerName ? `${escapeMarkerText(customerName)} ` : "";
   return `<div class="map-ignition-bubble">🔑 ${who}출발</div>`;

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -465,7 +465,7 @@ export function MapShell({
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
       const isSelected = pin.bikeId === selectedBikeId;
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected, pin.currentDispatchCustomerName);
       // 배지는 icon wrapper(overflow:visible) 안에 position:absolute 로 내장되므로
       // icon.size 는 아이콘 자체 크기(28×28) 고정. 배지는 visually 아래로 넘침.
       const icon = {
@@ -776,8 +776,15 @@ function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceT
  * CSS animation (.map-ignition-bubble) 으로 4초 후 자동 소멸.
  * NCP firstChild-only 제약상 markerWrapper 안에 badge 와 함께 삽입.
  */
-function ignitionBubbleMarkup(): string {
-  return `<div class="map-ignition-bubble">🔑 이동 시작</div>`;
+function escapeMarkerText(value: string): string {
+  return value.replace(/[<>&"]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === "&" ? "&amp;" : "&quot;"
+  );
+}
+
+function ignitionBubbleMarkup(customerName?: string | null): string {
+  const who = customerName ? `${escapeMarkerText(customerName)} ` : "";
+  return `<div class="map-ignition-bubble">🔑 ${who}출발</div>`;
 }
 
 // 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
@@ -869,14 +876,15 @@ function bikeMarkerHtml(
   deliveryCount?: number,
   ignitionOnAt?: number | null,
   serviceType?: ServiceType,
-  selected?: boolean
+  selected?: boolean,
+  currentDispatchCustomerName?: string | null
 ): string {
   const badge =
     servicePhase != null
       ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0, serviceType)
       : "";
   const showBubble = serviceType === "CLEANING" && ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
-  const bubble = showBubble ? ignitionBubbleMarkup() : "";
+  const bubble = showBubble ? ignitionBubbleMarkup(currentDispatchCustomerName) : "";
   const extras = badge || bubble ? badge + bubble : undefined;
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras, selected);
   if (!showLabel) return wrapped;

--- a/development/front-admin-web/components/layout/NotificationBell.tsx
+++ b/development/front-admin-web/components/layout/NotificationBell.tsx
@@ -55,19 +55,12 @@ export function NotificationBell() {
           ) : (
             [...notifications].reverse().map((n) => (
               <div key={n.id} className="notif-item" role="listitem">
-                {n.customerName ? (
-                  <>
-                    <span className="notif-item-text">
-                      📞 {n.plateNumber} → {n.customerName} {n.customerPhone}
-                    </span>
-                    <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="notif-item-text">🔑 {n.plateNumber} 이동 시작</span>
-                    <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
-                  </>
-                )}
+                <span className="notif-item-text">
+                  🔑 {n.plateNumber} 출발
+                  {n.customerName ? ` → ${n.customerName}` : ""}
+                  {n.address ? ` (${n.address})` : ""}
+                </span>
+                <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
               </div>
             ))
           )}

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -12,8 +12,11 @@ export type IgnitionNotification = {
   id: string;
   plateNumber: string;
   startedAt: number;
-  /** CLEANING 차량 시동 ON 시 설정. 없으면 기존 "이동 시작" 알림 표시. */
+  /** CLEANING 차량 출발 시 현재 배차(dispatch) 고객명. 없으면 "출발"만 표시. */
   customerName?: string;
+  /** CLEANING 차량 출발 시 현재 배차 주소. 벨 항목에 괄호로 표기. */
+  address?: string;
+  /** @deprecated C3 이후 미사용 — 과거 next-customer 알림 호환용. */
   customerPhone?: string;
 };
 

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
 
-import { AddressSearchButton } from "@/components/management/AddressSearchButton";
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import {
   deriveMaintenanceRows,
@@ -10,9 +9,7 @@ import {
   type MaintenanceStatus
 } from "@/components/management/vehicle-maintenance-derive";
 import {
-  getNextCustomerAction,
   markVehicleMaintenanceServicedAction,
-  setNextCustomerAction,
   setRiderInsuranceFromVehicleAction,
   updateVehicleFromOverviewAction
 } from "@/app/actions";
@@ -209,9 +206,6 @@ export function VehicleDetailDialog({
             bikeId={vehicleIdForFetch ?? null}
             state={simState}
           />
-          {vehicle.serviceType === "CLEANING" && vehicleIdForFetch && (
-            <NextCustomerSection bikeId={vehicleIdForFetch} />
-          )}
           {vehicleIdForFetch && <DispatchQueueSection bikeId={vehicleIdForFetch} />}
           <TelemetrySection current={overlaidCurrent} loading={maintenance === null} />
           <InsuranceSection
@@ -896,186 +890,6 @@ function formatRemaining(ms: number): string {
   const sec = totalSec % 60;
   if (min > 0) return `${min}분 ${sec}초`;
   return `${sec}초`;
-}
-
-// ============================================================================
-// 현재 고객 / 다음 고객 섹션 (CLEANING 전용)
-// ============================================================================
-
-function NextCustomerSection({ bikeId }: { bikeId: string }) {
-  // 현재 고객 (read-only — promote 시 자동 갱신)
-  const [currentCustomerName, setCurrentCustomerName] = useState("");
-  const [currentCustomerPhone, setCurrentCustomerPhone] = useState("");
-  const [currentCustomerAddress, setCurrentCustomerAddress] = useState("");
-
-  // 다음 고객 (editable form)
-  const [customerName, setCustomerName] = useState("");
-  const [customerPhone, setCustomerPhone] = useState("");
-  const [address, setAddress] = useState("");
-  const [savedCoords, setSavedCoords] = useState<{ lat: number; lng: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  // 초기 데이터 로드 — 서버에서 현재 고객 + 다음 고객 모두 조회
-  useEffect(() => {
-    let cancelled = false;
-    getNextCustomerAction(bikeId).then((data) => {
-      if (cancelled || !data) return;
-      // 현재 고객
-      setCurrentCustomerName(data.currentCustomerName ?? "");
-      setCurrentCustomerPhone(data.currentCustomerPhone ?? "");
-      setCurrentCustomerAddress(data.currentCustomerAddress ?? "");
-      // 다음 고객
-      setCustomerName(data.customerName ?? "");
-      setCustomerPhone(data.customerPhone ?? "");
-      setAddress(data.address ?? "");
-      if (data.latitude != null && data.longitude != null) {
-        setSavedCoords({ lat: data.latitude, lng: data.longitude });
-      } else {
-        setSavedCoords(null);
-      }
-      setError(null);
-    });
-    return () => { cancelled = true; };
-  }, [bikeId]);
-
-  // ignitionOnAt 변화 감지:
-  //   null → non-null (WORKING→MOVING, 출발): 다음 고객 form 값 → 현재 고객으로 승격; 폼 초기화
-  //   non-null → null (MOVING→WORKING, 도착): 현재 고객 유지 (아무것도 안 함)
-  const { simulated, updatePinNextCustomer } = useFleetSimulation();
-  const ignitionOnAt = simulated.get(bikeId)?.ignitionOnAt ?? null;
-  const prevIgnitionOnAtRef = useRef(ignitionOnAt);
-  // form 값을 ref 에 보관 — ignitionOnAt 이펙트에서 stale closure 없이 읽기 위해
-  const customerNameRef = useRef(customerName);
-  const customerPhoneRef = useRef(customerPhone);
-  const addressRef = useRef(address);
-  useEffect(() => { customerNameRef.current = customerName; }, [customerName]);
-  useEffect(() => { customerPhoneRef.current = customerPhone; }, [customerPhone]);
-  useEffect(() => { addressRef.current = address; }, [address]);
-
-  useEffect(() => {
-    if (prevIgnitionOnAtRef.current === ignitionOnAt) return;
-    const prev = prevIgnitionOnAtRef.current;
-    prevIgnitionOnAtRef.current = ignitionOnAt;
-
-    if (prev === null && ignitionOnAt !== null) {
-      // 출발: 다음 고객 → 현재 고객으로 승격 (로컬 상태)
-      setCurrentCustomerName(customerNameRef.current);
-      setCurrentCustomerPhone(customerPhoneRef.current);
-      setCurrentCustomerAddress(addressRef.current);
-      // 다음 고객 폼 초기화
-      setCustomerName("");
-      setCustomerPhone("");
-      setAddress("");
-      setSavedCoords(null);
-      setError(null);
-    }
-    // 도착(non-null → null): 현재 고객은 그대로 유지 — 아무것도 안 함
-  }, [ignitionOnAt]);
-
-  async function handleSave(e: React.FormEvent) {
-    e.preventDefault();
-    if (!customerName.trim() || !customerPhone.trim() || !address.trim()) {
-      setError("모든 항목을 입력해주세요.");
-      return;
-    }
-    setSaving(true);
-    setError(null);
-    const result = await setNextCustomerAction(bikeId, { customerName, customerPhone, address });
-    setSaving(false);
-    if (result.ok) {
-      setSavedCoords({ lat: result.lat, lng: result.lng });
-      updatePinNextCustomer(bikeId, result.lat, result.lng, customerName, customerPhone);
-    } else {
-      setError(result.error);
-    }
-  }
-
-  return (
-    <section className="delivery-section">
-      {/* ── 현재 고객 (read-only) ── */}
-      <h4>📍 현재 고객 <span className="muted" style={{ fontSize: "0.8em" }}>(이동 중)</span></h4>
-      {currentCustomerName ? (
-        <dl className="delivery-meta">
-          <div className="delivery-meta-row">
-            <dt>고객 이름</dt>
-            <dd>{currentCustomerName}</dd>
-          </div>
-          <div className="delivery-meta-row">
-            <dt>전화번호</dt>
-            <dd>{currentCustomerPhone}</dd>
-          </div>
-          {currentCustomerAddress && (
-            <div className="delivery-meta-row">
-              <dt>주소</dt>
-              <dd>{currentCustomerAddress}</dd>
-            </div>
-          )}
-        </dl>
-      ) : (
-        <p className="muted" style={{ fontSize: "0.85em", margin: "4px 0 12px" }}>아직 이동 이력 없음</p>
-      )}
-
-      {/* ── 다음 고객 (editable) ── */}
-      <h4 style={{ marginTop: "14px" }}>🧹 다음 고객 <span className="muted" style={{ fontSize: "0.8em" }}>(CLEANING 전용)</span></h4>
-      <form onSubmit={handleSave}>
-        <dl className="delivery-meta">
-          <div className="delivery-meta-row">
-            <dt>고객 이름</dt>
-            <dd>
-              <input
-                type="text"
-                value={customerName}
-                onChange={(e) => setCustomerName(e.target.value)}
-                placeholder="홍길동"
-                className="next-customer-input"
-              />
-            </dd>
-          </div>
-          <div className="delivery-meta-row">
-            <dt>전화번호</dt>
-            <dd>
-              <input
-                type="text"
-                value={customerPhone}
-                onChange={(e) => setCustomerPhone(e.target.value)}
-                placeholder="010-1234-5678"
-                className="next-customer-input"
-              />
-            </dd>
-          </div>
-          <div className="delivery-meta-row">
-            <dt>주소</dt>
-            <dd>
-              <div className="station-address-field">
-                <input
-                  type="text"
-                  value={address}
-                  onChange={(e) => setAddress(e.target.value)}
-                  placeholder="주소 검색 버튼을 눌러 주소를 선택하세요"
-                  className="next-customer-input"
-                  readOnly
-                />
-                <AddressSearchButton onSelect={setAddress} />
-              </div>
-            </dd>
-          </div>
-          {savedCoords && (
-            <div className="delivery-meta-row">
-              <dt>좌표</dt>
-              <dd style={{ color: "#4ade80" }}>
-                ✓ {savedCoords.lat.toFixed(4)} / {savedCoords.lng.toFixed(4)}
-              </dd>
-            </div>
-          )}
-        </dl>
-        {error && <p style={{ color: "#f87171", fontSize: "0.8em", margin: "4px 0" }}>{error}</p>}
-        <button type="submit" disabled={saving} className="action-btn primary" style={{ marginTop: "6px" }}>
-          {saving ? "저장 중…" : "저장"}
-        </button>
-      </form>
-    </section>
-  );
 }
 
 // ============================================================================

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -98,8 +98,8 @@ export function FleetSimulationProvider({
   // 자동 트리거: matchedImeiSet 이 변경되면 새로 매칭된 bike 를 시뮬레이션에 추가.
   // - DELIVERY/OTHER: 항상 MOVING 으로 시작. 차량별로 0~5분 랜덤 오프셋을 줘
   //   사이클이 분산되도록 한다 (마치 이미 서로 다른 시점에 출발한 것처럼).
-  // - CLEANING: nextCustomerDestination 이 설정돼 있으면 MOVING, 없으면 WORKING(대기)
-  //   으로 시작. 주소 없이 랜덤 좌표로 이동하는 것을 방지.
+  // - CLEANING: 현재 배차(currentDispatch) 좌표가 있으면 MOVING, 없으면 IDLE(대기 중)
+  //   으로 시작. 좌표 없이 랜덤 좌표로 이동하는 것을 방지.
   useEffect(() => {
     const nowMs = Date.now();
     setSimulated((prev) => {
@@ -168,7 +168,8 @@ export function FleetSimulationProvider({
       const key = dispatchKeyOf(pin);
       if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);
     }
-    // 시뮬레이션에서 빠진 bike 의 ref 항목 정리
+    // 시뮬레이션에서 빠진 bike 의 ref 항목 정리 (알림 dedup + 출발 가드 두 Map).
+    // Map 은 .keys() 순회 중 이미 방문한 키 삭제가 안전하다.
     for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
       if (!simulated.has(bikeId)) lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
     }
@@ -203,7 +204,7 @@ export function FleetSimulationProvider({
             dKey != null && lastDepartedDispatchKeyRef.current.get(bikeId) === dKey;
           const newDest =
             pin?.serviceType === "CLEANING" && dKey != null && !alreadyDeparted
-              ? { lat: pin.currentDispatchLatitude as number, lng: pin.currentDispatchLongitude as number }
+              ? { lat: pin.currentDispatchLatitude!, lng: pin.currentDispatchLongitude! }
               : null;
           const prevDest = state.nextCustomerDestination;
           const destChanged =

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -275,7 +275,12 @@ export function FleetSimulationProvider({
 const EMPTY_SIMULATED: ReadonlyMap<string, SimulatedBikeState> = new Map();
 const NOOP_SEED = () => {};
 
-/** 현재 배차의 신원 복합키. 좌표·고객명이 모두 없으면 null(배차 없음). */
+/**
+ * 현재 배차의 신원 복합키. 좌표·고객명이 모두 없으면 null(배차 없음).
+ * 한계: pin 에 주문 id 가 없어 좌표+고객명으로 식별한다 — 동일 좌표·동일 고객에게
+ * 연속 배차되면 두 건이 같은 키가 되어 재출발 가드가 두 번째를 이미 다녀온 것으로
+ * 오인할 수 있다. 실무상 CLEANING 배차점은 좌표로 구분되므로 데모 범위에선 허용.
+ */
 function dispatchKeyOf(pin: FrontendDashboardBikePin | undefined): string | null {
   if (!pin || pin.currentDispatchLatitude == null || pin.currentDispatchLongitude == null) return null;
   return `${pin.currentDispatchLatitude},${pin.currentDispatchLongitude},${pin.currentDispatchCustomerName ?? ""}`;

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -12,7 +12,6 @@ import {
   type ServicePhase
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
-import { promoteNextToCurrentAction } from "@/app/actions";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
@@ -32,13 +31,6 @@ type FleetSimulationContextValue = {
   simulated: ReadonlyMap<string, SimulatedBikeState>;
   /** OverviewMapBanner / FullscreenMapHost 가 호출 — origin 좌표 조회용. */
   seedBikePins: (pins: ReadonlyArray<FrontendDashboardBikePin>) => void;
-  /**
-   * 운영자가 다음 고객 저장 후 즉시 호출 — pinsRef 를 갱신해 tick 루프가
-   * 새 nextCustomerDestination 을 즉시 감지하도록 한다.
-   * page revalidation 없이도 시뮬레이션이 MOVING 으로 전환되며,
-   * 알림 발송 시 고객 이름·전화번호도 함께 포함된다.
-   */
-  updatePinNextCustomer: (bikeId: string, lat: number, lng: number, name?: string, phone?: string) => void;
 };
 
 const FleetSimulationContext = createContext<FleetSimulationContextValue | null>(null);
@@ -63,8 +55,8 @@ export function FleetSimulationProvider({
   const { addNotification } = useNotifications();
   /** bikeId → last ignitionOnAt that was notified. Prevents duplicate notifications. */
   const lastNotifiedIgnitionOnAtRef = useRef<Map<string, number>>(new Map());
-  /** bikeId → last deliveryCount seen. MOVING→WORKING(도착) 감지용. */
-  const lastDeliveryCountRef = useRef<Map<string, number>>(new Map());
+  /** bikeId → 마지막으로 출발(시동 ON)한 현재 배차의 복합키. 같은 건으론 재출발하지 않도록 한다. */
+  const lastDepartedDispatchKeyRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     mountedRef.current = true;
@@ -75,20 +67,6 @@ export function FleetSimulationProvider({
 
   const seedBikePins = useCallback((pins: ReadonlyArray<FrontendDashboardBikePin>) => {
     pinsRef.current = pins;
-  }, []);
-
-  const updatePinNextCustomer = useCallback((bikeId: string, lat: number, lng: number, name?: string, phone?: string) => {
-    pinsRef.current = pinsRef.current.map((p) =>
-      p.bikeId === bikeId
-        ? {
-            ...p,
-            nextCustomerLat: lat,
-            nextCustomerLng: lng,
-            nextCustomerName: name ?? p.nextCustomerName,
-            nextCustomerPhone: phone ?? p.nextCustomerPhone,
-          }
-        : p
-    );
   }, []);
 
   // 직렬화된 배열 → Set/Map (useMemo 로 참조 안정화).
@@ -133,15 +111,15 @@ export function FleetSimulationProvider({
         const origin = pin
           ? { lat: pin.latitude, lng: pin.longitude }
           : { lat: 37.5665, lng: 126.978 }; // 서울 중심 fallback
-        const nextCustomerDestination =
+        // CLEANING: 현재 배차(dispatch) 좌표가 있으면 그곳으로 출발, 없으면 IDLE 대기.
+        const dispatchDestination =
           pin?.serviceType === "CLEANING" &&
-          pin.nextCustomerLat != null &&
-          pin.nextCustomerLng != null
-            ? { lat: pin.nextCustomerLat, lng: pin.nextCustomerLng }
+          pin.currentDispatchLatitude != null &&
+          pin.currentDispatchLongitude != null
+            ? { lat: pin.currentDispatchLatitude, lng: pin.currentDispatchLongitude }
             : null;
-        // CLEANING 차량은 목적지가 없으면 IDLE(대기 중) 으로 시작 — 랜덤 좌표 이동 방지.
         const initialPhase: "MOVING" | "IDLE" =
-          pin?.serviceType === "CLEANING" && nextCustomerDestination === null
+          pin?.serviceType === "CLEANING" && dispatchDestination === null
             ? "IDLE"
             : "MOVING";
         // MOVING 시작 시에만 오프셋으로 사이클 분산. WORKING 은 어차피 대기이므로 불필요.
@@ -158,7 +136,7 @@ export function FleetSimulationProvider({
             initialBatteryPercent:
               typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90,
             serviceType: pin?.serviceType ?? "DELIVERY",
-            nextCustomerDestination
+            nextCustomerDestination: dispatchDestination
           })
         );
         mutated = true;
@@ -167,59 +145,37 @@ export function FleetSimulationProvider({
     });
   }, [matchedImeiSet]);
 
-  // Detect WORKING→MOVING transitions (ignitionOnAt null → non-null).
-  // 클리닝 차량에 한해:
-  //   1. 알림 발송 (기존 로직 유지)
-  //   2. promote 호출 (fire-and-forget): DB에서 next→current 복사 후 next 초기화
-  //   3. pinsRef nextCustomer 필드 초기화 — tick 루프가 이전 목적지로 재트리거하지 않도록
+  // 시동 ON(WORKING→MOVING) 감지 — CLEANING 차량에 한해:
+  //   1. 알림 발송 (현재 배차 고객명 + 주소)
+  //   2. lastDepartedDispatchKeyRef 에 이번 출발한 현재 배차 키 기록 → tick 루프가
+  //      같은 건으로 재출발(재트리거)하지 않도록 함. 운영자 "완료" → 다음 건이
+  //      현재 배차가 되면 키가 바뀌어 다시 출발한다.
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
+      if (state.serviceType !== "CLEANING") continue;
       if (state.ignitionOnAt == null) continue;
       const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
       if (last === state.ignitionOnAt) continue;
-      if (state.serviceType !== "CLEANING") continue;
       lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
       const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
       const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
-      // 1. 알림
       addNotification({
         plateNumber,
         startedAt: state.ignitionOnAt,
-        customerName: pin?.nextCustomerName ?? undefined,
-        customerPhone: pin?.nextCustomerPhone ?? undefined
+        customerName: pin?.currentDispatchCustomerName ?? undefined,
+        address: pin?.currentDispatchAddress ?? undefined
       });
-      // 2. DB promote (fire-and-forget)
-      promoteNextToCurrentAction(bikeId).catch(() => undefined);
-      // 3. pinsRef nextCustomer 초기화 — 다음 입력 전까지 새 이동 트리거 방지
-      pinsRef.current = pinsRef.current.map((p) =>
-        p.bikeId === bikeId
-          ? { ...p, nextCustomerLat: null, nextCustomerLng: null,
-                nextCustomerName: null, nextCustomerPhone: null }
-          : p
-      );
+      const key = dispatchKeyOf(pin);
+      if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);
     }
-    // Clean up ref entries for bikes that left simulation
+    // 시뮬레이션에서 빠진 bike 의 ref 항목 정리
     for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
-      if (!simulated.has(bikeId)) {
-        lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
-      }
+      if (!simulated.has(bikeId)) lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
+    }
+    for (const bikeId of lastDepartedDispatchKeyRef.current.keys()) {
+      if (!simulated.has(bikeId)) lastDepartedDispatchKeyRef.current.delete(bikeId);
     }
   }, [simulated, addNotification]);
-
-  // Detect MOVING→WORKING transitions (deliveryCount 증가) → ref 정리만.
-  // 고객 정보는 도착 시 초기화하지 않음 — 현재 고객은 다음 출발 전까지 유지.
-  // pinsRef nextCustomer 정리는 이제 ignitionOnAt 이펙트(출발 시)에서 수행.
-  useEffect(() => {
-    for (const [bikeId, state] of simulated) {
-      if (state.serviceType !== "CLEANING") continue;
-      const last = lastDeliveryCountRef.current.get(bikeId) ?? 0;
-      if (state.deliveryCount <= last) continue;
-      lastDeliveryCountRef.current.set(bikeId, state.deliveryCount);
-    }
-    for (const bikeId of lastDeliveryCountRef.current.keys()) {
-      if (!simulated.has(bikeId)) lastDeliveryCountRef.current.delete(bikeId);
-    }
-  }, [simulated]);
 
   // 250ms tick loop — mount 시 한 번만 interval 을 생성. simulated.size 를
   // dep 으로 두면 size 변화 시점에 효과가 재실행되면서 stale closure 가 발생해
@@ -240,11 +196,14 @@ export function FleetSimulationProvider({
           // 순서가 중요: CLEANING 차량이 대기 중(phaseEndsAt=Infinity)일 때 목적지가 새로
           // 설정되면 advance 함수가 그 값을 보고 즉시 MOVING 으로 전환해야 하기 때문.
           const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+          // 현재 배차 키가 이번 차량이 마지막으로 출발한 키와 같으면(이미 다녀옴)
+          // 목적지를 주지 않아 도착 후 같은 건으로 재출발하지 않게 한다.
+          const dKey = dispatchKeyOf(pin);
+          const alreadyDeparted =
+            dKey != null && lastDepartedDispatchKeyRef.current.get(bikeId) === dKey;
           const newDest =
-            pin?.serviceType === "CLEANING" &&
-            pin.nextCustomerLat != null &&
-            pin.nextCustomerLng != null
-              ? { lat: pin.nextCustomerLat, lng: pin.nextCustomerLng }
+            pin?.serviceType === "CLEANING" && dKey != null && !alreadyDeparted
+              ? { lat: pin.currentDispatchLatitude as number, lng: pin.currentDispatchLongitude as number }
               : null;
           const prevDest = state.nextCustomerDestination;
           const destChanged =
@@ -304,8 +263,8 @@ export function FleetSimulationProvider({
   }, [simulated]);
 
   const value = useMemo<FleetSimulationContextValue>(
-    () => ({ simulated, seedBikePins, updatePinNextCustomer }),
-    [simulated, seedBikePins, updatePinNextCustomer]
+    () => ({ simulated, seedBikePins }),
+    [simulated, seedBikePins]
   );
 
   return <FleetSimulationContext.Provider value={value}>{children}</FleetSimulationContext.Provider>;
@@ -314,7 +273,12 @@ export function FleetSimulationProvider({
 // 모듈 스코프 상수 — fallback 에서 호출마다 새 참조를 만들지 않도록.
 const EMPTY_SIMULATED: ReadonlyMap<string, SimulatedBikeState> = new Map();
 const NOOP_SEED = () => {};
-const NOOP_UPDATE = () => {};
+
+/** 현재 배차의 신원 복합키. 좌표·고객명이 모두 없으면 null(배차 없음). */
+function dispatchKeyOf(pin: FrontendDashboardBikePin | undefined): string | null {
+  if (!pin || pin.currentDispatchLatitude == null || pin.currentDispatchLongitude == null) return null;
+  return `${pin.currentDispatchLatitude},${pin.currentDispatchLongitude},${pin.currentDispatchCustomerName ?? ""}`;
+}
 
 /**
  * Provider 없는 환경에서도 안전하게 호출되도록 noop fallback 반환.
@@ -322,7 +286,7 @@ const NOOP_UPDATE = () => {};
 export function useFleetSimulation(): FleetSimulationContextValue {
   const ctx = useContext(FleetSimulationContext);
   if (!ctx) {
-    return { simulated: EMPTY_SIMULATED, seedBikePins: NOOP_SEED, updatePinNextCustomer: NOOP_UPDATE };
+    return { simulated: EMPTY_SIMULATED, seedBikePins: NOOP_SEED };
   }
   return ctx;
 }

--- a/docs/superpowers/plans/2026-06-12-group-c-cleaning-dispatch.md
+++ b/docs/superpowers/plans/2026-06-12-group-c-cleaning-dispatch.md
@@ -1,0 +1,404 @@
+# Group C3 — 클리닝 배차 통합 (시동 알림 → dispatch 큐) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** CLEANING 차량의 시뮬레이션 이동·시동(출발) 알림 소스를 옛 `BikeNextCustomer`(promote)에서 C0/C2의 DispatchOrder 큐 '현재 배차'로 완전 이전한다 (프론트엔드 전용, 백엔드 무변경).
+
+**Architecture:** 대시보드 BikePin은 이미 `currentDispatchCustomerName/Address/Latitude/Longitude` + `dispatchQueueCount`를 싣고 있고 `completeDispatchOrderAction`이 `/`를 revalidate한다. `FleetSimulationContext`가 CLEANING 차량의 목적지를 `nextCustomer*` 대신 `currentDispatch*`에서 읽고, 이미 출발한 현재 배차는 복합키 가드로 재출발을 막는다. 운영자가 "완료" 클릭 → 큐 진행 → 새 현재 배차 → 새 키 → 재출발. 옛 next-customer UI/promote 경로는 CLEANING에서 제거한다.
+
+**Tech Stack:** Next.js App Router, React Context, TypeScript. (백엔드/DB 변경 없음.)
+
+**검증 방식 (이 코드베이스 관례):** 이 사이클의 파일들(시뮬레이션 Context, 다이얼로그, 지도 마커, 알림)은 단위 테스트가 없고 — 기존 동일 작업(시동 알림/next-customer 사이클, 완료 task #51–79)과 마찬가지로 `npm run typecheck && npm run lint`(태스크별) + 최종 `npm run build` + 프로덕션 QA로 검증한다. 핵심 로직(이동 목적지 소스·재출발 가드)은 React 훅 안에 있어 RTL 없이 단위 테스트가 어렵다(프로젝트에 RTL 미설정). 따라서 TDD 대신 타입체크/빌드/QA로 검증한다.
+
+**작업 디렉터리:** 모든 명령은 `cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web` 기준 (PowerShell이 아닌 Bash 툴 사용, cwd가 호출마다 리셋되므로 절대경로 cd를 매 명령에 포함).
+
+**브랜치:** 시작 전 `dev`에서 feature 브랜치 생성:
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git checkout dev && git pull && git checkout -b cc-c3-cleaning-dispatch
+```
+
+---
+
+## 파일 구조 (변경 대상)
+
+| 파일 | 책임 | 변경 |
+|---|---|---|
+| `components/layout/NotificationContext.tsx` | 알림 상태 | `IgnitionNotification`에 `address?` 추가 |
+| `components/layout/NotificationBell.tsx` | 알림 드롭다운 | 표시를 "출발 → 고객명(주소)"로 |
+| `components/management/VehicleDetailDialog.tsx` | 차량 상세 | 옛 `NextCustomerSection` + 미사용 import 제거 |
+| `components/overview/FleetSimulationContext.tsx` | 시뮬레이션 구동 | 목적지 소스 currentDispatch로, 재출발 가드, 알림 재작성, promote/updatePinNextCustomer 제거 |
+| `components/dashboard/MapShell.tsx` | 지도 마커 | 시동 말풍선 텍스트에 현재 배차 고객명 (선택 폴리시) |
+
+`lib/services/fleet-simulation.ts`는 **변경 없음** — `nextCustomerDestination` 필드를 "CLEANING 목적지"로 그대로 재사용하며 소스만 Context에서 교체된다.
+
+---
+
+### Task 1: NotificationContext + NotificationBell — 주소 필드 + 출발 문구
+
+**Files:**
+- Modify: `components/layout/NotificationContext.tsx:11-18`
+- Modify: `components/layout/NotificationBell.tsx:56-72`
+
+- [ ] **Step 1: `IgnitionNotification` 타입에 `address` 추가**
+
+`NotificationContext.tsx` 11-18행을 다음으로 교체:
+```ts
+export type IgnitionNotification = {
+  id: string;
+  plateNumber: string;
+  startedAt: number;
+  /** CLEANING 차량 출발 시 현재 배차(dispatch) 고객명. 없으면 "출발"만 표시. */
+  customerName?: string;
+  /** CLEANING 차량 출발 시 현재 배차 주소. 벨 항목에 괄호로 표기. */
+  address?: string;
+  /** @deprecated C3 이후 미사용 — 과거 next-customer 알림 호환용. */
+  customerPhone?: string;
+};
+```
+
+- [ ] **Step 2: 벨 드롭다운 표시를 dispatch 출발 문구로 교체**
+
+`NotificationBell.tsx` 56-72행(`[...notifications].reverse().map(...)` 블록)을 다음으로 교체:
+```tsx
+            [...notifications].reverse().map((n) => (
+              <div key={n.id} className="notif-item" role="listitem">
+                <span className="notif-item-text">
+                  🔑 {n.plateNumber} 출발
+                  {n.customerName ? ` → ${n.customerName}` : ""}
+                  {n.address ? ` (${n.address})` : ""}
+                </span>
+                <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
+              </div>
+            ))
+```
+
+- [ ] **Step 3: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과 (에러 0). `customerPhone` 미사용 경고 없음(타입 필드 잔존은 무해).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/layout/NotificationContext.tsx development/front-admin-web/components/layout/NotificationBell.tsx && git commit -m "feat(c3): notification carries dispatch address, '출발' wording"
+```
+
+---
+
+### Task 2: VehicleDetailDialog — 옛 NextCustomerSection 제거
+
+`DispatchQueueSection`(배차 큐, C0/C2)가 이미 현재/대기 + 완료/취소를 제공하므로 CLEANING의 옛 "다음 고객" 섹션은 중복. 제거하고 이 섹션만 쓰던 import도 정리한다.
+
+**Files:**
+- Modify: `components/management/VehicleDetailDialog.tsx` (import 5,13,16행 · 렌더 212-214행 · 함수 905-1079행)
+
+- [ ] **Step 1: `NextCustomerSection` 렌더 제거**
+
+212-214행:
+```tsx
+          {vehicle.serviceType === "CLEANING" && vehicleIdForFetch && (
+            <NextCustomerSection bikeId={vehicleIdForFetch} />
+          )}
+```
+→ 이 3줄을 **삭제**. (바로 아래 `{vehicleIdForFetch && <DispatchQueueSection bikeId={vehicleIdForFetch} />}`는 유지.)
+
+- [ ] **Step 2: `NextCustomerSection` 함수 정의 제거**
+
+905-1079행 전체 — 주석 헤더 `// === 현재 고객 / 다음 고객 섹션 (CLEANING 전용) ===`(901-903행)부터 `NextCustomerSection` 함수 닫는 `}`(1079행)까지 **삭제**. (1081행부터의 `// === 배차 큐 섹션 ===`와 `DispatchQueueSection`은 유지.)
+
+- [ ] **Step 3: 미사용 import 제거**
+
+5행 삭제:
+```tsx
+import { AddressSearchButton } from "@/components/management/AddressSearchButton";
+```
+13·16행 — `@/app/actions` import에서 `getNextCustomerAction`, `setNextCustomerAction` 제거. 결과:
+```tsx
+import {
+  markVehicleMaintenanceServicedAction,
+  setRiderInsuranceFromVehicleAction,
+  updateVehicleFromOverviewAction
+} from "@/app/actions";
+```
+(155행 `const { simulated } = useFleetSimulation();`는 그대로 — `simState`에 쓰임. `updatePinNextCustomer`는 destructure하지 않으므로 이 파일에서 더는 참조 없음.)
+
+- [ ] **Step 4: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과. `AddressSearchButton`/`getNextCustomerAction`/`setNextCustomerAction`/`useState`·`useRef` 미사용 경고가 없어야 함 — 남은 import가 다른 곳(편집 폼 등)에서 쓰이는지 린트가 확인. 만약 `useEffect` 등 hook import가 `NextCustomerSection`에서만 쓰였다면 린트가 잡으므로 해당 미사용 import도 함께 제거.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/VehicleDetailDialog.tsx && git commit -m "feat(c3): drop legacy next-customer section from vehicle detail (dispatch queue replaces it)"
+```
+
+---
+
+### Task 3: FleetSimulationContext — currentDispatch 소스 + 재출발 가드 + 알림 재작성
+
+핵심 태스크. CLEANING 목적지를 `pin.currentDispatch*`에서 읽고, 이미 출발한 현재 배차는 복합키로 가드해 재출발을 막으며, 알림은 현재 배차 고객명+주소를 쓴다. `promoteNextToCurrentAction`·`updatePinNextCustomer`를 제거한다.
+
+**Files:**
+- Modify: `components/overview/FleetSimulationContext.tsx`
+
+- [ ] **Step 1: import + 가드 ref + 헬퍼 추가**
+
+15행 `import { promoteNextToCurrentAction } from "@/app/actions";` **삭제**.
+
+`lastNotifiedIgnitionOnAtRef` 선언(64-65행) 아래, `lastDeliveryCountRef`(66-67행)를 **제거**하고 대신 다음 ref를 추가:
+```ts
+  /** bikeId → 마지막으로 출발(시동 ON)한 현재 배차의 복합키. 같은 건으론 재출발하지 않도록 한다. */
+  const lastDepartedDispatchKeyRef = useRef<Map<string, string>>(new Map());
+```
+
+파일 하단 모듈 스코프(예: `const EMPTY_SIMULATED` 근처, 314행 부근)에 헬퍼 추가:
+```ts
+/** 현재 배차의 신원 복합키. 좌표·고객명이 모두 없으면 null(배차 없음). */
+function dispatchKeyOf(pin: FrontendDashboardBikePin | undefined): string | null {
+  if (!pin || pin.currentDispatchLatitude == null || pin.currentDispatchLongitude == null) return null;
+  return `${pin.currentDispatchLatitude},${pin.currentDispatchLongitude},${pin.currentDispatchCustomerName ?? ""}`;
+}
+```
+
+- [ ] **Step 2: 자동 트리거 effect — 초기 목적지를 currentDispatch에서**
+
+125-168행 `useEffect`(matchedImeiSet 진입 시 시뮬 추가) 안에서, 136-146행의 `nextCustomerDestination`/`initialPhase` 계산을 다음으로 교체:
+```ts
+        // CLEANING: 현재 배차(dispatch) 좌표가 있으면 그곳으로 출발, 없으면 IDLE 대기.
+        const dispatchDestination =
+          pin?.serviceType === "CLEANING" &&
+          pin.currentDispatchLatitude != null &&
+          pin.currentDispatchLongitude != null
+            ? { lat: pin.currentDispatchLatitude, lng: pin.currentDispatchLongitude }
+            : null;
+        const initialPhase: "MOVING" | "IDLE" =
+          pin?.serviceType === "CLEANING" && dispatchDestination === null
+            ? "IDLE"
+            : "MOVING";
+```
+그리고 161행 `nextCustomerDestination` 인자를 교체:
+```ts
+            nextCustomerDestination: dispatchDestination
+```
+(149-150행 `maxOffsetMs`/`offsetMs`는 그대로 — CLEANING 분기 유지.)
+
+- [ ] **Step 3: 출발 감지 effect — 알림(현재 배차 고객+주소) + 가드 기록**
+
+175-207행 `useEffect`(WORKING→MOVING 감지) 전체를 다음으로 교체:
+```ts
+  // 시동 ON(WORKING→MOVING) 감지 — CLEANING 차량에 한해:
+  //   1. 알림 발송 (현재 배차 고객명 + 주소)
+  //   2. lastDepartedDispatchKeyRef 에 이번 출발한 현재 배차 키 기록 → tick 루프가
+  //      같은 건으로 재출발(재트리거)하지 않도록 함. 운영자 "완료" → 다음 건이
+  //      현재 배차가 되면 키가 바뀌어 다시 출발한다.
+  useEffect(() => {
+    for (const [bikeId, state] of simulated) {
+      if (state.serviceType !== "CLEANING") continue;
+      if (state.ignitionOnAt == null) continue;
+      const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
+      if (last === state.ignitionOnAt) continue;
+      lastNotifiedIgnitionOnAtRef.current.set(bikeId, state.ignitionOnAt);
+      const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+      const plateNumber = pin?.plateNumber ?? bikeId.slice(0, 8);
+      addNotification({
+        plateNumber,
+        startedAt: state.ignitionOnAt,
+        customerName: pin?.currentDispatchCustomerName ?? undefined,
+        address: pin?.currentDispatchAddress ?? undefined
+      });
+      const key = dispatchKeyOf(pin);
+      if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);
+    }
+    // 시뮬레이션에서 빠진 bike 의 ref 항목 정리
+    for (const bikeId of lastNotifiedIgnitionOnAtRef.current.keys()) {
+      if (!simulated.has(bikeId)) lastNotifiedIgnitionOnAtRef.current.delete(bikeId);
+    }
+    for (const bikeId of lastDepartedDispatchKeyRef.current.keys()) {
+      if (!simulated.has(bikeId)) lastDepartedDispatchKeyRef.current.delete(bikeId);
+    }
+  }, [simulated, addNotification]);
+```
+
+- [ ] **Step 4: MOVING→WORKING effect(212-222행) 제거**
+
+이 effect는 `lastDeliveryCountRef`만 갱신하던 dead 코드(가드가 재출발을 대신 처리). 209-222행(주석 포함 `// Detect MOVING→WORKING transitions ...`부터 닫는 `}, [simulated]);`까지)을 **삭제**.
+
+- [ ] **Step 5: tick 루프 — newDest를 currentDispatch + 가드로**
+
+228-274행 tick 루프 안, 242-254행의 `pin`/`newDest`/`prevDest`/`destChanged`/`stateForAdvance` 계산 블록에서 `newDest` 산출(243-248행)을 다음으로 교체:
+```ts
+          const pin = pinsRef.current.find((p) => p.bikeId === bikeId);
+          // 현재 배차 키가 이번 차량이 마지막으로 출발한 키와 같으면(이미 다녀옴)
+          // 목적지를 주지 않아 도착 후 같은 건으로 재출발하지 않게 한다.
+          const dKey = dispatchKeyOf(pin);
+          const alreadyDeparted =
+            dKey != null && lastDepartedDispatchKeyRef.current.get(bikeId) === dKey;
+          const newDest =
+            pin?.serviceType === "CLEANING" && dKey != null && !alreadyDeparted
+              ? { lat: pin.currentDispatchLatitude as number, lng: pin.currentDispatchLongitude as number }
+              : null;
+```
+(249-254행 `prevDest`/`destChanged`/`stateForAdvance`는 그대로 유지 — `newDest`만 소스가 바뀜.)
+
+- [ ] **Step 6: `updatePinNextCustomer` 제거 (타입·정의·value·fallback)**
+
+- 41행 `FleetSimulationContextValue`의 `updatePinNextCustomer: (...) => void;` 멤버 + 그 위 35-40행 JSDoc 삭제.
+- 80-92행 `const updatePinNextCustomer = useCallback(...)` 정의 삭제.
+- 306-309행 `useMemo` value에서 `updatePinNextCustomer` 제거:
+```ts
+  const value = useMemo<FleetSimulationContextValue>(
+    () => ({ simulated, seedBikePins }),
+    [simulated, seedBikePins]
+  );
+```
+- 316-317행 `const NOOP_UPDATE = () => {};` 삭제, 322-328행 fallback에서 `updatePinNextCustomer: NOOP_UPDATE` 제거:
+```ts
+  if (!ctx) {
+    return { simulated: EMPTY_SIMULATED, seedBikePins: NOOP_SEED };
+  }
+```
+
+- [ ] **Step 7: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과. `promoteNextToCurrentAction` 미사용 import 없음, `updatePinNextCustomer` 잔존 참조 없음(Task 2에서 마지막 consumer 제거됨).
+
+- [ ] **Step 8: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/overview/FleetSimulationContext.tsx && git commit -m "feat(c3): drive CLEANING simulation from dispatch queue, re-depart guard, dispatch-customer notification"
+```
+
+---
+
+### Task 4: MapShell — 시동 말풍선에 현재 배차 고객명 (선택 폴리시)
+
+말풍선 텍스트 "🔑 이동 시작" → "🔑 {고객명} 출발". 고객명은 운영자 엑셀 자유 텍스트라 HTML 이스케이프한다.
+
+**Files:**
+- Modify: `components/dashboard/MapShell.tsx` (779-781행 · 865-880행 · 호출부 468행)
+
+- [ ] **Step 1: `ignitionBubbleMarkup`에 고객명 인자 + 이스케이프**
+
+779-781행을 다음으로 교체:
+```ts
+function escapeMarkerText(value: string): string {
+  return value.replace(/[<>&"]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === "&" ? "&amp;" : "&quot;"
+  );
+}
+
+function ignitionBubbleMarkup(customerName?: string | null): string {
+  const who = customerName ? `${escapeMarkerText(customerName)} ` : "";
+  return `<div class="map-ignition-bubble">🔑 ${who}출발</div>`;
+}
+```
+
+- [ ] **Step 2: `bikeMarkerHtml` 시그니처에 고객명 추가 + 전달**
+
+865-872행 시그니처 마지막에 인자 추가:
+```ts
+function bikeMarkerHtml(
+  plateNumber: string,
+  showLabel: boolean,
+  servicePhase?: ServicePhase | null,
+  deliveryCount?: number,
+  ignitionOnAt?: number | null,
+  serviceType?: ServiceType,
+  selected?: boolean,
+  currentDispatchCustomerName?: string | null
+): string {
+```
+879행 `const bubble = showBubble ? ignitionBubbleMarkup() : "";`를 교체:
+```ts
+  const bubble = showBubble ? ignitionBubbleMarkup(currentDispatchCustomerName) : "";
+```
+
+- [ ] **Step 3: 호출부에 고객명 전달**
+
+468행:
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected);
+```
+→ 마지막 인자 추가 (`pin`은 `FrontendDashboardBikePin` 확장형이라 `currentDispatchCustomerName` 보유):
+```ts
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected, pin.currentDispatchCustomerName);
+```
+
+- [ ] **Step 4: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/dashboard/MapShell.tsx && git commit -m "feat(c3): show dispatch customer name in ignition bubble"
+```
+
+---
+
+### Task 5: 최종 빌드 검증 + PR
+
+**Files:** 없음 (검증/PR만)
+
+- [ ] **Step 1: 풀 빌드**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 세 단계 모두 통과, Next.js 프로덕션 빌드 성공.
+
+- [ ] **Step 2: 변경 요약 확인**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git diff dev --stat
+```
+Expected: 5개 파일 변경 (NotificationContext, NotificationBell, VehicleDetailDialog, FleetSimulationContext, MapShell), 백엔드/마이그레이션 변경 0.
+
+- [ ] **Step 3: 푸시 + PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git push -u origin cc-c3-cleaning-dispatch && gh pr create --base dev --title "Group C3: CLEANING 배차 통합 (시동 알림 → dispatch 큐)" --body "$(cat <<'EOF'
+## Summary
+- CLEANING 차량 시뮬레이션 이동·시동 알림 소스를 옛 next-customer에서 C0/C2 dispatch 큐의 현재 배차로 완전 이전 (프론트 전용, 백엔드 무변경)
+- 차량 상세에서 옛 "다음 고객" 섹션 제거 — "배차 큐" 섹션으로 통합
+- 출발 시 벨/지도 말풍선에 현재 배차 고객명(+주소) 표시
+- 재출발 가드(복합키)로 도착 후 같은 건 재출발 방지, 운영자 "완료" 시 다음 건으로 재출발
+
+## Test Plan
+- [ ] typecheck + lint + build 통과
+- [ ] 프로덕션 QA: CLEANING 차량 배차 엑셀(C2) 업로드 → 라이더 매칭 → 출발 시 벨/말풍선에 현재 배차 고객명+주소 → 차량 상세 배차 큐 "완료" → 다음 건으로 재출발
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- 목적지 소스 currentDispatch → Task 3 (Step 2,5). ✓
+- 시동 알림 현재 배차 고객+주소 → Task 1 + Task 3 (Step 3). ✓
+- 도착 후 운영자 완료 → 큐 진행 → 재출발 → Task 3 가드(Step 1,3,5) + 기존 `completeDispatchOrderAction` revalidate. ✓
+- 옛 "다음 고객" 섹션 제거 → Task 2. ✓
+- `promoteNextToCurrentAction` 호출 제거 → Task 3 (Step 1,3). ✓
+- 말풍선 다듬기 → Task 4. ✓
+- 백엔드/DB 무변경 → 전 태스크 프론트만. ✓
+
+**2. Placeholder scan:** 모든 코드 블록 구체적, TBD/TODO 없음. 빈 단계 없음.
+
+**3. Type consistency:** `dispatchKeyOf(pin)` 헬퍼는 Task 3 Step 1에서 정의되어 Step 3·5에서 사용 — 일관. `lastDepartedDispatchKeyRef`는 Step 1 정의 → Step 3·5 사용. `FleetSimulationContextValue`에서 `updatePinNextCustomer` 제거(Step 6)는 Task 2가 마지막 consumer를 제거한 뒤라 안전. `IgnitionNotification.address`(Task 1) ↔ `addNotification({ address })`(Task 3 Step 3) ↔ 벨 표시(Task 1 Step 2) 일치. `currentDispatchCustomerName`/`currentDispatchAddress`/`currentDispatchLatitude`/`currentDispatchLongitude`는 `FrontendDashboardBikePin`의 기존 필드명과 일치(service-ops-api.ts 792-796행 확인).
+
+**주의(구현자에게):** Task 2와 Task 3 사이 중간 커밋에서는 CLEANING 차량이 일시적으로 움직이지 않는다(옛 next-customer 제거됨, currentDispatch 배선 전). 각 커밋은 컴파일/실행되지만 기능 완성은 Task 3 이후다 — feature 브랜치 전체를 PR하므로 문제 없음. Task 2를 Task 3보다 먼저 해야 `updatePinNextCustomer` 제거가 안전하다(순서 고정).

--- a/docs/superpowers/specs/2026-06-12-group-c-cleaning-dispatch-design.md
+++ b/docs/superpowers/specs/2026-06-12-group-c-cleaning-dispatch-design.md
@@ -1,0 +1,132 @@
+# Group C3 — 클리닝 배차 통합 (시동 알림 → dispatch 큐) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** CLEANING 차량의 시뮬레이션 이동·시동(출발) 알림 소스를 옛 `BikeNextCustomer`(현재/다음 고객 + promote)에서 **C0/C2의 DispatchOrder 큐 '현재 배차'**로 완전 이전한다. 백엔드 변경 없이 프론트엔드 배선만 교체한다.
+
+**Architecture:** C0/C2가 이미 대시보드 BikePin에 `currentDispatchCustomerName/Address/Latitude/Longitude` + `dispatchQueueCount`를 실어 보내고, `completeDispatchOrderAction(id)`가 `/`·`/management`를 revalidate한다. C3는 기존 fleet-simulation + ignition-alarm(벨/말풍선) 인프라가 읽는 목적지·알림 소스를 next-customer에서 currentDispatch로 바꾸고, "완료" 클릭으로 큐가 진행되면 차량이 다음 현재 배차로 재출발하도록 연결한다.
+
+**Tech Stack:** Next.js App Router, React Context, TypeScript. (백엔드/DB 변경 없음.)
+
+---
+
+## 1. 범위
+
+### 이번 스펙 (C3)
+- CLEANING 차량 시뮬레이션 목적지 소스: `nextCustomer*` → `currentDispatch*`.
+- 시동(WORKING→MOVING) 알림: 현재 배차 고객명 + 주소를 벨/말풍선에 표시.
+- 도착 후 운영자 "완료" 클릭 → 큐 진행 → 차량이 다음 현재 배차로 재출발(중복 출발 방지 가드).
+- 차량 상세에서 CLEANING의 옛 "다음 고객" 섹션 제거(C0/C2 "배차 큐" 섹션과 중복 제거).
+- 옛 `promoteNextToCurrentAction` 호출 제거(프론트에서 next-customer 경로 단절).
+
+### 범위 외 (후속/별도)
+- 실제 텔레메트리 시동 이벤트 기반 알림 (`TelemetryIgnitionStatus`)
+- 고객 SMS/푸시 등 외부 메시징
+- 배차형(DELIVERY)/배민(C1)/유모차(C4) 알림
+- 백엔드 DB·엔티티 변경, 옛 `BikeNextCustomer` 백엔드 삭제(휴면으로 남김)
+
+---
+
+## 2. 핵심 동작 결정 (확정)
+
+| 항목 | 결정 |
+|---|---|
+| 알림 성격 | **새 dispatch 큐와 통합** (시뮬레이션 기반, 운영자 콘솔 내부 벨/말풍선) |
+| next-customer | **완전 이전** — CLEANING은 dispatch 큐로만 구동, 옛 promote 경로는 CLEANING에서 단절 |
+| 도착 후 진행 | **운영자 "완료" 클릭** → 다음 건이 현재 배차로 승격 → 차량 재출발 (C0 결정과 일관) |
+| 데이터 소스 | **프론트엔드 전용 (Approach A)** — 백엔드 무변경. currentDispatch 좌표/고객명/주소는 이미 BikePin에 존재 |
+| 현재 배차 신원 | 복합키 `"lat,lng,customerName"` (주문 id를 pin에 추가하지 않음) |
+| 알림 표시 정보 | 고객명 + 주소 (전화번호는 BikePin에 없어 미사용 — 클리닝엔 주소가 유용) |
+
+---
+
+## 3. 변경 파일 (모두 front-admin-web)
+
+### 3.1 `components/overview/FleetSimulationContext.tsx` (핵심)
+
+**목적지 소스 교체 (자동 트리거 effect + tick loop):**
+CLEANING 차량의 목적지 계산을 `pin.nextCustomerLat/Lng` → **`pin.currentDispatchLatitude/Longitude`**로 변경.
+```ts
+const dispatchDestination =
+  pin?.serviceType === "CLEANING" &&
+  pin.currentDispatchLatitude != null &&
+  pin.currentDispatchLongitude != null
+    ? { lat: pin.currentDispatchLatitude, lng: pin.currentDispatchLongitude }
+    : null;
+```
+이 값을 `makeInitialState({ ..., nextCustomerDestination: dispatchDestination })` 및 tick loop의 `newDest`로 전달(기존 destination 동기화 로직 재사용).
+
+**출발(시동 ON) effect 재작성:**
+- 알림: `currentDispatchCustomerName` + `currentDispatchAddress` 사용.
+  ```ts
+  addNotification({
+    plateNumber,
+    startedAt: state.ignitionOnAt,
+    customerName: pin?.currentDispatchCustomerName ?? undefined,
+    address: pin?.currentDispatchAddress ?? undefined,
+  });
+  ```
+- **`promoteNextToCurrentAction(bikeId)` 호출 제거.**
+- **pinsRef의 nextCustomer 초기화 블록 제거** (DB 상태를 못 지우므로 대신 가드 사용).
+
+**신규 중복 출발 방지 가드:**
+```ts
+// bikeId → 마지막으로 출발한 현재 배차의 복합키. 같은 건으론 재출발하지 않음.
+const lastDepartedDispatchKeyRef = useRef<Map<string, string>>(new Map());
+
+function dispatchKey(pin): string | null {
+  if (pin?.currentDispatchLatitude == null || pin?.currentDispatchLongitude == null) return null;
+  return `${pin.currentDispatchLatitude},${pin.currentDispatchLongitude},${pin.currentDispatchCustomerName ?? ""}`;
+}
+```
+시동 ON 감지 시 현재 배차 키가 `lastDepartedDispatchKeyRef`와 다를 때만 알림+출발로 간주하고 키를 갱신. 운영자 완료 → 큐 진행 → currentDispatch 좌표/고객이 다음 건으로 바뀜 → 키 변경 → 재출발. 시뮬레이션에서 사라진 bike의 ref 항목은 정리.
+
+**`updatePinNextCustomer`:** CLEANING의 next-customer 즉시 갱신용이었으나 더 이상 next-customer를 쓰지 않으므로 제거하거나 no-op로 유지. (제거 시 호출처 정리 필요 — 3.3 참조.)
+
+### 3.2 `lib/services/fleet-simulation.ts`
+
+내부 `nextCustomerDestination` 필드는 CLEANING 이동 목적지로 그대로 재사용한다(소스만 currentDispatch로 교체되므로 필드 의미는 "현재 배차지"로 일반화됨). 명확성을 위해 `dispatchDestination`로 리네임하는 것은 선택 — 리네임 시 `makeInitialState`/`advanceBikeState`/`SimulatedBikeState`의 모든 참조를 함께 변경. **기본 방침: 리네임하지 않고 재사용**(churn 최소화), 주석으로 "currentDispatch 좌표가 들어온다"를 명시. 도착→대기(IDLE, phaseEndsAt=Infinity) 로직은 변경 없음.
+
+### 3.3 `components/management/VehicleDetailDialog.tsx`
+
+- CLEANING 차량의 **옛 "다음 고객"(NextCustomerSection) UI 제거** — C0/C2에서 추가한 "배차 큐"(DispatchQueueSection) 섹션이 현재/대기 + 완료/취소를 이미 제공하므로 중복.
+- DispatchQueueSection의 "완료" 버튼은 `completeDispatchOrderAction(id)` → `revalidatePath("/")`로 pin이 갱신되어 시뮬레이션이 다음 현재 배차로 재출발. (즉시성 보강용 client-side pin 갱신 헬퍼 추가 여부는 plan 단계에서 결정 — 기본은 revalidate 의존.)
+- `getNextCustomerAction`/`setNextCustomerAction`/`promoteNextToCurrentAction`이 이 다이얼로그 외 사용처가 없으면 import/호출 제거.
+
+### 3.4 `components/layout/NotificationContext.tsx` + `NotificationBell.tsx`
+
+- `IgnitionNotification`에 선택적 `address?: string` 추가.
+- 벨 항목 텍스트: `"🔑 {plateNumber} 출발"` + 고객명 있으면 `" → {customerName}"`, 주소 있으면 `" ({address})"`.
+- 기존 `customerPhone` 필드는 유지하되 C3에서는 set하지 않음(undefined).
+
+### 3.5 `components/dashboard/MapShell.tsx` (선택, 다듬기)
+
+지도 말풍선 텍스트 `"🔑 이동 시작"` → 현재 배차 고객이 있으면 `"🔑 {고객명} 출발"`. bikePin에 이미 `currentDispatchCustomerName`이 있으므로 `bikeMarkerHtml` 시그니처에 해당 값을 넘겨 말풍선에 반영. 데이터 없으면 기존 문구 유지.
+
+---
+
+## 4. 데이터 흐름
+
+```
+[엑셀(C2)] CLEANING 차량들에 DispatchOrder 큐 적재(ASSIGNED, sequence)
+[대시보드] map-state → BikePin.currentDispatch*(첫 ASSIGNED) + dispatchQueueCount
+[시뮬레이션] CLEANING + 매칭 + currentDispatch 좌표 있음 → MOVING(현재 배차지로)
+   시동 ON(WORKING→MOVING) & 현재 배차 키 변경 → 벨/말풍선(고객명+주소)
+[차량] 현재 배차지 도착 → IDLE(대기), 같은 건으론 재출발 안 함
+[운영자] 차량 상세 "배차 큐" → 완료 클릭 → completeDispatchOrderAction
+   → 해당 건 COMPLETED, 다음 ASSIGNED가 현재 배차로 → revalidate("/")
+[시뮬레이션] 새 currentDispatch 키 감지 → 다음 배차지로 재출발 (반복)
+큐 소진(currentDispatch 없음) → 대기 유지
+```
+
+## 5. 배포 영향
+- **DB 변경 없음, 백엔드 변경 없음.** 프론트엔드 전용 → 프론트 빌드/타입체크/lint만.
+- 옛 `BikeNextCustomer` 백엔드는 휴면(엔드포인트 잔존, 프론트 미사용).
+
+## 6. 테스트/검증
+- 신규 백엔드 계약 테스트 없음(무변경).
+- 프론트 `npm run typecheck && npm run lint && npm run build`.
+- 프로덕션 QA: CLEANING 차량 배차 엑셀 업로드(C2) → 라이더 매칭 → 출발 시 벨/말풍선에 현재 배차 고객명+주소 표시 → 차량 상세 배차 큐에서 완료 → 다음 건으로 재출발 확인.
+
+## 7. 비범위 재확인
+실제 텔레메트리 시동, 고객 SMS, 배차형/배민/유모차 알림, 백엔드 DB 변경, 옛 next-customer 백엔드 삭제는 이 스펙에 포함하지 않는다.


### PR DESCRIPTION
## Release scope
dev → main 릴리스. **Group C3** 단일 기능만 포함 (다른 대기 작업 없음).

### Group C3 — CLEANING 배차 통합 (프론트엔드 전용)
CLEANING 차량의 시뮬레이션 이동·시동(출발) 알림 소스를 옛 `BikeNextCustomer`(next-customer/promote)에서 **C0/C2 DispatchOrder 큐의 '현재 배차'**로 완전 이전.

- 이동 소스: pin 의 `currentDispatchLatitude/Longitude` (옛 `nextCustomer*` 대신)
- 시동 알림: 출발 시 벨/지도 말풍선에 현재 배차 **고객명(+주소)**
- 재출발 가드: `dispatchKeyOf` 복합키 → 도착 후 같은 건 재출발 방지, 운영자 "완료" → 큐 진행 → 재출발
- 옛 "다음 고객" UI 섹션 제거(−186줄), 배차 큐 섹션으로 통합

순변경 **+608 / −287** (소스 5개 + 설계/플랜 문서 2개).

## 배포 영향
- **DB 마이그레이션 없음, 백엔드 변경 없음.** 프론트엔드만 변경 → main push 시 배포 파이프라인(npm ci/lint/typecheck/build → systemctl restart)으로 반영.
- 옛 `BikeNextCustomer` 백엔드/server action 은 dead code 로 휴면 잔존 (정리는 후속).

## 검증
- [x] `typecheck + lint + next build` 그린
- [x] 태스크별 spec+quality 리뷰 + 최종 holistic 리뷰 "ready to merge"
- [ ] **머지 후 프로덕션 QA** (thcr.cleversystem.ai): CLEANING 배차 엑셀 업로드 → 매칭 → 출발 알림/말풍선 → 배차 큐 완료 → 재출발

머지 시 프로덕션 배포가 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)