### PR TITLE
Release: Group C1 배민 배송 (단건 콜)

### DIFF
--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import {
   ServiceOpsApiError,
+  type DeliveryCallPayload,
   type DispatchBulkApplyRow,
   type DispatchBulkPreviewRow,
   type DispatchBulkSummary,
@@ -176,4 +177,68 @@ export async function startDeliveryAction(
   } catch (err) {
     return { ok: false, error: extractError(err) };
   }
+}
+
+async function geocodeCallForm(
+  formData: FormData
+): Promise<{ ok: true; payload: DeliveryCallPayload } | { ok: false; error: string }> {
+  const customerName = String(formData.get("customerName") ?? "").trim();
+  const customerPhone = String(formData.get("customerPhone") ?? "").trim();
+  const address = String(formData.get("address") ?? "").trim();
+  if (!customerName || !customerPhone || !address) {
+    return { ok: false, error: "모든 항목을 입력해주세요." };
+  }
+  const coords = await geocodeAddress(address);
+  if (!coords) return { ok: false, error: "주소를 찾을 수 없습니다. 다시 확인해주세요." };
+  return { ok: true, payload: { customerName, customerPhone, address, latitude: coords.latitude, longitude: coords.longitude } };
+}
+
+export async function createSystemCallAction(
+  formData: FormData
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  const geo = await geocodeCallForm(formData);
+  if (!geo.ok) return geo;
+  try {
+    await client.systemDispatchCall(geo.payload);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function createOfferedCallAction(
+  formData: FormData
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  const geo = await geocodeCallForm(formData);
+  if (!geo.ok) return geo;
+  try {
+    await client.offerCall(geo.payload);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function acceptCallAction(
+  orderId: string,
+  bikeId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    await client.acceptCall(orderId, bikeId);
+    revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function listOfferedCallsAction(): Promise<ServiceOpsDispatchOrder[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listOfferedCalls().catch(() => []);
 }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1566,3 +1566,28 @@ textarea { padding-top: 10px; min-height: 96px; }
 .stroller-round-progress-sep {
   color: var(--color-text-muted);
 }
+
+/* ── 배민 콜 섹션 ────────────────────────────────────────────────────────── */
+.baemin-call-form { display: grid; gap: 10px; margin-bottom: 16px; }
+.baemin-call-form-row { display: grid; grid-template-columns: 72px 1fr; gap: 8px; align-items: center; }
+.baemin-call-form-label { font-size: 13px; font-weight: 600; color: var(--color-text-muted); white-space: nowrap; }
+.baemin-call-form-input { height: 34px; padding: 0 10px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-soft); color: var(--color-text-primary); font-size: 13px; font-family: var(--font-sans); width: 100%; box-sizing: border-box; }
+.baemin-call-form-input:focus { outline: none; border-color: var(--color-accent, #3b82f6); }
+.baemin-call-address-row { display: flex; gap: 6px; align-items: center; }
+.baemin-call-address-row .baemin-call-form-input { flex: 1; min-width: 0; }
+.baemin-call-mode-row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; padding-top: 2px; }
+.baemin-call-mode-option { display: flex; align-items: center; gap: 5px; font-size: 13px; color: var(--color-text-primary); cursor: pointer; }
+.baemin-call-form-actions { display: flex; justify-content: flex-end; padding-top: 4px; }
+.baemin-call-error { margin: 0; font-size: 12px; color: var(--rm-battery-low, #ef4444); }
+.baemin-call-notice { margin: 0; font-size: 12px; color: #166534; }
+.baemin-call-offered-list { display: flex; flex-direction: column; gap: 8px; }
+.baemin-call-offered-heading { margin: 0 0 4px; font-size: 12px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--color-text-muted); }
+.baemin-call-card { padding: 10px 12px; border-radius: 10px; border: 1px solid var(--color-border); background: var(--color-bg-soft); display: flex; flex-direction: column; gap: 6px; }
+.baemin-call-card-info { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; font-size: 13px; }
+.baemin-call-card-name { font-weight: 700; color: var(--color-text-primary); }
+.baemin-call-card-phone { color: var(--color-text-primary); font-variant-numeric: tabular-nums; }
+.baemin-call-card-address { color: var(--color-text-muted); }
+.baemin-call-card-sep { color: var(--color-text-muted); }
+.baemin-call-accept-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.baemin-call-vehicle-select { height: 32px; padding: 0 8px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-soft); color: var(--color-text-primary); font-size: 13px; font-family: var(--font-sans); min-width: 120px; }
+.baemin-call-hint { font-size: 12px; color: var(--color-text-muted); }

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -3,12 +3,22 @@ import { RidersManagementPanel } from "@/components/management/RidersManagementP
 import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
 import { DispatchPanel } from "@/components/management/DispatchPanel";
 import { StrollerRoundPanel } from "@/components/management/StrollerRoundPanel";
-import { getActiveRoundAction } from "@/app/dispatch/actions";
+import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
+import { getActiveRoundAction, listOfferedCallsAction } from "@/app/dispatch/actions";
+import { listVehiclesAction } from "@/app/management/vehicles/actions";
 
 export const dynamic = "force-dynamic";
 
 export default async function ManagementPage() {
-  const activeRound = await getActiveRoundAction();
+  const [activeRound, offeredCalls, vehiclesPage] = await Promise.all([
+    getActiveRoundAction(),
+    listOfferedCallsAction(),
+    listVehiclesAction()
+  ]);
+
+  const deliveryVehicles = vehiclesPage
+    .filter((v) => v.serviceType === "DELIVERY")
+    .map((v) => ({ id: v.slug, plateNumber: v.plateNumber }));
 
   return (
     <div className="management-page">
@@ -17,6 +27,7 @@ export default async function ManagementPage() {
       <MatchingManagementPanel exportUrl="/api/management/matching/export" />
       <DispatchPanel exportUrl="/api/management/dispatch/export" />
       <StrollerRoundPanel initialRound={activeRound} />
+      <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
     </div>
   );
 }

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -18,7 +18,7 @@ export default async function ManagementPage() {
 
   const deliveryVehicles = vehiclesPage
     .filter((v) => v.serviceType === "DELIVERY")
-    .map((v) => ({ id: v.slug, plateNumber: v.plateNumber }));
+    .map((v) => ({ id: v.id ?? v.slug, plateNumber: v.plateNumber }));
 
   return (
     <div className="management-page">

--- a/development/front-admin-web/components/management/BaeminCallPanel.tsx
+++ b/development/front-admin-web/components/management/BaeminCallPanel.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import type { ServiceOpsDispatchOrder } from "@/lib/services/service-ops-api";
+import {
+  createSystemCallAction,
+  createOfferedCallAction,
+  acceptCallAction,
+  listOfferedCallsAction
+} from "@/app/dispatch/actions";
+import { AddressSearchButton } from "@/components/management/AddressSearchButton";
+
+type DeliveryVehicleOption = { id: string; plateNumber: string };
+
+export function BaeminCallPanel({
+  initialOffered,
+  deliveryVehicles
+}: {
+  initialOffered: ServiceOpsDispatchOrder[];
+  deliveryVehicles: DeliveryVehicleOption[];
+}) {
+  // ── call form state ──────────────────────────────────────────────────────
+  const [customerName, setCustomerName] = useState("");
+  const [customerPhone, setCustomerPhone] = useState("");
+  const [address, setAddress] = useState("");
+  const [mode, setMode] = useState<"system" | "offer">("system");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formNotice, setFormNotice] = useState<string | null>(null);
+  const [isSubmitting, startSubmit] = useTransition();
+
+  // ── offered list state ───────────────────────────────────────────────────
+  const [offered, setOffered] = useState<ServiceOpsDispatchOrder[]>(initialOffered);
+  // per-card selected bikeId; keyed by order id
+  const [selectedBike, setSelectedBike] = useState<Record<string, string>>({});
+  // per-card accept error; keyed by order id
+  const [acceptErrors, setAcceptErrors] = useState<Record<string, string>>({});
+  const [isAccepting, startAccept] = useTransition();
+
+  const reloadOffered = async () => {
+    const next = await listOfferedCallsAction();
+    setOffered(next);
+  };
+
+  const clearForm = () => {
+    setCustomerName("");
+    setCustomerPhone("");
+    setAddress("");
+    setMode("system");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFormNotice(null);
+    startSubmit(async () => {
+      const fd = new FormData();
+      fd.append("customerName", customerName);
+      fd.append("customerPhone", customerPhone);
+      fd.append("address", address);
+      const result =
+        mode === "system"
+          ? await createSystemCallAction(fd)
+          : await createOfferedCallAction(fd);
+      if (result.ok) {
+        clearForm();
+        setFormNotice("콜이 등록되었습니다.");
+        await reloadOffered();
+      } else {
+        setFormError(result.error);
+      }
+    });
+  };
+
+  const handleAccept = (order: ServiceOpsDispatchOrder) => {
+    const bikeId = selectedBike[order.id] ?? (deliveryVehicles[0]?.id ?? "");
+    if (!bikeId) return;
+    setAcceptErrors((prev) => ({ ...prev, [order.id]: "" }));
+    startAccept(async () => {
+      const result = await acceptCallAction(order.id, bikeId);
+      if (result.ok) {
+        await reloadOffered();
+      } else {
+        setAcceptErrors((prev) => ({ ...prev, [order.id]: result.error }));
+      }
+    });
+  };
+
+  const noVehicles = deliveryVehicles.length === 0;
+
+  return (
+    <div className="management-panel">
+      {/* ── header ─────────────────────────────────────────────────────── */}
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">배민 콜</span>
+          {offered.length > 0 && (
+            <span className="mgmt-panel-count">{offered.length}</span>
+          )}
+        </div>
+      </div>
+
+      {/* ── call registration form ──────────────────────────────────────── */}
+      <form className="baemin-call-form" onSubmit={handleSubmit}>
+        <div className="baemin-call-form-row">
+          <label className="baemin-call-form-label" htmlFor="bc-customerName">
+            고객명
+          </label>
+          <input
+            id="bc-customerName"
+            className="baemin-call-form-input"
+            type="text"
+            value={customerName}
+            onChange={(e) => setCustomerName(e.target.value)}
+            placeholder="홍길동"
+            required
+          />
+        </div>
+
+        <div className="baemin-call-form-row">
+          <label className="baemin-call-form-label" htmlFor="bc-customerPhone">
+            연락처
+          </label>
+          <input
+            id="bc-customerPhone"
+            className="baemin-call-form-input"
+            type="text"
+            value={customerPhone}
+            onChange={(e) => setCustomerPhone(e.target.value)}
+            placeholder="010-0000-0000"
+            required
+          />
+        </div>
+
+        <div className="baemin-call-form-row">
+          <label className="baemin-call-form-label" htmlFor="bc-address">
+            배달지
+          </label>
+          <div className="baemin-call-address-row">
+            <input
+              id="bc-address"
+              className="baemin-call-form-input"
+              type="text"
+              value={address}
+              readOnly
+              placeholder="주소 검색 버튼을 눌러주세요"
+              required
+            />
+            <AddressSearchButton onSelect={(addr) => setAddress(addr)} />
+          </div>
+        </div>
+
+        <div className="baemin-call-mode-row">
+          <span className="baemin-call-form-label">배차 방식</span>
+          <label className="baemin-call-mode-option">
+            <input
+              type="radio"
+              name="bc-mode"
+              value="system"
+              checked={mode === "system"}
+              onChange={() => setMode("system")}
+            />
+            시스템 자동 배차
+          </label>
+          <label className="baemin-call-mode-option">
+            <input
+              type="radio"
+              name="bc-mode"
+              value="offer"
+              checked={mode === "offer"}
+              onChange={() => setMode("offer")}
+            />
+            라이더 수락
+          </label>
+        </div>
+
+        {formError ? (
+          <p role="alert" className="baemin-call-error">
+            {formError}
+          </p>
+        ) : null}
+        {formNotice ? (
+          <p role="status" className="baemin-call-notice">
+            {formNotice}
+          </p>
+        ) : null}
+
+        <div className="baemin-call-form-actions">
+          <button
+            type="submit"
+            className="button-primary"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "등록 중..." : "콜 등록"}
+          </button>
+        </div>
+      </form>
+
+      {/* ── OFFERED list ───────────────────────────────────────────────── */}
+      {offered.length > 0 ? (
+        <div className="baemin-call-offered-list">
+          <p className="baemin-call-offered-heading">수락 대기 중인 콜</p>
+          {offered.map((order) => {
+            const cardBikeId =
+              selectedBike[order.id] ?? (deliveryVehicles[0]?.id ?? "");
+            const cardError = acceptErrors[order.id];
+            return (
+              <div key={order.id} className="baemin-call-card">
+                <div className="baemin-call-card-info">
+                  <span className="baemin-call-card-name">{order.customerName}</span>
+                  <span className="baemin-call-card-sep">·</span>
+                  <span className="baemin-call-card-phone">{order.customerPhone}</span>
+                  <span className="baemin-call-card-sep">·</span>
+                  <span className="baemin-call-card-address">{order.address}</span>
+                </div>
+                <div className="baemin-call-accept-row">
+                  <select
+                    className="baemin-call-vehicle-select"
+                    value={cardBikeId}
+                    onChange={(e) =>
+                      setSelectedBike((prev) => ({
+                        ...prev,
+                        [order.id]: e.target.value
+                      }))
+                    }
+                    disabled={noVehicles || isAccepting}
+                  >
+                    {noVehicles ? (
+                      <option value="">배송 차량 없음</option>
+                    ) : (
+                      deliveryVehicles.map((v) => (
+                        <option key={v.id} value={v.id}>
+                          {v.plateNumber}
+                        </option>
+                      ))
+                    )}
+                  </select>
+                  <button
+                    type="button"
+                    className="button-primary"
+                    onClick={() => handleAccept(order)}
+                    disabled={noVehicles || isAccepting}
+                    title={
+                      noVehicles
+                        ? "배송 서비스 유형 차량이 없습니다."
+                        : undefined
+                    }
+                  >
+                    수락
+                  </button>
+                  {noVehicles && (
+                    <span className="baemin-call-hint">
+                      배송 차량이 없어 수락할 수 없습니다.
+                    </span>
+                  )}
+                </div>
+                {cardError ? (
+                  <p role="alert" className="baemin-call-error">
+                    {cardError}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1049,7 +1049,7 @@ export interface BulkApplyResponse {
   skipped: number;
 }
 
-export type ServiceOpsDispatchOrderStatus = "ASSIGNED" | "COMPLETED";
+export type ServiceOpsDispatchOrderStatus = "OFFERED" | "ASSIGNED" | "COMPLETED";
 export type ServiceOpsDispatchOrderKind = "PICKUP" | "DELIVERY";
 export type ServiceOpsDispatchRoundStatus = "COLLECTING" | "DELIVERING" | "DONE";
 export type ServiceOpsDispatchRound = {
@@ -1061,11 +1061,19 @@ export type ServiceOpsDispatchRound = {
   deliveryDone: number;
 };
 
+export type DeliveryCallPayload = {
+  customerName: string;
+  customerPhone: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+};
+
 /** 배차 주문 단건 — backend `DispatchOrderReadResponse` 와 1:1. lat/lng 는 JSON number. */
 export type ServiceOpsDispatchOrder = {
   id: string;
   idx: number | null;
-  bikeId: string;
+  bikeId: string | null;
   customerName: string;
   customerPhone: string;
   address: string;
@@ -1268,6 +1276,12 @@ export type ServiceOpsApiClient = {
   getActiveDispatchRound: () => Promise<ServiceOpsDispatchRound | null>;
   createDispatchRound: (rows: DispatchBulkApplyRow[]) => Promise<ServiceOpsDispatchRound>;
   startDispatchDelivery: (batchId: string) => Promise<ServiceOpsDispatchRound>;
+
+  // ── 배민 단건 콜 (C1) ──
+  systemDispatchCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
+  offerCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
+  acceptCall: (orderId: string, bikeId: string) => Promise<ServiceOpsDispatchOrder>;
+  listOfferedCalls: () => Promise<ServiceOpsDispatchOrder[]>;
 };
 
 type ServiceOpsApiOptions = {
@@ -1918,6 +1932,25 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         `/dispatch-batches/${encodeURIComponent(batchId)}/start-delivery`,
         { method: "POST" }
       ),
+
+    // ── 배민 단건 콜 (C1) ──
+    systemDispatchCall: (payload) =>
+      request<ServiceOpsDispatchOrder>("/dispatch-orders/calls/system", {
+        body: JSON.stringify(payload),
+        method: "POST"
+      }),
+    offerCall: (payload) =>
+      request<ServiceOpsDispatchOrder>("/dispatch-orders/calls/offer", {
+        body: JSON.stringify(payload),
+        method: "POST"
+      }),
+    acceptCall: (orderId, bikeId) =>
+      request<ServiceOpsDispatchOrder>(`/dispatch-orders/calls/${encodeURIComponent(orderId)}/accept`, {
+        body: JSON.stringify({ bikeId }),
+        method: "POST"
+      }),
+    listOfferedCalls: () =>
+      request<ServiceOpsDispatchOrder[]>("/dispatch-orders/calls/offered", { method: "GET" }),
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
@@ -4,7 +4,10 @@ import com.thundercrew.opsapi.common.bulk.BulkApplyResponse;
 import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRequest;
 import com.thundercrew.opsapi.dispatch.dto.DispatchBulkPreviewResponse;
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderCreateRequest;
+import com.thundercrew.opsapi.dispatch.dto.DeliveryCallAcceptRequest;
+import com.thundercrew.opsapi.dispatch.dto.DeliveryCallCreateRequest;
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.service.DeliveryCallService;
 import com.thundercrew.opsapi.dispatch.service.DispatchOrderBulkService;
 import com.thundercrew.opsapi.dispatch.service.DispatchOrderCommandService;
 import jakarta.validation.Valid;
@@ -30,11 +33,14 @@ public class DispatchOrderCommandController {
 
     private final DispatchOrderCommandService dispatchOrderCommandService;
     private final DispatchOrderBulkService dispatchOrderBulkService;
+    private final DeliveryCallService deliveryCallService;
 
     public DispatchOrderCommandController(DispatchOrderCommandService dispatchOrderCommandService,
-                                          DispatchOrderBulkService dispatchOrderBulkService) {
+                                          DispatchOrderBulkService dispatchOrderBulkService,
+                                          DeliveryCallService deliveryCallService) {
         this.dispatchOrderCommandService = dispatchOrderCommandService;
         this.dispatchOrderBulkService = dispatchOrderBulkService;
+        this.deliveryCallService = deliveryCallService;
     }
 
     @PostMapping
@@ -65,6 +71,24 @@ public class DispatchOrderCommandController {
     @PostMapping("/bulk-apply")
     BulkApplyResponse bulkApply(@Valid @RequestBody DispatchBulkApplyRequest request) {
         return dispatchOrderBulkService.apply(request);
+    }
+
+    @PostMapping("/calls/system")
+    DispatchOrderReadResponse systemCall(@Valid @RequestBody DeliveryCallCreateRequest request) {
+        return deliveryCallService.systemDispatch(request.customerName(), request.customerPhone(),
+                request.address(), request.latitude(), request.longitude());
+    }
+
+    @PostMapping("/calls/offer")
+    DispatchOrderReadResponse offerCall(@Valid @RequestBody DeliveryCallCreateRequest request) {
+        return deliveryCallService.offerCall(request.customerName(), request.customerPhone(),
+                request.address(), request.latitude(), request.longitude());
+    }
+
+    @PostMapping("/calls/{id}/accept")
+    DispatchOrderReadResponse acceptCall(@PathVariable UUID id,
+                                         @Valid @RequestBody DeliveryCallAcceptRequest request) {
+        return deliveryCallService.acceptCall(id, request.bikeId());
     }
 
     @GetMapping("/export")

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.dispatch.controller;
 
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.service.DeliveryCallService;
 import com.thundercrew.opsapi.dispatch.service.DispatchOrderReadService;
 import java.util.List;
 import java.util.UUID;
@@ -14,13 +15,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class DispatchOrderReadController {
 
     private final DispatchOrderReadService dispatchOrderReadService;
+    private final DeliveryCallService deliveryCallService;
 
-    public DispatchOrderReadController(DispatchOrderReadService dispatchOrderReadService) {
+    public DispatchOrderReadController(DispatchOrderReadService dispatchOrderReadService,
+                                       DeliveryCallService deliveryCallService) {
         this.dispatchOrderReadService = dispatchOrderReadService;
+        this.deliveryCallService = deliveryCallService;
     }
 
     @GetMapping
     List<DispatchOrderReadResponse> listByBike(@RequestParam UUID bikeId) {
         return dispatchOrderReadService.listByBike(bikeId);
+    }
+
+    @GetMapping("/calls/offered")
+    List<DispatchOrderReadResponse> offeredCalls() {
+        return deliveryCallService.listOffered();
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
@@ -75,6 +75,9 @@ public class DispatchOrder extends DisplaySequencedEntity {
     }
 
     public void complete(Instant when) {
+        if (this.status != DispatchOrderStatus.ASSIGNED) {
+            throw new InvalidStateTransitionException("배정된 배차만 완료할 수 있습니다. 현재: " + this.status);
+        }
         this.status = DispatchOrderStatus.COMPLETED;
         this.completedAt = when;
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
@@ -1,5 +1,6 @@
 package com.thundercrew.opsapi.dispatch.domain;
 
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,7 +14,7 @@ import java.util.UUID;
 @Table(name = "dispatch_orders")
 public class DispatchOrder extends DisplaySequencedEntity {
 
-    @Column(name = "bike_id", nullable = false)
+    @Column(name = "bike_id")
     private UUID bikeId;
 
     @Column(nullable = false, columnDefinition = "text")
@@ -76,6 +77,33 @@ public class DispatchOrder extends DisplaySequencedEntity {
     public void complete(Instant when) {
         this.status = DispatchOrderStatus.COMPLETED;
         this.completedAt = when;
+    }
+
+    /** 배민 라이더 수락 콜: 차량 미배정(OFFERED) 생성. 수락 시 assign 으로 차량/순번 부여. */
+    public static DispatchOrder createOffered(String customerName, String customerPhone,
+                                              String address, double latitude, double longitude) {
+        DispatchOrder order = new DispatchOrder();
+        order.bikeId = null;
+        order.customerName = customerName;
+        order.customerPhone = customerPhone;
+        order.address = address;
+        order.latitude = latitude;
+        order.longitude = longitude;
+        order.sequence = 0L;
+        order.status = DispatchOrderStatus.OFFERED;
+        order.kind = DispatchOrderKind.DELIVERY;
+        order.batchId = null;
+        return order;
+    }
+
+    /** OFFERED 콜을 차량에 배정. OFFERED 가 아니면 거부. */
+    public void assign(UUID bikeId, long sequence) {
+        if (this.status != DispatchOrderStatus.OFFERED) {
+            throw new InvalidStateTransitionException("이미 배정된 콜입니다. 현재: " + this.status);
+        }
+        this.bikeId = bikeId;
+        this.sequence = sequence;
+        this.status = DispatchOrderStatus.ASSIGNED;
     }
 
     public UUID getBikeId() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrderStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrderStatus.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.dispatch.domain;
 
 public enum DispatchOrderStatus {
+    OFFERED,
     ASSIGNED,
     COMPLETED
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallAcceptRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallAcceptRequest.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.dispatch.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record DeliveryCallAcceptRequest(@NotNull UUID bikeId) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallCreateRequest.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.dispatch.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+public record DeliveryCallCreateRequest(
+        @NotBlank String customerName,
+        @NotBlank String customerPhone,
+        @NotBlank String address,
+        @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallCreateRequest.java
@@ -3,11 +3,12 @@ package com.thundercrew.opsapi.dispatch.dto;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record DeliveryCallCreateRequest(
-        @NotBlank String customerName,
-        @NotBlank String customerPhone,
-        @NotBlank String address,
+        @NotBlank @Size(max = 255) String customerName,
+        @NotBlank @Size(max = 255) String customerPhone,
+        @NotBlank @Size(max = 2000) String address,
         @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
         @DecimalMin("-180.0") @DecimalMax("180.0") double longitude
 ) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
@@ -26,5 +26,7 @@ public interface DispatchOrderRepository extends Repository<DispatchOrder, UUID>
     List<DispatchOrder> findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
             UUID batchId, DispatchOrderKind kind, DispatchOrderStatus status);
 
+    List<DispatchOrder> findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus status);
+
     DispatchOrder save(DispatchOrder order);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
@@ -1,0 +1,91 @@
+package com.thundercrew.opsapi.dispatch.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 배민 단건 콜 오케스트레이션.
+ * - systemDispatch: 가장 적게 배정된 DELIVERY 차량을 골라 즉시 ASSIGNED 주문 생성.
+ * - offerCall: 차량 미배정(OFFERED) 콜 생성.
+ * - acceptCall: OFFERED 콜을 운영자가 지정한 차량에 배정(ASSIGNED).
+ */
+@Service
+@Transactional
+public class DeliveryCallService {
+
+    private final DispatchOrderRepository orderRepository;
+    private final BikeRepository bikeRepository;
+    private final DispatchOrderCommandService commandService;
+
+    public DeliveryCallService(DispatchOrderRepository orderRepository,
+                               BikeRepository bikeRepository,
+                               DispatchOrderCommandService commandService) {
+        this.orderRepository = orderRepository;
+        this.bikeRepository = bikeRepository;
+        this.commandService = commandService;
+    }
+
+    /** 시스템 자동 배차: 가장 적게 배정된 DELIVERY 차량 선택 → ASSIGNED 주문. */
+    public DispatchOrderReadResponse systemDispatch(String customerName, String customerPhone,
+                                                    String address, double latitude, double longitude) {
+        List<Bike> deliveryBikes = bikeRepository.findAllByDeletedAtIsNull().stream()
+                .filter(b -> b.getServiceType() == BikeServiceType.DELIVERY)
+                .toList();
+        if (deliveryBikes.isEmpty()) {
+            throw new InvalidStateTransitionException("가용 배송 차량이 없습니다.");
+        }
+        Map<UUID, Long> assignedCount = orderRepository
+                .findByStatusAndDeletedAtIsNull(DispatchOrderStatus.ASSIGNED).stream()
+                .filter(o -> o.getBikeId() != null)
+                .collect(Collectors.groupingBy(DispatchOrder::getBikeId, Collectors.counting()));
+        Bike target = deliveryBikes.stream()
+                .min(Comparator.comparingLong(b -> assignedCount.getOrDefault(b.getId(), 0L)))
+                .orElseThrow(() -> new InvalidStateTransitionException("가용 배송 차량이 없습니다."));
+        return commandService.appendForBike(
+                target.getId(), customerName, customerPhone, address, latitude, longitude);
+    }
+
+    /** 라이더 수락 콜: 차량 미배정 OFFERED 생성. */
+    public DispatchOrderReadResponse offerCall(String customerName, String customerPhone,
+                                               String address, double latitude, double longitude) {
+        DispatchOrder order = orderRepository.save(
+                DispatchOrder.createOffered(customerName, customerPhone, address, latitude, longitude));
+        return DispatchOrderReadResponse.from(order);
+    }
+
+    /** OFFERED 콜을 운영자 지정 차량에 배정. */
+    public DispatchOrderReadResponse acceptCall(UUID orderId, UUID bikeId) {
+        DispatchOrder order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", orderId));
+        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        long nextSequence = orderRepository
+                .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
+                .map(o -> o.getSequence() + 1)
+                .orElse(1L);
+        order.assign(bikeId, nextSequence); // dirty-checking flush
+        return DispatchOrderReadResponse.from(order);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DispatchOrderReadResponse> listOffered() {
+        return orderRepository
+                .findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus.OFFERED).stream()
+                .map(DispatchOrderReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V35__dispatch_orders_offered_status.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V35__dispatch_orders_offered_status.sql
@@ -1,0 +1,3 @@
+alter table dispatch_orders alter column bike_id drop not null;
+alter table dispatch_orders drop constraint ck_dispatch_orders_status;
+alter table dispatch_orders add constraint ck_dispatch_orders_status check (status in ('OFFERED', 'ASSIGNED', 'COMPLETED'));

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
@@ -1,0 +1,294 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DeliveryCallApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID  = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa10");
+    private static final UUID BIKE_A_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb10");
+    private static final UUID BIKE_B_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb11");
+    private static final UUID BIKE_C_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb12");
+
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+    private static final Pattern ID_PATTERN =
+            Pattern.compile("\\\"id\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from dispatch_orders");
+        jdbcTemplate.update("delete from dispatch_batch");
+        jdbcTemplate.update("delete from bike_current_states");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'delivery-admin', 'delivery@example.test', ?, 'Delivery Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① systemDispatch — seed 1 DELIVERY bike → 200, status ASSIGNED, bikeId not null.
+    //   GET /dispatch-orders?bikeId= contains the new order.
+    @Test
+    void systemDispatchPicksDeliveryBikeAndReturnsAssigned() throws Exception {
+        seedDeliveryBike(BIKE_A_ID, "배송-A", "VIN-DELIVERY-A-001");
+
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-orders/calls/system")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("홍길동", "010-1111-1111", "서울 강남구 역삼동 1")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ASSIGNED"))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_A_ID.toString()))
+                .andExpect(jsonPath("$.customerName").value("홍길동"))
+                .andReturn();
+
+        String orderId = extractId(result.getResponse().getContentAsString());
+
+        mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", BIKE_A_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='" + orderId + "')]").isArray())
+                .andExpect(jsonPath("$[?(@.id=='" + orderId + "')].length()").value(1));
+    }
+
+    // ② least-loaded — seed 2 DELIVERY bikes A, B. Pre-assign 1 order to A.
+    //   Second call/system → picks B (fewest assigned orders).
+    @Test
+    void systemDispatchPicksLeastLoadedDeliveryBike() throws Exception {
+        seedDeliveryBike(BIKE_A_ID, "배송-A", "VIN-DELIVERY-A-002");
+        seedDeliveryBike(BIKE_B_ID, "배송-B", "VIN-DELIVERY-B-002");
+
+        // Pre-assign 1 order to BIKE_A via /calls/system (it picks least-loaded; both have 0 so it picks one).
+        // We force an order on A by using the standard /dispatch-orders create endpoint (which takes explicit bikeId).
+        mockMvc.perform(post("/api/v1/dispatch-orders")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s","customerName":"기존고객","customerPhone":"010-0000-0000",
+                                 "address":"서울 강남구 역삼동 99","latitude":37.4987,"longitude":127.0276}
+                                """.formatted(BIKE_A_ID)))
+                .andExpect(status().isCreated());
+
+        // Now /calls/system should pick BIKE_B (0 assigned) over BIKE_A (1 assigned).
+        mockMvc.perform(post("/api/v1/dispatch-orders/calls/system")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("신규고객", "010-2222-2222", "서울 강남구 역삼동 2")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ASSIGNED"))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_B_ID.toString()));
+    }
+
+    // ③ no available bike — seed a CLEANING bike (not DELIVERY) → POST /calls/system → 409,
+    //   response body contains "배송 차량".
+    @Test
+    void systemDispatchReturns409WhenNoDeliveryBikeExists() throws Exception {
+        seedCleaningBike(BIKE_C_ID, "클리닝-C", "VIN-CLEANING-C-001");
+
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-orders/calls/system")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("고객X", "010-9999-9999", "서울 종로구 청진동 1")))
+                .andExpect(status().isConflict())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsString()).contains("배송 차량");
+    }
+
+    // ④ offer + list — POST /calls/offer → 200, status OFFERED, bikeId null.
+    //   GET /calls/offered contains the new order.
+    @Test
+    void offerCallReturnsOfferedStatusWithNullBikeId() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/dispatch-orders/calls/offer")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("오퍼고객", "010-3333-3333", "서울 마포구 합정동 1")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OFFERED"))
+                .andExpect(jsonPath("$.bikeId").value(Matchers.nullValue()))
+                .andReturn();
+
+        String offeredId = extractId(result.getResponse().getContentAsString());
+
+        mockMvc.perform(get("/api/v1/dispatch-orders/calls/offered")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='" + offeredId + "')]").isArray())
+                .andExpect(jsonPath("$[?(@.id=='" + offeredId + "')].length()").value(1));
+    }
+
+    // ⑤ accept — offer then accept with a DELIVERY bike → 200, status ASSIGNED, bikeId set.
+    //   GET /dispatch-orders?bikeId= contains it; GET /calls/offered no longer contains it.
+    @Test
+    void acceptCallAssignsOfferedOrderToDeliveryBike() throws Exception {
+        seedDeliveryBike(BIKE_A_ID, "배송-A", "VIN-DELIVERY-A-005");
+
+        MvcResult offerResult = mockMvc.perform(post("/api/v1/dispatch-orders/calls/offer")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("수락고객", "010-4444-4444", "서울 서초구 방배동 1")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OFFERED"))
+                .andReturn();
+
+        String offeredId = extractId(offerResult.getResponse().getContentAsString());
+
+        mockMvc.perform(post("/api/v1/dispatch-orders/calls/{id}/accept", offeredId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s"}
+                                """.formatted(BIKE_A_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ASSIGNED"))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_A_ID.toString()));
+
+        // Now visible in /dispatch-orders?bikeId=
+        mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", BIKE_A_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='" + offeredId + "')].length()").value(1));
+
+        // No longer in /calls/offered
+        mockMvc.perform(get("/api/v1/dispatch-orders/calls/offered")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='" + offeredId + "')]").isEmpty());
+    }
+
+    // ⑥ re-accept — accepting an already-ASSIGNED order → 409.
+    @Test
+    void reAcceptAlreadyAssignedOrderReturns409() throws Exception {
+        seedDeliveryBike(BIKE_A_ID, "배송-A", "VIN-DELIVERY-A-006");
+
+        MvcResult offerResult = mockMvc.perform(post("/api/v1/dispatch-orders/calls/offer")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("재수락고객", "010-5555-5555", "서울 동작구 상도동 1")))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String offeredId = extractId(offerResult.getResponse().getContentAsString());
+
+        // First accept
+        mockMvc.perform(post("/api/v1/dispatch-orders/calls/{id}/accept", offeredId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s"}
+                                """.formatted(BIKE_A_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ASSIGNED"));
+
+        // Second accept → 409
+        mockMvc.perform(post("/api/v1/dispatch-orders/calls/{id}/accept", offeredId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s"}
+                                """.formatted(BIKE_A_ID)))
+                .andExpect(status().isConflict());
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    /**
+     * Seed a DELIVERY bike (service_type = 'DELIVERY') using inline SQL.
+     * The existing seedBike helpers in other tests rely on the DB column default 'DELIVERY',
+     * but here we are explicit to clearly document intent and support future schema changes.
+     */
+    private void seedDeliveryBike(UUID id, String plateNumber, String vin) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, ignition_blocked)
+                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'DELIVERY', 'IN_SERVICE', false)
+                """, id, plateNumber, vin);
+    }
+
+    /**
+     * Seed a CLEANING bike (service_type = 'CLEANING') — not eligible for delivery auto-dispatch.
+     */
+    private void seedCleaningBike(UUID id, String plateNumber, String vin) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, ignition_blocked)
+                values (?, ?, ?, 'Cleaning Van', 'ICE', 'CLEANING', 'IN_SERVICE', false)
+                """, id, plateNumber, vin);
+    }
+
+    private String callBody(String name, String phone, String address) {
+        return """
+                {"customerName":"%s","customerPhone":"%s","address":"%s","latitude":37.4987,"longitude":127.0276}
+                """.formatted(name, phone, address);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"delivery-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(String json) {
+        Matcher matcher = ID_PATTERN.matcher(json);
+        if (!matcher.find()) {
+            throw new IllegalStateException("No id in response: " + json);
+        }
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-12-group-c1-baemin-call.md
+++ b/docs/superpowers/plans/2026-06-12-group-c1-baemin-call.md
@@ -1,0 +1,581 @@
+# Group C1 — 배민 배송 (단건 콜) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 배민 단건 콜(고객 배달지)을 웹 폼으로 입력하고 시스템 자동 배차(가장 적게 배정된 DELIVERY 차량) 또는 라이더 수락(OFFERED→accept)으로 배정한다.
+
+**Architecture:** 기존 `DispatchOrder`를 확장 — `DispatchOrderStatus.OFFERED` 추가 + `bike_id` nullable. OFFERED 콜은 차량 미배정(차량별 ASSIGNED 쿼리에서 자연 제외), 수락/자동배차로 ASSIGNED 되면 기존 배차 큐/지도/완료 재사용. 신규 `DeliveryCallService`가 자동선택·offer·accept를 오케스트레이션한다.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA `Repository<T,UUID>`, JUnit/Testcontainers, Next.js App Router, TypeScript.
+
+**작업 경로:** 백엔드 `development/service-ops-api`, 프론트 `development/front-admin-web`. Bash 툴 + 절대경로 `cd /c/Users/user/repositories/clever/thundercrew-domain/...` (cwd 매 호출 리셋). 브랜치 `cc-c1-baemin-call` 이미 체크아웃 — 새 브랜치 만들지 말 것.
+
+**테스트:** ArchUnit Docker 불필요. 계약/Testcontainers는 **Docker 필요(이 머신 없음)** → 컴파일까지만, 실행은 CI. 프론트 `npm run typecheck && npm run lint && npm run build`.
+
+---
+
+## 파일 구조
+
+**백엔드 (신규):** `dto/DeliveryCallCreateRequest.java`, `dto/DeliveryCallAcceptRequest.java`, `service/DeliveryCallService.java`, `db/migration/V35__dispatch_orders_offered_status.sql`, `test/.../DeliveryCallApiContractTests.java`.
+**백엔드 (수정):** `domain/DispatchOrderStatus.java`(+OFFERED), `domain/DispatchOrder.java`(nullable bikeId + createOffered + assign), `repository/DispatchOrderRepository.java`(+1 메서드), `controller/DispatchOrderCommandController.java`(+3 라우트), `controller/DispatchOrderReadController.java`(+1 라우트).
+**프론트 (신규):** `components/management/BaeminCallPanel.tsx`.
+**프론트 (수정):** `lib/services/service-ops-api.ts`, `app/dispatch/actions.ts`, `app/management/page.tsx`, `app/globals.css`.
+
+---
+
+### Task 1: V35 + OFFERED status + DispatchOrder 확장
+
+**Files:**
+- Create: `development/service-ops-api/src/main/resources/db/migration/V35__dispatch_orders_offered_status.sql`
+- Modify: `.../dispatch/domain/DispatchOrderStatus.java`
+- Modify: `.../dispatch/domain/DispatchOrder.java`
+
+- [ ] **Step 1: 마이그레이션**
+
+`V35__dispatch_orders_offered_status.sql`:
+```sql
+alter table dispatch_orders alter column bike_id drop not null;
+alter table dispatch_orders drop constraint ck_dispatch_orders_status;
+alter table dispatch_orders add constraint ck_dispatch_orders_status check (status in ('OFFERED', 'ASSIGNED', 'COMPLETED'));
+```
+
+- [ ] **Step 2: OFFERED 추가**
+
+READ `DispatchOrderStatus.java`. 현재 `{ASSIGNED, COMPLETED}` → `OFFERED` 를 맨 앞에 추가:
+```java
+public enum DispatchOrderStatus {
+    OFFERED,
+    ASSIGNED,
+    COMPLETED
+}
+```
+
+- [ ] **Step 3: DispatchOrder — nullable bikeId + createOffered + assign**
+
+READ `DispatchOrder.java`. 변경:
+1. `bikeId` 필드의 `@Column(name = "bike_id", nullable = false)` → `@Column(name = "bike_id")` (nullable 허용).
+2. 기존 `complete(Instant)` 메서드 아래에 추가:
+```java
+    /** 배민 라이더 수락 콜: 차량 미배정(OFFERED) 생성. 수락 시 assign 으로 차량/순번 부여. */
+    public static DispatchOrder createOffered(String customerName, String customerPhone,
+                                              String address, double latitude, double longitude) {
+        DispatchOrder order = new DispatchOrder();
+        order.bikeId = null;
+        order.customerName = customerName;
+        order.customerPhone = customerPhone;
+        order.address = address;
+        order.latitude = latitude;
+        order.longitude = longitude;
+        order.sequence = 0L;
+        order.status = DispatchOrderStatus.OFFERED;
+        order.kind = DispatchOrderKind.DELIVERY;
+        order.batchId = null;
+        return order;
+    }
+
+    /** OFFERED 콜을 차량에 배정. OFFERED 가 아니면 거부. */
+    public void assign(UUID bikeId, long sequence) {
+        if (this.status != DispatchOrderStatus.OFFERED) {
+            throw new com.thundercrew.opsapi.common.api.InvalidStateTransitionException(
+                    "이미 배정된 콜입니다. 현재: " + this.status);
+        }
+        this.bikeId = bikeId;
+        this.sequence = sequence;
+        this.status = DispatchOrderStatus.ASSIGNED;
+    }
+```
+(`DispatchOrderKind`/`UUID`/`DispatchOrderStatus` 는 같은 패키지/기존 import. `InvalidStateTransitionException` 은 FQN 으로 쓰거나 import 추가. `bikeId` 필드는 `private UUID bikeId;` — null 대입 가능.)
+
+- [ ] **Step 4: 컴파일**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/resources/db/migration/V35__dispatch_orders_offered_status.sql development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/ && git commit -m "feat(c1): V35 OFFERED status + nullable bike_id, DispatchOrder.createOffered/assign"
+```
+
+---
+
+### Task 2: Repository — OFFERED 목록 조회
+
+**Files:**
+- Modify: `.../dispatch/repository/DispatchOrderRepository.java`
+
+- [ ] **Step 1: 메서드 추가**
+
+READ the file. `save` 선언 위에 추가:
+```java
+    List<DispatchOrder> findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus status);
+```
+(`List`, `DispatchOrderStatus` 이미 import. `createdAt` 은 `DisplaySequencedEntity` 베이스 필드 — 파생 쿼리 정렬 가능.)
+
+- [ ] **Step 2: 컴파일 + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java && git commit -m "feat(c1): findByStatus OrderByCreatedAtAsc for OFFERED calls"
+```
+
+---
+
+### Task 3: DeliveryCallService + DTOs
+
+**Files:**
+- Create: `.../dispatch/dto/DeliveryCallCreateRequest.java`
+- Create: `.../dispatch/dto/DeliveryCallAcceptRequest.java`
+- Create: `.../dispatch/service/DeliveryCallService.java`
+
+- [ ] **Step 1: DTOs**
+
+먼저 READ 기존 `dto/DispatchOrderCreateRequest.java` 로 검증 애너테이션 스타일(@NotBlank/@DecimalMin 등)을 확인하고 동일하게 맞춘다. 그런 다음:
+
+`DeliveryCallCreateRequest.java`:
+```java
+package com.thundercrew.opsapi.dispatch.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+public record DeliveryCallCreateRequest(
+        @NotBlank String customerName,
+        @NotBlank String customerPhone,
+        @NotBlank String address,
+        @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude
+) {
+}
+```
+(만약 `DispatchOrderCreateRequest` 가 다른 검증 idiom 을 쓰면 그걸 따른다.)
+
+`DeliveryCallAcceptRequest.java`:
+```java
+package com.thundercrew.opsapi.dispatch.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record DeliveryCallAcceptRequest(@NotNull UUID bikeId) {
+}
+```
+
+- [ ] **Step 2: DeliveryCallService**
+
+먼저 READ `Bike.java`(getServiceType() 존재·반환 enum 확인) + `BikeServiceType.java`(DELIVERY) + `bike/repository/BikeRepository.java`(findAllByDeletedAtIsNull 존재, 단건 조회 메서드) + `DispatchOrderCommandService.java`(appendForBike 시그니처). 그런 다음:
+
+`DeliveryCallService.java`:
+```java
+package com.thundercrew.opsapi.dispatch.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 배민 단건 콜 오케스트레이션.
+ * - systemDispatch: 가장 적게 배정된 DELIVERY 차량을 골라 즉시 ASSIGNED 주문 생성.
+ * - offerCall: 차량 미배정(OFFERED) 콜 생성.
+ * - acceptCall: OFFERED 콜을 운영자가 지정한 차량에 배정(ASSIGNED).
+ */
+@Service
+@Transactional
+public class DeliveryCallService {
+
+    private final DispatchOrderRepository orderRepository;
+    private final BikeRepository bikeRepository;
+    private final DispatchOrderCommandService commandService;
+
+    public DeliveryCallService(DispatchOrderRepository orderRepository,
+                               BikeRepository bikeRepository,
+                               DispatchOrderCommandService commandService) {
+        this.orderRepository = orderRepository;
+        this.bikeRepository = bikeRepository;
+        this.commandService = commandService;
+    }
+
+    /** 시스템 자동 배차: 가장 적게 배정된 DELIVERY 차량 선택 → ASSIGNED 주문. */
+    public DispatchOrderReadResponse systemDispatch(String customerName, String customerPhone,
+                                                    String address, double latitude, double longitude) {
+        List<Bike> deliveryBikes = bikeRepository.findAllByDeletedAtIsNull().stream()
+                .filter(b -> b.getServiceType() == BikeServiceType.DELIVERY)
+                .toList();
+        if (deliveryBikes.isEmpty()) {
+            throw new InvalidStateTransitionException("가용 배송 차량이 없습니다.");
+        }
+        Map<UUID, Long> assignedCount = orderRepository
+                .findByStatusAndDeletedAtIsNull(DispatchOrderStatus.ASSIGNED).stream()
+                .filter(o -> o.getBikeId() != null)
+                .collect(Collectors.groupingBy(DispatchOrder::getBikeId, Collectors.counting()));
+        Bike target = deliveryBikes.stream()
+                .min(Comparator.comparingLong(b -> assignedCount.getOrDefault(b.getId(), 0L)))
+                .orElseThrow(() -> new InvalidStateTransitionException("가용 배송 차량이 없습니다."));
+        return commandService.appendForBike(
+                target.getId(), customerName, customerPhone, address, latitude, longitude);
+    }
+
+    /** 라이더 수락 콜: 차량 미배정 OFFERED 생성. */
+    public DispatchOrderReadResponse offerCall(String customerName, String customerPhone,
+                                               String address, double latitude, double longitude) {
+        DispatchOrder order = orderRepository.save(
+                DispatchOrder.createOffered(customerName, customerPhone, address, latitude, longitude));
+        return DispatchOrderReadResponse.from(order);
+    }
+
+    /** OFFERED 콜을 운영자 지정 차량에 배정. */
+    public DispatchOrderReadResponse acceptCall(UUID orderId, UUID bikeId) {
+        DispatchOrder order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", orderId));
+        bikeRepository.findAllByIdIn(List.of(bikeId)).stream().findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        long nextSequence = orderRepository
+                .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
+                .map(o -> o.getSequence() + 1)
+                .orElse(1L);
+        order.assign(bikeId, nextSequence); // dirty-checking flush
+        return DispatchOrderReadResponse.from(order);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DispatchOrderReadResponse> listOffered() {
+        return orderRepository
+                .findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus.OFFERED).stream()
+                .map(DispatchOrderReadResponse::from)
+                .toList();
+    }
+}
+```
+주의: `Bike.getServiceType()`/`BikeServiceType.DELIVERY`/`Bike.getId()`/`BikeRepository.findAllByIdIn` 가 실제 존재하는지 READ 로 확인하고, 다르면 실제 API 에 맞춰 조정(예: 단건 bike 조회 메서드가 따로 있으면 그걸 사용). `appendForBike` 가 `DispatchOrderReadResponse` 를 반환하는지 확인(맞음).
+
+- [ ] **Step 3: 컴파일 + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallCreateRequest.java development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DeliveryCallAcceptRequest.java && git commit -m "feat(c1): DeliveryCallService — systemDispatch/offer/accept + DTOs"
+```
+
+---
+
+### Task 4: 컨트롤러 라우트 (배민 콜)
+
+**Files:**
+- Modify: `.../dispatch/controller/DispatchOrderCommandController.java`
+- Modify: `.../dispatch/controller/DispatchOrderReadController.java`
+
+- [ ] **Step 1: Command 라우트 3개**
+
+READ `DispatchOrderCommandController.java`. `DeliveryCallService` 를 생성자 주입에 추가하고(기존 두 서비스 옆) 라우트 추가. import: `DeliveryCallCreateRequest`, `DeliveryCallAcceptRequest`, `DeliveryCallService`. 클래스 내부에 추가:
+```java
+    @PostMapping("/calls/system")
+    DispatchOrderReadResponse systemCall(@Valid @RequestBody DeliveryCallCreateRequest request) {
+        return deliveryCallService.systemDispatch(request.customerName(), request.customerPhone(),
+                request.address(), request.latitude(), request.longitude());
+    }
+
+    @PostMapping("/calls/offer")
+    DispatchOrderReadResponse offerCall(@Valid @RequestBody DeliveryCallCreateRequest request) {
+        return deliveryCallService.offerCall(request.customerName(), request.customerPhone(),
+                request.address(), request.latitude(), request.longitude());
+    }
+
+    @PostMapping("/calls/{id}/accept")
+    DispatchOrderReadResponse acceptCall(@PathVariable UUID id,
+                                         @Valid @RequestBody DeliveryCallAcceptRequest request) {
+        return deliveryCallService.acceptCall(id, request.bikeId());
+    }
+```
+생성자: 기존 `(DispatchOrderCommandService, DispatchOrderBulkService)` 에 `DeliveryCallService deliveryCallService` 파라미터를 추가하고 필드 대입.
+(ArchUnit: 이 컨트롤러는 이미 `isDispatchCommand` allow-list 에 등록돼 있어 신규 @RequestBody/write 라우트가 자동 커버됨 — ArchUnit 변경 불필요.)
+
+- [ ] **Step 2: Read 라우트 1개**
+
+READ `DispatchOrderReadController.java`. `DeliveryCallService` 주입 추가 + 라우트:
+```java
+    @GetMapping("/calls/offered")
+    List<DispatchOrderReadResponse> offeredCalls() {
+        return deliveryCallService.listOffered();
+    }
+```
+생성자에 `DeliveryCallService` 추가. import `DeliveryCallService` (List 이미 import).
+
+- [ ] **Step 3: 컴파일 + ArchUnit (Docker 불필요)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q && ./gradlew test --tests "com.thundercrew.opsapi.ArchitectureBoundaryTests" -q
+```
+Expected: 컴파일 성공. ArchUnit 은 기존 pre-red 베이스라인(타 도메인)만 실패 — **dispatch-orders 컨트롤러의 새 라우트가 위반에 등장하면 안 됨**(이미 allow-list). 실패 목록에 `DispatchOrderCommandController` 가 새로 나타나면 조사.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/ && git commit -m "feat(c1): baemin call routes (system/offer/accept/offered)"
+```
+
+---
+
+### Task 5: 계약 테스트 (DeliveryCallApiContractTests)
+
+**Files:**
+- Create: `development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java`
+
+- [ ] **Step 1: 작성**
+
+READ `DispatchOrderApiContractTests.java`(베이스/시드/MockMvc 방식) 와 `DispatchRoundApiContractTests.java`(409 IllegalState→InvalidStateTransition 매핑 확인 — `InvalidStateTransitionException`→409). 동일 harness 로 작성. 케이스:
+1. **시스템 배차**: 차량 2대 시드(둘 다 DELIVERY). `POST /api/v1/dispatch-orders/calls/system` (고객/주소/좌표) → 200, 응답 `status=="ASSIGNED"`, `bikeId != null`. `GET /api/v1/dispatch-orders?bikeId={배정차량}` 에 등장.
+2. **least-loaded 선택**: 차량 A에 ASSIGNED 주문 1건 선등록, B는 0건. systemDispatch → 응답 bikeId == B(적게 배정된 쪽).
+3. **가용 차량 없음**: DELIVERY 차량이 없도록 시드(또는 모두 다른 serviceType) → systemDispatch → 409, 메시지 "배송 차량".
+4. **offer + 목록**: `POST /calls/offer` → 200 `status=="OFFERED"`, `bikeId==null`. `GET /calls/offered` 에 그 콜 포함.
+5. **accept**: offer 후 `POST /calls/{id}/accept` body `{"bikeId":"..."}` → 200 `status=="ASSIGNED"`, `bikeId` 설정. `GET /dispatch-orders?bikeId=` 에 등장. `GET /calls/offered` 에서 사라짐.
+6. **이미 ASSIGNED accept**: 5의 주문을 다시 accept → 409 (InvalidStateTransition).
+
+(좌표는 요청 body 에 포함. 차량 serviceType 시드 방법은 기존 테스트의 bikes insert SQL 에 service_type 컬럼을 'DELIVERY'/다른 값으로 넣어 제어 — 기존 seedBike SQL 확인.)
+
+- [ ] **Step 2: 컴파일 (실행은 Docker/CI)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileTestJava -q
+```
+Expected: BUILD SUCCESSFUL. (`./gradlew test` 로 이 테스트는 돌리지 말 것 — Docker 필요.)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java && git commit -m "test(c1): DeliveryCall contract tests (system/least-loaded/offer/accept)"
+```
+
+---
+
+### Task 6: 프론트 — 타입 + 클라이언트 + 서버 액션
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/service-ops-api.ts`
+- Modify: `development/front-admin-web/app/dispatch/actions.ts`
+
+- [ ] **Step 1: 타입 + 클라이언트**
+
+READ `service-ops-api.ts`. 변경:
+- `ServiceOpsDispatchOrderStatus` 에 `"OFFERED"` 추가 (현재 `"ASSIGNED" | "COMPLETED"` → `"OFFERED" | "ASSIGNED" | "COMPLETED"`).
+- `ServiceOpsDispatchOrder.bikeId` 를 `string | null` 로 (현재 string).
+- 신규 payload 타입:
+```ts
+export type DeliveryCallPayload = {
+  customerName: string;
+  customerPhone: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+};
+```
+- 클라이언트 메서드(타입 + factory, 기존 dispatch 메서드 옆):
+```ts
+    systemDispatchCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
+    offerCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
+    acceptCall: (orderId: string, bikeId: string) => Promise<ServiceOpsDispatchOrder>;
+    listOfferedCalls: () => Promise<ServiceOpsDispatchOrder[]>;
+```
+factory 구현(기존 `request<T>` + JSON POST 패턴 미러링):
+```ts
+    systemDispatchCall: (payload) =>
+      request<ServiceOpsDispatchOrder>("/dispatch-orders/calls/system", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload)
+      }),
+    offerCall: (payload) =>
+      request<ServiceOpsDispatchOrder>("/dispatch-orders/calls/offer", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload)
+      }),
+    acceptCall: (orderId, bikeId) =>
+      request<ServiceOpsDispatchOrder>(`/dispatch-orders/calls/${orderId}/accept`, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ bikeId })
+      }),
+    listOfferedCalls: () =>
+      request<ServiceOpsDispatchOrder[]>("/dispatch-orders/calls/offered", { method: "GET" }),
+```
+(실제 `request` 시그니처/헤더 관례는 기존 `createDispatchRound`/`applyDispatchOrders` 호출부를 그대로 따른다.)
+
+- [ ] **Step 2: 서버 액션**
+
+READ `app/dispatch/actions.ts`. `geocodeAddress`(ncp-geocoder), `extractError`, `createAuthenticatedServiceOpsApiClient`, `DeliveryCallPayload` import. 추가:
+```ts
+async function geocodeFormToPayload(formData: FormData):
+  Promise<{ ok: true; payload: DeliveryCallPayload } | { ok: false; error: string }> {
+  const customerName = String(formData.get("customerName") ?? "").trim();
+  const customerPhone = String(formData.get("customerPhone") ?? "").trim();
+  const address = String(formData.get("address") ?? "").trim();
+  if (!customerName || !customerPhone || !address) {
+    return { ok: false, error: "모든 항목을 입력해주세요." };
+  }
+  const coords = await geocodeAddress(address);
+  if (!coords) return { ok: false, error: "주소를 찾을 수 없습니다. 다시 확인해주세요." };
+  return { ok: true, payload: { customerName, customerPhone, address, latitude: coords.latitude, longitude: coords.longitude } };
+}
+
+export async function createSystemCallAction(
+  formData: FormData
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  const geo = await geocodeFormToPayload(formData);
+  if (!geo.ok) return geo;
+  try {
+    await client.systemDispatchCall(geo.payload);
+    revalidatePath("/management"); revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function createOfferedCallAction(
+  formData: FormData
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  const geo = await geocodeFormToPayload(formData);
+  if (!geo.ok) return geo;
+  try {
+    await client.offerCall(geo.payload);
+    revalidatePath("/management"); revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function acceptCallAction(
+  orderId: string, bikeId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    await client.acceptCall(orderId, bikeId);
+    revalidatePath("/management"); revalidatePath("/");
+    return { ok: true };
+  } catch (err) { return { ok: false, error: extractError(err) }; }
+}
+
+export async function listOfferedCallsAction(): Promise<ServiceOpsDispatchOrder[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listOfferedCalls().catch(() => []);
+}
+```
+import 에 `DeliveryCallPayload`, `ServiceOpsDispatchOrder` 추가(이미 있으면 생략).
+
+- [ ] **Step 3: typecheck + lint**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/app/dispatch/actions.ts && git commit -m "feat(c1): frontend baemin call types/client/actions"
+```
+
+---
+
+### Task 7: 프론트 — /management 배민 콜 섹션
+
+**Files:**
+- Create: `development/front-admin-web/components/management/BaeminCallPanel.tsx`
+- Modify: `development/front-admin-web/app/management/page.tsx`
+- Modify: `development/front-admin-web/app/globals.css`
+
+- [ ] **Step 1: BaeminCallPanel 작성**
+
+`"use client"` 컴포넌트, 섹션 "배민 콜". props: `initialOffered: ServiceOpsDispatchOrder[]`, `deliveryVehicles: { id: string; plateNumber: string }[]` (수락 시 차량 선택용 — 서버 페이지에서 DELIVERY 차량 추출해 전달). 구성:
+- **콜 입력 폼**: 고객명(input) / 연락처(input) / 배달지(읽기전용 input + `AddressSearchButton` onSelect 로 주소 채움 — `VehicleDetailDialog` 의 옛 NextCustomer 폼 또는 station 폼에서 AddressSearchButton 사용법 참고) / 모드 라디오(`system` | `offer`). 제출(useTransition): FormData 구성(customerName/customerPhone/address) → 모드가 system 이면 `createSystemCallAction(fd)`, offer 면 `createOfferedCallAction(fd)`. 성공 시 폼 초기화 + offered 목록 reload(`listOfferedCallsAction()`); 실패 시 `error` 표시(가용 차량 없음 등 409 메시지).
+- **OFFERED 목록**: `offered` state(초기 prop), 각 콜 카드(고객명/연락처/주소) + 차량 선택 `<select>`(deliveryVehicles) + **수락** 버튼 → `acceptCallAction(order.id, selectedBikeId)`; 성공 시 목록 reload.
+- AddressSearchButton import: `@/components/management/AddressSearchButton`.
+
+CSS 클래스는 `globals.css`(Step 3)에 추가, 기존 `.dispatch-*`/관리 폼 스타일 관례 따름.
+
+- [ ] **Step 2: page.tsx 연결**
+
+READ `app/management/page.tsx`(서버 컴포넌트). `listOfferedCallsAction()` 으로 초기 OFFERED 를 await 하고, 차량 목록(이미 페이지가 로드하는 vehicles 데이터에서 serviceType==="DELIVERY" 추출해 `{id, plateNumber}[]`)을 만들어 `<BaeminCallPanel initialOffered={...} deliveryVehicles={...} />` 로 전달. 기존 DispatchPanel/StrollerRoundPanel 섹션 옆에 배치. (페이지가 차량 데이터를 어떻게 로드하는지 확인 후 DELIVERY 필터; 없으면 차량 로더 재사용.)
+
+- [ ] **Step 3: CSS**
+
+`app/globals.css` 에 `.baemin-call-*`(폼, 모드 라디오, OFFERED 카드, 수락 행) 클래스 추가. 기존 관리 폼/`.dispatch-*` 스타일 미러링.
+
+- [ ] **Step 4: typecheck + lint + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/BaeminCallPanel.tsx development/front-admin-web/app/management/page.tsx development/front-admin-web/app/globals.css && git commit -m "feat(c1): /management 배민 콜 섹션 (입력 폼 + OFFERED 수락)"
+```
+
+---
+
+### Task 8: 최종 검증 + PR
+
+- [ ] **Step 1: 백엔드 + 프론트 풀 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q && ./gradlew test --tests "com.thundercrew.opsapi.ArchitectureBoundaryTests" -q
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 백엔드 컴파일 성공, ArchUnit dispatch 위반 0(기존 베이스라인만), 프론트 빌드 성공.
+
+- [ ] **Step 2: PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git diff dev --stat && git push -u origin cc-c1-baemin-call && gh pr create --base dev --title "Group C1: 배민 배송 (단건 콜: 시스템 배차/라이더 수락)" --body "$(cat <<'EOF'
+## Summary
+- DispatchOrder 확장(OFFERED status + nullable bike_id, V35)으로 배민 단건 콜
+- 시스템 자동 배차(가장 적게 배정된 DELIVERY 차량) 또는 라이더 수락(OFFERED→운영자 차량 지정 accept)
+- /management 배민 콜 섹션(입력 폼 + 모드 라디오 + OFFERED 목록/수락)
+- OFFERED 는 차량별 ASSIGNED 쿼리에서 제외 → 대시보드/큐/완료 핫패스 무변경; 수락 후 합류
+
+## 배포 영향
+- **V35 마이그레이션 신규**(bike_id nullable + status check OFFERED 추가) — 재기동 시 Flyway 적용, 기존 데이터 영향 없음
+- 백엔드 + 프론트
+
+## Test Plan
+- [x] 백엔드 compileJava/compileTestJava, ArchUnit(dispatch 위반 0), 프론트 typecheck/lint/build
+- [ ] 계약 테스트 DeliveryCallApiContractTests — Docker/CI
+- [ ] 프로덕션 QA: 배민 콜 입력(시스템 배차 → 차량 자동 배정 / 라이더 수락 → OFFERED → 수락) → 차량 배차 큐 반영
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- V35(bike_id nullable + status OFFERED) → Task 1. ✓
+- OFFERED status + createOffered/assign → Task 1. ✓
+- 시스템 자동 배차(least-loaded DELIVERY) → Task 3 systemDispatch. ✓
+- 라이더 수락(offer + accept) → Task 3 offerCall/acceptCall. ✓
+- 가용 차량 없음 409 → Task 3 (InvalidStateTransitionException). ✓
+- 컨트롤러 라우트(system/offer/accept/offered) → Task 4. ArchUnit 기존 allow-list 커버. ✓
+- OFFERED 목록 → Task 2 repo + Task 3 listOffered + Task 4 read route. ✓
+- 계약 테스트(시스템/least-loaded/없음/offer/accept/재배정) → Task 5. ✓
+- 프론트 타입/클라이언트/액션 → Task 6. ✓
+- /management 배민 콜 섹션 + 수락 → Task 7. ✓
+- 지도/차량상세 자동 반영(별도 UI 없음) → 기존 C0/C2 재사용, 신규 작업 없음. ✓
+- DELIVERY serviceType 재사용 → 신규 enum 없음. ✓
+
+**2. Placeholder scan:** 백엔드 신규 파일은 완전 코드. 프론트(Task 6/7)는 일부 "기존 X 패턴 미러링"으로 위임 — request<T> 호출 관례, page.tsx 차량 로더 구조, AddressSearchButton 사용법이 코드베이스 의존이라 구현자가 해당 파일을 읽어야 정확. 위임마다 따를 구체 대상(파일/심볼) 명시. 순수 신규 로직(systemDispatch/accept/least-loaded)은 완전 코드 제공.
+
+**3. Type consistency:** `DispatchOrderStatus{OFFERED,ASSIGNED,COMPLETED}`, `DispatchOrder.createOffered(name,phone,address,lat,lng)`/`assign(bikeId,sequence)`, `DeliveryCallService.systemDispatch/offerCall/acceptCall/listOffered`, repo `findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc`, `DeliveryCallCreateRequest(customerName,customerPhone,address,latitude,longitude)`, `DeliveryCallAcceptRequest(bikeId)` — Task 간 일관. 프론트 `DeliveryCallPayload`/`systemDispatchCall`/`offerCall`/`acceptCall`/`listOfferedCalls` + 액션 `createSystemCallAction`/`createOfferedCallAction`/`acceptCallAction`/`listOfferedCallsAction` 일관. `ServiceOpsDispatchOrder.bikeId: string|null` + status OFFERED 추가.
+
+**구현자 주의:** 백엔드 순차 의존(엔티티→레포→서비스→컨트롤러→테스트). 프론트(6→7)는 백엔드 status/bikeId 변경에 의존. Task 3 의 `Bike.getServiceType()`/`BikeServiceType.DELIVERY`/`BikeRepository` 단건조회는 실제 API 를 READ 로 확인 후 조정.

--- a/docs/superpowers/specs/2026-06-12-group-c1-baemin-call-design.md
+++ b/docs/superpowers/specs/2026-06-12-group-c1-baemin-call-design.md
@@ -1,0 +1,124 @@
+# Group C1 — 배민 배송 (단건 콜: 시스템 자동 배차 / 라이더 수락) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 배민 배송 단건 콜을 웹 폼으로 입력하고, 두 가지 배정 방식 — **시스템 자동 배차**(가용 라이더 즉시 배정) 또는 **라이더 수락**(미배정 OFFERED → 운영자가 라이더 지정해 수락) — 으로 처리한다. 단일 목적지(고객 배달지) call.
+
+**Architecture:** 기존 `DispatchOrder`를 확장한다 — `DispatchOrderStatus`에 `OFFERED` 추가 + `bike_id`를 nullable로. 배정된(ASSIGNED) 콜은 기존 단건 배차와 동일(배차 큐/지도/완료 재사용); OFFERED는 "차량 없는 status"로 표현해 대시보드·큐·알림 핫패스(차량별 ASSIGNED 기준)에서 자연히 제외된다. 시스템 배차는 가장 적게 배정된 DELIVERY 차량을 자동 선택, 라이더 수락은 운영자가 차량을 지정한다.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA `Repository<T,UUID>`, NCP Geocoding(프론트), Next.js App Router, TypeScript.
+
+---
+
+## 1. 범위
+
+### 이번 스펙 (C1)
+- 배민 콜 단건 웹 입력(고객명/연락처/배달지 + 배정 모드).
+- **시스템 자동 배차**: 가용 DELIVERY 차량 자동 선택 → 즉시 ASSIGNED.
+- **라이더 수락**: OFFERED 생성 → 운영자가 차량 지정 수락 → ASSIGNED.
+- OFFERED 콜 목록 + 수락 UI. 배정된 콜은 기존 배차 큐/완료 재사용.
+
+### 범위 외 (후속/별도)
+- 가게 픽업(2지점), 실제 배민 API 연동, 라이더 앱(실제 수락)
+- 콜 자동 재배정/만료, 라이더 거절 흐름, 다중 라이더 브로드캐스트 경쟁 수락
+- 시동 알림(배민=DELIVERY, 알림은 CLEANING 전용 — 변경 없음)
+- 새 serviceType (DELIVERY 재사용)
+
+---
+
+## 2. 핵심 동작 결정 (확정)
+
+| 항목 | 결정 |
+|---|---|
+| call 구조 | **단일 목적지** — 고객명+연락처+배달지(주소→좌표) |
+| 배정 방식 | call마다 선택: **시스템 자동 배차** 또는 **라이더 수락** |
+| 시스템 자동 선택 규칙 | **가장 적게 배정된(ASSIGNED 큐가 짧은) DELIVERY 차량**. 동률은 임의. 가용 차량 없으면 409 에러 |
+| OFFERED 표현 | **DispatchOrderStatus.OFFERED + bike_id null** (새 도메인 아님). 수락 시 차량 지정 + sequence 부여 + ASSIGNED |
+| OFFERED 풀 | 특정 라이더 미지정(미배정). 수락 시 운영자가 차량 선택 |
+| 차량 serviceType | DELIVERY 재사용 (새 enum 없음) |
+| 입력 | 단건 웹 폼 (엑셀 없음). 지오코딩은 프론트 server action(C2 hybrid 재사용) |
+
+---
+
+## 3. 백엔드 (service-ops-api · `com.thundercrew.opsapi.dispatch`)
+
+### 3.1 마이그레이션 `V35__dispatch_orders_offered_status.sql`
+- `alter table dispatch_orders alter column bike_id drop not null;` (OFFERED 콜은 차량 미배정)
+- 기존 status check 제약(`ck_dispatch_orders_status in ('ASSIGNED','COMPLETED')`)을 **drop 후 재생성**해 `OFFERED` 포함:
+  - `alter table dispatch_orders drop constraint ck_dispatch_orders_status;`
+  - `alter table dispatch_orders add constraint ck_dispatch_orders_status check (status in ('OFFERED','ASSIGNED','COMPLETED'));`
+- 기존 인덱스/데이터는 영향 없음(OFFERED 신규 값).
+
+### 3.2 도메인
+- **`DispatchOrderStatus`**: `OFFERED` 추가 → `{OFFERED, ASSIGNED, COMPLETED}`.
+- **`DispatchOrder`**:
+  - `bikeId` nullable 허용(필드 타입 UUID 그대로, not-null 제약은 DB에서 제거; 엔티티 `@Column(nullable = true)`).
+  - 신규 팩토리 `createOffered(customerName, customerPhone, address, latitude, longitude)`: status=OFFERED, bikeId=null, sequence=0(미배정), kind=DELIVERY.
+  - 신규 메서드 `assign(UUID bikeId, long sequence)`: OFFERED→ASSIGNED 전환(상태 검증; OFFERED 아니면 `InvalidStateTransitionException`), bikeId·sequence 설정.
+  - 기존 `create(...)`(ASSIGNED)·`createForBatch(...)`·`complete(...)` 변경 없음.
+- **`DispatchOrderRepository`** 추가: `findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus)`(OFFERED 목록), `countByBikeIdAndStatusAndDeletedAtIsNull(UUID, DispatchOrderStatus)` 또는 기존 `findByStatusAndDeletedAtIsNull(ASSIGNED)` 재사용해 in-memory 집계.
+
+### 3.3 서비스 — `DeliveryCallService` (`@Transactional`)
+- `systemDispatch(customerName, phone, address, lat, lng)`: 가용 DELIVERY 차량 자동 선택 → `commandService.appendForBike(bikeId, ...)`(ASSIGNED). 선택 규칙: `bikeRepository.findAllByDeletedAtIsNull()`에서 serviceType==DELIVERY 필터 → 각 차량의 ASSIGNED 주문 수(`dispatchOrderRepository.findByStatusAndDeletedAtIsNull(ASSIGNED)` 그룹 집계) 최소 차량. 후보 없으면 `InvalidStateTransitionException("가용 배송 차량이 없습니다.")`.
+- `offerCall(customerName, phone, address, lat, lng)`: `DispatchOrder.createOffered(...)` 저장(OFFERED, bike null). 반환 DTO.
+- `acceptCall(orderId, bikeId)`: OFFERED 주문 find-or-404, 차량 존재 검증, `order.assign(bikeId, nextSequence(bikeId))`(dirty-checking). 이미 ASSIGNED면 `InvalidStateTransitionException`.
+- `listOffered()`(readOnly): OFFERED 주문 목록(createdAt asc).
+- nextSequence는 기존 CommandService 헬퍼 패턴(차량 max+1) 재사용(필요 시 노출).
+
+### 3.4 컨트롤러 (ArchUnit allow-list — 기존 `isDispatchCommand` 커버)
+`DispatchOrderCommandController`(`/api/v1/dispatch-orders`)에 라우트 추가(이미 allow-list 등록된 컨트롤러라 신규 predicate 불필요):
+- `POST /calls/system` (@RequestBody system 콜) → 자동 배차.
+- `POST /calls/offer` (@RequestBody) → OFFERED 생성.
+- `POST /calls/{id}/accept` (@RequestBody {bikeId}) → 수락.
+`DispatchOrderReadController`에 `GET /calls/offered` → OFFERED 목록.
+DTO: `DeliveryCallCreateRequest`(@NotBlank name/phone/address, lat/lng range), `DeliveryCallAcceptRequest`(@NotNull bikeId). 응답은 기존 `DispatchOrderReadResponse`(이미 kind/status 포함; bikeId nullable 반영).
+
+### 3.5 Dashboard / 큐 영향
+- OFFERED 주문은 bike_id null → 차량별 ASSIGNED 쿼리(currentDispatch·배차 큐·export)에 **미포함**(변경 없음). 수락되면 ASSIGNED로 그 차량 큐 합류.
+- `DispatchOrderReadResponse.bikeId`가 null 가능해짐(OFFERED) — 프론트 타입도 nullable.
+
+### 3.6 테스트
+`DeliveryCallApiContractTests`(PostgresContainerSupport): 시스템 배차(가용 차량 자동 선택 → ASSIGNED, bike 지정됨), 가용 차량 없음 → 409, offer(OFFERED, bike null) → GET /calls/offered 포함, accept(OFFERED→ASSIGNED, bike·sequence 설정) → 차량 큐 조회에 등장, 이미 ASSIGNED accept → 409, 시스템 배차 시 least-loaded 선택(2차량 중 적게 배정된 쪽).
+
+---
+
+## 4. 프론트엔드 (front-admin-web)
+
+### 4.1 타입 + API 클라이언트 (service-ops-api.ts)
+- `ServiceOpsDispatchOrderStatus`에 `"OFFERED"` 추가. `ServiceOpsDispatchOrder.bikeId`를 `string | null`로.
+- 메서드: `systemDispatchCall(payload)`, `offerCall(payload)`, `acceptCall(orderId, bikeId)`, `listOfferedCalls()`.
+
+### 4.2 서버 액션 (app/dispatch/actions.ts)
+- `createSystemCallAction(formData)`: 주소 지오코딩(`geocodeAddress`, C2 패턴) → `systemDispatchCall({name,phone,address,lat,lng})`. 지오코딩 실패/가용차량 없음 → `{ok:false,error}`(409 한글 메시지 노출).
+- `createOfferedCallAction(formData)`: 지오코딩 → `offerCall(...)`.
+- `acceptCallAction(orderId, bikeId)`: `acceptCall(...)`.
+- `listOfferedCallsAction()`: OFFERED 목록(미인증/오류 시 빈 배열).
+- 모두 `{ok,error}` + `revalidatePath("/management")`,`("/")`.
+
+### 4.3 /management "배민 콜" 섹션 (BaeminCallPanel)
+- **콜 입력 폼**: 고객명 / 연락처 / 배달지(주소 검색) + **모드 라디오**(시스템 자동 배차 / 라이더 수락). 제출 → 모드에 따라 system/offer 액션.
+- **OFFERED 콜 목록**: 미배정 콜 카드(고객/주소) + **수락** 버튼 → 차량 선택(드롭다운: DELIVERY 차량 또는 매칭 차량) → `acceptCallAction(orderId, bikeId)`.
+- 시스템 배차 성공 시 배정 차량 표시; 가용 차량 없음 등 에러는 `{ok:false}` 메시지로.
+- 차량 선택 드롭다운 데이터: 기존 차량 목록(매칭/운영 차량)에서 DELIVERY 추출.
+
+### 4.4 지도 / 차량 상세
+- 변경 최소: 수락/시스템 배차로 ASSIGNED 되면 기존 배차 큐(차량 상세) + 지도 배지(N건)에 자동 반영(기존 C0/C2 로직). 별도 UI 불필요.
+
+---
+
+## 5. 데이터 흐름
+
+```
+[배민 콜 입력(고객/연락처/주소 + 모드)] → 지오코딩(프론트)
+  ├ 시스템 자동 배차 → systemDispatch: least-loaded DELIVERY 차량 선택 → ASSIGNED 주문(차량 큐 합류)
+  └ 라이더 수락 → offer: OFFERED 주문(bike null) → /management OFFERED 목록
+        → 운영자 '수락' + 차량 선택 → accept: bike·sequence 설정 + ASSIGNED(차량 큐 합류)
+[배정 후] 차량 상세 배차 큐 + 지도 배지에 반영 → 운영자 '완료'(기존 C0/C2)
+```
+
+## 6. 배포 영향
+- **V35 마이그레이션 신규**(bike_id nullable + status check 재생성) — 재기동 시 Flyway 적용. 기존 데이터 영향 없음(OFFERED 신규 값). 엔티티 매핑(bikeId nullable) 일치 필수.
+- 백엔드 + 프론트. 지오코딩 프론트(C2 hybrid) 재사용.
+
+## 7. 비범위 재확인
+가게 픽업 2지점, 실제 배민/라이더 앱 연동, 콜 만료/거절/재배정, 시동 알림(배민), 새 serviceType 은 이 스펙에 포함하지 않는다.


### PR DESCRIPTION
## Release scope
dev → main 릴리스. **Group C1 (배민 배송 단건 콜)** 단독. 이로써 Group C 5개 하위 흐름 전부 프로덕션.

### Group C1 — 배민 배송 (단건 콜)
기존 `DispatchOrder` 확장(OFFERED status + nullable bike_id, V35)으로 배민 단건 콜:
- **시스템 자동 배차**: 가장 적게 배정된 DELIVERY 차량 자동 선택 → ASSIGNED
- **라이더 수락**: OFFERED(미배정) → 운영자 차량 지정 수락 → ASSIGNED
- /management 배민 콜 섹션(입력 폼 + 모드 라디오 + OFFERED 목록/수락)
- OFFERED는 차량별 ASSIGNED 쿼리에서 제외 → 대시보드/큐/완료/라운드 핫패스 무변경
- 거부(가용 차량 없음·재수락·OFFERED 완료 시도)는 409 + 한글 메시지

## 배포 영향
- **V35 마이그레이션 신규**(bike_id nullable + status check OFFERED 추가) — main push 시 재기동 → Flyway 적용. 기존 ASSIGNED/COMPLETED 데이터 하위호환(영향 없음). compileJava/compileTestJava로 스키마·엔티티 매핑 일치 확인.
- 백엔드 + 프론트

## 검증
- [x] 백엔드 compile(main+test), ArchUnit(dispatch 위반 0), 프론트 typecheck/lint/build
- [ ] 계약 테스트 DeliveryCallApiContractTests — CI(Docker)
- [ ] **머지 후 프로덕션 QA**: 배민 콜 시스템 배차 / 라이더 수락 → 차량 배차 큐 반영

머지 시 프로덕션 배포가 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)