### PR TITLE
Release: /management 레이아웃 + 필터 칩 UX 수정 (A3/A4/B1)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -218,6 +218,33 @@ button, input, select, textarea { font: inherit; }
 /* /management 테이블은 내부 고정-높이 스크롤을 쓰지 않고 페이지 전체로 스크롤한다. */
 .management-panel .table-card { height: auto; overflow-y: visible; }
 .management-panel .vehicles-table-scroll { max-height: none; overflow-y: visible; }
+.management-section-nav {
+  position: sticky;
+  top: 16px;
+  z-index: 60;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--rm-bg-panel);
+  box-shadow: var(--shadow-panel);
+}
+.management-section-nav-link {
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: background .12s ease, color .12s ease;
+}
+.management-section-nav-link:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-muted);
+}
+/* 앵커 점프 시 sticky 내비 + fixed 바 아래로 가려지지 않게 여백 확보. */
+.management-anchor { scroll-margin-top: 96px; }
 .management-section-title { margin: 0 0 12px; font-size: 13px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--color-text-muted); }
 .mgmt-panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; gap: 12px; }
 .mgmt-panel-header-left { display: flex; align-items: center; gap: 8px; }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1233,17 +1233,26 @@ textarea { padding-top: 10px; min-height: 96px; }
   border-radius: 999px;
   font-size: 12px;
   font-weight: 700;
-  border: 1px solid var(--rm-line-subtle);
-  background: transparent;
+  border: 1px solid transparent;        /* 비활성은 상시 테두리 제거 */
+  background: var(--color-bg-muted);     /* 비활성 = 옅은 채움(off pill) */
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background .12s ease, color .12s ease, border-color .12s ease;
+  transition: background .12s ease, color .12s ease, border-color .12s ease, box-shadow .12s ease;
 }
-.service-type-tab:hover { color: var(--color-text-primary); }
+.service-type-tab:hover {
+  color: var(--color-text-primary);
+  background: color-mix(in srgb, var(--baemin-mint) 14%, transparent);
+}
 .service-type-tab.is-active {
   background: var(--baemin-mint);
   color: #fff;
   border-color: var(--baemin-mint);
+  box-shadow: 0 1px 6px color-mix(in srgb, var(--baemin-mint) 45%, transparent); /* 선택을 또렷하게 */
+}
+/* 키보드 포커스만 별도 아웃라인 — 마우스 클릭 후엔 안 보여 '선택'과 혼동 없음. */
+.service-type-tab:focus-visible {
+  outline: 2px solid var(--baemin-mint);
+  outline-offset: 2px;
 }
 
 /* ── Notification Bell ──────────────────────────────────────────── */

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -206,7 +206,18 @@ button, input, select, textarea { font: inherit; }
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
 }
 
-.management-page { display: flex; flex-direction: column; gap: 40px; }
+.management-page {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  /* 1200px 중앙 정렬 + 좌우 여백. 상단 88px 로 fixed .top-actions(top16+높이~56) 아래에서 시작. */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 88px 24px 96px;
+}
+/* /management 테이블은 내부 고정-높이 스크롤을 쓰지 않고 페이지 전체로 스크롤한다. */
+.management-panel .table-card { height: auto; overflow-y: visible; }
+.management-panel .vehicles-table-scroll { max-height: none; overflow-y: visible; }
 .management-section-title { margin: 0 0 12px; font-size: 13px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--color-text-muted); }
 .mgmt-panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; gap: 12px; }
 .mgmt-panel-header-left { display: flex; align-items: center; gap: 8px; }

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -4,6 +4,7 @@ import { MatchingManagementPanel } from "@/components/management/MatchingManagem
 import { DispatchPanel } from "@/components/management/DispatchPanel";
 import { StrollerRoundPanel } from "@/components/management/StrollerRoundPanel";
 import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
+import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
 import { getActiveRoundAction, listOfferedCallsAction } from "@/app/dispatch/actions";
 import { listVehiclesAction } from "@/app/management/vehicles/actions";
 
