### PR TITLE
refactor(c3): remove dead promoteNextToCurrentAction server action

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -939,18 +939,3 @@ export async function setNextCustomerAction(
     return { ok: false, error: "저장 중 오류가 발생했습니다. 다시 시도해주세요." };
   }
 }
-
-/**
- * CLEANING 차량의 다음 고객 → 현재 고객으로 승격.
- * 시동 ON(WORKING→MOVING) 시점에 FleetSimulationContext 가 호출.
- */
-export async function promoteNextToCurrentAction(bikeId: string): Promise<{ ok: boolean }> {
-  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
-  if (!client) return { ok: false };
-  try {
-    await client.promoteNextToCurrentBikeCustomer(bikeId);
-    return { ok: true };
-  } catch {
-    return { ok: false };
-  }
-}


### PR DESCRIPTION
## Summary
C3에서 마지막 호출처(`FleetSimulationContext.tsx`)가 제거되며 더는 import되지 않는 dead export `promoteNextToCurrentAction` 를 `app/actions.ts` 에서 제거.

`grep -rn "promoteNextToCurrentAction" development/front-admin-web/ --include="*.tsx" --include="*.ts"` → 정의 1건만, 호출/import 0건 확인 후 제거.

## Test Plan
- [x] typecheck + lint + `next build` 그린 (잔존 의존 없음 확인)

15 deletions, 1 file. 프론트 전용, 백엔드/DB 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)