### PR TITLE
Group C4: 유모차 클리닝 (수거→배송 2단계 라운드)

### DIFF
--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -7,7 +7,8 @@ import {
   type DispatchBulkApplyRow,
   type DispatchBulkPreviewRow,
   type DispatchBulkSummary,
-  type ServiceOpsDispatchOrder
+  type ServiceOpsDispatchOrder,
+  type ServiceOpsDispatchRound
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 import { geocodeAddress } from "@/lib/services/ncp-geocoder";
@@ -133,6 +134,42 @@ export async function cancelDispatchOrderAction(
 
   try {
     await client.cancelDispatchOrder(id);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function getActiveRoundAction(): Promise<ServiceOpsDispatchRound | null> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return null;
+  return client.getActiveDispatchRound().catch(() => null);
+}
+
+export async function createRoundAction(
+  rows: DispatchBulkApplyRow[]
+): Promise<{ ok: true; round: ServiceOpsDispatchRound } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    const round = await client.createDispatchRound(rows);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true, round };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function startDeliveryAction(
+  batchId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    await client.startDispatchDelivery(batchId);
     revalidatePath("/management");
     revalidatePath("/");
     return { ok: true };

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1496,3 +1496,73 @@ textarea { padding-top: 10px; min-height: 96px; }
 .tip-dialog-error {
   margin-bottom: 12px;
 }
+
+/* ─── 배차 큐 수거/배송 kind badge ────────────────────────────── */
+/* DispatchOrderRow 의 고객 이름 옆에 인라인으로 붙는 소형 레이블.
+   dispatch-order-row 의 delivery-meta 톤과 어울리도록 compact pill. */
+.dispatch-kind-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  vertical-align: middle;
+  line-height: 1.5;
+}
+.dispatch-kind-badge--pickup {
+  background: #fff7ed;
+  color: #c2410c;
+  border: 1px solid #fed7aa;
+}
+.dispatch-kind-badge--delivery {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
+/* ─── 유모차 라운드 패널 (StrollerRoundPanel) ────────────────── */
+/* Status badge — 현재 라운드 단계를 패널 헤더에 표시. */
+.stroller-round-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+.stroller-round-status-badge--none {
+  background: var(--color-bg-muted);
+  color: var(--color-text-muted);
+}
+.stroller-round-status-badge--collecting {
+  background: #fff7ed;
+  color: #c2410c;
+}
+.stroller-round-status-badge--delivering {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+.stroller-round-status-badge--done {
+  background: #f0fdf4;
+  color: #166534;
+}
+/* Progress line — 수거 n/m · 배송 n/m */
+.stroller-round-progress {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.stroller-round-progress-item {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.stroller-round-progress-sep {
+  color: var(--color-text-muted);
+}

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -2,16 +2,21 @@ import { VehiclesManagementPanel } from "@/components/management/VehiclesManagem
 import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
 import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
 import { DispatchPanel } from "@/components/management/DispatchPanel";
+import { StrollerRoundPanel } from "@/components/management/StrollerRoundPanel";
+import { getActiveRoundAction } from "@/app/dispatch/actions";
 
 export const dynamic = "force-dynamic";
 
-export default function ManagementPage() {
+export default async function ManagementPage() {
+  const activeRound = await getActiveRoundAction();
+
   return (
     <div className="management-page">
       <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
       <RidersManagementPanel exportUrl="/api/management/riders/export" />
       <MatchingManagementPanel exportUrl="/api/management/matching/export" />
       <DispatchPanel exportUrl="/api/management/dispatch/export" />
+      <StrollerRoundPanel initialRound={activeRound} />
     </div>
   );
 }

--- a/development/front-admin-web/components/layout/NotificationBell.tsx
+++ b/development/front-admin-web/components/layout/NotificationBell.tsx
@@ -56,9 +56,10 @@ export function NotificationBell() {
             [...notifications].reverse().map((n) => (
               <div key={n.id} className="notif-item" role="listitem">
                 <span className="notif-item-text">
-                  🔑 {n.plateNumber} 출발
-                  {n.customerName ? ` → ${n.customerName}` : ""}
-                  {n.address ? ` (${n.address})` : ""}
+                  {(() => {
+                    const kindLabel = n.kind === "PICKUP" ? "수거" : n.kind === "DELIVERY" ? "배송" : "";
+                    return <>🔑 {n.plateNumber}{kindLabel ? ` ${kindLabel}` : ""} 출발{n.customerName ? ` → ${n.customerName}` : ""}{n.address ? ` (${n.address})` : ""}</>;
+                  })()}
                 </span>
                 <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
               </div>

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -18,6 +18,8 @@ export type IgnitionNotification = {
   address?: string;
   /** @deprecated C3 이후 미사용 — 과거 next-customer 알림 호환용. */
   customerPhone?: string;
+  /** 유모차 라운드: 현재 태스크 종류. 벨에 수거/배송 라벨로 표시. */
+  kind?: "PICKUP" | "DELIVERY";
 };
 
 type NotificationContextValue = {

--- a/development/front-admin-web/components/management/StrollerRoundPanel.tsx
+++ b/development/front-admin-web/components/management/StrollerRoundPanel.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import React, { useRef, useState, useTransition } from "react";
+
+import {
+  previewDispatchAction,
+  getActiveRoundAction,
+  createRoundAction,
+  startDeliveryAction,
+  type DispatchPreviewRow
+} from "@/app/dispatch/actions";
+import type {
+  DispatchBulkApplyRow,
+  DispatchBulkSummary,
+  ServiceOpsDispatchRound
+} from "@/lib/services/service-ops-api";
+import "./BulkPreviewModal.css";
+
+/**
+ * /management 유모차 라운드 섹션.
+ *
+ * 업로드 플로우는 DispatchPanel 과 동일하게 HYBRID 다:
+ *   파일 선택 → `previewDispatchAction`(서버에서 파싱 + 지오코딩) → 미리보기
+ *   모달 → 확인 시 NEW 행만 `createRoundAction(rows)` 로 라운드 생성.
+ *
+ * 라운드 상태에 따라 stage badge + 진행도를 표시하고,
+ * 수거 완료 시 "배송 시작" 버튼을 통해 `startDeliveryAction` 을 호출한다.
+ *
+ * Props:
+ *   initialRound — 서버 페이지에서 `getActiveRoundAction()` 결과를 넘겨받는다.
+ *                  null 이면 진행 라운드 없음 상태로 시작.
+ */
+
+interface DispatchPreviewState {
+  rows: DispatchPreviewRow[];
+  summary: DispatchBulkSummary;
+}
+
+function roundStatusLabel(status: ServiceOpsDispatchRound["status"] | undefined): string {
+  if (!status) return "진행 라운드 없음";
+  switch (status) {
+    case "COLLECTING":
+      return "수거 중";
+    case "DELIVERING":
+      return "배송 중";
+    case "DONE":
+      return "완료됨";
+    default:
+      return "진행 라운드 없음";
+  }
+}
+
+export function StrollerRoundPanel({
+  initialRound
+}: {
+  initialRound: ServiceOpsDispatchRound | null;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [round, setRound] = useState<ServiceOpsDispatchRound | null>(initialRound);
+  const [preview, setPreview] = useState<DispatchPreviewState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  /** 활성 라운드를 서버에서 다시 조회해 state 에 반영. */
+  const reloadRound = async () => {
+    const next = await getActiveRoundAction();
+    setRound(next);
+  };
+
+  // 라운드가 활성 상태인 경우 업로드를 비활성화한다.
+  const isRoundActive = round != null && round.status !== "DONE";
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    setNotice(null);
+    setLoading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const result = await previewDispatchAction(fd);
+      if (result.ok) {
+        setPreview({ rows: result.rows, summary: result.summary });
+      } else {
+        setError(result.error);
+      }
+    } finally {
+      setLoading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!preview) return;
+    const applyRows: DispatchBulkApplyRow[] = preview.rows
+      .filter(
+        (r): r is DispatchPreviewRow & { bikeId: string; latitude: number; longitude: number } =>
+          r.status === "NEW" &&
+          r.bikeId != null &&
+          r.latitude != null &&
+          r.longitude != null
+      )
+      .map((r) => ({
+        bikeId: r.bikeId,
+        customerName: r.customerName,
+        customerPhone: r.customerPhone,
+        address: r.address,
+        latitude: r.latitude,
+        longitude: r.longitude
+      }));
+
+    setLoading(true);
+    try {
+      const result = await createRoundAction(applyRows);
+      if (result.ok) {
+        setPreview(null);
+        setNotice("유모차 라운드가 생성되었습니다.");
+        await reloadRound();
+      } else {
+        setError(result.error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setPreview(null);
+    setError(null);
+  };
+
+  const handleStartDelivery = () => {
+    if (!round) return;
+    const batchId = round.batchId;
+    startTransition(async () => {
+      setError(null);
+      const result = await startDeliveryAction(batchId);
+      if (result.ok) {
+        setNotice("배송이 시작되었습니다.");
+        await reloadRound();
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  const applicableCount = preview
+    ? preview.rows.filter((r) => r.status === "NEW").length
+    : 0;
+
+  const canStartDelivery =
+    round?.status === "COLLECTING" &&
+    round.pickupTotal > 0 &&
+    round.pickupDone === round.pickupTotal;
+
+  const statusLabel = round ? roundStatusLabel(round.status) : "진행 라운드 없음";
+  const statusVariant =
+    round?.status === "COLLECTING"
+      ? "collecting"
+      : round?.status === "DELIVERING"
+        ? "delivering"
+        : round?.status === "DONE"
+          ? "done"
+          : "none";
+
+  return (
+    <div className="management-panel">
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">유모차 라운드</span>
+          <span className={`stroller-round-status-badge stroller-round-status-badge--${statusVariant}`}>
+            {statusLabel}
+          </span>
+        </div>
+        <div className="mgmt-panel-header-actions">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xlsx"
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            className="button-primary"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={loading || isRoundActive}
+            title={isRoundActive ? "진행 중인 라운드가 있습니다. 완료 후 업로드하세요." : undefined}
+          >
+            {loading ? "처리 중..." : "업로드"}
+          </button>
+          <button
+            type="button"
+            className="button-primary"
+            onClick={handleStartDelivery}
+            disabled={!canStartDelivery || isPending}
+            title={canStartDelivery ? "수거 완료 — 배송 시작" : "수거가 모두 완료돼야 배송을 시작할 수 있습니다."}
+          >
+            {isPending ? "처리 중..." : "배송 시작"}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
+          {error}
+        </p>
+      ) : null}
+      {notice ? (
+        <p role="status" style={{ color: "#166534", marginBottom: 8 }}>
+          {notice}
+        </p>
+      ) : null}
+
+      {round && round.status !== "DONE" ? (
+        <div className="stroller-round-progress">
+          <span className="stroller-round-progress-item">
+            수거 {round.pickupDone}/{round.pickupTotal}
+          </span>
+          <span className="stroller-round-progress-sep" aria-hidden="true">·</span>
+          <span className="stroller-round-progress-item">
+            배송 {round.deliveryDone}/{round.deliveryTotal}
+          </span>
+        </div>
+      ) : null}
+
+      {preview ? (
+        <div className="bulk-preview-overlay">
+          <div className="bulk-preview-modal">
+            <h2 className="bulk-preview-title">유모차 라운드 업로드 미리보기</h2>
+
+            <div className="bulk-preview-summary">
+              <span className="bulk-preview-summary-new">신규 {preview.summary.new}</span>
+              <span className="bulk-preview-summary-error">오류 {preview.summary.error}</span>
+              <span className="bulk-preview-summary-total">합계 {preview.summary.total}</span>
+            </div>
+
+            <div className="bulk-preview-table-wrapper">
+              <table className="bulk-preview-table">
+                <thead>
+                  <tr>
+                    <th>행</th>
+                    <th>상태</th>
+                    <th>차량번호</th>
+                    <th>고객명</th>
+                    <th>연락처</th>
+                    <th>배송지주소</th>
+                    <th>좌표</th>
+                    <th>비고</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((row) => (
+                    <tr key={row.rowNumber} className={`bulk-preview-row-${row.status}`}>
+                      <td>{row.rowNumber}</td>
+                      <td>{row.status === "NEW" ? "신규" : "오류"}</td>
+                      <td>{row.plateNumber}</td>
+                      <td>{row.customerName}</td>
+                      <td>{row.customerPhone}</td>
+                      <td>{row.address}</td>
+                      <td>
+                        {row.latitude != null && row.longitude != null
+                          ? `${row.latitude.toFixed(5)}, ${row.longitude.toFixed(5)}`
+                          : ""}
+                      </td>
+                      <td>{row.message ?? ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="bulk-preview-actions">
+              <button onClick={handleCancel} disabled={loading} className="button-neutral">
+                취소
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={loading || applicableCount === 0}
+                className="button-primary"
+              >
+                {loading ? "저장 중..." : `${applicableCount}건 라운드 생성`}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -1017,7 +1017,16 @@ function DispatchOrderRow({
       <dl className="delivery-meta">
         <div className="delivery-meta-row">
           <dt>고객 이름</dt>
-          <dd>{order.customerName || "—"}</dd>
+          <dd>
+            {order.customerName || "—"}
+            {order.kind ? (
+              <span
+                className={`dispatch-kind-badge dispatch-kind-badge--${order.kind === "PICKUP" ? "pickup" : "delivery"}`}
+              >
+                {order.kind === "PICKUP" ? "수거" : "배송"}
+              </span>
+            ) : null}
+          </dd>
         </div>
         <div className="delivery-meta-row">
           <dt>연락처</dt>

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -163,7 +163,8 @@ export function FleetSimulationProvider({
         plateNumber,
         startedAt: state.ignitionOnAt,
         customerName: pin?.currentDispatchCustomerName ?? undefined,
-        address: pin?.currentDispatchAddress ?? undefined
+        address: pin?.currentDispatchAddress ?? undefined,
+        kind: pin?.currentDispatchKind ?? undefined,
       });
       const key = dispatchKeyOf(pin);
       if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);

--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -128,6 +128,7 @@ export function generatePinsForUntrackedVehicles(
         currentDispatchAddress: null,
         currentDispatchLatitude: null,
         currentDispatchLongitude: null,
+        currentDispatchKind: null,
         dispatchQueueCount: 0
       };
     });

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -695,6 +695,7 @@ export type ServiceOpsDashboardBikePin = {
   currentDispatchAddress?: string | null;
   currentDispatchLatitude?: number | string | null;
   currentDispatchLongitude?: number | string | null;
+  currentDispatchKind?: ServiceOpsDispatchOrderKind | null;
   dispatchQueueCount?: number | null;
 };
 
@@ -780,6 +781,7 @@ export type FrontendDashboardBikePin = Omit<
   | "nextCustomerLng"
   | "currentDispatchLatitude"
   | "currentDispatchLongitude"
+  | "currentDispatchKind"
   | "dispatchQueueCount"
 > & {
   slug: string;
@@ -793,6 +795,7 @@ export type FrontendDashboardBikePin = Omit<
   currentDispatchAddress: string | null;
   currentDispatchLatitude: number | null;
   currentDispatchLongitude: number | null;
+  currentDispatchKind: ServiceOpsDispatchOrderKind | null;
   dispatchQueueCount: number;
 };
 
@@ -1047,6 +1050,16 @@ export interface BulkApplyResponse {
 }
 
 export type ServiceOpsDispatchOrderStatus = "ASSIGNED" | "COMPLETED";
+export type ServiceOpsDispatchOrderKind = "PICKUP" | "DELIVERY";
+export type ServiceOpsDispatchRoundStatus = "COLLECTING" | "DELIVERING" | "DONE";
+export type ServiceOpsDispatchRound = {
+  batchId: string;
+  status: ServiceOpsDispatchRoundStatus;
+  pickupTotal: number;
+  pickupDone: number;
+  deliveryTotal: number;
+  deliveryDone: number;
+};
 
 /** 배차 주문 단건 — backend `DispatchOrderReadResponse` 와 1:1. lat/lng 는 JSON number. */
 export type ServiceOpsDispatchOrder = {
@@ -1060,6 +1073,7 @@ export type ServiceOpsDispatchOrder = {
   longitude: number;
   sequence: number;
   status: ServiceOpsDispatchOrderStatus;
+  kind: ServiceOpsDispatchOrderKind;
   completedAt: string | null;
   createdAt: string;
 };
@@ -1249,6 +1263,11 @@ export type ServiceOpsApiClient = {
   previewDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
   applyDispatchOrders: (rows: DispatchBulkApplyRow[]) => Promise<BulkApplyResponse>;
   getDispatchOrdersExportUrl: () => string;
+
+  // ── Dispatch round (라운드) ──
+  getActiveDispatchRound: () => Promise<ServiceOpsDispatchRound | null>;
+  createDispatchRound: (rows: DispatchBulkApplyRow[]) => Promise<ServiceOpsDispatchRound>;
+  startDispatchDelivery: (batchId: string) => Promise<ServiceOpsDispatchRound>;
 };
 
 type ServiceOpsApiOptions = {
@@ -1863,6 +1882,42 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         method: "POST"
       }),
     getDispatchOrdersExportUrl: () => `${baseUrl}/api/v1/dispatch-orders/export`,
+
+    // ── Dispatch round (라운드) ──
+    getActiveDispatchRound: async () => {
+      if (!baseUrl) {
+        throw new ServiceOpsApiError("SERVICE_OPS_API_BASE_URL is not configured.", 0, "SERVICE_OPS_API_NOT_CONFIGURED");
+      }
+      const url = new URL(`${baseUrl}/api/v1/dispatch-batches/active`);
+      const headers = new Headers();
+      if (accessToken) {
+        headers.set("authorization", `Bearer ${accessToken}`);
+      }
+      const res = await fetchImpl(url, { method: "GET", cache: "no-store", headers });
+      if (res.status === 204) return null;
+      const responseText = await res.text();
+      const body = parseResponseBody(responseText);
+      if (!res.ok) {
+        const errorBody = isApiErrorBody(body) ? body : undefined;
+        throw new ServiceOpsApiError(
+          errorBody?.message ?? `Service ops API request failed with status ${res.status}.`,
+          res.status,
+          errorBody?.code,
+          body
+        );
+      }
+      return body as ServiceOpsDispatchRound;
+    },
+    createDispatchRound: (rows) =>
+      request<ServiceOpsDispatchRound>("/dispatch-batches/round", {
+        body: JSON.stringify({ rows }),
+        method: "POST"
+      }),
+    startDispatchDelivery: (batchId) =>
+      request<ServiceOpsDispatchRound>(
+        `/dispatch-batches/${encodeURIComponent(batchId)}/start-delivery`,
+        { method: "POST" }
+      ),
   };
 }
 
@@ -1894,6 +1949,7 @@ export function toFrontendDashboardMapState(mapState: ServiceOpsDashboardMapStat
       currentDispatchAddress: pin.currentDispatchAddress ?? null,
       currentDispatchLatitude: toNullableNumber(pin.currentDispatchLatitude),
       currentDispatchLongitude: toNullableNumber(pin.currentDispatchLongitude),
+      currentDispatchKind: pin.currentDispatchKind ?? null,
       dispatchQueueCount: pin.dispatchQueueCount ?? 0
     })),
     stationPins: mapState.stationPins.map((pin) => ({

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.dashboard.dto;
 
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
 import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
 import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
 import java.math.BigDecimal;
@@ -59,6 +60,7 @@ public record DashboardMapStateResponse(
             String currentDispatchAddress,
             BigDecimal currentDispatchLatitude,
             BigDecimal currentDispatchLongitude,
+            DispatchOrderKind currentDispatchKind,
             int dispatchQueueCount
     ) {
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
@@ -9,6 +9,7 @@ import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository;
 import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository.BikePinRow;
 import com.thundercrew.opsapi.dashboard.repository.DashboardMapQueryRepository.StationPinRow;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
 import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
 import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
@@ -127,6 +128,7 @@ public class DashboardMapStateService {
                 currentDispatch == null ? null : currentDispatch.getAddress(),
                 currentDispatch == null ? null : BigDecimal.valueOf(currentDispatch.getLatitude()),
                 currentDispatch == null ? null : BigDecimal.valueOf(currentDispatch.getLongitude()),
+                currentDispatch == null ? null : currentDispatch.getKind(),
                 dispatchQueueCount
         );
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchBatchCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchBatchCommandController.java
@@ -1,0 +1,34 @@
+package com.thundercrew.opsapi.dispatch.controller;
+
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRequest;
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.service.DispatchRoundService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dispatch-batches")
+public class DispatchBatchCommandController {
+
+    private final DispatchRoundService dispatchRoundService;
+
+    public DispatchBatchCommandController(DispatchRoundService dispatchRoundService) {
+        this.dispatchRoundService = dispatchRoundService;
+    }
+
+    /** 새 라운드 생성(프론트 지오코딩 완료 행, JSON). */
+    @PostMapping("/round")
+    DispatchRoundResponse createRound(@Valid @RequestBody DispatchBulkApplyRequest request) {
+        return dispatchRoundService.createRound(request);
+    }
+
+    @PostMapping("/{id}/start-delivery")
+    DispatchRoundResponse startDelivery(@PathVariable UUID id) {
+        return dispatchRoundService.startDelivery(id);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchBatchReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchBatchReadController.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.dispatch.controller;
+
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.service.DispatchRoundService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dispatch-batches")
+public class DispatchBatchReadController {
+
+    private final DispatchRoundService dispatchRoundService;
+
+    public DispatchBatchReadController(DispatchRoundService dispatchRoundService) {
+        this.dispatchRoundService = dispatchRoundService;
+    }
+
+    /** 현재 활성 유모차 라운드 + 진척. 없으면 204. */
+    @GetMapping("/active")
+    ResponseEntity<DispatchRoundResponse> active() {
+        return dispatchRoundService.activeRound()
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatch.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatch.java
@@ -1,5 +1,6 @@
 package com.thundercrew.opsapi.dispatch.domain;
 
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,7 +27,7 @@ public class DispatchBatch extends DisplaySequencedEntity {
     /** 전체 수거 완료 후 운영자 '배송 시작'. COLLECTING 에서만 허용. */
     public void startDelivery() {
         if (status != DispatchBatchStatus.COLLECTING) {
-            throw new IllegalStateException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + status);
+            throw new InvalidStateTransitionException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + status);
         }
         this.status = DispatchBatchStatus.DELIVERING;
     }
@@ -34,7 +35,7 @@ public class DispatchBatch extends DisplaySequencedEntity {
     /** 전체 배송 완료. DELIVERING 에서만 허용. */
     public void markDone(UUID actorId, Instant when) {
         if (status != DispatchBatchStatus.DELIVERING) {
-            throw new IllegalStateException("완료는 배송 단계에서만 가능합니다. 현재: " + status);
+            throw new InvalidStateTransitionException("완료는 배송 단계에서만 가능합니다. 현재: " + status);
         }
         this.status = DispatchBatchStatus.DONE;
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatch.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatch.java
@@ -1,0 +1,48 @@
+package com.thundercrew.opsapi.dispatch.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "dispatch_batch")
+public class DispatchBatch extends DisplaySequencedEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchBatchStatus status;
+
+    public static DispatchBatch create() {
+        DispatchBatch batch = new DispatchBatch();
+        batch.status = DispatchBatchStatus.COLLECTING;
+        return batch;
+    }
+
+    /** 전체 수거 완료 후 운영자 '배송 시작'. COLLECTING 에서만 허용. */
+    public void startDelivery() {
+        if (status != DispatchBatchStatus.COLLECTING) {
+            throw new IllegalStateException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + status);
+        }
+        this.status = DispatchBatchStatus.DELIVERING;
+    }
+
+    /** 전체 배송 완료. DELIVERING 에서만 허용. */
+    public void markDone(UUID actorId, Instant when) {
+        if (status != DispatchBatchStatus.DELIVERING) {
+            throw new IllegalStateException("완료는 배송 단계에서만 가능합니다. 현재: " + status);
+        }
+        this.status = DispatchBatchStatus.DONE;
+    }
+
+    public DispatchBatchStatus getStatus() {
+        return status;
+    }
+
+    protected DispatchBatch() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatchStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatchStatus.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.dispatch.domain;
+
+public enum DispatchBatchStatus {
+    COLLECTING,
+    DELIVERING,
+    DONE
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
@@ -41,6 +41,13 @@ public class DispatchOrder extends DisplaySequencedEntity {
     @Column
     private Instant completedAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchOrderKind kind;
+
+    @Column(name = "batch_id")
+    private UUID batchId;
+
     public static DispatchOrder create(UUID bikeId, String customerName, String customerPhone,
                                        String address, double latitude, double longitude, long sequence) {
         DispatchOrder order = new DispatchOrder();
@@ -52,6 +59,17 @@ public class DispatchOrder extends DisplaySequencedEntity {
         order.longitude = longitude;
         order.sequence = sequence;
         order.status = DispatchOrderStatus.ASSIGNED;
+        order.kind = DispatchOrderKind.DELIVERY;
+        order.batchId = null;
+        return order;
+    }
+
+    public static DispatchOrder createForBatch(UUID bikeId, String customerName, String customerPhone,
+                                               String address, double latitude, double longitude, long sequence,
+                                               DispatchOrderKind kind, UUID batchId) {
+        DispatchOrder order = create(bikeId, customerName, customerPhone, address, latitude, longitude, sequence);
+        order.kind = kind;
+        order.batchId = batchId;
         return order;
     }
 
@@ -94,6 +112,14 @@ public class DispatchOrder extends DisplaySequencedEntity {
 
     public Instant getCompletedAt() {
         return completedAt;
+    }
+
+    public DispatchOrderKind getKind() {
+        return kind;
+    }
+
+    public UUID getBatchId() {
+        return batchId;
     }
 
     protected DispatchOrder() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrderKind.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrderKind.java
@@ -1,0 +1,6 @@
+package com.thundercrew.opsapi.dispatch.domain;
+
+public enum DispatchOrderKind {
+    PICKUP,
+    DELIVERY
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchOrderReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchOrderReadResponse.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.dispatch.dto;
 
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
 import java.time.Instant;
 import java.util.UUID;
@@ -16,6 +17,7 @@ public record DispatchOrderReadResponse(
         double longitude,
         long sequence,
         DispatchOrderStatus status,
+        DispatchOrderKind kind,
         Instant completedAt,
         Instant createdAt
 ) {
@@ -31,6 +33,7 @@ public record DispatchOrderReadResponse(
                 order.getLongitude(),
                 order.getSequence(),
                 order.getStatus(),
+                order.getKind(),
                 order.getCompletedAt(),
                 order.getCreatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchRoundResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchRoundResponse.java
@@ -1,0 +1,21 @@
+package com.thundercrew.opsapi.dispatch.dto;
+
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import java.util.UUID;
+
+/** 현재 유모차 라운드 + 진척. 활성 라운드 없으면 컨트롤러가 204 로 응답. */
+public record DispatchRoundResponse(
+        UUID batchId,
+        DispatchBatchStatus status,
+        int pickupTotal,
+        int pickupDone,
+        int deliveryTotal,
+        int deliveryDone
+) {
+    public static DispatchRoundResponse of(DispatchBatch batch, int pickupTotal, int pickupDone,
+                                           int deliveryTotal, int deliveryDone) {
+        return new DispatchRoundResponse(
+                batch.getId(), batch.getStatus(), pickupTotal, pickupDone, deliveryTotal, deliveryDone);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchBatchRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchBatchRepository.java
@@ -1,0 +1,18 @@
+package com.thundercrew.opsapi.dispatch.repository;
+
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface DispatchBatchRepository extends Repository<DispatchBatch, UUID> {
+
+    List<DispatchBatch> findByStatusInAndDeletedAtIsNull(Collection<DispatchBatchStatus> statuses);
+
+    Optional<DispatchBatch> findByIdAndDeletedAtIsNull(UUID id);
+
+    DispatchBatch save(DispatchBatch batch);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.dispatch.repository;
 
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,11 @@ public interface DispatchOrderRepository extends Repository<DispatchOrder, UUID>
     Optional<DispatchOrder> findByIdAndDeletedAtIsNull(UUID id);
 
     Optional<DispatchOrder> findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(UUID bikeId);
+
+    List<DispatchOrder> findByBatchIdAndDeletedAtIsNull(UUID batchId);
+
+    List<DispatchOrder> findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+            UUID batchId, DispatchOrderKind kind, DispatchOrderStatus status);
 
     DispatchOrder save(DispatchOrder order);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderCommandService.java
@@ -1,9 +1,14 @@
 package com.thundercrew.opsapi.dispatch.service;
 
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderCreateRequest;
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchBatchRepository;
 import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
 import java.time.Clock;
 import java.util.UUID;
@@ -15,10 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class DispatchOrderCommandService {
 
     private final DispatchOrderRepository dispatchOrderRepository;
+    private final DispatchBatchRepository dispatchBatchRepository;
     private final Clock clock;
 
-    public DispatchOrderCommandService(DispatchOrderRepository dispatchOrderRepository, Clock clock) {
+    public DispatchOrderCommandService(DispatchOrderRepository dispatchOrderRepository,
+                                       DispatchBatchRepository dispatchBatchRepository,
+                                       Clock clock) {
         this.dispatchOrderRepository = dispatchOrderRepository;
+        this.dispatchBatchRepository = dispatchBatchRepository;
         this.clock = clock;
     }
 
@@ -35,9 +44,16 @@ public class DispatchOrderCommandService {
     public DispatchOrderReadResponse complete(UUID id) {
         DispatchOrder order = dispatchOrderRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", id));
-        // 관리 엔티티는 @Transactional 종료 시 dirty-checking 으로 flush 되므로
-        // mutate 경로에는 명시적 save() 를 두지 않는다 (Tip update/delete 와 동일).
+        // 관리 엔티티는 @Transactional 종료 시 dirty-checking 으로 flush 되므로 mutate 경로에 명시적 save() 없음.
         order.complete(clock.instant());
+        // 유모차 라운드: 마지막 배송 완료 시 배치를 DONE 으로 자동 전환.
+        if (order.getBatchId() != null && order.getKind() == DispatchOrderKind.DELIVERY
+                && dispatchOrderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+                        order.getBatchId(), DispatchOrderKind.DELIVERY, DispatchOrderStatus.ASSIGNED).isEmpty()) {
+            dispatchBatchRepository.findByIdAndDeletedAtIsNull(order.getBatchId())
+                    .filter(b -> b.getStatus() == DispatchBatchStatus.DELIVERING)
+                    .ifPresent(b -> b.markDone(null, clock.instant()));
+        }
         return DispatchOrderReadResponse.from(order);
     }
 
@@ -49,12 +65,25 @@ public class DispatchOrderCommandService {
 
     public DispatchOrderReadResponse appendForBike(UUID bikeId, String customerName, String customerPhone,
                                                    String address, double latitude, double longitude) {
-        long nextSequence = dispatchOrderRepository
-                .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
-                .map(order -> order.getSequence() + 1)
-                .orElse(1L);
+        long nextSequence = nextSequence(bikeId);
         DispatchOrder order = DispatchOrder.create(
                 bikeId, customerName, customerPhone, address, latitude, longitude, nextSequence);
         return DispatchOrderReadResponse.from(dispatchOrderRepository.save(order));
+    }
+
+    /** 라운드(batch) 소속 주문을 차량 큐에 append. kind 와 batchId 를 부여한다. */
+    public DispatchOrder appendForBatch(UUID bikeId, String customerName, String customerPhone, String address,
+                                        double latitude, double longitude, DispatchOrderKind kind, UUID batchId) {
+        long nextSequence = nextSequence(bikeId);
+        DispatchOrder order = DispatchOrder.createForBatch(
+                bikeId, customerName, customerPhone, address, latitude, longitude, nextSequence, kind, batchId);
+        return dispatchOrderRepository.save(order);
+    }
+
+    private long nextSequence(UUID bikeId) {
+        return dispatchOrderRepository
+                .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
+                .map(order -> order.getSequence() + 1)
+                .orElse(1L);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
@@ -44,6 +44,9 @@ public class DispatchRoundService {
 
     /** 새 라운드 생성. 동시 활성 라운드는 1개만 허용. 각 행을 PICKUP 주문으로 적재. */
     public DispatchRoundResponse createRound(DispatchBulkApplyRequest request) {
+        if (request.rows().isEmpty()) {
+            throw new InvalidStateTransitionException("업로드할 배차 행이 없습니다.");
+        }
         if (!batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).isEmpty()) {
             throw new InvalidStateTransitionException("이미 진행 중인 유모차 라운드가 있습니다.");
         }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
@@ -1,0 +1,96 @@
+package com.thundercrew.opsapi.dispatch.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRequest;
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRow;
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchBatchRepository;
+import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 유모차 라운드(2단계 배치) 오케스트레이션.
+ * 업로드 → 수거(PICKUP) 주문 생성, '배송 시작' → 완료된 수거로부터 배송(DELIVERY) 주문 생성.
+ * 활성 단계의 주문만 ASSIGNED 로 존재하도록(배송은 전환 시 생성) 하여 큐/대시보드 쿼리를 단순 유지.
+ */
+@Service
+@Transactional
+public class DispatchRoundService {
+
+    private static final List<DispatchBatchStatus> ACTIVE =
+            List.of(DispatchBatchStatus.COLLECTING, DispatchBatchStatus.DELIVERING);
+
+    private final DispatchBatchRepository batchRepository;
+    private final DispatchOrderRepository orderRepository;
+    private final DispatchOrderCommandService commandService;
+
+    public DispatchRoundService(DispatchBatchRepository batchRepository,
+                                DispatchOrderRepository orderRepository,
+                                DispatchOrderCommandService commandService) {
+        this.batchRepository = batchRepository;
+        this.orderRepository = orderRepository;
+        this.commandService = commandService;
+    }
+
+    /** 새 라운드 생성. 동시 활성 라운드는 1개만 허용. 각 행을 PICKUP 주문으로 적재. */
+    public DispatchRoundResponse createRound(DispatchBulkApplyRequest request) {
+        if (!batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).isEmpty()) {
+            throw new IllegalStateException("이미 진행 중인 유모차 라운드가 있습니다.");
+        }
+        DispatchBatch batch = batchRepository.save(DispatchBatch.create());
+        for (DispatchBulkApplyRow row : request.rows()) {
+            commandService.appendForBatch(row.bikeId(), row.customerName(), row.customerPhone(),
+                    row.address(), row.latitude(), row.longitude(), DispatchOrderKind.PICKUP, batch.getId());
+        }
+        return progress(batch);
+    }
+
+    /** 전체 수거 완료 후 배송 단계로 전환. 완료된 수거 각각에서 배송 주문을 생성. */
+    public DispatchRoundResponse startDelivery(UUID batchId) {
+        DispatchBatch batch = batchRepository.findByIdAndDeletedAtIsNull(batchId)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchBatch", batchId));
+        List<DispatchOrder> remainingPickups = orderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+                batchId, DispatchOrderKind.PICKUP, DispatchOrderStatus.ASSIGNED);
+        if (!remainingPickups.isEmpty()) {
+            throw new IllegalStateException("수거가 모두 완료되지 않았습니다. 남은 수거: " + remainingPickups.size());
+        }
+        List<DispatchOrder> allPickups = orderRepository.findByBatchIdAndDeletedAtIsNull(batchId).stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.PICKUP)
+                .toList();
+        for (DispatchOrder p : allPickups) {
+            commandService.appendForBatch(p.getBikeId(), p.getCustomerName(), p.getCustomerPhone(),
+                    p.getAddress(), p.getLatitude(), p.getLongitude(), DispatchOrderKind.DELIVERY, batchId);
+        }
+        batch.startDelivery();
+        return progress(batch);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<DispatchRoundResponse> activeRound() {
+        return batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).stream()
+                .findFirst()
+                .map(this::progress);
+    }
+
+    private DispatchRoundResponse progress(DispatchBatch batch) {
+        List<DispatchOrder> orders = orderRepository.findByBatchIdAndDeletedAtIsNull(batch.getId());
+        int pickupTotal = (int) orders.stream().filter(o -> o.getKind() == DispatchOrderKind.PICKUP).count();
+        int pickupDone = (int) orders.stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.PICKUP && o.getStatus() == DispatchOrderStatus.COMPLETED)
+                .count();
+        int deliveryTotal = (int) orders.stream().filter(o -> o.getKind() == DispatchOrderKind.DELIVERY).count();
+        int deliveryDone = (int) orders.stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.DELIVERY && o.getStatus() == DispatchOrderStatus.COMPLETED)
+                .count();
+        return DispatchRoundResponse.of(batch, pickupTotal, pickupDone, deliveryTotal, deliveryDone);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
@@ -58,6 +58,9 @@ public class DispatchRoundService {
     public DispatchRoundResponse startDelivery(UUID batchId) {
         DispatchBatch batch = batchRepository.findByIdAndDeletedAtIsNull(batchId)
                 .orElseThrow(() -> new ResourceNotFoundException("DispatchBatch", batchId));
+        if (batch.getStatus() != DispatchBatchStatus.COLLECTING) {
+            throw new IllegalStateException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + batch.getStatus());
+        }
         List<DispatchOrder> remainingPickups = orderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
                 batchId, DispatchOrderKind.PICKUP, DispatchOrderStatus.ASSIGNED);
         if (!remainingPickups.isEmpty()) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
@@ -1,5 +1,6 @@
 package com.thundercrew.opsapi.dispatch.service;
 
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
 import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
@@ -44,7 +45,7 @@ public class DispatchRoundService {
     /** 새 라운드 생성. 동시 활성 라운드는 1개만 허용. 각 행을 PICKUP 주문으로 적재. */
     public DispatchRoundResponse createRound(DispatchBulkApplyRequest request) {
         if (!batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).isEmpty()) {
-            throw new IllegalStateException("이미 진행 중인 유모차 라운드가 있습니다.");
+            throw new InvalidStateTransitionException("이미 진행 중인 유모차 라운드가 있습니다.");
         }
         DispatchBatch batch = batchRepository.save(DispatchBatch.create());
         for (DispatchBulkApplyRow row : request.rows()) {
@@ -59,12 +60,12 @@ public class DispatchRoundService {
         DispatchBatch batch = batchRepository.findByIdAndDeletedAtIsNull(batchId)
                 .orElseThrow(() -> new ResourceNotFoundException("DispatchBatch", batchId));
         if (batch.getStatus() != DispatchBatchStatus.COLLECTING) {
-            throw new IllegalStateException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + batch.getStatus());
+            throw new InvalidStateTransitionException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + batch.getStatus());
         }
         List<DispatchOrder> remainingPickups = orderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
                 batchId, DispatchOrderKind.PICKUP, DispatchOrderStatus.ASSIGNED);
         if (!remainingPickups.isEmpty()) {
-            throw new IllegalStateException("수거가 모두 완료되지 않았습니다. 남은 수거: " + remainingPickups.size());
+            throw new InvalidStateTransitionException("수거가 모두 완료되지 않았습니다. 남은 수거: " + remainingPickups.size());
         }
         List<DispatchOrder> allPickups = orderRepository.findByBatchIdAndDeletedAtIsNull(batchId).stream()
                 .filter(o -> o.getKind() == DispatchOrderKind.PICKUP)

--- a/development/service-ops-api/src/main/resources/db/migration/V34__add_dispatch_batch_and_order_kind.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V34__add_dispatch_batch_and_order_kind.sql
@@ -1,0 +1,17 @@
+alter table dispatch_orders add column kind varchar(20) not null default 'DELIVERY';
+alter table dispatch_orders add constraint ck_dispatch_orders_kind check (kind in ('PICKUP', 'DELIVERY'));
+alter table dispatch_orders add column batch_id uuid;
+create index ix_dispatch_orders_batch on dispatch_orders (batch_id, kind, status) where deleted_at is null;
+
+create table dispatch_batch (
+    id uuid primary key,
+    idx bigserial not null unique,
+    status varchar(20) not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_dispatch_batch_status check (status in ('COLLECTING', 'DELIVERING', 'DONE'))
+);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -108,6 +108,7 @@ class ArchitectureBoundaryTests {
                         || isStationCommand(method)
                         || isTipCommand(method)
                         || isDispatchCommand(method)
+                        || isDispatchBatchCommand(method)
                         || isTelemetryIngestionCommand(method)
                         || isDeviceApiSyncCommand(method)
                         || isTestVehicleCommand(method)
@@ -149,6 +150,7 @@ class ArchitectureBoundaryTests {
                         && !isStationCommand(method)
                         && !isTipCommand(method)
                         && !isDispatchCommand(method)
+                        && !isDispatchBatchCommand(method)
                         && !isTelemetryIngestionCommand(method)
                         && !isDeviceApiSyncCommand(method)
                         && !isTestVehicleCommand(method)
@@ -271,6 +273,11 @@ class ArchitectureBoundaryTests {
         // bulk-preview / bulk-apply / bulk-export command methods on the same controller.
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.dispatch.controller.DispatchOrderCommandController");
+    }
+
+    private static boolean isDispatchBatchCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.dispatch.controller.DispatchBatchCommandController");
     }
 
     private static boolean isTelemetryIngestionCommand(JavaMethod method) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
@@ -112,8 +112,8 @@ class DispatchRoundApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$[1].status").value("ASSIGNED"));
     }
 
-    // ② concurrent round rejected — second POST /dispatch-batches/round with active round present → 500
-    //   (IllegalStateException falls through to the generic Exception handler → 500).
+    // ② concurrent round rejected — second POST /dispatch-batches/round with active round present → 409
+    //   (InvalidStateTransitionException → GlobalExceptionHandler → 409 CONFLICT with message body).
     @Test
     void secondCreateRoundIsRejectedWhenActiveRoundExists() throws Exception {
         mockMvc.perform(post("/api/v1/dispatch-batches/round")
@@ -126,17 +126,17 @@ class DispatchRoundApiContractTests extends PostgresContainerSupport {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(buildRoundBody(1)))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isConflict());
     }
 
-    // ③ start-delivery gate — with pickups still ASSIGNED, POST /start-delivery → 500, message references "수거".
+    // ③ start-delivery gate — with pickups still ASSIGNED, POST /start-delivery → 409, message references "수거".
     @Test
     void startDeliveryIsRejectedWhenPickupsAreIncomplete() throws Exception {
         String batchId = createRound(1);
 
         MvcResult result = mockMvc.perform(post("/api/v1/dispatch-batches/{id}/start-delivery", batchId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-                .andExpect(status().isInternalServerError())
+                .andExpect(status().isConflict())
                 .andReturn();
 
         assertThat(result.getResponse().getContentAsString()).contains("수거");

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
@@ -1,0 +1,350 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DispatchRoundApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab");
+    private static final UUID BIKE_ID  = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbc");
+    private static final UUID DEVICE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccd");
+    private static final String BIKE_PLATE = "서울CC-0002";
+
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+    private static final Pattern ID_PATTERN =
+            Pattern.compile("\\\"id\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+    private static final Pattern BATCH_ID_PATTERN =
+            Pattern.compile("\\\"batchId\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from dispatch_orders");
+        jdbcTemplate.update("delete from dispatch_batch");
+        jdbcTemplate.update("delete from bike_current_states");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'round-admin', 'round@example.test', ?, 'Round Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        seedBike(BIKE_ID, BIKE_PLATE, "VIN-ROUND-001", "IN_SERVICE");
+
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① createRound — POST /dispatch-batches/round → 200, COLLECTING, pickupTotal==N, pickupDone==0,
+    //   deliveryTotal==0. GET /dispatch-orders?bikeId → N orders with kind==PICKUP, status==ASSIGNED.
+    @Test
+    void createRoundReturnsBatchInCollectingWithPickupOrders() throws Exception {
+        int n = 2;
+        String body = buildRoundBody(n);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-batches/round")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.batchId").isString())
+                .andExpect(jsonPath("$.status").value("COLLECTING"))
+                .andExpect(jsonPath("$.pickupTotal").value(n))
+                .andExpect(jsonPath("$.pickupDone").value(0))
+                .andExpect(jsonPath("$.deliveryTotal").value(0))
+                .andExpect(jsonPath("$.deliveryDone").value(0))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+
+        mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", BIKE_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(n))
+                .andExpect(jsonPath("$[0].kind").value("PICKUP"))
+                .andExpect(jsonPath("$[0].status").value("ASSIGNED"))
+                .andExpect(jsonPath("$[1].kind").value("PICKUP"))
+                .andExpect(jsonPath("$[1].status").value("ASSIGNED"));
+    }
+
+    // ② concurrent round rejected — second POST /dispatch-batches/round with active round present → 500
+    //   (IllegalStateException falls through to the generic Exception handler → 500).
+    @Test
+    void secondCreateRoundIsRejectedWhenActiveRoundExists() throws Exception {
+        mockMvc.perform(post("/api/v1/dispatch-batches/round")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(buildRoundBody(1)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/dispatch-batches/round")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(buildRoundBody(1)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    // ③ start-delivery gate — with pickups still ASSIGNED, POST /start-delivery → 500, message references "수거".
+    @Test
+    void startDeliveryIsRejectedWhenPickupsAreIncomplete() throws Exception {
+        String batchId = createRound(1);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-batches/{id}/start-delivery", batchId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isInternalServerError())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsString()).contains("수거");
+    }
+
+    // ④ full pickup → transition — complete all PICKUP orders, POST /start-delivery → 200, DELIVERING,
+    //   deliveryTotal==N. GET /dispatch-orders?bikeId → N DELIVERY orders ASSIGNED plus N completed pickups.
+    @Test
+    void startDeliverySucceedsAfterAllPickupsCompleted() throws Exception {
+        int n = 2;
+        String batchId = createRound(n);
+
+        List<String> pickupIds = listOrderIds(BIKE_ID);
+        assertThat(pickupIds).hasSize(n);
+        for (String orderId : pickupIds) {
+            mockMvc.perform(post("/api/v1/dispatch-orders/{id}/complete", orderId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("COMPLETED"));
+        }
+
+        mockMvc.perform(post("/api/v1/dispatch-batches/{id}/start-delivery", batchId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DELIVERING"))
+                .andExpect(jsonPath("$.deliveryTotal").value(n))
+                .andExpect(jsonPath("$.pickupDone").value(n));
+
+        mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", BIKE_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                // n PICKUP (COMPLETED) + n DELIVERY (ASSIGNED)
+                .andExpect(jsonPath("$.length()").value(n * 2))
+                .andExpect(jsonPath("$[?(@.kind=='DELIVERY' && @.status=='ASSIGNED')].length()").value(n));
+    }
+
+    // ⑤ delivery complete → DONE — complete all DELIVERY orders, then GET /dispatch-batches/active → 204.
+    @Test
+    void activeRoundReturns204AfterAllDeliveriesCompleted() throws Exception {
+        int n = 2;
+        String batchId = createRound(n);
+
+        // Complete all pickups
+        List<String> pickupIds = listOrderIds(BIKE_ID);
+        for (String orderId : pickupIds) {
+            mockMvc.perform(post("/api/v1/dispatch-orders/{id}/complete", orderId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk());
+        }
+
+        // Transition to delivery
+        mockMvc.perform(post("/api/v1/dispatch-batches/{id}/start-delivery", batchId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DELIVERING"));
+
+        // Collect the new DELIVERY order ids (ASSIGNED ones among all orders)
+        List<String> deliveryIds = listOrderIdsByKind(BIKE_ID, "DELIVERY");
+        assertThat(deliveryIds).hasSize(n);
+        for (String orderId : deliveryIds) {
+            mockMvc.perform(post("/api/v1/dispatch-orders/{id}/complete", orderId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk());
+        }
+
+        // Batch should now be DONE → /active returns 204
+        mockMvc.perform(get("/api/v1/dispatch-batches/active")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+    }
+
+    // ⑥ dashboard currentDispatchKind — after createRound, GET /dashboard/map-state → bikePin has
+    //   currentDispatchKind == "PICKUP".
+    @Test
+    void dashboardBikePinExposesCurrentDispatchKindAfterCreateRound() throws Exception {
+        insertCurrentState(BIKE_ID, DEVICE_ID, Instant.now().minusSeconds(60), "ON", "10.00", "80.00");
+
+        createRound(1);
+
+        mockMvc.perform(get("/api/v1/dashboard/map-state")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikePins[?(@.bikeId=='" + BIKE_ID + "')].currentDispatchKind")
+                        .value(org.hamcrest.Matchers.contains("PICKUP")));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private String buildRoundBody(int n) {
+        StringBuilder sb = new StringBuilder("{\"rows\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) sb.append(',');
+            sb.append("""
+                    {"bikeId":"%s","customerName":"라운드고객%d","customerPhone":"010-%04d-%04d",
+                     "address":"서울 강남구 역삼동 %d","latitude":37.%d,"longitude":127.%d}
+                    """.formatted(BIKE_ID, i + 1, i + 1, i + 1, i + 100, 4987 + i, 276 + i));
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    /**
+     * Creates a round with n rows and returns the batchId.
+     */
+    private String createRound(int n) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-batches/round")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(buildRoundBody(n)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractBatchId(result.getResponse().getContentAsString());
+    }
+
+    /**
+     * Lists all order ids for a bike (in sequence order, as returned by the API).
+     */
+    private List<String> listOrderIds(UUID bikeId) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", bikeId.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extractAllIds(result.getResponse().getContentAsString());
+    }
+
+    /**
+     * Lists order ids for a bike that match the given kind (PICKUP or DELIVERY).
+     * Uses a simple filter on the JSON response; collects all ids for matching objects.
+     */
+    private List<String> listOrderIdsByKind(UUID bikeId, String kind) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", bikeId.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        String body = result.getResponse().getContentAsString();
+        // Parse each object block { ... } in the JSON array, collect id where kind matches.
+        List<String> ids = new ArrayList<>();
+        Pattern objPattern = Pattern.compile("\\{[^\\{\\}]*\\}");
+        Matcher objMatcher = objPattern.matcher(body);
+        while (objMatcher.find()) {
+            String obj = objMatcher.group();
+            if (obj.contains("\"" + kind + "\"")) {
+                Matcher idMatcher = ID_PATTERN.matcher(obj);
+                if (idMatcher.find()) {
+                    ids.add(idMatcher.group(1));
+                }
+            }
+        }
+        return ids;
+    }
+
+    private void seedBike(UUID id, String plateNumber, String vin, String operationStatus) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status)
+                values (?, ?, ?, 'Thunder M1', ?)
+                """, id, plateNumber, vin, operationStatus);
+    }
+
+    private void insertCurrentState(UUID bikeId, UUID deviceId, Instant receivedAt,
+                                    String ignitionStatus, String speedKph, String batteryPercent) {
+        jdbcTemplate.update("""
+                insert into bike_current_states (
+                    bike_id, device_id, telemetry_log_id, last_received_at,
+                    latitude, longitude, speed_kph, battery_percent, ignition_status, telemetry_source
+                ) values (?, ?, ?, ?::timestamptz, 37.5010000, 127.0396000, ?::numeric, ?::numeric, ?, 'POLLING')
+                """, bikeId, deviceId, UUID.randomUUID(), receivedAt.toString(), speedKph, batteryPercent, ignitionStatus);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"round-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractBatchId(String json) {
+        Matcher matcher = BATCH_ID_PATTERN.matcher(json);
+        if (!matcher.find()) {
+            throw new IllegalStateException("No batchId in response: " + json);
+        }
+        return matcher.group(1);
+    }
+
+    private String extractId(String json) {
+        Matcher matcher = ID_PATTERN.matcher(json);
+        if (!matcher.find()) {
+            throw new IllegalStateException("No id in response: " + json);
+        }
+        return matcher.group(1);
+    }
+
+    private List<String> extractAllIds(String json) {
+        List<String> ids = new ArrayList<>();
+        Matcher matcher = ID_PATTERN.matcher(json);
+        while (matcher.find()) {
+            ids.add(matcher.group(1));
+        }
+        return ids;
+    }
+}

--- a/docs/superpowers/plans/2026-06-12-group-c4-stroller-round.md
+++ b/docs/superpowers/plans/2026-06-12-group-c4-stroller-round.md
@@ -1,0 +1,926 @@
+# Group C4 — 유모차 클리닝 (수거 → 배송 2단계 라운드) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 유모차 클리닝의 "전체 수거 → 전체 배송" 2단계 배치 흐름을, 기존 `DispatchOrder`(태스크 단위) 확장 + 신규 `DispatchBatch`(라운드 단계) 엔티티로 구축한다 (백엔드 full-stack + 프론트).
+
+**Architecture:** `dispatch_orders`에 `kind`(PICKUP/DELIVERY)·`batch_id`를 더하고, 라운드 단계(COLLECTING→DELIVERING→DONE)를 가진 `dispatch_batch`를 신설한다. **활성 단계의 태스크만 ASSIGNED로 존재**(배송 주문은 '배송 시작' 시점 생성)시켜 대시보드·배차 큐·시동 알림 핫패스 쿼리를 C2/C3와 동일하게 유지한다. 엑셀 벌크·지오코딩·배차 큐 UI·시동 알림(C3)을 재사용한다.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA `Repository<T,UUID>`, JUnit/Testcontainers, Next.js App Router, TypeScript.
+
+**작업 경로:** 백엔드 `development/service-ops-api`, 프론트 `development/front-admin-web` (절대경로 `cd /c/Users/user/repositories/clever/thundercrew-domain/...`, Bash 툴, cwd 매 호출 리셋). 브랜치 `cc-c4-stroller-round` 이미 체크아웃 — 새 브랜치 만들지 말 것.
+
+**테스트 실행 주의:** ArchUnit 테스트는 Docker 불필요(바이트코드 분석). 계약/Testcontainers 테스트는 **Docker 필요(이 머신엔 없음)** → 작성·컴파일까지만, 실행은 CI. 프론트는 `npm run typecheck && npm run lint && npm run build`.
+
+---
+
+## 파일 구조
+
+**백엔드 (신규)** `com.thundercrew.opsapi.dispatch`:
+- `domain/DispatchOrderKind.java` — enum PICKUP/DELIVERY
+- `domain/DispatchBatchStatus.java` — enum COLLECTING/DELIVERING/DONE
+- `domain/DispatchBatch.java` — 라운드 엔티티
+- `repository/DispatchBatchRepository.java`
+- `service/DispatchRoundService.java` — createRound/startDelivery/activeRound
+- `dto/DispatchRoundResponse.java`
+- `controller/DispatchBatchReadController.java`, `controller/DispatchBatchCommandController.java`
+- `db/migration/V34__add_dispatch_batch_and_order_kind.sql`
+- `test/.../DispatchRoundApiContractTests.java`
+
+**백엔드 (수정):** `domain/DispatchOrder.java`(kind/batchId), `repository/DispatchOrderRepository.java`(+2 메서드), `service/DispatchOrderCommandService.java`(appendForBatch + complete 확장), `dto/DispatchOrderReadResponse.java`(+kind), `dashboard/dto/DashboardMapStateResponse.java`+`dashboard/service/DashboardMapStateService.java`(+currentDispatchKind), `test/.../ArchitectureBoundaryTests.java`(allow-list).
+
+**프론트 (신규):** `components/management/StrollerRoundPanel.tsx`.
+**프론트 (수정):** `lib/services/service-ops-api.ts`, `app/dispatch/actions.ts`, `app/management/page.tsx`, `components/management/VehicleDetailDialog.tsx`(큐 수거/배송 라벨), `components/overview/FleetSimulationContext.tsx`+`components/layout/NotificationContext.tsx`+`components/layout/NotificationBell.tsx`(알림 kind 라벨).
+
+---
+
+### Task 1: V34 마이그레이션 + enum + 엔티티 확장 + DispatchBatch
+
+**Files:**
+- Create: `development/service-ops-api/src/main/resources/db/migration/V34__add_dispatch_batch_and_order_kind.sql`
+- Create: `development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrderKind.java`
+- Create: `development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatchStatus.java`
+- Create: `development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchBatch.java`
+- Modify: `development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java`
+
+- [ ] **Step 1: 마이그레이션 작성**
+
+`V34__add_dispatch_batch_and_order_kind.sql`:
+```sql
+alter table dispatch_orders add column kind varchar(20) not null default 'DELIVERY';
+alter table dispatch_orders add constraint ck_dispatch_orders_kind check (kind in ('PICKUP', 'DELIVERY'));
+alter table dispatch_orders add column batch_id uuid;
+create index ix_dispatch_orders_batch on dispatch_orders (batch_id, kind, status) where deleted_at is null;
+
+create table dispatch_batch (
+    id uuid primary key,
+    idx bigserial not null unique,
+    status varchar(20) not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid,
+    constraint ck_dispatch_batch_status check (status in ('COLLECTING', 'DELIVERING', 'DONE'))
+);
+```
+
+- [ ] **Step 2: enum 2개 작성**
+
+`DispatchOrderKind.java`:
+```java
+package com.thundercrew.opsapi.dispatch.domain;
+
+public enum DispatchOrderKind {
+    PICKUP,
+    DELIVERY
+}
+```
+`DispatchBatchStatus.java`:
+```java
+package com.thundercrew.opsapi.dispatch.domain;
+
+public enum DispatchBatchStatus {
+    COLLECTING,
+    DELIVERING,
+    DONE
+}
+```
+
+- [ ] **Step 3: DispatchBatch 엔티티 작성**
+
+`DispatchBatch.java`:
+```java
+package com.thundercrew.opsapi.dispatch.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "dispatch_batch")
+public class DispatchBatch extends DisplaySequencedEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchBatchStatus status;
+
+    public static DispatchBatch create() {
+        DispatchBatch batch = new DispatchBatch();
+        batch.status = DispatchBatchStatus.COLLECTING;
+        return batch;
+    }
+
+    /** 전체 수거 완료 후 운영자 '배송 시작'. COLLECTING 에서만 허용. */
+    public void startDelivery() {
+        if (status != DispatchBatchStatus.COLLECTING) {
+            throw new IllegalStateException("배송 시작은 수거 단계에서만 가능합니다. 현재: " + status);
+        }
+        this.status = DispatchBatchStatus.DELIVERING;
+    }
+
+    /** 전체 배송 완료. DELIVERING 에서만 허용. */
+    public void markDone(UUID actorId, Instant when) {
+        if (status != DispatchBatchStatus.DELIVERING) {
+            throw new IllegalStateException("완료는 배송 단계에서만 가능합니다. 현재: " + status);
+        }
+        this.status = DispatchBatchStatus.DONE;
+    }
+
+    public DispatchBatchStatus getStatus() {
+        return status;
+    }
+
+    protected DispatchBatch() {
+    }
+}
+```
+
+- [ ] **Step 4: DispatchOrder 에 kind/batchId 추가**
+
+`DispatchOrder.java` — `completedAt` 필드 선언(`@Column private Instant completedAt;`) 아래에 추가:
+```java
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchOrderKind kind;
+
+    @Column(name = "batch_id")
+    private UUID batchId;
+```
+기존 `create(...)` 팩토리의 `order.status = DispatchOrderStatus.ASSIGNED;` 다음 줄에 추가(단건 주문 하위호환 = DELIVERY/배치 없음):
+```java
+        order.kind = DispatchOrderKind.DELIVERY;
+        order.batchId = null;
+```
+`create(...)` 아래에 배치용 팩토리 추가:
+```java
+    public static DispatchOrder createForBatch(UUID bikeId, String customerName, String customerPhone,
+                                               String address, double latitude, double longitude, long sequence,
+                                               DispatchOrderKind kind, UUID batchId) {
+        DispatchOrder order = create(bikeId, customerName, customerPhone, address, latitude, longitude, sequence);
+        order.kind = kind;
+        order.batchId = batchId;
+        return order;
+    }
+```
+getter 추가(`getCompletedAt()` 아래):
+```java
+    public DispatchOrderKind getKind() {
+        return kind;
+    }
+
+    public UUID getBatchId() {
+        return batchId;
+    }
+```
+
+- [ ] **Step 5: 컴파일 확인**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/resources/db/migration/V34__add_dispatch_batch_and_order_kind.sql development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/ && git commit -m "feat(c4): V34 dispatch_batch + dispatch_orders kind/batch_id, DispatchBatch entity"
+```
+
+---
+
+### Task 2: Repository — DispatchBatchRepository + DispatchOrderRepository 추가
+
+**Files:**
+- Create: `.../dispatch/repository/DispatchBatchRepository.java`
+- Modify: `.../dispatch/repository/DispatchOrderRepository.java`
+
+- [ ] **Step 1: DispatchBatchRepository 작성**
+
+```java
+package com.thundercrew.opsapi.dispatch.repository;
+
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface DispatchBatchRepository extends Repository<DispatchBatch, UUID> {
+
+    List<DispatchBatch> findByStatusInAndDeletedAtIsNull(Collection<DispatchBatchStatus> statuses);
+
+    Optional<DispatchBatch> findByIdAndDeletedAtIsNull(UUID id);
+
+    DispatchBatch save(DispatchBatch batch);
+}
+```
+
+- [ ] **Step 2: DispatchOrderRepository 에 메서드 추가**
+
+`DispatchOrderRepository.java` — `save` 선언 위에 추가 (import: `DispatchOrderKind`):
+```java
+    List<DispatchOrder> findByBatchIdAndDeletedAtIsNull(UUID batchId);
+
+    List<DispatchOrder> findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+            UUID batchId, DispatchOrderKind kind, DispatchOrderStatus status);
+```
+파일 상단에 `import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;` 추가.
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/ && git commit -m "feat(c4): DispatchBatchRepository + batch/kind order queries"
+```
+
+---
+
+### Task 3: appendForBatch + complete 확장 (배치 자동 완료)
+
+**Files:**
+- Modify: `.../dispatch/service/DispatchOrderCommandService.java`
+
+- [ ] **Step 1: DispatchBatchRepository 주입 + appendForBatch + complete 확장**
+
+`DispatchOrderCommandService.java` 전체를 다음으로 교체:
+```java
+package com.thundercrew.opsapi.dispatch.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderCreateRequest;
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchBatchRepository;
+import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class DispatchOrderCommandService {
+
+    private final DispatchOrderRepository dispatchOrderRepository;
+    private final DispatchBatchRepository dispatchBatchRepository;
+    private final Clock clock;
+
+    public DispatchOrderCommandService(DispatchOrderRepository dispatchOrderRepository,
+                                       DispatchBatchRepository dispatchBatchRepository,
+                                       Clock clock) {
+        this.dispatchOrderRepository = dispatchOrderRepository;
+        this.dispatchBatchRepository = dispatchBatchRepository;
+        this.clock = clock;
+    }
+
+    public DispatchOrderReadResponse create(DispatchOrderCreateRequest request) {
+        return appendForBike(
+                request.bikeId(),
+                request.customerName(),
+                request.customerPhone(),
+                request.address(),
+                request.latitude(),
+                request.longitude());
+    }
+
+    public DispatchOrderReadResponse complete(UUID id) {
+        DispatchOrder order = dispatchOrderRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", id));
+        // 관리 엔티티는 @Transactional 종료 시 dirty-checking 으로 flush 되므로 mutate 경로에 명시적 save() 없음.
+        order.complete(clock.instant());
+        // 유모차 라운드: 마지막 배송 완료 시 배치를 DONE 으로 자동 전환.
+        if (order.getBatchId() != null && order.getKind() == DispatchOrderKind.DELIVERY
+                && dispatchOrderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+                        order.getBatchId(), DispatchOrderKind.DELIVERY, DispatchOrderStatus.ASSIGNED).isEmpty()) {
+            dispatchBatchRepository.findByIdAndDeletedAtIsNull(order.getBatchId())
+                    .filter(b -> b.getStatus() == com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus.DELIVERING)
+                    .ifPresent(b -> b.markDone(null, clock.instant()));
+        }
+        return DispatchOrderReadResponse.from(order);
+    }
+
+    public void cancel(UUID id) {
+        DispatchOrder order = dispatchOrderRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", id));
+        order.markDeleted(null, clock.instant());
+    }
+
+    public DispatchOrderReadResponse appendForBike(UUID bikeId, String customerName, String customerPhone,
+                                                   String address, double latitude, double longitude) {
+        long nextSequence = nextSequence(bikeId);
+        DispatchOrder order = DispatchOrder.create(
+                bikeId, customerName, customerPhone, address, latitude, longitude, nextSequence);
+        return DispatchOrderReadResponse.from(dispatchOrderRepository.save(order));
+    }
+
+    /** 라운드(batch) 소속 주문을 차량 큐에 append. kind 와 batchId 를 부여한다. */
+    public DispatchOrder appendForBatch(UUID bikeId, String customerName, String customerPhone, String address,
+                                        double latitude, double longitude, DispatchOrderKind kind, UUID batchId) {
+        long nextSequence = nextSequence(bikeId);
+        DispatchOrder order = DispatchOrder.createForBatch(
+                bikeId, customerName, customerPhone, address, latitude, longitude, nextSequence, kind, batchId);
+        return dispatchOrderRepository.save(order);
+    }
+
+    private long nextSequence(UUID bikeId) {
+        return dispatchOrderRepository
+                .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
+                .map(order -> order.getSequence() + 1)
+                .orElse(1L);
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderCommandService.java && git commit -m "feat(c4): appendForBatch + auto-DONE batch on last delivery complete"
+```
+
+---
+
+### Task 4: DispatchRoundService + DispatchRoundResponse
+
+**Files:**
+- Create: `.../dispatch/dto/DispatchRoundResponse.java`
+- Create: `.../dispatch/service/DispatchRoundService.java`
+
+- [ ] **Step 1: DispatchRoundResponse 작성**
+
+```java
+package com.thundercrew.opsapi.dispatch.dto;
+
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import java.util.UUID;
+
+/** 현재 유모차 라운드 + 진척. 활성 라운드 없으면 컨트롤러가 204 로 응답. */
+public record DispatchRoundResponse(
+        UUID batchId,
+        DispatchBatchStatus status,
+        int pickupTotal,
+        int pickupDone,
+        int deliveryTotal,
+        int deliveryDone
+) {
+    public static DispatchRoundResponse of(DispatchBatch batch, int pickupTotal, int pickupDone,
+                                           int deliveryTotal, int deliveryDone) {
+        return new DispatchRoundResponse(
+                batch.getId(), batch.getStatus(), pickupTotal, pickupDone, deliveryTotal, deliveryDone);
+    }
+}
+```
+
+- [ ] **Step 2: DispatchRoundService 작성**
+
+```java
+package com.thundercrew.opsapi.dispatch.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
+import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRequest;
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRow;
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchBatchRepository;
+import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 유모차 라운드(2단계 배치) 오케스트레이션.
+ * 업로드 → 수거(PICKUP) 주문 생성, '배송 시작' → 완료된 수거로부터 배송(DELIVERY) 주문 생성.
+ * 활성 단계의 주문만 ASSIGNED 로 존재하도록(배송은 전환 시 생성) 하여 큐/대시보드 쿼리를 단순 유지.
+ */
+@Service
+@Transactional
+public class DispatchRoundService {
+
+    private static final List<DispatchBatchStatus> ACTIVE =
+            List.of(DispatchBatchStatus.COLLECTING, DispatchBatchStatus.DELIVERING);
+
+    private final DispatchBatchRepository batchRepository;
+    private final DispatchOrderRepository orderRepository;
+    private final DispatchOrderCommandService commandService;
+
+    public DispatchRoundService(DispatchBatchRepository batchRepository,
+                                DispatchOrderRepository orderRepository,
+                                DispatchOrderCommandService commandService) {
+        this.batchRepository = batchRepository;
+        this.orderRepository = orderRepository;
+        this.commandService = commandService;
+    }
+
+    /** 새 라운드 생성. 동시 활성 라운드는 1개만 허용. 각 행을 PICKUP 주문으로 적재. */
+    public DispatchRoundResponse createRound(DispatchBulkApplyRequest request) {
+        if (!batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).isEmpty()) {
+            throw new IllegalStateException("이미 진행 중인 유모차 라운드가 있습니다.");
+        }
+        DispatchBatch batch = batchRepository.save(DispatchBatch.create());
+        for (DispatchBulkApplyRow row : request.rows()) {
+            commandService.appendForBatch(row.bikeId(), row.customerName(), row.customerPhone(),
+                    row.address(), row.latitude(), row.longitude(), DispatchOrderKind.PICKUP, batch.getId());
+        }
+        return progress(batch);
+    }
+
+    /** 전체 수거 완료 후 배송 단계로 전환. 완료된 수거 각각에서 배송 주문을 생성. */
+    public DispatchRoundResponse startDelivery(UUID batchId) {
+        DispatchBatch batch = batchRepository.findByIdAndDeletedAtIsNull(batchId)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchBatch", batchId));
+        List<DispatchOrder> pickups = orderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
+                batchId, DispatchOrderKind.PICKUP, DispatchOrderStatus.ASSIGNED);
+        if (!pickups.isEmpty()) {
+            throw new IllegalStateException("수거가 모두 완료되지 않았습니다. 남은 수거: " + pickups.size());
+        }
+        // 완료된 수거 = batch 의 PICKUP 전체. 같은 차량/고객/주소로 배송 주문 생성.
+        List<DispatchOrder> allPickups = orderRepository.findByBatchIdAndDeletedAtIsNull(batchId).stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.PICKUP)
+                .toList();
+        for (DispatchOrder p : allPickups) {
+            commandService.appendForBatch(p.getBikeId(), p.getCustomerName(), p.getCustomerPhone(),
+                    p.getAddress(), p.getLatitude(), p.getLongitude(), DispatchOrderKind.DELIVERY, batchId);
+        }
+        batch.startDelivery();
+        return progress(batch);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<DispatchRoundResponse> activeRound() {
+        return batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).stream()
+                .findFirst()
+                .map(this::progress);
+    }
+
+    private DispatchRoundResponse progress(DispatchBatch batch) {
+        List<DispatchOrder> orders = orderRepository.findByBatchIdAndDeletedAtIsNull(batch.getId());
+        int pickupTotal = (int) orders.stream().filter(o -> o.getKind() == DispatchOrderKind.PICKUP).count();
+        int pickupDone = (int) orders.stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.PICKUP && o.getStatus() == DispatchOrderStatus.COMPLETED)
+                .count();
+        int deliveryTotal = (int) orders.stream().filter(o -> o.getKind() == DispatchOrderKind.DELIVERY).count();
+        int deliveryDone = (int) orders.stream()
+                .filter(o -> o.getKind() == DispatchOrderKind.DELIVERY && o.getStatus() == DispatchOrderStatus.COMPLETED)
+                .count();
+        return DispatchRoundResponse.of(batch, pickupTotal, pickupDone, deliveryTotal, deliveryDone);
+    }
+}
+```
+주의: `findByBatchIdAndDeletedAtIsNull` 는 cancel(soft-delete)된 주문을 제외하므로 진척 분모는 "취소되지 않은" 기준이다.
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchRoundResponse.java && git commit -m "feat(c4): DispatchRoundService — createRound/startDelivery/activeRound"
+```
+
+---
+
+### Task 5: 컨트롤러 (Batch Read/Command) + ArchUnit allow-list
+
+**Files:**
+- Create: `.../dispatch/controller/DispatchBatchReadController.java`
+- Create: `.../dispatch/controller/DispatchBatchCommandController.java`
+- Modify: `development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java`
+
+- [ ] **Step 1: DispatchBatchReadController 작성**
+
+```java
+package com.thundercrew.opsapi.dispatch.controller;
+
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.service.DispatchRoundService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dispatch-batches")
+public class DispatchBatchReadController {
+
+    private final DispatchRoundService dispatchRoundService;
+
+    public DispatchBatchReadController(DispatchRoundService dispatchRoundService) {
+        this.dispatchRoundService = dispatchRoundService;
+    }
+
+    /** 현재 활성 유모차 라운드 + 진척. 없으면 204. */
+    @GetMapping("/active")
+    ResponseEntity<DispatchRoundResponse> active() {
+        return dispatchRoundService.activeRound()
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+}
+```
+
+- [ ] **Step 2: DispatchBatchCommandController 작성**
+
+```java
+package com.thundercrew.opsapi.dispatch.controller;
+
+import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRequest;
+import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
+import com.thundercrew.opsapi.dispatch.service.DispatchRoundService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dispatch-batches")
+public class DispatchBatchCommandController {
+
+    private final DispatchRoundService dispatchRoundService;
+
+    public DispatchBatchCommandController(DispatchRoundService dispatchRoundService) {
+        this.dispatchRoundService = dispatchRoundService;
+    }
+
+    /** 새 라운드 생성(프론트 지오코딩 완료 행, JSON). */
+    @PostMapping("/round")
+    DispatchRoundResponse createRound(@Valid @RequestBody DispatchBulkApplyRequest request) {
+        return dispatchRoundService.createRound(request);
+    }
+
+    @PostMapping("/{id}/start-delivery")
+    DispatchRoundResponse startDelivery(@PathVariable UUID id) {
+        return dispatchRoundService.startDelivery(id);
+    }
+}
+```
+
+- [ ] **Step 3: ArchUnit allow-list 등록**
+
+`ArchitectureBoundaryTests.java` 를 읽고, 기존 `isDispatchCommand` predicate(DispatchOrderCommandController owner-keyed) 정의부를 찾아 바로 아래에 동일 패턴으로 추가:
+```java
+    private static final DescribedPredicate<JavaClass> isDispatchBatchCommand =
+            owner("com.thundercrew.opsapi.dispatch.controller.DispatchBatchCommandController");
+```
+(실제 헬퍼 이름이 `owner(...)`가 아니면 `isDispatchCommand` 가 쓰는 그 헬퍼/형식을 그대로 따른다.) 그런 다음 `isDispatchCommand` 가 OR 로 들어가 있는 **두 규칙**(write-route 예외 `issue_70_..._write_route_exceptions` + @RequestBody 예외 `..._request_body_exceptions`) 각각에 `.or(isDispatchBatchCommand)` 를 추가한다.
+
+- [ ] **Step 4: ArchUnit 테스트 실행 (Docker 불필요)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew test --tests "com.thundercrew.opsapi.ArchitectureBoundaryTests" -q
+```
+Expected: PASS — dispatch-batch 컨트롤러 write/@RequestBody 위반 0.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/ development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java && git commit -m "feat(c4): dispatch-batch read/command controllers + arch allow-list"
+```
+
+---
+
+### Task 6: Dashboard — currentDispatchKind + DispatchOrderReadResponse.kind
+
+**Files:**
+- Modify: `.../dispatch/dto/DispatchOrderReadResponse.java`
+- Modify: `.../dashboard/dto/DashboardMapStateResponse.java`
+- Modify: `.../dashboard/service/DashboardMapStateService.java`
+
+- [ ] **Step 1: DispatchOrderReadResponse 에 kind 추가**
+
+`DispatchOrderReadResponse.java` — record 컴포넌트에 `DispatchOrderStatus status,` 다음 줄에 `DispatchOrderKind kind,` 추가(import `DispatchOrderKind`), `from(...)` 의 `order.getStatus(),` 다음에 `order.getKind(),` 추가.
+
+- [ ] **Step 2: Dashboard BikePin 에 currentDispatchKind 추가**
+
+`DashboardMapStateResponse.java` 를 읽고, BikePin 레코드/필드에서 기존 `currentDispatchCustomerName` 옆에 nullable `DispatchOrderKind currentDispatchKind` 필드를 추가한다(기존 currentDispatch* 필드와 동일 위치/직렬화 방식). `DashboardMapStateService.java` 의 `toBikePin`(또는 현재 배차 집계 부분)에서, 현재 배차(최저 sequence ASSIGNED) 주문의 `getKind()` 를 `currentDispatchKind` 로 매핑한다. 현재 배차 없으면 null.
+
+(정확한 필드 형태는 `currentDispatchCustomerName`/`currentDispatchAddress` 가 들어간 줄을 그대로 미러링. enum 직렬화는 Jackson 기본 — 문자열 PICKUP/DELIVERY.)
+
+- [ ] **Step 3: 컴파일 + 관련 테스트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchOrderReadResponse.java development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/ && git commit -m "feat(c4): expose currentDispatchKind on dashboard + order read response"
+```
+
+---
+
+### Task 7: 계약 테스트 (DispatchRoundApiContractTests)
+
+**Files:**
+- Create: `development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java`
+
+- [ ] **Step 1: 계약 테스트 작성**
+
+기존 `DispatchOrderApiContractTests` 를 읽어 동일한 베이스(`PostgresContainerSupport`), 시드(bike plate `서울CC-0001` + bike_current_states), MockMvc/RestAssured 호출 방식을 그대로 따른다. 케이스:
+1. **라운드 생성:** `POST /api/v1/dispatch-batches/round` (rows N건, 좌표 포함) → 200, `pickupTotal=N, pickupDone=0, deliveryTotal=0`, status `COLLECTING`. `GET /api/v1/dispatch-orders?bikeId=` → PICKUP N건 ASSIGNED.
+2. **동시 라운드 거부:** 활성 라운드 존재 시 두 번째 `/round` → 4xx(IllegalState).
+3. **수거 미완료 start-delivery 거부:** `POST /{id}/start-delivery` → 4xx, 메시지에 "수거".
+4. **전체 수거 → 전환:** 모든 PICKUP `POST /{orderId}/complete` 후 `/start-delivery` → 200 status `DELIVERING`, `deliveryTotal=N`. 큐에 DELIVERY N건 ASSIGNED.
+5. **배송 완료 → DONE:** 모든 DELIVERY complete 후 `GET /active` → 204 (활성 없음; 배치 DONE 으로 빠짐).
+6. **dashboard currentDispatchKind:** 라운드 생성 후 `GET /api/v1/dashboard/map-state` → 해당 bike pin `currentDispatchKind == "PICKUP"`.
+
+(4xx 검증은 GlobalExceptionHandler 의 IllegalStateException 매핑을 따른다 — 기존 테스트에서 IllegalState/validation 이 어떤 status 로 매핑되는지 확인해 일치시킬 것.)
+
+- [ ] **Step 2: 컴파일 확인 (Docker 없어 실행 불가 → 컴파일만)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileTestJava -q
+```
+Expected: BUILD SUCCESSFUL. (테스트 실행은 Docker 필요 → CI 에서.)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java && git commit -m "test(c4): DispatchRound contract tests (round create/gate/transition/done)"
+```
+
+---
+
+### Task 8: 프론트 — 타입 + API 클라이언트 + 정규화 + 서버 액션
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/service-ops-api.ts`
+- Modify: `development/front-admin-web/app/dispatch/actions.ts`
+
+- [ ] **Step 1: 타입 + BikePin + 클라이언트 메서드**
+
+`service-ops-api.ts`:
+- `ServiceOpsDispatchOrder` 타입에 `kind: "PICKUP" | "DELIVERY"` 필드 추가(백엔드 read response 에 kind 추가됨).
+- 신규 타입:
+```ts
+export type ServiceOpsDispatchOrderKind = "PICKUP" | "DELIVERY";
+export type ServiceOpsDispatchRoundStatus = "COLLECTING" | "DELIVERING" | "DONE";
+export type ServiceOpsDispatchRound = {
+  batchId: string;
+  status: ServiceOpsDispatchRoundStatus;
+  pickupTotal: number;
+  pickupDone: number;
+  deliveryTotal: number;
+  deliveryDone: number;
+};
+```
+- BikePin raw + Frontend 타입에 `currentDispatchKind?: ServiceOpsDispatchOrderKind | null` 추가, 정규화(`toFrontendDashboardMapState`)에서 `currentDispatchKind: pin.currentDispatchKind ?? null` (기존 currentDispatch* 미러링).
+- 클라이언트 메서드 추가(기존 dispatch 메서드 옆):
+```ts
+    getActiveDispatchRound: () => Promise<ServiceOpsDispatchRound | null>;
+    createDispatchRound: (rows: DispatchBulkApplyRow[]) => Promise<ServiceOpsDispatchRound>;
+    startDispatchDelivery: (batchId: string) => Promise<ServiceOpsDispatchRound>;
+```
+구현(factory):
+```ts
+    getActiveDispatchRound: async () => {
+      const res = await rawRequest("/dispatch-batches/active", { method: "GET" });
+      if (res.status === 204) return null;
+      return (await res.json()) as ServiceOpsDispatchRound;
+    },
+    createDispatchRound: (rows) =>
+      request<ServiceOpsDispatchRound>("/dispatch-batches/round", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows })
+      }),
+    startDispatchDelivery: (batchId) =>
+      request<ServiceOpsDispatchRound>(`/dispatch-batches/${batchId}/start-delivery`, { method: "POST" }),
+```
+주의: `getActiveDispatchRound` 는 204(빈 본문)를 다뤄야 하므로 `request<T>`(JSON 파싱 가정)가 아닌 저수준 fetch 가 필요하다. 기존 클라이언트에 raw fetch 접근자가 있으면 사용하고, 없으면 `request` 가 204 를 어떻게 처리하는지 확인해 null 반환하도록 맞춘다(구현 디테일은 기존 `cancelDispatchOrder` 가 204 를 어떻게 다루는지 참고 — 그 패턴 재사용).
+
+- [ ] **Step 2: 서버 액션**
+
+`app/dispatch/actions.ts` 에 추가(기존 `applyDispatchAction` 패턴 미러링 — 미리보기/지오코딩은 기존 `previewDispatchAction` 그대로 재사용):
+```ts
+export async function getActiveRoundAction(): Promise<ServiceOpsDispatchRound | null> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return null;
+  return client.getActiveDispatchRound().catch(() => null);
+}
+
+export async function createRoundAction(
+  rows: DispatchBulkApplyRow[]
+): Promise<{ ok: true; round: ServiceOpsDispatchRound } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    const round = await client.createDispatchRound(rows);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true, round };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function startDeliveryAction(
+  batchId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    await client.startDispatchDelivery(batchId);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+```
+`ServiceOpsDispatchRound` import 추가.
+
+- [ ] **Step 3: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/app/dispatch/actions.ts && git commit -m "feat(c4): frontend round types/client/actions + currentDispatchKind"
+```
+
+---
+
+### Task 9: 프론트 — /management 유모차 라운드 섹션 + 큐 수거/배송 라벨
+
+**Files:**
+- Create: `development/front-admin-web/components/management/StrollerRoundPanel.tsx`
+- Modify: `development/front-admin-web/app/management/page.tsx`
+- Modify: `development/front-admin-web/components/management/VehicleDetailDialog.tsx`
+- Modify: `development/front-admin-web/app/globals.css`
+
+- [ ] **Step 1: StrollerRoundPanel 작성**
+
+`"use client"` 컴포넌트. props 로 초기 활성 라운드(`ServiceOpsDispatchRound | null`)를 받거나, 마운트 시 `getActiveRoundAction()` 로 로드. 구성:
+- 헤더 "유모차 라운드" + 단계 배지: status null→"진행 라운드 없음", COLLECTING→"수거 중", DELIVERING→"배송 중".
+- 진척: `수거 {pickupDone}/{pickupTotal}`, `배송 {deliveryDone}/{deliveryTotal}`.
+- 업로드: 기존 배차 업로드 UI(ExcelImportButton + 미리보기) 재사용하되 apply 를 `createRoundAction(rows)` 로. (기존 DispatchPanel 의 업로드/미리보기 흐름을 참고해 그대로 따르고, 적용 함수만 교체.)
+- `배송 시작` 버튼: `status === "COLLECTING" && pickupTotal > 0 && pickupDone === pickupTotal` 일 때만 enabled. onClick → `startDeliveryAction(batchId)` (useTransition), 성공 시 라운드 재로드, 실패 시 error 표시.
+
+구현은 기존 `components/management/DispatchPanel.tsx`(있다면) / BulkPreviewModal / ExcelImportButton 패턴을 그대로 미러링한다. 새 CSS 클래스는 `globals.css` 에 추가(Step 3).
+
+- [ ] **Step 2: /management 에 섹션 추가**
+
+`app/management/page.tsx` — 기존 배차(DispatchPanel) 섹션 옆/아래에 `<StrollerRoundPanel ... />` 추가. SSR 에서 `getActiveRoundAction()` 로 초기 라운드를 받아 prop 으로 넘기거나, 클라이언트 로드. (page.tsx 가 server component 면 `getActiveRoundAction()` 를 await 해 prop 전달.)
+
+- [ ] **Step 3: 배차 큐에 수거/배송 라벨 + CSS**
+
+`VehicleDetailDialog.tsx` 의 `DispatchOrderRow` 에서 `order.kind` 에 따라 라벨 칩을 표시: `PICKUP`→"수거", `DELIVERY`→"배송". 고객 이름 행 옆 또는 헤더에 작은 배지. (`ServiceOpsDispatchOrder.kind` 사용.) `globals.css` 에 `.dispatch-kind-badge`(+ pickup/delivery 변형)와 `.stroller-round-*` 클래스 추가.
+
+- [ ] **Step 4: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/StrollerRoundPanel.tsx development/front-admin-web/app/management/page.tsx development/front-admin-web/components/management/VehicleDetailDialog.tsx development/front-admin-web/app/globals.css && git commit -m "feat(c4): /management stroller-round panel + 수거/배송 queue labels"
+```
+
+---
+
+### Task 10: 프론트 — 시동 알림에 수거/배송 라벨
+
+**Files:**
+- Modify: `development/front-admin-web/components/layout/NotificationContext.tsx`
+- Modify: `development/front-admin-web/components/layout/NotificationBell.tsx`
+- Modify: `development/front-admin-web/components/overview/FleetSimulationContext.tsx`
+
+- [ ] **Step 1: IgnitionNotification 에 kind 추가**
+
+`NotificationContext.tsx` — `IgnitionNotification` 타입에 `kind?: "PICKUP" | "DELIVERY"` 추가(주소 필드 옆, optional).
+
+- [ ] **Step 2: 출발 effect 에서 currentDispatchKind 전달**
+
+`FleetSimulationContext.tsx` — 출발 감지 effect 의 `addNotification({...})` 에 `kind: pin?.currentDispatchKind ?? undefined` 추가. (pin 은 `FrontendDashboardBikePin`, currentDispatchKind 필드 Task 8 에서 추가됨.)
+
+- [ ] **Step 3: 벨 표시에 라벨**
+
+`NotificationBell.tsx` — 항목 텍스트에서 고객명 앞/뒤에 kind 라벨을 붙인다: `kind === "PICKUP" ? "수거" : kind === "DELIVERY" ? "배송" : ""`. 예: `🔑 {plate} 출발 ({수거}) → {고객명} ({주소})`. kind 없으면 라벨 생략.
+
+- [ ] **Step 4: 타입체크 + 린트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/layout/NotificationContext.tsx development/front-admin-web/components/layout/NotificationBell.tsx development/front-admin-web/components/overview/FleetSimulationContext.tsx && git commit -m "feat(c4): ignition notification shows 수거/배송 kind label"
+```
+
+---
+
+### Task 11: 최종 검증 + PR
+
+- [ ] **Step 1: 백엔드 컴파일 + ArchUnit**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava && ./gradlew test --tests "com.thundercrew.opsapi.ArchitectureBoundaryTests" -q
+```
+Expected: BUILD SUCCESSFUL, ArchUnit PASS. (계약 테스트는 Docker 필요 → CI.)
+
+- [ ] **Step 2: 프론트 풀 빌드**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 통과, Next 빌드 성공.
+
+- [ ] **Step 3: 변경 요약 + PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git diff dev --stat && git push -u origin cc-c4-stroller-round && gh pr create --base dev --title "Group C4: 유모차 클리닝 (수거→배송 2단계 라운드)" --body "$(cat <<'EOF'
+## Summary
+- DispatchOrder 확장(kind PICKUP/DELIVERY + batch_id) + 신규 DispatchBatch(라운드 단계) 로 유모차 2단계 배치 흐름 구축 (V34)
+- 엑셀 업로드 → 수거 주문 생성 → 전체 수거 완료 → '배송 시작' → 배송 주문 생성 → 전체 배송 완료 → 라운드 DONE
+- /management 유모차 라운드 섹션(단계·진척·업로드·배송 시작), 배차 큐 + 시동 알림에 수거/배송 라벨
+- 활성 단계만 ASSIGNED 유지 → 대시보드/큐/알림 핫패스 무변경
+
+## 배포 영향
+- **V34 마이그레이션 신규** (dispatch_orders ALTER + dispatch_batch) — 재기동 시 Flyway 적용
+- 백엔드 + 프론트
+
+## Test Plan
+- [x] 백엔드 컴파일 + ArchUnit PASS
+- [ ] 계약 테스트(DispatchRoundApiContractTests) — Docker/CI 에서 실행
+- [x] 프론트 typecheck/lint/build
+- [ ] 프로덕션 QA: 유모차 엑셀 업로드 → 수거 완료 → 배송 시작 → 배송 완료 → 라운드 종료
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- V34(dispatch_orders ALTER + dispatch_batch) → Task 1. ✓
+- DispatchOrder kind/batchId + DispatchBatch(startDelivery/markDone) → Task 1. ✓
+- Repository(batch + kind 쿼리) → Task 2. ✓
+- createRound/startDelivery(게이트)/activeRound → Task 4; appendForBatch + 자동 DONE → Task 3. ✓
+- 컨트롤러 Read/Command + ArchUnit → Task 5. ✓
+- currentDispatchKind(대시보드) → Task 6. ✓
+- 계약 테스트(생성·게이트·전환·완료·dashboard) → Task 7. ✓
+- 프론트 타입/클라이언트/액션 → Task 8. ✓
+- /management 라운드 섹션 + 큐 라벨 → Task 9. ✓
+- 시동 알림 라벨 → Task 10. ✓
+- 동시 라운드 1개 → Task 4 createRound 거부. ✓
+- CLEANING serviceType 재사용 → 별도 백엔드 변경 없음(유모차 차량은 CLEANING 으로 등록; 알림은 기존 serviceType==CLEANING 게이트 그대로). ✓
+
+**2. Placeholder scan:** 신규 백엔드 파일은 완전한 코드. 일부 프론트 태스크(Task 8 raw-204 처리, Task 9 업로드 모달 재사용, Task 6 dashboard 필드 위치)는 "기존 X 패턴을 읽고 미러링"으로 위임 — 해당 파일들의 정확한 형태가 코드베이스에 의존하고(예: request<T> 의 204 처리, DashboardMapStateService 의 toBikePin 구조), 구현자가 그 파일을 읽어야 정확하기 때문. 각 위임에는 따를 구체 대상(파일·기존 심볼)을 명시했다. 순수 새 로직(게이트·전환·진척)은 전부 완전 코드로 제공.
+
+**3. Type consistency:** `DispatchOrderKind{PICKUP,DELIVERY}`, `DispatchBatchStatus{COLLECTING,DELIVERING,DONE}`, `DispatchRoundResponse(batchId,status,pickupTotal,pickupDone,deliveryTotal,deliveryDone)`, `appendForBatch(...,kind,batchId)`, `createForBatch(...,kind,batchId)`, repo `findByBatchIdAndKindAndStatusAndDeletedAtIsNull`/`findByBatchIdAndDeletedAtIsNull`/`findByStatusInAndDeletedAtIsNull` — Task 간 일관. 프론트 `ServiceOpsDispatchRound`/`currentDispatchKind`/`createRoundAction`/`startDeliveryAction` 일관.
+
+**구현자 주의:** 백엔드 Task(1–7)는 순차 의존(엔티티→레포→서비스→컨트롤러→대시보드→테스트). 프론트 Task(8–10)는 백엔드 read response 의 `kind` + dashboard `currentDispatchKind` 에 의존하므로 백엔드 이후. Task 6 의 dashboard 변경은 실제 `DashboardMapStateService`/`DashboardMapStateResponse` 구조를 읽고 기존 currentDispatch* 필드를 그대로 미러링할 것.

--- a/docs/superpowers/specs/2026-06-12-group-c4-stroller-round-design.md
+++ b/docs/superpowers/specs/2026-06-12-group-c4-stroller-round-design.md
@@ -1,0 +1,120 @@
+# Group C4 — 유모차 클리닝 (수거 → 배송 2단계 라운드) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 유모차 클리닝의 "전체 수거 → 전체 배송" 2단계 배치 흐름을 구축한다. 엑셀 한 행(담당 차량+고객+주소)이 그 고객의 **수거 + 배송 왕복 태스크**를 만들고, 운영자는 1단계로 전체 수거를 완료한 뒤 '배송 시작'으로 2단계 전체 배송으로 전환한다.
+
+**Architecture:** 기존 C0/C2 `DispatchOrder`(태스크 단위)를 확장한다 — `kind`(PICKUP/DELIVERY) + `batch_id`(라운드) 컬럼 추가 + 신규 `dispatch_batch`(라운드, 단계 상태) 엔티티. **활성 단계의 태스크만 ASSIGNED로 존재**시켜(배송 주문은 '배송 시작' 시점에 생성), 대시보드·배차 큐·시동 알림의 핫패스 쿼리를 C2/C3와 동일하게 유지한다. 엑셀 벌크·지오코딩·배차 큐 UI·시동 알림(C3)을 재사용한다.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA `Repository<T,UUID>`, Apache POI, NCP Geocoding(프론트), Next.js App Router, TypeScript.
+
+---
+
+## 1. 범위
+
+### 이번 스펙 (C4)
+- 유모차 라운드 도메인: `DispatchBatch`(단계) + `DispatchOrder` 확장(kind/batch).
+- 엑셀 업로드 → 라운드 생성(수거 태스크) → 전체 수거 완료 → '배송 시작' → 배송 태스크 생성 → 전체 배송 완료 → 라운드 종료.
+- /management "유모차 라운드" 섹션(단계·진척·업로드·배송 시작), 차량 상세 배차 큐 + 지도 + 시동 알림에 수거/배송 라벨.
+
+### 범위 외 (후속/별도)
+- 배민 배송(C1)
+- 다중 동시 활성 라운드(이번엔 1개만)
+- 수거지 ≠ 배송지(주소 분리), 픽업 2지점
+- 실제 경로 계산, 세척장 위치, 라이더 앱 연동
+- 새 `STROLLER` serviceType (CLEANING 재사용)
+
+---
+
+## 2. 핵심 동작 결정 (확정)
+
+| 항목 | 결정 |
+|---|---|
+| 수거/배송 구조 | **왕복** — 한 고객(주소 1개) = 수거 + 배송. 엑셀 한 행이 두 태스크의 소스 |
+| 단계 전환 | **전체 수거 완료 후 일괄 전환** — 모든 PICKUP COMPLETED → 운영자 '배송 시작' → 전체 배송 단계 |
+| 배정 | 엑셀 행마다 **담당 차량번호 명시** (C2/C3 동일 템플릿) |
+| 배송 주문 생성 시점 | **'배송 시작' 전환 시 생성** (업로드 시엔 수거만) → 항상 활성 단계만 ASSIGNED → 기존 쿼리 무수정 |
+| 차량 serviceType | **CLEANING 재사용** (새 enum 없음). 유모차 여부 = batch 소속으로 구분 → 시동 알림/필터 무료 재사용 |
+| 동시 활성 라운드 | **1개** (업로드 = 라운드 1개) |
+| 시동 알림 | C3 재사용 — CLEANING 차량 출발 시 현재 태스크(수거/배송) 고객 표시 |
+
+---
+
+## 3. 백엔드 (service-ops-api · `com.thundercrew.opsapi.dispatch`)
+
+### 3.1 마이그레이션 `V34__add_dispatch_batch_and_order_kind.sql`
+- `dispatch_orders` ALTER:
+  - `kind varchar(20) not null default 'DELIVERY'` + check (`PICKUP`,`DELIVERY`) — 기존 단건(C2/C3) 주문은 DELIVERY로 백필
+  - `batch_id uuid null` (라운드 식별; 단건 주문은 null) + 인덱스 `(batch_id, kind, status)`
+- `dispatch_batch` 신규 (V33 컨벤션 준수):
+  - `id uuid pk`, `idx bigserial unique`
+  - `status varchar(20) not null` (`COLLECTING`,`DELIVERING`,`DONE`) + check
+  - 표준 audit/soft-delete: `created_at/by`, `updated_at/by`, `deleted_at/by`
+
+### 3.2 도메인
+- **`DispatchOrder`** (확장): `kind`(enum `DispatchOrderKind{PICKUP,DELIVERY}`), `batchId`(UUID nullable) 필드. 신규 팩토리 `createForBatch(bikeId, name, phone, address, lat, lng, sequence, kind, batchId)`. 기존 `create(...)`는 `kind=DELIVERY, batchId=null`로 위임(하위호환).
+- **`DispatchBatch`** (신규, `DisplaySequencedEntity` 상속): `status`(enum `DispatchBatchStatus{COLLECTING,DELIVERING,DONE}`). 정적 팩토리 `create()`(status=COLLECTING). 메서드 `startDelivery()`(COLLECTING→DELIVERING), `markDone(actorId,Instant)`(DELIVERING→DONE). 잘못된 전환은 `IllegalStateException`.
+- **`DispatchBatchRepository`** (`Repository<DispatchBatch,UUID>`): `findByStatusInAndDeletedAtIsNull`(활성 라운드 조회), `findByIdAndDeletedAtIsNull`, `save`.
+- **`DispatchOrderRepository`** 추가: `findByBatchIdAndDeletedAtIsNull`, `findByBatchIdAndKindAndStatusAndDeletedAtIsNull`(게이트/진척 집계).
+
+### 3.3 서비스
+- **`DispatchRoundService`** (`@Transactional`):
+  - `createRound(rows)`: 활성 라운드 존재 시 거부(동시 1개). `DispatchBatch` 생성(COLLECTING). 각 행 → 담당 차량 lookup, `kind=PICKUP` 주문 생성(차량별 sequence = max+1), batchId 연결. 좌표는 행에 포함(프론트 지오코딩 선처리).
+  - `startDelivery(batchId)`: 배치 COLLECTING 검증. 해당 배치 **모든 PICKUP COMPLETED** 검증(미완료 시 거부, 메시지). 각 PICKUP에서 같은 차량/고객/주소/좌표로 `kind=DELIVERY` 주문 생성(ASSIGNED, sequence 부여). `batch.startDelivery()`.
+  - `activeRound()`(readOnly): 활성 배치 + 진척(수거 완료/전체, 배송 완료/전체, 단계) DTO.
+- **`DispatchOrderCommandService.complete(id)`** 확장: 완료 주문이 batch 소속 DELIVERY이고 해당 배치 전 DELIVERY가 모두 COMPLETED면 `batch.markDone(...)`. (PICKUP 완료는 단계 전환 안 함 — '배송 시작'은 운영자 클릭.)
+
+### 3.4 컨트롤러 (ArchUnit allow-list — issue_70)
+- `DispatchBatchReadController` `@RequestMapping("/api/v1/dispatch-batches")`: GET `/active`(현재 라운드+진척).
+- `DispatchBatchCommandController`: POST `/round`(라운드 생성 = bulk apply), POST `/{id}/start-delivery`. (Read/Command 분리, `isDispatchBatchCommand` allow-list 등록 — write-route + @RequestBody 규칙 양쪽.)
+- 라운드 업로드 미리보기/검증은 C2 `DispatchOrderBulkService` 패턴 재사용(차량번호 검증 + NEW/ERROR). apply만 라운드 생성 경로.
+
+### 3.5 Dashboard 확장
+- `DashboardMapStateResponse.BikePin`에 `currentDispatchKind`(PICKUP/DELIVERY nullable) 1필드 추가 — current(최저 seq ASSIGNED) 주문의 kind. current 선택 로직은 **무변경**(활성 단계만 ASSIGNED이므로).
+
+### 3.6 테스트
+`DispatchRoundApiContractTests` (PostgresContainerSupport): 라운드 생성(수거 주문 N건, 배치 COLLECTING), 수거 완료, 미완료 상태 start-delivery 거부, 전체 수거 후 start-delivery → 배송 주문 N건 생성 + 배치 DELIVERING, 배송 완료 → 배치 DONE, 동시 라운드 생성 거부, dashboard currentDispatchKind 반영.
+
+---
+
+## 4. 프론트엔드 (front-admin-web)
+
+### 4.1 타입 + API 클라이언트 (service-ops-api.ts)
+- `ServiceOpsDispatchRound`(status, 수거/배송 진척 수치), `ServiceOpsDispatchOrderKind`. BikePin에 `currentDispatchKind` 추가 + 정규화.
+- 메서드: `getActiveDispatchRound()`, `createDispatchRound(rows)`, `startDispatchDelivery(batchId)`, 라운드 미리보기(C2 preview 재사용).
+
+### 4.2 서버 액션 (app/dispatch/actions.ts 또는 stroller actions)
+`previewRoundAction`(C2 previewDispatchAction 패턴 — 지오코딩), `createRoundAction(rows)`, `startDeliveryAction(batchId)` — `{ok,error}` + `revalidatePath("/management")`,`("/")`.
+
+### 4.3 /management "유모차 라운드" 섹션
+차량/라이더/매칭/배차 옆 **유모차 라운드** 섹션:
+- 현재 단계 배지: 수거 중 / 배송 중 / 진행 라운드 없음
+- 진척: "수거 N/M 완료", "배송 N/M 완료"
+- **유모차 엑셀 업로드**(C2 ExcelImport/preview 모달 재사용, 라운드 생성)
+- **'배송 시작' 버튼**: 단계 COLLECTING + 전체 수거 완료일 때만 활성. 클릭 → `startDeliveryAction`.
+
+### 4.4 지도 / 차량 상세 / 알림 (수거·배송 라벨)
+- 차량 상세 "배차 큐": 현재/대기 각 건에 **수거/배송 라벨**(order.kind). 완료/취소는 기존 그대로.
+- 시동 알림(벨/말풍선): 현재 태스크 고객명 + **수거/배송 라벨**(currentDispatchKind). C3 알림 경로 재사용.
+- 지도 마커 배지: 기존 "N건" 유지(선택적으로 단계 라벨). 시뮬 이동은 currentDispatch 좌표(기존 C3 가드) 그대로.
+
+---
+
+## 5. 데이터 흐름
+
+```
+[엑셀 업로드(차량/고객/연락처/주소)] → 미리보기(차량 검증+지오코딩, C2)
+  → createRound: DispatchBatch(COLLECTING) + 행마다 PICKUP 주문(ASSIGNED)
+[수거] 차량이 현재 수거지로(시뮬·시동 알림) → 운영자 배차 큐 완료
+  → 전체 PICKUP 완료 시 '배송 시작' 활성
+[배송 시작] startDelivery: 게이트 검증 → PICKUP들로 DELIVERY 주문 생성(ASSIGNED) + 배치 DELIVERING
+[배송] 차량이 현재 배송지로 → 운영자 완료 → 마지막 배송 완료 시 배치 DONE
+[대시보드] 활성 단계 주문만 ASSIGNED → currentDispatch(+kind) 제공 → 마커/알림/큐
+```
+
+## 6. 배포 영향
+- **V34 마이그레이션 신규** (dispatch_orders ALTER + dispatch_batch) — api 재기동 시 Flyway 적용. 파이프라인 `-x test`라 스키마/엔티티 매핑 일치 필수.
+- 백엔드+프론트 변경. 지오코딩은 프론트(C2 hybrid) 재사용.
+
+## 7. 비범위 재확인
+배민(C1), 다중 동시 라운드, 수거지≠배송지, 실제 경로/세척장, 새 serviceType 은 이 스펙에 포함하지 않는다.


### PR DESCRIPTION
## Summary
유모차 클리닝의 "전체 수거 → 전체 배송" 2단계 배치 흐름을, 기존 C0/C2 `DispatchOrder` 도메인 확장으로 구축.

- **V34**: `dispatch_orders`에 `kind`(PICKUP/DELIVERY, 기존행 DELIVERY 백필) + `batch_id`; 신규 `dispatch_batch`(라운드 단계 COLLECTING→DELIVERING→DONE)
- **흐름**: 엑셀 업로드(차량/고객/주소) → 라운드 생성(수거 주문) → 전체 수거 완료 → '배송 시작'(게이트) → 완료된 수거로부터 배송 주문 생성 → 전체 배송 완료 → 라운드 자동 DONE
- **활성 단계만 ASSIGNED 유지**(배송 주문은 전환 시 생성) → 대시보드/배차 큐/시동 알림 핫패스 쿼리 무변경
- **/management 유모차 라운드** 섹션(단계·진척·업로드·배송 시작), 배차 큐 + 시동 알림에 **수거/배송 라벨**(currentDispatchKind)
- 라운드 거부(동시 라운드·수거 미완료·빈 행)는 `InvalidStateTransitionException` → **409 + 한글 메시지**가 운영자 UI에 노출

## 배포 영향
- **V34 마이그레이션 신규** (dispatch_orders ALTER + dispatch_batch) — 재기동 시 Flyway 적용 (C0/C2와 동일 위험)
- 백엔드 + 프론트. 지오코딩은 C2 hybrid(프론트) 재사용. CLEANING serviceType 재사용(새 enum 없음)

## Test Plan
- [x] 백엔드 compileJava + compileTestJava 성공
- [x] ArchUnit: dispatch-batch 컨트롤러 위반 0 (기존 pre-red 베이스라인만 잔존)
- [ ] 계약 테스트 `DispatchRoundApiContractTests` (6 케이스) — **Docker/CI 에서 실행** (이 머신 Docker 없음, 컴파일만 확인)
- [x] 프론트 typecheck/lint/build 성공
- [ ] 프로덕션 QA: 유모차 엑셀 업로드 → 수거 완료 → 배송 시작 → 배송 완료 → 라운드 종료

## 후속(비차단)
- 계약 테스트 `listOrderIdsByKind` 헬퍼의 정규식 JSON 파싱 → jsonPath 로 교체(현 평면 스키마에선 동작, 견고성 개선)
- `DispatchBatch.markDone(actorId, when)` 파라미터 미사용(향후 `completed_at` 컬럼 추가 시 활용 또는 시그니처 단순화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)