@@ -22,12 +23,25 @@ export default async function ManagementPage() {
 
   return (
     <div className="management-page">
-      <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
-      <RidersManagementPanel exportUrl="/api/management/riders/export" />
-      <MatchingManagementPanel exportUrl="/api/management/matching/export" />
-      <DispatchPanel exportUrl="/api/management/dispatch/export" />
-      <StrollerRoundPanel initialRound={activeRound} />
-      <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
+      <ManagementSectionNav />
+      <section id="mgmt-vehicles" className="management-anchor">
+        <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
+      </section>
+      <section id="mgmt-riders" className="management-anchor">
+        <RidersManagementPanel exportUrl="/api/management/riders/export" />
+      </section>
+      <section id="mgmt-matching" className="management-anchor">
+        <MatchingManagementPanel exportUrl="/api/management/matching/export" />
+      </section>
+      <section id="mgmt-dispatch" className="management-anchor">
+        <DispatchPanel exportUrl="/api/management/dispatch/export" />
+      </section>
+      <section id="mgmt-stroller" className="management-anchor">
+        <StrollerRoundPanel initialRound={activeRound} />
+      </section>
+      <section id="mgmt-baemin" className="management-anchor">
+        <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
+      </section>
     </div>
   );
 }

--- a/development/front-admin-web/components/management/ManagementSectionNav.tsx
+++ b/development/front-admin-web/components/management/ManagementSectionNav.tsx
@@ -1,0 +1,21 @@
+const SECTIONS: { id: string; label: string }[] = [
+  { id: "mgmt-vehicles", label: "차량" },
+  { id: "mgmt-riders", label: "라이더" },
+  { id: "mgmt-matching", label: "매칭" },
+  { id: "mgmt-dispatch", label: "배차" },
+  { id: "mgmt-stroller", label: "유모차" },
+  { id: "mgmt-baemin", label: "배민 콜" }
+];
+
+/** /management 상단 sticky 섹션 점프 내비 (앵커 링크). */
+export function ManagementSectionNav() {
+  return (
+    <nav className="management-section-nav" aria-label="관리 섹션 이동">
+      {SECTIONS.map((s) => (
+        <a key={s.id} href={`#${s.id}`} className="management-section-nav-link">
+          {s.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/docs/superpowers/plans/2026-06-12-ux-mgmt-layout-filter.md
+++ b/docs/superpowers/plans/2026-06-12-ux-mgmt-layout-filter.md
@@ -1,0 +1,299 @@
+# /management 레이아웃 + 필터 칩 UX 수정 (A3/A4/B1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 프론트엔드 전용으로 3개 UX 결함 수정 — A3(플로팅 바가 /management 첫 섹션 액션 가림), A4(관리 테이블 중첩 스크롤 + 섹션 내비 부재), B1(지도 서비스 필터 칩 활성/포커스 대비 약함).
+
+**Architecture:** 백엔드·데이터 무변경. `app/globals.css` 조정 + `app/management/page.tsx`에 섹션 래퍼/내비 추가 + 신규 `ManagementSectionNav.tsx`. 공유 `.table-card`는 `.management-panel` 하위로만 override해 다른 화면 회귀 방지.
+
+**Tech Stack:** Next.js App Router, CSS, TypeScript.
+
+**작업 경로:** `development/front-admin-web`. Bash 절대경로 `cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web` (cwd 매 호출 리셋). 브랜치 `cc-ux-mgmt-layout-filter` 체크아웃 — 새 브랜치 만들지 말 것. 검증은 `npm run typecheck && npm run lint && npm run build`.
+
+**알려진 현재 CSS (globals.css):**
+- `.management-page { display: flex; flex-direction: column; gap: 40px; }` (~209행)
+- `.page-container { width: min(100% - 48px, 1200px); margin: 0 auto; padding-bottom: 96px; }` (166행)
+- `.top-actions { position: fixed; top: 16px; right: 16px; z-index: 80; ... }` (171행, 높이 ~56px)
+- `.table-card { overflow: hidden; height: 240px; overflow-y: auto; }` (~400행) — **공유**(RidersPanel `/?tab=riders`, MaintenancePanel 등도 사용)
+- `.vehicles-table-scroll { max-height: 560px; overflow: auto; }` (~418행)
+- `.service-type-tab` / `.is-active` (~1193–1209행)
+- 관리 패널 root = `.management-panel`. page.tsx 순서: VehiclesManagementPanel, RidersManagementPanel, MatchingManagementPanel, DispatchPanel, StrollerRoundPanel, BaeminCallPanel.
+
+---
+
+### Task 1: A3 + A4a — 관리 페이지 컨테이너/여백 + 중첩 스크롤 제거 (globals.css)
+
+**Files:**
+- Modify: `development/front-admin-web/app/globals.css`
+
+- [ ] **Step 1: `.management-page`에 컨테이너/상단 여백 부여 (A3)**
+
+`.management-page { display: flex; flex-direction: column; gap: 40px; }` 를 다음으로 교체:
+```css
+.management-page {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  /* 1200px 중앙 정렬 + 좌우 여백. 상단 88px 로 fixed .top-actions(top16+높이~56) 아래에서 시작. */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 88px 24px 96px;
+}
+```
+
+- [ ] **Step 2: 관리 테이블 중첩 스크롤 제거 (A4a, `.management-panel` 하위로 한정)**
+
+globals.css 의 `.management-page` 규칙 바로 아래에 추가(공유 `.table-card`/`.vehicles-table-scroll` 베이스는 건드리지 않고 management 안에서만 해제):
+```css
+/* /management 테이블은 내부 고정-높이 스크롤을 쓰지 않고 페이지 전체로 스크롤한다. */
+.management-panel .table-card { height: auto; overflow-y: visible; }
+.management-panel .vehicles-table-scroll { max-height: none; overflow-y: visible; }
+```
+(가로 스크롤 `.table-card { overflow-x: auto }`(~1156행, 좁은 화면용)은 유지된다 — 위 override는 세로만 해제.)
+
+- [ ] **Step 3: 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과. (CSS 변경이라 typecheck 영향 없음, lint 통과.)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/app/globals.css && git commit -m "fix(ux): A3 management page container+top padding; A4 remove nested table scroll (scoped)"
+```
+
+---
+
+### Task 2: A4b — sticky 섹션 내비 + page.tsx 섹션 래퍼
+
+**Files:**
+- Create: `development/front-admin-web/components/management/ManagementSectionNav.tsx`
+- Modify: `development/front-admin-web/app/management/page.tsx`
+- Modify: `development/front-admin-web/app/globals.css`
+
+- [ ] **Step 1: ManagementSectionNav 컴포넌트 (순수 앵커, 서버 컴포넌트)**
+
+`components/management/ManagementSectionNav.tsx`:
+```tsx
+const SECTIONS: { id: string; label: string }[] = [
+  { id: "mgmt-vehicles", label: "차량" },
+  { id: "mgmt-riders", label: "라이더" },
+  { id: "mgmt-matching", label: "매칭" },
+  { id: "mgmt-dispatch", label: "배차" },
+  { id: "mgmt-stroller", label: "유모차" },
+  { id: "mgmt-baemin", label: "배민 콜" }
+];
+
+/** /management 상단 sticky 섹션 점프 내비 (앵커 링크). */
+export function ManagementSectionNav() {
+  return (
+    <nav className="management-section-nav" aria-label="관리 섹션 이동">
+      {SECTIONS.map((s) => (
+        <a key={s.id} href={`#${s.id}`} className="management-section-nav-link">
+          {s.label}
+        </a>
+      ))}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 2: page.tsx — 내비 + 각 패널을 앵커 섹션으로 래핑**
+
+`app/management/page.tsx` 의 return 블록을 다음으로 교체(기존 import + Promise.all + deliveryVehicles 계산은 유지, import 에 `ManagementSectionNav` 추가):
+```tsx
+  return (
+    <div className="management-page">
+      <ManagementSectionNav />
+      <section id="mgmt-vehicles" className="management-anchor">
+        <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
+      </section>
+      <section id="mgmt-riders" className="management-anchor">
+        <RidersManagementPanel exportUrl="/api/management/riders/export" />
+      </section>
+      <section id="mgmt-matching" className="management-anchor">
+        <MatchingManagementPanel exportUrl="/api/management/matching/export" />
+      </section>
+      <section id="mgmt-dispatch" className="management-anchor">
+        <DispatchPanel exportUrl="/api/management/dispatch/export" />
+      </section>
+      <section id="mgmt-stroller" className="management-anchor">
+        <StrollerRoundPanel initialRound={activeRound} />
+      </section>
+      <section id="mgmt-baemin" className="management-anchor">
+        <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
+      </section>
+    </div>
+  );
+```
+상단 import 에 추가: `import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";`
+
+- [ ] **Step 3: globals.css — sticky 내비 + 앵커 scroll-margin**
+
+globals.css 의 Task1 management 블록 아래에 추가:
+```css
+.management-section-nav {
+  position: sticky;
+  top: 16px;
+  z-index: 60; /* fixed .top-actions(z80) 보다 아래 — 우상단 코너에서만 겹치고 링크는 좌측이라 실사용 충돌 없음 */
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--rm-bg-panel);
+  box-shadow: var(--shadow-panel);
+}
+.management-section-nav-link {
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: background .12s ease, color .12s ease;
+}
+.management-section-nav-link:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-muted);
+}
+/* 앵커 점프 시 sticky 내비 + fixed 바 아래로 가려지지 않게 여백 확보. */
+.management-anchor { scroll-margin-top: 96px; }
+```
+(`--rm-bg-panel`, `--shadow-panel`, `--color-text-muted`, `--color-text-primary`, `--color-bg-muted` 는 globals.css 에 이미 정의됨 — 확인 후 사용.)
+
+- [ ] **Step 4: 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/ManagementSectionNav.tsx development/front-admin-web/app/management/page.tsx development/front-admin-web/app/globals.css && git commit -m "feat(ux): A4 sticky section nav + anchored management sections"
+```
+
+---
+
+### Task 3: B1 — 서비스 필터 칩 활성/포커스 대비 (globals.css)
+
+**Files:**
+- Modify: `development/front-admin-web/app/globals.css`
+
+- [ ] **Step 1: `.service-type-tab*` 규칙 교체**
+
+기존(~1193–1209행):
+```css
+.service-type-tab {
+  padding: 4px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid var(--rm-line-subtle);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background .12s ease, color .12s ease, border-color .12s ease;
+}
+.service-type-tab:hover { color: var(--color-text-primary); }
+.service-type-tab.is-active {
+  background: var(--baemin-mint);
+  color: #fff;
+  border-color: var(--baemin-mint);
+}
+```
+를 다음으로 교체:
+```css
+.service-type-tab {
+  padding: 4px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid transparent;        /* 비활성은 상시 테두리 제거 */
+  background: var(--color-bg-muted);     /* 비활성 = 옅은 채움(off pill) */
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background .12s ease, color .12s ease, border-color .12s ease, box-shadow .12s ease;
+}
+.service-type-tab:hover {
+  color: var(--color-text-primary);
+  background: color-mix(in srgb, var(--baemin-mint) 14%, transparent);
+}
+.service-type-tab.is-active {
+  background: var(--baemin-mint);
+  color: #fff;
+  border-color: var(--baemin-mint);
+  box-shadow: 0 1px 6px color-mix(in srgb, var(--baemin-mint) 45%, transparent); /* 선택을 또렷하게 */
+}
+/* 키보드 포커스만 별도 아웃라인 — 마우스 클릭 후엔 안 보여 '선택'과 혼동 없음. */
+.service-type-tab:focus-visible {
+  outline: 2px solid var(--baemin-mint);
+  outline-offset: 2px;
+}
+```
+(`--baemin-mint`, `--color-bg-muted`, `--color-text-muted`, `--color-text-primary` 이미 정의됨. `ServiceTypeFilterTabs.tsx` 마크업은 변경 없음 — `is-active`/`aria-selected` 그대로.)
+
+- [ ] **Step 2: 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/app/globals.css && git commit -m "fix(ux): B1 service-type filter chip active/focus contrast"
+```
+
+---
+
+### Task 4: 최종 검증 + PR
+
+- [ ] **Step 1: 풀 빌드**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 세 단계 통과, Next 빌드 성공.
+
+- [ ] **Step 2: 변경 요약 + PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git diff dev --stat && git push -u origin cc-ux-mgmt-layout-filter && gh pr create --base dev --title "UX 수정: /management 레이아웃(A3/A4) + 필터 칩 대비(B1)" --body "$(cat <<'EOF'
+## Summary
+운영자 UX 점검 3건 수정 (프론트 전용):
+- **A3**: /management 를 1200px 컨테이너 + 상단 88px 여백으로 → 첫 섹션 내려받기/업로드가 플로팅 유틸바에 안 가림
+- **A4**: 관리 테이블 내부 고정-높이 스크롤 제거(`.management-panel` 하위로 한정 → 다른 화면 무영향) → 페이지 단일 스크롤 + sticky 섹션 내비(차량·라이더·매칭·배차·유모차·배민 앵커)
+- **B1**: 서비스 필터 칩 비활성 테두리 제거·활성 mint 강조·`:focus-visible` 별도 아웃라인 → 활성/포커스 또렷
+
+## 배포 영향
+- 프론트 전용 (globals.css + management/page.tsx + 신규 ManagementSectionNav). 백엔드/마이그레이션 없음.
+
+## Test Plan
+- [x] typecheck + lint + build
+- [ ] 프로덕션 QA: (A3) 첫 섹션 버튼 안 가림 / (A4) 표 위 스크롤이 페이지 이동 + 검은 빈영역 없음 + 섹션 내비 점프 / (B1) 필터 칩 활성 또렷
+
+## 비범위(후속)
+관리 테이블 검색/필터/정렬, 차량 운영방식 태그 + 방식별 지도 필터, 마커 declutter/범례.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** A3(컨테이너+상단여백)→Task1. A4a(중첩 스크롤 제거, 공유클래스 scoped)→Task1. A4b(sticky 섹션 내비+앵커+scroll-margin)→Task2. B1(칩 활성/포커스 대비)→Task3. 검증/PR→Task4. ✓ 비범위(테이블 필터·방식 태그·declutter)는 제외 명시.
+
+**2. Placeholder scan:** 모든 CSS/TSX 완전 코드. "적절히" 류 없음. 오프셋 값(88px/96px/top16/z60)은 구체값 — 시각적 미세조정 여지는 있으나 placeholder 아님.
+
+**3. Type consistency:** 섹션 id (`mgmt-vehicles`…`mgmt-baemin`)가 ManagementSectionNav 의 SECTIONS 와 page.tsx `<section id>` 에서 동일. 클래스명(`.management-page`, `.management-panel`, `.management-anchor`, `.management-section-nav(-link)`, `.service-type-tab(.is-active)(:focus-visible)`) 일관. 사용 CSS 변수는 기존 정의 재사용(구현자 확인).
+
+**구현자 주의:** Task1 의 `.management-panel .table-card` override 는 `.table-card` 베이스(다른 화면 RidersPanel/MaintenancePanel)를 건드리지 않는지 — `.management-panel` 루트가 /management 패널에만 있는지 grep 으로 확인(VehiclesManagementPanel 도 `.management-panel` 인지 포함). `.vehicles-table-scroll` 가 VehiclesManagementPanel 외에서 쓰이면 동일하게 scoped 처리.

--- a/docs/superpowers/specs/2026-06-12-ux-mgmt-layout-filter-design.md
+++ b/docs/superpowers/specs/2026-06-12-ux-mgmt-layout-filter-design.md
@@ -1,0 +1,68 @@
+# /management 레이아웃 + 필터 칩 UX 수정 (A3/A4/B1) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 운영자 관점 UX 점검에서 드러난 3가지 결함을 프론트엔드 전용으로 수정한다 — (A3) /management 첫 섹션 액션 버튼이 플로팅 유틸바에 가림, (A4) 관리 테이블의 중첩(내부) 스크롤 + 섹션 내비 부재, (B1) 지도 서비스 필터 칩의 활성/선택 상태 대비 약함.
+
+**Architecture:** 백엔드·데이터 변경 없음. `globals.css` + `app/management/page.tsx` 래퍼 + 신규 작은 sticky 섹션 내비 컴포넌트만 손댄다. 기존 패널·테이블 마크업은 유지하되 스크롤/레이아웃 CSS만 조정한다.
+
+**Tech Stack:** Next.js App Router, CSS (globals.css), TypeScript.
+
+**비범위:** 관리 테이블 검색·상태 필터·정렬·페이지네이션(A1/A2), 차량 '운영 방식' 분류 태그 + 방식별 지도 필터, 마커 declutter, 범례 — 모두 별도 사이클.
+
+---
+
+## 1. A3 — 플로팅 유틸바가 첫 섹션 액션을 가림
+
+**현상:** `.top-actions`(`position:fixed; top:16; right:16; z-index:80`, 높이 ~56px)가 `/management` 첫 섹션(차량)의 헤더 우측 "내려받기/업로드" 버튼 위에 겹친다. `app/management/page.tsx`는 `<div className="management-page">`를 컨테이너(`.page-container`: 1200px 중앙+좌우 여백) 없이 full-bleed로 렌더해, 콘텐츠가 화면 최상단·최우측까지 차서 고정 바와 충돌한다.
+
+**수정:**
+- `management-page`를 `.page-container`(또는 동등한 max-width/중앙정렬/좌우 여백)로 감싼다 → 콘텐츠가 1200px 중앙 정렬 + 좌우 여백 확보.
+- `/management` 콘텐츠 상단에 `padding-top`을 줘(약 **72px**: 바 top16 + 높이56) 첫 섹션 헤더가 고정 바 **아래에서** 시작하도록 한다. (management 전용 — 다른 페이지엔 영향 없게 `.management-page` 또는 management 래퍼에만 적용.)
+- 결과: 차량 섹션의 내려받기/업로드가 더 이상 플로팅 바에 가리지 않음. 라이더 이하 섹션은 기존대로 정상.
+
+---
+
+## 2. A4 — 중첩 스크롤 해소 + 섹션 내비
+
+**현상:** 관리 테이블이 고정 높이 + 내부 `overflow` 스크롤이라, 표 위에서 스크롤하면 페이지가 아니라 표만 움직이고 과도 스크롤 시 검은 빈 영역이 보인다(중첩 스크롤). 원인 CSS:
+- `.table-card { overflow: hidden; height: 240px; overflow-y: auto; }` (globals.css 라인 ~400) — 라이더/매칭 테이블 240px 고정.
+- `.vehicles-table-scroll { max-height: 560px; overflow: auto; }` (라인 ~418) — 차량 테이블 560px 캡.
+
+또한 6개 섹션(차량/라이더/매칭/배차/유모차/배민)이 한 페이지에 길게 쌓이는데 섹션 이동 내비가 없다.
+
+**수정:**
+1. **내부 스크롤 제거** — 관리 테이블이 내용만큼 자라고 **페이지 전체가 하나로 스크롤**되게 한다:
+   - `.table-card`: `height: 240px; overflow-y: auto;` 제거(높이 고정·세로 내부 스크롤 해제). 가로 스크롤(`overflow-x: auto`, 라인 ~1156)은 좁은 화면용으로 유지.
+   - `.vehicles-table-scroll`: `max-height: 560px; overflow: auto;` 제거(또는 세로 스크롤 해제).
+   - **주의:** `.table-card`가 management 외 다른 테이블에서도 쓰이면 그쪽 회귀가 없는지 확인하고, 공유 시 management 전용 modifier(예: 패널에 클래스 추가)로 범위를 한정한다. 구현 단계에서 사용처를 grep으로 확인.
+2. **sticky 섹션 내비 추가** — `/management` 상단(플로팅 바 아래)에 sticky 앵커 내비 바: `차량 · 라이더 · 매칭 · 배차 · 유모차 · 배민`. 각 링크는 해당 섹션으로 스크롤.
+   - 신규 컴포넌트 `components/management/ManagementSectionNav.tsx`(`"use client"` 불필요하면 서버 컴포넌트; 앵커 `<a href="#vehicles">` 등 순수 링크).
+   - 각 패널 래퍼에 `id`(`vehicles`/`riders`/`matching`/`dispatch`/`stroller`/`baemin`) 부여 — `page.tsx`에서 각 패널을 `<section id=...>`로 감싸거나 패널에 id prop 전달.
+   - 앵커 점프 시 섹션이 sticky 내비/고정 바 아래로 가려지지 않게 각 섹션에 `scroll-margin-top`(내비+바 높이만큼) 지정.
+   - sticky CSS: `.management-section-nav { position: sticky; top: <바 아래>; z-index: 1; ... }`.
+
+---
+
+## 3. B1 — 필터 칩 활성/선택 대비 강화
+
+**현상:** `.service-type-tab`은 비활성에도 항상 `border: 1px solid subtle`를 갖고, 활성(`.is-active`)은 `background: baemin-mint; color:#fff`. 클릭이 빗나가 브라우저 기본 포커스 링만 생기면 "선택됨"으로 오인되고, 활성 채움이 충분히 또렷하지 않다. (overview 헤더 + 차량 패널 공용 컴포넌트 `ServiceTypeFilterTabs`.)
+
+**수정 (globals.css `.service-type-tab*`):**
+- 비활성: 상시 테두리 제거(또는 매우 옅게) + 투명 배경 + muted 텍스트. hover는 기존대로 텍스트 강조.
+- 활성(`.is-active`): mint 채움 + 흰 텍스트 유지 + 약간의 강조(예: 미세 box-shadow 또는 더 진한 mint)로 선택을 또렷하게.
+- `:focus-visible`: 선택 채움과 **명확히 구분되는** 아웃라인(예: 2px accent ring + offset). 키보드 포커스 ≠ 선택. 마우스 클릭 후 포커스 링이 선택처럼 보이지 않도록 `:focus-visible`만 사용.
+- 컴포넌트 마크업(`ServiceTypeFilterTabs.tsx`)은 `aria-selected` + `is-active` 그대로 유지 — CSS만 조정.
+
+---
+
+## 4. 데이터 흐름 / 영향
+- 순수 프레젠테이션 변경. API·상태·데이터 흐름 변화 없음.
+- 영향 표면: `app/globals.css`, `app/management/page.tsx`, 신규 `ManagementSectionNav.tsx`. (필요 시 각 management 패널에 `id`/modifier 클래스 소폭 추가.)
+
+## 5. 검증
+- 프론트 `npm run typecheck && npm run lint && npm run build`.
+- 프로덕션/로컬 육안: (A3) /management 첫 섹션 내려받기/업로드가 플로팅 바에 안 가림. (A4) 표 위 스크롤이 페이지를 움직이고 검은 빈 영역 없음 + 섹션 내비로 점프. (B1) 필터 칩 활성이 또렷하고 포커스와 구분됨.
+
+## 6. 비범위 재확인
+관리 테이블 검색/필터/정렬/페이지네이션, 차량 운영방식 태그 + 방식별 지도 필터, 마커 declutter/범례, 차량상세 "배송" 라벨·IMEI 마스킹 등은 이 스펙에 포함하지 않는다(후속).


### PR DESCRIPTION
## Release scope
dev → main 릴리스. UX 수정 3건 단독 (프론트 전용, **마이그레이션 없음**).

- **A3**: /management 1200px 컨테이너 + 상단 88px 여백 → 첫 섹션 액션이 플로팅 유틸바에 안 가림
- **A4**: 관리 테이블 내부 고정-높이 스크롤 제거(`.management-panel` 하위 한정) + sticky 섹션 내비(차량·라이더·매칭·배차·유모차·배민)
- **B1**: 서비스 필터 칩 활성/포커스 대비 강화

## 배포 영향
- **프론트엔드 전용** (globals.css + management/page.tsx + 신규 ManagementSectionNav). 백엔드·DB 변경 없음 → 배포 위험 최소.

## 검증
- [x] typecheck + lint + build
- [ ] **머지 후 프로덕션 QA**: A3 버튼 안 가림 / A4 페이지 단일 스크롤 + 섹션 내비 / B1 필터 칩 또렷

머지 시 프로덕션 배포가 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)