### PR TITLE
[릴리스] 차량 운영 방식 5종 재분류 (콜/단일/순차/왕복/기타)

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -860,7 +860,13 @@ function parseEngineType(value: FormDataEntryValue | null): ServiceOpsBikeEngine
 // formData("serviceType") 가 빈 값이면 undefined 로. 인식 못 하는 값은 잡고 무시.
 function parseServiceType(value: FormDataEntryValue | null): ServiceOpsBikeServiceType | undefined {
   const text = String(value ?? "").trim();
-  if (text === "DELIVERY" || text === "CLEANING" || text === "OTHER") return text;
+  if (
+    text === "CALL" ||
+    text === "SINGLE" ||
+    text === "SEQUENTIAL" ||
+    text === "ROUND" ||
+    text === "OTHER"
+  ) return text;
   return undefined;
 }
 

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -7,6 +7,7 @@ import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
 import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
 import { getActiveRoundAction, listOfferedCallsAction } from "@/app/dispatch/actions";
 import { listVehiclesAction } from "@/app/management/vehicles/actions";
+import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +19,7 @@ export default async function ManagementPage() {
   ]);
 
   const deliveryVehicles = vehiclesPage
-    .filter((v) => v.serviceType === "DELIVERY")
+    .filter((v) => !isCleaningServiceType(v.serviceType))
     .map((v) => ({ id: v.id ?? v.slug, plateNumber: v.plateNumber }));
 
   return (

--- a/development/front-admin-web/app/management/page.tsx
+++ b/development/front-admin-web/app/management/page.tsx
@@ -7,7 +7,6 @@ import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
 import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
 import { getActiveRoundAction, listOfferedCallsAction } from "@/app/dispatch/actions";
 import { listVehiclesAction } from "@/app/management/vehicles/actions";
-import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 
 export const dynamic = "force-dynamic";
 
@@ -18,8 +17,9 @@ export default async function ManagementPage() {
     listVehiclesAction()
   ]);
 
+  // 배민 콜 후보 차량 = CALL∪SINGLE (systemDispatch 자동 배차 후보와 동일; OTHER·청소형 제외)
   const deliveryVehicles = vehiclesPage
-    .filter((v) => !isCleaningServiceType(v.serviceType))
+    .filter((v) => v.serviceType === "CALL" || v.serviceType === "SINGLE")
     .map((v) => ({ id: v.id ?? v.slug, plateNumber: v.plateNumber }));
 
   return (

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -13,6 +13,7 @@ import type {
   NaverMarkerInstance,
   NaverPolylineInstance
 } from "@/types/naver-maps";
+import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 import type { ServicePhase, ServiceType } from "@/lib/services/fleet-simulation";
 
 const NCP_CLIENT_ID = process.env.NEXT_PUBLIC_NCP_MAP_CLIENT_ID;
@@ -747,19 +748,19 @@ function labelMarkup(text: string): string {
  * 서비스 상태 배지 HTML.
  * position:absolute 로 내장하고 wrapper 에 overflow:visible 을 준다.
  *
- * DELIVERY (undefined 포함): MOVING=파랑 "배송 중", WORKING/IDLE=회색 "대기"
- * CLEANING / OTHER:           MOVING=파랑 "이동 중", WORKING=앰버 "작업 중", IDLE=회색 "대기 중"
+ * 배송형(CALL/SINGLE/OTHER, undefined 포함): MOVING=파랑 "배송 중", WORKING/IDLE=회색 "대기"
+ * 청소형(SEQUENTIAL/ROUND):                  MOVING=파랑 "이동 중", WORKING=앰버 "작업 중", IDLE=회색 "대기 중"
  * servicePhase === null 이면 빈 문자열 (시뮬레이션 대상 아님 → 배지 없음).
  */
 function serviceBadgeMarkup(phase: ServicePhase, deliveryCount: number, serviceType?: ServiceType): string {
   let bg: string;
   let label: string;
-  if (!serviceType || serviceType === "DELIVERY") {
+  if (!serviceType || !isCleaningServiceType(serviceType)) {
     const isMoving = phase === "MOVING";
     bg = isMoving ? "#3b82f6" : "#6b7280";
     label = isMoving ? "배송 중" : "대기";
   } else {
-    // CLEANING / OTHER
+    // 청소형(SEQUENTIAL/ROUND)
     if (phase === "MOVING")       { bg = "#3b82f6"; label = "이동 중"; }
     else if (phase === "WORKING") { bg = "#f59e0b"; label = "작업 중"; }
     else                          { bg = "#6b7280"; label = "대기 중"; } // IDLE
@@ -880,7 +881,7 @@ function bikeMarkerHtml(
     servicePhase != null
       ? serviceBadgeMarkup(servicePhase, deliveryCount ?? 0, serviceType)
       : "";
-  const showBubble = serviceType === "CLEANING" && ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
+  const showBubble = isCleaningServiceType(serviceType) && ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
   const bubble = showBubble ? ignitionBubbleMarkup(currentDispatchCustomerName) : "";
   const extras = badge || bubble ? badge + bubble : undefined;
   const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras, selected);

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -27,6 +27,7 @@ import type {
   ServiceOpsBikeServiceType,
   ServiceOpsDispatchOrder
 } from "@/lib/services/service-ops-api";
+import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 import type { SimulatedBikeState, ServiceType } from "@/lib/services/fleet-simulation";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
@@ -195,7 +196,7 @@ export function VehicleDetailDialog({
           <div className="detail-row-grid">
             <DetailField label="차량번호" value={vehicle.plateNumber} />
             <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
-            <DetailField label="서비스" value={serviceTypeLabel(vehicle.serviceType)} />
+            <DetailField label="운영 방식" value={serviceTypeLabel(vehicle.serviceType)} />
             <DetailField label="모델명" value={vehicle.model || "—"} />
             <DetailField label="운영 상태" value={vehicle.status} />
             <DetailField label="이름" value={row.riderName ?? "—"} />
@@ -249,10 +250,12 @@ export function VehicleDetailDialog({
             </select>
           </label>
           <label>
-            서비스 유형
-            <select name="serviceType" defaultValue={vehicle.serviceType ?? "DELIVERY"}>
-              <option value="DELIVERY">배송</option>
-              <option value="CLEANING">클리닝</option>
+            운영 방식
+            <select name="serviceType" defaultValue={vehicle.serviceType ?? "SINGLE"}>
+              <option value="CALL">콜 배차</option>
+              <option value="SINGLE">단일 배차</option>
+              <option value="SEQUENTIAL">순차 배차</option>
+              <option value="ROUND">왕복 배차</option>
               <option value="OTHER">기타</option>
             </select>
           </label>
@@ -308,9 +311,14 @@ function engineTypeLabel(value: FrontendVehicle["engineType"]): string {
 }
 
 function serviceTypeLabel(t?: ServiceOpsBikeServiceType): string {
-  if (t === "CLEANING") return "클리닝";
-  if (t === "OTHER") return "기타";
-  return "배송";
+  switch (t) {
+    case "CALL": return "콜 배차";
+    case "SINGLE": return "단일 배차";
+    case "SEQUENTIAL": return "순차 배차";
+    case "ROUND": return "왕복 배차";
+    case "OTHER": return "기타";
+    default: return "단일 배차";
+  }
 }
 
 // ============================================================================
@@ -870,10 +878,10 @@ function DeliverySection({
 }
 
 function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: ServiceType): string {
-  if (serviceType === "DELIVERY") {
+  if (!isCleaningServiceType(serviceType)) {
     return phase === "MOVING" ? "배송 중" : "대기";
   }
-  // CLEANING or OTHER
+  // cleaning-family (순차·왕복)
   if (phase === "MOVING")  return "이동 중";
   if (phase === "WORKING") return "작업 중";
   return "대기 중"; // IDLE

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -5,6 +5,7 @@ import { createContext, useCallback, useContext, useEffect, useLayoutEffect, use
 import {
   advanceBikeState,
   makeInitialState,
+  isCleaningServiceType,
   TICK_INTERVAL_MS,
   MOVING_DURATION_MAX_MS,
   CLEANING_MOVING_DURATION_MAX_MS,
@@ -111,20 +112,20 @@ export function FleetSimulationProvider({
         const origin = pin
           ? { lat: pin.latitude, lng: pin.longitude }
           : { lat: 37.5665, lng: 126.978 }; // 서울 중심 fallback
-        // CLEANING: 현재 배차(dispatch) 좌표가 있으면 그곳으로 출발, 없으면 IDLE 대기.
+        // 청소형: 현재 배차(dispatch) 좌표가 있으면 그곳으로 출발, 없으면 IDLE 대기.
         const dispatchDestination =
-          pin?.serviceType === "CLEANING" &&
-          pin.currentDispatchLatitude != null &&
-          pin.currentDispatchLongitude != null
+          isCleaningServiceType(pin?.serviceType) &&
+          pin?.currentDispatchLatitude != null &&
+          pin?.currentDispatchLongitude != null
             ? { lat: pin.currentDispatchLatitude, lng: pin.currentDispatchLongitude }
             : null;
         const initialPhase: "MOVING" | "IDLE" =
-          pin?.serviceType === "CLEANING" && dispatchDestination === null
+          isCleaningServiceType(pin?.serviceType) && dispatchDestination === null
             ? "IDLE"
             : "MOVING";
         // MOVING 시작 시에만 오프셋으로 사이클 분산. WORKING 은 어차피 대기이므로 불필요.
-        // CLEANING 은 최대 이동 시간이 5분이므로 그 범위 안에서만 오프셋을 줌.
-        const maxOffsetMs = pin?.serviceType === "CLEANING" ? CLEANING_MOVING_DURATION_MAX_MS : MOVING_DURATION_MAX_MS;
+        // 청소형은 최대 이동 시간이 5분이므로 그 범위 안에서만 오프셋을 줌.
+        const maxOffsetMs = isCleaningServiceType(pin?.serviceType) ? CLEANING_MOVING_DURATION_MAX_MS : MOVING_DURATION_MAX_MS;
         const offsetMs = initialPhase === "MOVING" ? Math.random() * maxOffsetMs : 0;
         next.set(
           bikeId,
@@ -135,7 +136,7 @@ export function FleetSimulationProvider({
             phase: initialPhase,
             initialBatteryPercent:
               typeof pin?.batteryPercent === "number" ? pin.batteryPercent : 90,
-            serviceType: pin?.serviceType ?? "DELIVERY",
+            serviceType: pin?.serviceType ?? "SINGLE",
             nextCustomerDestination: dispatchDestination
           })
         );
@@ -152,7 +153,7 @@ export function FleetSimulationProvider({
   //      현재 배차가 되면 키가 바뀌어 다시 출발한다.
   useEffect(() => {
     for (const [bikeId, state] of simulated) {
-      if (state.serviceType !== "CLEANING") continue;
+      if (!isCleaningServiceType(state.serviceType)) continue;
       if (state.ignitionOnAt == null) continue;
       const last = lastNotifiedIgnitionOnAtRef.current.get(bikeId);
       if (last === state.ignitionOnAt) continue;
@@ -204,8 +205,8 @@ export function FleetSimulationProvider({
           const alreadyDeparted =
             dKey != null && lastDepartedDispatchKeyRef.current.get(bikeId) === dKey;
           const newDest =
-            pin?.serviceType === "CLEANING" && dKey != null && !alreadyDeparted
-              ? { lat: pin.currentDispatchLatitude!, lng: pin.currentDispatchLongitude! }
+            isCleaningServiceType(pin?.serviceType) && dKey != null && !alreadyDeparted
+              ? { lat: pin!.currentDispatchLatitude!, lng: pin!.currentDispatchLongitude! }
               : null;
           const prevDest = state.nextCustomerDestination;
           const destChanged =

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -162,7 +162,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     () =>
       serviceTypeFilter === "ALL"
         ? vehicles
-        : vehicles.filter((v) => (v.serviceType ?? "DELIVERY") === serviceTypeFilter),
+        : vehicles.filter((v) => (v.serviceType ?? "SINGLE") === serviceTypeFilter),
     [vehicles, serviceTypeFilter]
   );
 

--- a/development/front-admin-web/components/overview/ServiceTypeFilterTabs.tsx
+++ b/development/front-admin-web/components/overview/ServiceTypeFilterTabs.tsx
@@ -6,8 +6,10 @@ export type ServiceTypeFilter = ServiceOpsBikeServiceType | "ALL";
 
 const TABS: { value: ServiceTypeFilter; label: string }[] = [
   { value: "ALL", label: "전체" },
-  { value: "DELIVERY", label: "배송" },
-  { value: "CLEANING", label: "클리닝" },
+  { value: "CALL", label: "콜 배차" },
+  { value: "SINGLE", label: "단일 배차" },
+  { value: "SEQUENTIAL", label: "순차 배차" },
+  { value: "ROUND", label: "왕복 배차" },
   { value: "OTHER", label: "기타" }
 ];
 

--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -121,7 +121,7 @@ export function generatePinsForUntrackedVehicles(
         connectionStatus: "ONLINE" as const,
         batteryStatus: sim.batteryStatus === "HEALTHY" ? "NORMAL" : sim.batteryStatus,
         pinLabel: vehicle.plateNumber,
-        serviceType: vehicle.serviceType ?? "DELIVERY",
+        serviceType: vehicle.serviceType ?? "SINGLE",
         nextCustomerLat: null,
         nextCustomerLng: null,
         currentDispatchCustomerName: null,

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -3,6 +3,7 @@ import {
   type ServiceOpsApiError,
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
+import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 import { generatePinsForUntrackedVehicles } from "@/lib/services/dashboard-dummy-bikes";
 
@@ -54,7 +55,7 @@ async function withSimulatedPins(
     // bike_next_customer 에 데이터가 있을 수 있으므로 개별 조회 후 병합.
     const simulated = await Promise.all(
       rawSimulated.map(async (pin) => {
-        if (pin.serviceType !== "CLEANING") return pin;
+        if (!isCleaningServiceType(pin.serviceType)) return pin;
         try {
           const nc = await client.getBikeNextCustomer(pin.bikeId);
           if (nc) {

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -8,7 +8,12 @@
 
 export type ServicePhase = "MOVING" | "WORKING" | "IDLE";
 
-export type ServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+export type ServiceType = "CALL" | "SINGLE" | "SEQUENTIAL" | "ROUND" | "OTHER";
+
+/** 청소형(순차·왕복) 운영 방식 — 시동 알림 + 청소 시뮬 phase 대상. */
+export function isCleaningServiceType(t: ServiceType | string | null | undefined): boolean {
+  return t === "SEQUENTIAL" || t === "ROUND";
+}
 
 export type SimulatedBikeState = {
   bikeId: string;

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -1,8 +1,8 @@
 /**
  * Fleet 서비스 시뮬레이션 순수 데이터 모델 + phase 진행 함수.
  *
- * Phase (CLEANING):  IDLE(대기 중) → MOVING(이동 중) → WORKING(작업 중, ~30초) → IDLE
- * Phase (DELIVERY):  WORKING(대기) ↔ MOVING(이동 중)
+ * Phase (청소형 — SEQUENTIAL/ROUND):  IDLE(대기 중) → MOVING(이동 중) → WORKING(작업 중, ~30초) → IDLE
+ * Phase (배송형 — CALL/SINGLE/OTHER): WORKING(대기) ↔ MOVING(이동 중)
  * isMatched=true 이면 IDLE → MOVING 자동 전환, false 이면 IDLE 유지.
  */
 
@@ -39,7 +39,7 @@ export type SimulatedBikeState = {
    * MOVING→WORKING 전환 시 null 로 초기화.
    */
   ignitionOnAt: number | null;
-  /** 서비스 유형. "CLEANING" 이면 알림 + 말풍선 활성. */
+  /** 서비스 유형. 청소형(SEQUENTIAL/ROUND) 이면 알림 + 말풍선 활성. */
   serviceType: ServiceType;
   /** 누적 km */
   odometerKm: number;
@@ -47,23 +47,23 @@ export type SimulatedBikeState = {
   batteryPercent: number;
   /** OSRM 경로 waypoints */
   routeWaypoints: ReadonlyArray<{ lat: number; lng: number }> | null;
-  /** CLEANING 전용. 관리자가 설정한 다음 고객 좌표. null 이면 randomSeoulPoint() 사용. */
+  /** 청소형 전용. 관리자가 설정한 다음 고객 좌표. null 이면 randomSeoulPoint() 사용. */
   nextCustomerDestination: { lat: number; lng: number } | null;
 };
 
 /** tick 간격 (ms) */
 export const TICK_INTERVAL_MS = 250;
-/** MOVING 한 주기 최소 길이 — DELIVERY/OTHER (15분) */
+/** MOVING 한 주기 최소 길이 — 배송형(CALL/SINGLE/OTHER) (15분) */
 export const MOVING_DURATION_MIN_MS = 15 * 60 * 1_000;
-/** MOVING 한 주기 최대 길이 — DELIVERY/OTHER (40분) */
+/** MOVING 한 주기 최대 길이 — 배송형(CALL/SINGLE/OTHER) (40분) */
 export const MOVING_DURATION_MAX_MS = 40 * 60 * 1_000;
 /** CLEANING 차량 MOVING 최소 길이 (2분) */
 export const CLEANING_MOVING_DURATION_MIN_MS = 2 * 60 * 1_000;
 /** CLEANING 차량 MOVING 최대 길이 (5분) */
 export const CLEANING_MOVING_DURATION_MAX_MS = 5 * 60 * 1_000;
-/** 완료 후 다음 사이클까지 최소 대기 (ms) — DELIVERY/OTHER */
+/** 완료 후 다음 사이클까지 최소 대기 (ms) — 배송형(CALL/SINGLE/OTHER) */
 export const WORKING_BETWEEN_MIN_MS = 5_000;
-/** 완료 후 다음 사이클까지 최대 대기 (ms) — DELIVERY/OTHER */
+/** 완료 후 다음 사이클까지 최대 대기 (ms) — 배송형(CALL/SINGLE/OTHER) */
 export const WORKING_BETWEEN_MAX_MS = 30_000;
 /** CLEANING 차량 작업 중(WORKING) 지속 시간 (30초) — 이후 IDLE(대기 중)으로 전환 */
 export const CLEANING_WORKING_DURATION_MS = 30_000;
@@ -77,8 +77,8 @@ const SEOUL_LAT_MAX = 37.65;
 const SEOUL_LNG_MIN = 126.87;
 const SEOUL_LNG_MAX = 127.10;
 
-function randomMovingDurationMs(random: () => number, serviceType: ServiceType = "DELIVERY"): number {
-  if (serviceType === "CLEANING") {
+function randomMovingDurationMs(random: () => number, serviceType: ServiceType = "SINGLE"): number {
+  if (isCleaningServiceType(serviceType)) {
     return CLEANING_MOVING_DURATION_MIN_MS + random() * (CLEANING_MOVING_DURATION_MAX_MS - CLEANING_MOVING_DURATION_MIN_MS);
   }
   return MOVING_DURATION_MIN_MS + random() * (MOVING_DURATION_MAX_MS - MOVING_DURATION_MIN_MS);
@@ -129,12 +129,12 @@ export function advanceBikeState(
   isMatched: boolean,
   random: () => number = Math.random
 ): SimulatedBikeState {
-  // CLEANING: IDLE(대기 중) 무한 대기 중 nextCustomerDestination 이 설정되면 즉시 MOVING 전환.
+  // 청소형: IDLE(대기 중) 무한 대기 중 nextCustomerDestination 이 설정되면 즉시 MOVING 전환.
   // phaseEndsAt 체크보다 먼저 실행해야 Infinity 대기 상태도 처리됨.
   if (
     prev.phase === "IDLE" &&
     isMatched &&
-    prev.serviceType === "CLEANING" &&
+    isCleaningServiceType(prev.serviceType) &&
     prev.nextCustomerDestination !== null
   ) {
     return {
@@ -184,7 +184,7 @@ export function advanceBikeState(
       if (!isMatched) {
         return { ...prev, phaseEndsAt: Number.POSITIVE_INFINITY };
       }
-      if (prev.serviceType === "CLEANING") {
+      if (isCleaningServiceType(prev.serviceType)) {
         // 작업 중 30초 완료 → 대기 중(IDLE)으로 전환
         return {
           ...prev,
@@ -193,7 +193,7 @@ export function advanceBikeState(
           phaseEndsAt: Number.POSITIVE_INFINITY
         };
       }
-      // DELIVERY / OTHER: 랜덤 목적지로 이동 시작
+      // 배송형(CALL/SINGLE/OTHER): 랜덤 목적지로 이동 시작
       const destination = randomSeoulPoint(random);
       return {
         ...prev,
@@ -211,12 +211,12 @@ export function advanceBikeState(
     }
     case "MOVING": {
       const finalPosition = prev.destination ?? prev.origin;
-      // CLEANING: 도착 후 30초 작업 중(WORKING) → 이후 IDLE(대기 중)로 전환.
-      // DELIVERY/OTHER: 5~30초 WORKING 후 다음 사이클 이동.
+      // 청소형: 도착 후 30초 작업 중(WORKING) → 이후 IDLE(대기 중)로 전환.
+      // 배송형(CALL/SINGLE/OTHER): 5~30초 WORKING 후 다음 사이클 이동.
       // 비매칭(isMatched=false) 이면 Infinity 대기.
       const workingDurationMs = !isMatched
         ? Number.POSITIVE_INFINITY
-        : prev.serviceType === "CLEANING"
+        : isCleaningServiceType(prev.serviceType)
           ? CLEANING_WORKING_DURATION_MS
           : WORKING_BETWEEN_MIN_MS +
             Math.floor(random() * (WORKING_BETWEEN_MAX_MS - WORKING_BETWEEN_MIN_MS));
@@ -227,7 +227,7 @@ export function advanceBikeState(
         position: finalPosition,
         origin: finalPosition,
         destination: null,
-        // CLEANING: 도착 즉시 초기화 — pinsRef 정리 전 다음 tick 이 재트리거하지 않도록.
+        // 청소형: 도착 즉시 초기화 — pinsRef 정리 전 다음 tick 이 재트리거하지 않도록.
         nextCustomerDestination: null,
         phaseStartedAt: nowMs,
         phaseEndsAt: workingDurationMs === Number.POSITIVE_INFINITY ? workingDurationMs : nowMs + workingDurationMs,
@@ -260,7 +260,7 @@ export function makeInitialState(input: {
     random = Math.random,
     initialOdometerKm = 0,
     initialBatteryPercent = 90,
-    serviceType = "DELIVERY",
+    serviceType = "SINGLE",
     nextCustomerDestination = null
   } = input;
 
@@ -286,9 +286,9 @@ export function makeInitialState(input: {
     };
   }
 
-  // CLEANING 차량은 초기 대기 상태를 IDLE(대기 중)로 시작.
-  // DELIVERY/OTHER 는 WORKING(대기) 유지.
-  const idlePhase: ServicePhase = serviceType === "CLEANING" ? "IDLE" : "WORKING";
+  // 청소형(SEQUENTIAL/ROUND)은 초기 대기 상태를 IDLE(대기 중)로 시작.
+  // 배송형(CALL/SINGLE/OTHER)은 WORKING(대기) 유지.
+  const idlePhase: ServicePhase = isCleaningServiceType(serviceType) ? "IDLE" : "WORKING";
   return {
     bikeId,
     phase: idlePhase,

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -131,7 +131,7 @@ export type ServiceOpsBikeWheelType = "TWO_WHEEL" | "FOUR_WHEEL";
  */
 export type ServiceOpsBikeEngineType = "ELECTRIC" | "ICE";
 
-export type ServiceOpsBikeServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+export type ServiceOpsBikeServiceType = "CALL" | "SINGLE" | "SEQUENTIAL" | "ROUND" | "OTHER";
 
 export type ServiceOpsBike = {
   id: string;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java
@@ -1,14 +1,27 @@
 package com.thundercrew.opsapi.bike.domain;
 
 /**
- * 차량의 서비스 유형. 배송(오토바이)과 클리닝(자동차)을 운영자 필터·알림 분기의
- * 기준 축으로 구분한다. engineType(동력 종류)과 직교하는 독립 분류.
+ * 차량 운영 방식. 배차가 동작하는 방식으로 차량을 분류한다(필터·알림·시뮬 분기 축).
  */
 public enum BikeServiceType {
-    /** 배송 서비스 (오토바이). 기존 차량의 기본값. */
-    DELIVERY,
-    /** 클리닝 서비스 (자동차). 세스코라이프케어 등. */
-    CLEANING,
-    /** 기타 서비스. */
-    OTHER
+    /** 콜 배차 — 단건 콜, 라이더 수락/시스템 자동 배차. */
+    CALL,
+    /** 단일 배차 — 목적지 1개 단순 배차. */
+    SINGLE,
+    /** 순차 배차 — 목적지 + 순서 큐. */
+    SEQUENTIAL,
+    /** 왕복 배차 — 일괄 수거 → 배송 2단계. */
+    ROUND,
+    /** 기타. */
+    OTHER;
+
+    /** 시동 알림·청소형 시뮬 대상(순차·왕복). */
+    public boolean isCleaningFamily() {
+        return this == SEQUENTIAL || this == ROUND;
+    }
+
+    /** 배송형 시뮬·시스템 배차 후보(콜·단일·기타). */
+    public boolean isDeliveryFamily() {
+        return !isCleaningFamily();
+    }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeBulkService.java
@@ -66,7 +66,7 @@ public class BikeBulkService {
                     bikeRepository.save(bike);
                 } else {
                     Bike bike = Bike.create(plateNumber, null, null, engineType,
-                            BikeServiceType.DELIVERY, BikeOperationStatus.READY, null);
+                            BikeServiceType.SINGLE, BikeOperationStatus.READY, null);
                     bike.setWheelType(wheelType);
                     bike.setImei(imei);
                     bikeRepository.save(bike);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeCommandService.java
@@ -56,7 +56,7 @@ public class BikeCommandService {
                 : BikeEngineType.ELECTRIC;
         BikeServiceType serviceType = request.serviceType() != null
                 ? request.serviceType()
-                : BikeServiceType.DELIVERY;
+                : BikeServiceType.SINGLE;
         Bike bike = Bike.create(
                 request.plateNumber(),
                 vin,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/service/BikeNextCustomerService.java
@@ -66,7 +66,7 @@ public class BikeNextCustomerService {
     private void requireCleaningBike(UUID bikeId) {
         Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
-        if (bike.getServiceType() != BikeServiceType.CLEANING) {
+        if (!bike.getServiceType().isCleaningFamily()) {
             throw new InvalidStateTransitionException(
                     "Bike " + bikeId + " is not of CLEANING service type.");
         }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
@@ -43,7 +43,8 @@ public class DeliveryCallService {
     public DispatchOrderReadResponse systemDispatch(String customerName, String customerPhone,
                                                     String address, double latitude, double longitude) {
         List<Bike> deliveryBikes = bikeRepository.findAllByDeletedAtIsNull().stream()
-                .filter(b -> b.getServiceType() == BikeServiceType.DELIVERY)
+                .filter(b -> b.getServiceType() == BikeServiceType.CALL
+                        || b.getServiceType() == BikeServiceType.SINGLE)
                 .toList();
         if (deliveryBikes.isEmpty()) {
             throw new InvalidStateTransitionException("가용 배송 차량이 없습니다.");

--- a/development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql
@@ -1,0 +1,9 @@
+-- 기존 분류 → 운영 방식 매핑 (OTHER 는 유지)
+update bikes set service_type = 'SINGLE'     where service_type = 'DELIVERY';
+update bikes set service_type = 'SEQUENTIAL' where service_type = 'CLEANING';
+-- check 제약 재생성
+alter table bikes drop constraint ck_bikes_service_type;
+alter table bikes add constraint ck_bikes_service_type
+    check (service_type in ('CALL', 'SINGLE', 'SEQUENTIAL', 'ROUND', 'OTHER'));
+-- 컬럼 기본값 변경 (기존 default 'DELIVERY')
+alter table bikes alter column service_type set default 'SINGLE';

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeBulkApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeBulkApiTests.java
@@ -83,7 +83,7 @@ class BikeBulkApiTests extends PostgresContainerSupport {
                 insert into bikes (id, idx, plate_number, engine_type, service_type,
                                    operation_status, wheel_type, ignition_blocked)
                 values (gen_random_uuid(), nextval('bikes_idx_seq'), '34나5678', 'ELECTRIC',
-                        'DELIVERY', 'READY', 'TWO_WHEEL', false)
+                        'SINGLE', 'READY', 'TWO_WHEEL', false)
                 """);
 
         MockMultipartFile file = buildBikeExcel(
@@ -103,7 +103,7 @@ class BikeBulkApiTests extends PostgresContainerSupport {
                 insert into bikes (id, idx, plate_number, engine_type, service_type,
                                    operation_status, wheel_type, ignition_blocked)
                 values (gen_random_uuid(), nextval('bikes_idx_seq'), '56다7890', 'ELECTRIC',
-                        'DELIVERY', 'READY', 'TWO_WHEEL', false)
+                        'SINGLE', 'READY', 'TWO_WHEEL', false)
                 """);
 
         MockMultipartFile file = buildBikeExcel(
@@ -124,7 +124,7 @@ class BikeBulkApiTests extends PostgresContainerSupport {
                 insert into bikes (id, idx, plate_number, engine_type, service_type,
                                    operation_status, wheel_type, ignition_blocked)
                 values (gen_random_uuid(), nextval('bikes_idx_seq'), '34나5678', 'ELECTRIC',
-                        'DELIVERY', 'READY', 'TWO_WHEEL', false)
+                        'SINGLE', 'READY', 'TWO_WHEEL', false)
                 """);
 
         MockMultipartFile file = buildBikeExcel(
@@ -145,7 +145,7 @@ class BikeBulkApiTests extends PostgresContainerSupport {
                 insert into bikes (id, idx, plate_number, engine_type, service_type,
                                    operation_status, wheel_type, ignition_blocked)
                 values (gen_random_uuid(), nextval('bikes_idx_seq'), '12가3456', 'ELECTRIC',
-                        'DELIVERY', 'READY', 'TWO_WHEEL', false)
+                        'SINGLE', 'READY', 'TWO_WHEEL', false)
                 """);
 
         mockMvc.perform(get("/api/v1/bikes/export")

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeCommandApiContractTests.java
@@ -355,15 +355,15 @@ class BikeCommandApiContractTests extends PostgresContainerSupport {
                                 {
                                   "plateNumber":"서울B-2001",
                                   "operationStatus":"READY",
-                                  "serviceType":"CLEANING"
+                                  "serviceType":"SEQUENTIAL"
                                 }
                                 """))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.serviceType").value("CLEANING"));
+                .andExpect(jsonPath("$.serviceType").value("SEQUENTIAL"));
     }
 
     @Test
-    void createBikeWithoutServiceTypeDefaultsToDelivery() throws Exception {
+    void createBikeWithoutServiceTypeDefaultsToSingle() throws Exception {
         mockMvc.perform(post("/api/v1/bikes")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -374,7 +374,7 @@ class BikeCommandApiContractTests extends PostgresContainerSupport {
                                 }
                                 """))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.serviceType").value("DELIVERY"));
+                .andExpect(jsonPath("$.serviceType").value("SINGLE"));
     }
 
     @Test
@@ -385,17 +385,17 @@ class BikeCommandApiContractTests extends PostgresContainerSupport {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"serviceType":"CLEANING"}
+                                {"serviceType":"SEQUENTIAL"}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.serviceType").value("CLEANING"));
+                .andExpect(jsonPath("$.serviceType").value("SEQUENTIAL"));
     }
 
     private void seedBike(UUID id, String plateNumber, String vin, String operationStatus, String deletedAtSql) {
         String deletedAtExpression = deletedAtSql == null ? "null" : deletedAtSql;
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, memo, deleted_at)
-                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'DELIVERY', ?, 'fixture bike', %s)
+                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'SINGLE', ?, 'fixture bike', %s)
                 """.formatted(deletedAtExpression), id, plateNumber, vin, operationStatus);
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/BikeNextCustomerApiContractTests.java
@@ -61,13 +61,13 @@ class BikeNextCustomerApiContractTests extends PostgresContainerSupport {
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, model_name, engine_type, service_type,
                                    operation_status, ignition_blocked)
-                values (?, '서울CC-0001', '청소차 M1', 'ICE', 'CLEANING', 'IN_SERVICE', false)
+                values (?, '서울CC-0001', '청소차 M1', 'ICE', 'SEQUENTIAL', 'IN_SERVICE', false)
                 """, CLEANING_BIKE);
 
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, model_name, engine_type, service_type,
                                    operation_status, ignition_blocked)
-                values (?, '서울DD-0001', '배송 오토바이', 'ELECTRIC', 'DELIVERY', 'IN_SERVICE', false)
+                values (?, '서울DD-0001', '배송 오토바이', 'ELECTRIC', 'SINGLE', 'IN_SERVICE', false)
                 """, DELIVERY_BIKE);
 
         accessToken = loginAndExtractToken();

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
@@ -64,7 +64,7 @@ class ContractBulkApiTests extends PostgresContainerSupport {
         jdbcTemplate.update("""
                 insert into bikes (id, idx, plate_number, engine_type, service_type,
                                    operation_status, wheel_type, ignition_blocked)
-                values (?, nextval('bikes_idx_seq'), '12가3456', 'ELECTRIC', 'DELIVERY',
+                values (?, nextval('bikes_idx_seq'), '12가3456', 'ELECTRIC', 'SINGLE',
                         'READY', 'TWO_WHEEL', false)
                 """, BIKE_ID);
         jdbcTemplate.update("""

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
@@ -242,24 +242,23 @@ class DeliveryCallApiContractTests extends PostgresContainerSupport {
     // --- helpers ---------------------------------------------------------
 
     /**
-     * Seed a DELIVERY bike (service_type = 'DELIVERY') using inline SQL.
-     * The existing seedBike helpers in other tests rely on the DB column default 'DELIVERY',
-     * but here we are explicit to clearly document intent and support future schema changes.
+     * Seed a SINGLE bike (service_type = 'SINGLE') using inline SQL.
+     * SINGLE is the delivery-family type (formerly DELIVERY) eligible for systemDispatch.
      */
     private void seedDeliveryBike(UUID id, String plateNumber, String vin) {
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, ignition_blocked)
-                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'DELIVERY', 'IN_SERVICE', false)
+                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'SINGLE', 'IN_SERVICE', false)
                 """, id, plateNumber, vin);
     }
 
     /**
-     * Seed a CLEANING bike (service_type = 'CLEANING') — not eligible for delivery auto-dispatch.
+     * Seed a SEQUENTIAL bike (service_type = 'SEQUENTIAL') — cleaning-family, not eligible for delivery auto-dispatch.
      */
     private void seedCleaningBike(UUID id, String plateNumber, String vin) {
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, ignition_blocked)
-                values (?, ?, ?, 'Cleaning Van', 'ICE', 'CLEANING', 'IN_SERVICE', false)
+                values (?, ?, ?, 'Cleaning Van', 'ICE', 'SEQUENTIAL', 'IN_SERVICE', false)
                 """, id, plateNumber, vin);
     }
 

--- a/docs/superpowers/plans/2026-06-12-vehicle-operating-mode.md
+++ b/docs/superpowers/plans/2026-06-12-vehicle-operating-mode.md
@@ -1,0 +1,370 @@
+# 차량 운영 방식 (serviceType 5종 재분류) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `BikeServiceType` 값을 도메인명(DELIVERY/CLEANING/OTHER)에서 운영 방식 5종(CALL/SINGLE/SEQUENTIAL/ROUND/OTHER)으로 in-place 교체하고, 분기 로직을 패밀리 매핑(cleaning=SEQUENTIAL∪ROUND, delivery=CALL∪SINGLE∪OTHER)으로 전환해 동작을 보존한다.
+
+**Architecture:** 타입명 `BikeServiceType`·컬럼 `service_type` 유지, 값만 교체(V36). 백엔드/프론트의 `=== "CLEANING"`/`=== "DELIVERY"` 분기를 패밀리 헬퍼로 교체. 지도 필터 6칩 + 차량 편집폼 5옵션.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA, Next.js App Router, TypeScript.
+
+**작업 경로:** 백엔드 `development/service-ops-api`, 프론트 `development/front-admin-web`. Bash 절대경로 cd (cwd 매 호출 리셋). 브랜치 `cc-operating-mode` 체크아웃 — 새 브랜치 만들지 말 것. ArchUnit Docker 불필요, 계약 테스트 Docker 필요(컴파일만). 프론트 `npm run typecheck && lint && build`.
+
+**매핑 (기준):**
+- 값: `DELIVERY→SINGLE`, `CLEANING→SEQUENTIAL`, `OTHER→OTHER`(유지). 신규 `CALL`,`ROUND`.
+- cleaning-family = `SEQUENTIAL ∪ ROUND` (시동알림·시뮬 cleaning phase). delivery-family = `CALL ∪ SINGLE ∪ OTHER`. 시스템배차 = `CALL ∪ SINGLE`.
+- 라벨: CALL=콜 배차, SINGLE=단일 배차, SEQUENTIAL=순차 배차, ROUND=왕복 배차, OTHER=기타.
+
+---
+
+### Task 1: 백엔드 enum + V36 마이그레이션
+
+**Files:**
+- Modify: `development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java`
+- Create: `development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql`
+
+- [ ] **Step 1: enum 값 교체 + 패밀리 헬퍼**
+
+`BikeServiceType.java` 전체 교체:
+```java
+package com.thundercrew.opsapi.bike.domain;
+
+/**
+ * 차량 운영 방식. 배차가 동작하는 방식으로 차량을 분류한다(필터·알림·시뮬 분기 축).
+ */
+public enum BikeServiceType {
+    /** 콜 배차 — 단건 콜, 라이더 수락/시스템 자동 배차. */
+    CALL,
+    /** 단일 배차 — 목적지 1개 단순 배차. */
+    SINGLE,
+    /** 순차 배차 — 목적지 + 순서 큐. */
+    SEQUENTIAL,
+    /** 왕복 배차 — 일괄 수거 → 배송 2단계. */
+    ROUND,
+    /** 기타. */
+    OTHER;
+
+    /** 시동 알림·청소형 시뮬 대상(순차·왕복). */
+    public boolean isCleaningFamily() {
+        return this == SEQUENTIAL || this == ROUND;
+    }
+
+    /** 배송형 시뮬·시스템 배차 후보(콜·단일·기타). */
+    public boolean isDeliveryFamily() {
+        return !isCleaningFamily();
+    }
+}
+```
+
+- [ ] **Step 2: V36 마이그레이션**
+
+`V36__rebrand_bikes_service_type_to_operating_mode.sql`:
+```sql
+-- 기존 분류 → 운영 방식 매핑 (OTHER 는 유지)
+update bikes set service_type = 'SINGLE'     where service_type = 'DELIVERY';
+update bikes set service_type = 'SEQUENTIAL' where service_type = 'CLEANING';
+-- check 제약 재생성
+alter table bikes drop constraint ck_bikes_service_type;
+alter table bikes add constraint ck_bikes_service_type
+    check (service_type in ('CALL', 'SINGLE', 'SEQUENTIAL', 'ROUND', 'OTHER'));
+-- 컬럼 기본값 변경 (기존 default 'DELIVERY')
+alter table bikes alter column service_type set default 'SINGLE';
+```
+(기존 `ck_bikes_service_type` 이름·`default 'DELIVERY'` 는 V25 에서 확인됨. 실제와 다르면 실제 이름 사용.)
+
+- [ ] **Step 3: 컴파일**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/bike/domain/BikeServiceType.java development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql && git commit -m "feat(opmode): BikeServiceType 5-value operating mode + V36 migration"
+```
+
+---
+
+### Task 2: 백엔드 분기 사이트 + 계약 테스트
+
+**Files:**
+- Modify: `.../bike/service/BikeBulkService.java`
+- Modify: `.../dispatch/service/DeliveryCallService.java`
+- Modify: 영향받는 계약 테스트들
+
+- [ ] **Step 1: BikeBulkService 기본값**
+
+READ `BikeBulkService.java`. 약 69행 `BikeServiceType.DELIVERY` (벌크 차량 생성 기본값)을 `BikeServiceType.SINGLE` 로 교체.
+
+- [ ] **Step 2: DeliveryCallService 시스템 배차 필터**
+
+READ `DeliveryCallService.java`. `systemDispatch` 의 DELIVERY 필터:
+```java
+.filter(b -> b.getServiceType() == BikeServiceType.DELIVERY)
+```
+를 시스템 배차 후보(콜∪단일)로 교체:
+```java
+.filter(b -> b.getServiceType() == BikeServiceType.CALL
+        || b.getServiceType() == BikeServiceType.SINGLE)
+```
+(에러 메시지 "가용 배송 차량이 없습니다." 유지.)
+
+- [ ] **Step 3: 다른 serviceType 분기 grep**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && grep -rn "ServiceType\.\(DELIVERY\|CLEANING\)\|getServiceType() ==" src/main/java
+```
+나오는 곳(예상: 위 2곳 외 없음. DashboardMapStateService/BikeNextCustomerService 가 serviceType 을 단순 노출/저장만 하면 무변경)을 확인하고, **값 분기**가 있으면 패밀리 헬퍼(`isCleaningFamily()`/`isDeliveryFamily()`)로 교체. 단순 노출은 건드리지 말 것.
+
+- [ ] **Step 4: 계약 테스트 갱신**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && grep -rln "DELIVERY\|CLEANING\|service_type" src/test/java
+```
+serviceType 값을 시드/단언하는 테스트(특히 `DeliveryCallApiContractTests` 의 `seedDeliveryBike`(service_type='DELIVERY')→`'SINGLE'`, `seedCleaningBike`(='CLEANING')→`'SEQUENTIAL'`; 그 외 Bike/Dashboard 계약 테스트의 service_type 시드)를 새 값으로 교체. DeliveryCall 의 systemDispatch 테스트가 CALL/SINGLE 만 선택하고 SEQUENTIAL/ROUND/OTHER 는 제외하는지 단언 유지(seedCleaningBike 가 SEQUENTIAL 이 되며 자동으로 후보 제외됨 — 케이스3 "no delivery bike" 가 여전히 통과하도록 시드를 SEQUENTIAL 로). 헬퍼 메서드 SQL 의 service_type 리터럴도 교체.
+
+- [ ] **Step 5: 컴파일 (main + test)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+```
+Expected: BUILD SUCCESSFUL. (계약 테스트 실행은 Docker 필요 → CI.)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java development/service-ops-api/src/test/java && git commit -m "feat(opmode): systemDispatch=CALL∪SINGLE, bulk default SINGLE, tests to new values"
+```
+
+---
+
+### Task 3: 프론트 타입 + 필터 탭 + 라벨/헬퍼
+
+**Files:**
+- Modify: `lib/services/service-ops-api.ts`
+- Modify: `lib/services/fleet-simulation.ts` (헬퍼만 추가)
+- Modify: `components/overview/ServiceTypeFilterTabs.tsx`
+
+- [ ] **Step 1: 타입 교체**
+
+`lib/services/service-ops-api.ts` L134:
+```ts
+export type ServiceOpsBikeServiceType = "DELIVERY" | "CLEANING" | "OTHER";
+```
+→
+```ts
+export type ServiceOpsBikeServiceType = "CALL" | "SINGLE" | "SEQUENTIAL" | "ROUND" | "OTHER";
+```
+(다른 위치의 `| "OTHER"` (L397 부근)는 이 타입과 무관하면 건드리지 말 것 — grep 으로 해당 union 이 serviceType 인지 확인.)
+
+- [ ] **Step 2: cleaning-family 헬퍼 (공용)**
+
+`lib/services/fleet-simulation.ts` 의 `ServiceType` 정의(L11) 교체 + 헬퍼 export 추가:
+```ts
+export type ServiceType = "CALL" | "SINGLE" | "SEQUENTIAL" | "ROUND" | "OTHER";
+
+/** 청소형(순차·왕복) 운영 방식 — 시동 알림 + 청소 시뮬 phase 대상. */
+export function isCleaningServiceType(t: ServiceType | string | null | undefined): boolean {
+  return t === "SEQUENTIAL" || t === "ROUND";
+}
+```
+
+- [ ] **Step 3: ServiceTypeFilterTabs 6칩**
+
+`components/overview/ServiceTypeFilterTabs.tsx` 의 `TABS` 교체:
+```ts
+const TABS: { value: ServiceTypeFilter; label: string }[] = [
+  { value: "ALL", label: "전체" },
+  { value: "CALL", label: "콜 배차" },
+  { value: "SINGLE", label: "단일 배차" },
+  { value: "SEQUENTIAL", label: "순차 배차" },
+  { value: "ROUND", label: "왕복 배차" },
+  { value: "OTHER", label: "기타" }
+];
+```
+(`ServiceTypeFilter = ServiceOpsBikeServiceType | "ALL"` 그대로 — 새 값 자동 반영.)
+
+- [ ] **Step 4: typecheck + lint**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과. (이 시점에 VehicleDetailDialog/MapShell/FleetSimulationContext 의 옛 값 비교가 타입 에러를 낼 수 있음 — Task 4/5 에서 정리. 만약 typecheck 가 실패하면 그 에러는 Task 4/5 대상 파일인지 확인하고, **이 태스크 범위(3개 파일)만** 통과하도록 두되 전체 통과는 Task 5 말미에 보장. 실패가 3개 파일 내부면 수정.)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/lib/services/fleet-simulation.ts development/front-admin-web/components/overview/ServiceTypeFilterTabs.tsx && git commit -m "feat(opmode): frontend type 5-value + cleaning-family helper + filter 6 chips"
+```
+
+---
+
+### Task 4: VehicleDetailDialog — 라벨 + 편집 select + phase 라벨
+
+**Files:**
+- Modify: `components/management/VehicleDetailDialog.tsx`
+
+- [ ] **Step 1: 상세 필드 라벨 + serviceTypeLabel 헬퍼**
+
+L198 `<DetailField label="서비스" ...>` → `label="운영 방식"`.
+`serviceTypeLabel` 헬퍼(L310–313):
+```ts
+function serviceTypeLabel(t?: ServiceOpsBikeServiceType): string {
+  if (t === "CLEANING") return "클리닝";
+  if (t === "OTHER") return "기타";
+  return "배송";
+}
+```
+→
+```ts
+function serviceTypeLabel(t?: ServiceOpsBikeServiceType): string {
+  switch (t) {
+    case "CALL": return "콜 배차";
+    case "SINGLE": return "단일 배차";
+    case "SEQUENTIAL": return "순차 배차";
+    case "ROUND": return "왕복 배차";
+    case "OTHER": return "기타";
+    default: return "단일 배차";
+  }
+}
+```
+
+- [ ] **Step 2: 편집 select 5옵션**
+
+L253–256:
+```tsx
+<select name="serviceType" defaultValue={vehicle.serviceType ?? "DELIVERY"}>
+  <option value="DELIVERY">배송</option>
+  <option value="CLEANING">클리닝</option>
+  <option value="OTHER">기타</option>
+</select>
+```
+→
+```tsx
+<select name="serviceType" defaultValue={vehicle.serviceType ?? "SINGLE"}>
+  <option value="CALL">콜 배차</option>
+  <option value="SINGLE">단일 배차</option>
+  <option value="SEQUENTIAL">순차 배차</option>
+  <option value="ROUND">왕복 배차</option>
+  <option value="OTHER">기타</option>
+</select>
+```
+편집 라벨도 "서비스 유형" → "운영 방식"(해당 `<label>` 텍스트가 있으면 교체).
+
+- [ ] **Step 3: renderPhaseLabel 패밀리화**
+
+L872–876:
+```ts
+function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: ServiceType): string {
+  if (serviceType === "DELIVERY") {
+    return phase === "MOVING" ? "배송 중" : "대기";
+  }
+  // CLEANING or OTHER
+```
+를 cleaning-family 기준으로:
+```ts
+function renderPhaseLabel(phase: SimulatedBikeState["phase"], serviceType: ServiceType): string {
+  if (!isCleaningServiceType(serviceType)) {
+    return phase === "MOVING" ? "배송 중" : "대기";
+  }
+  // cleaning-family (순차·왕복)
+```
+(나머지 블록 — 이동 중/작업 중/대기 중 — 유지.) `isCleaningServiceType` 를 `@/lib/services/fleet-simulation` 에서 import.
+
+- [ ] **Step 4: typecheck + lint**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+```
+Expected: 통과(또는 잔여 에러가 Task 5 대상인 MapShell/FleetSimulationContext 면 그대로 — 이 파일 내부 에러는 0).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/VehicleDetailDialog.tsx && git commit -m "feat(opmode): vehicle detail 운영 방식 label/select(5) + family phase label"
+```
+
+---
+
+### Task 5: 시뮬 + MapShell 패밀리 분기
+
+**Files:**
+- Modify: `lib/services/fleet-simulation.ts`
+- Modify: `components/overview/FleetSimulationContext.tsx`
+- Modify: `components/dashboard/MapShell.tsx`
+
+- [ ] **Step 1: fleet-simulation.ts 내부 CLEANING 분기**
+
+READ. `serviceType === "CLEANING"` 으로 청소 phase(IDLE 시작, nextCustomerDestination 이동)를 분기하는 곳을 `isCleaningServiceType(serviceType)` 로 교체. `makeInitialState` 의 기본값 `serviceType = "DELIVERY"` → `"SINGLE"`. (Step 2(Task3)에서 export 한 `isCleaningServiceType` 사용 — 같은 파일이라 직접 호출.)
+
+- [ ] **Step 2: FleetSimulationContext.tsx 분기**
+
+READ. `pin?.serviceType === "CLEANING"` (L116,122,127,155 등) → `isCleaningServiceType(pin?.serviceType)`. 기본값 `serviceType: pin?.serviceType ?? "DELIVERY"`(L138) → `?? "SINGLE"`. `isCleaningServiceType` import 추가.
+
+- [ ] **Step 3: MapShell.tsx 배지/말풍선 패밀리화**
+
+READ. `serviceBadgeMarkup`(L754) 의 `if (!serviceType || serviceType === "DELIVERY")`(L757) → `if (!serviceType || !isCleaningServiceType(serviceType))` (delivery-family/미지정 = 배송 라벨). 주석(L750-751) 갱신. `showBubble`(L883) 의 `serviceType === "CLEANING"` → `isCleaningServiceType(serviceType)`. `isCleaningServiceType` import 추가.
+
+- [ ] **Step 4: typecheck + lint + build**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 전부 통과(전체 프론트에서 옛 "DELIVERY"/"CLEANING" 비교 잔존 0).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/fleet-simulation.ts development/front-admin-web/components/overview/FleetSimulationContext.tsx development/front-admin-web/components/dashboard/MapShell.tsx && git commit -m "feat(opmode): simulation + map badge use cleaning-family branching"
+```
+
+---
+
+### Task 6: 최종 검증 + PR
+
+- [ ] **Step 1: 백엔드 + 프론트 풀 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && grep -rn '"DELIVERY"\|"CLEANING"' components lib app | grep -vi "PICKUP\|kind\|test" || echo "no stray old values"
+```
+Expected: 백엔드 컴파일 성공, 프론트 빌드 성공, 옛 serviceType 값(`"DELIVERY"`/`"CLEANING"`) 잔존 없음(주: `DispatchOrderKind`의 "DELIVERY"는 별개 — grep 제외).
+
+- [ ] **Step 2: PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git diff dev --stat && git push -u origin cc-operating-mode && gh pr create --base dev --title "차량 운영 방식: serviceType 5종 재분류 (콜/단일/순차/왕복/기타)" --body "$(cat <<'EOF'
+## Summary
+차량 분류를 도메인명에서 **배차 동작 방식 5종**으로 재정의 (`BikeServiceType` 값 in-place 교체).
+- CALL(콜 배차)/SINGLE(단일 배차)/SEQUENTIAL(순차 배차)/ROUND(왕복 배차)/OTHER(기타)
+- **V36**: DELIVERY→SINGLE, CLEANING→SEQUENTIAL, OTHER 유지 + check 제약 재생성 + default SINGLE
+- 분기 로직 패밀리 매핑(동작 보존): cleaning=순차∪왕복(시동알림·시뮬), 시스템배차=콜∪단일
+- 지도 필터 6칩 + 차량 편집폼 5옵션 + 상세 "운영 방식" 라벨
+
+## 배포 영향
+- **V36 마이그레이션 신규** (값 매핑 + 제약 + default) — 재기동 시 Flyway 적용. enum↔제약 값 일치.
+
+## Test Plan
+- [x] 백엔드 compile(main+test), 프론트 typecheck/lint/build, 옛 값 잔존 0
+- [ ] 계약 테스트(Docker/CI)
+- [ ] 프로덕션 QA: 지도 필터 6칩 + 카운트, 차량 편집폼 5옵션, 시동알림(순차/왕복), 시스템배차(콜/단일)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** enum 5값(Task1), V36(Task1), 패밀리 헬퍼(Task1 백엔드/Task3 프론트), BikeBulk default·DeliveryCall 필터(Task2), 계약 테스트(Task2), 프론트 타입·필터(Task3), 편집폼·라벨·phase(Task4), 시뮬·MapShell 패밀리(Task5), 검증·PR(Task6). ✓ 비범위(타입명 리네임·시스템배차 CALL전용·declutter) 제외.
+
+**2. Placeholder scan:** enum/migration/helper/필터/select/serviceTypeLabel 완전 코드. 분기 사이트는 현재 코드 before→after 제시. Task2 Step3/4·Task5 의 "READ + grep 후 교체"는 코드베이스 의존(정확한 잔여 사이트)이라 구체 대상(파일·라인·패턴·헬퍼)을 명시 — placeholder 아님.
+
+**3. Type consistency:** `BikeServiceType{CALL,SINGLE,SEQUENTIAL,ROUND,OTHER}` + `isCleaningFamily/isDeliveryFamily`(백). 프론트 `ServiceOpsBikeServiceType`/`ServiceType` 동일 5값 + `isCleaningServiceType`(fleet-simulation.ts export, MapShell/FleetSimulationContext/VehicleDetailDialog 가 import). 라벨(콜 배차/단일 배차/순차 배차/왕복 배차/기타) 전 태스크 일관. 마이그레이션 매핑(DELIVERY→SINGLE, CLEANING→SEQUENTIAL) 일관.
+
+**구현자 주의:** 태스크 간 typecheck 가 중간에 실패할 수 있음(옛 값 비교가 여러 파일에 흩어짐) — 각 태스크는 자기 파일 내부 에러 0 을 목표로 하고, **전체 typecheck/lint/build 통과는 Task5 Step4 + Task6 에서 보장**. Task3 의 typecheck 실패가 MapShell/FleetSimulationContext/VehicleDetailDialog(아직 미수정) 때문이면 정상 — 진행.

--- a/docs/superpowers/specs/2026-06-12-vehicle-operating-mode-design.md
+++ b/docs/superpowers/specs/2026-06-12-vehicle-operating-mode-design.md
@@ -1,0 +1,101 @@
+# 차량 운영 방식 (operating mode) — serviceType 5종 재분류 Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 차량 분류를 도메인 명(배송/클리닝/기타)에서 **배차 동작 방식 5종**으로 재정의한다 — `CALL`(콜 배차)/`SINGLE`(단일 배차)/`SEQUENTIAL`(순차 배차)/`ROUND`(왕복 배차)/`OTHER`(기타). 지도 필터·차량 편집폼이 이 5종을 쓰고, 기존 분기 로직(시동 알림·시스템 배차·시뮬레이션)은 "패밀리 멤버십"으로 매핑해 동작을 보존한다.
+
+**Architecture:** 기존 `BikeServiceType` enum + `bikes.service_type` 컬럼을 **값만 in-place 교체**(타입명/컬럼명 유지 → 35개 사용처의 타입 참조는 그대로, 값 분기만 갱신). 새 컬럼/도메인을 만들지 않는다.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA, Next.js App Router, TypeScript.
+
+**비범위:** 시스템 배차를 CALL 전용으로 좁히기, 마커 declutter/범례, 관리 테이블 검색/필터, 타입명·컬럼명 리네임(`BikeServiceType`/`service_type` 유지).
+
+---
+
+## 1. 운영 방식 5종
+
+| enum | 라벨 | 동작 | 패밀리 |
+|---|---|---|---|
+| `CALL` | 콜 배차 | 단건 콜, 라이더 수락/시스템 자동 배차 (C1) | delivery |
+| `SINGLE` | 단일 배차 | 목적지 1개 단순 배차 (C2) | delivery |
+| `SEQUENTIAL` | 순차 배차 | 목적지 + 순서 큐 (C3) | cleaning |
+| `ROUND` | 왕복 배차 | 일괄 수거 → 배송 2단계 (C4) | cleaning |
+| `OTHER` | 기타 | 분류 외 | (delivery 동작) |
+
+**패밀리(기존 동작 보존):**
+- **cleaning-family** = `SEQUENTIAL ∪ ROUND` → 시동 알림 + 시뮬 cleaning phase(IDLE→MOVING, 목적지 기반).
+- **delivery-family** = `CALL ∪ SINGLE ∪ OTHER` → 시뮬 delivery phase(자동 MOVING). (기존 DELIVERY+OTHER 동작.)
+- **시스템 배차**(배민 콜 자동 배차) = `CALL ∪ SINGLE` 중 least-loaded (OTHER 제외; 기존 DELIVERY 동작 보존).
+
+---
+
+## 2. 백엔드 (service-ops-api)
+
+### 2.1 enum
+`bike/domain/BikeServiceType.java`: 값 교체 → `{ CALL, SINGLE, SEQUENTIAL, ROUND, OTHER }`. JavaDoc 갱신("차량 운영 방식").
+
+### 2.2 마이그레이션 `V36__rebrand_bikes_service_type_to_operating_mode.sql`
+```sql
+-- 기존 분류 → 운영 방식 매핑
+update bikes set service_type = 'SINGLE'     where service_type = 'DELIVERY';
+update bikes set service_type = 'SEQUENTIAL' where service_type = 'CLEANING';
+-- 'OTHER' 는 그대로 유지
+-- check 제약 재생성
+alter table bikes drop constraint ck_bikes_service_type;
+alter table bikes add constraint ck_bikes_service_type
+    check (service_type in ('CALL', 'SINGLE', 'SEQUENTIAL', 'ROUND', 'OTHER'));
+-- 컬럼 기본값 변경 (기존 default 'DELIVERY')
+alter table bikes alter column service_type set default 'SINGLE';
+```
+(`ix_bikes_service_type_active` 인덱스는 값 종류 무관 → 변경 없음.)
+
+### 2.3 분기 로직 — 패밀리 헬퍼
+`BikeServiceType` 에 헬퍼 추가(또는 서비스에서 집합 비교):
+```java
+public boolean isCleaningFamily() { return this == SEQUENTIAL || this == ROUND; }
+public boolean isDeliveryFamily() { return this == CALL || this == SINGLE || this == OTHER; }
+```
+적용:
+- **`DeliveryCallService.systemDispatch`**: `serviceType == DELIVERY` 필터 → `serviceType == CALL || serviceType == SINGLE` (OTHER 제외). 메시지 "가용 배송 차량" 유지.
+- (기타 백엔드에서 serviceType 을 분기하는 곳이 있으면 동일하게 패밀리로. 구현 단계에서 grep — `DashboardMapStateService`/`BikeNextCustomerService` 등은 단순 노출이면 무변경.)
+
+### 2.4 DTO·검증·엑셀
+- `BikeCreateRequest`/`BikeUpdateRequest`/`BikeBulkService`: serviceType 값 검증/파싱을 새 5값으로. 엑셀 업로드의 serviceType 컬럼은 한글 라벨(콜 배차/단일 배차/순차 배차/왕복 배차/기타) ↔ enum 매핑(기존 매핑 방식 따라). export 도 새 라벨.
+- `BikeReadResponse`/`DashboardMapStateResponse`: serviceType 그대로 노출(값만 바뀜).
+
+### 2.5 테스트
+serviceType 을 쓰는 계약 테스트(Bike, DeliveryCall least-loaded, Dashboard 등)의 시드/단언을 새 값으로 갱신. DeliveryCall 의 "DELIVERY 차량" 시드 → `SINGLE`/`CALL` 로, "CLEANING" → `SEQUENTIAL`. systemDispatch 가 CALL∪SINGLE 만 고르고 OTHER/SEQUENTIAL/ROUND 는 제외하는지 검증 추가.
+
+---
+
+## 3. 프론트엔드 (front-admin-web)
+
+### 3.1 타입 + 라벨
+- `ServiceOpsBikeServiceType` = `"CALL" | "SINGLE" | "SEQUENTIAL" | "ROUND" | "OTHER"`.
+- 공용 라벨 매핑(콜 배차/단일 배차/순차 배차/왕복 배차/기타).
+
+### 3.2 지도 필터
+`ServiceTypeFilterTabs`: 탭 = 전체 + 콜 배차 + 단일 배차 + 순차 배차 + 왕복 배차 + 기타 (6칩). `ServiceTypeFilter = ServiceOpsBikeServiceType | "ALL"`. 필터 적용 로직은 serviceType 동등 비교 그대로.
+
+### 3.3 차량 편집폼 + 표시
+- `VehicleDetailDialog`: 상세 "서비스" 필드 라벨 → **"운영 방식"**, 값 = 새 라벨. 편집 모드 select(배송/클리닝/기타 3옵션) → 5옵션(CALL/SINGLE/SEQUENTIAL/ROUND/OTHER). `serviceTypeLabel` 헬퍼 갱신.
+- `app/actions.ts`(updateVehicle…): serviceType 값 전달 그대로(값만 바뀜).
+
+### 3.4 MapShell 배지
+`MapShell` 의 serviceType 기반 배지 라벨/색 분기(`!serviceType || serviceType === "DELIVERY"` 등)를 패밀리 기준으로: cleaning-family(SEQUENTIAL/ROUND) = 기존 클리닝 라벨(이동 중/작업 중/대기 중), 그 외(CALL/SINGLE/OTHER) = 기존 배송 라벨(배송 중/대기). 헬퍼 `isCleaningFamily(serviceType)` 프론트 유틸.
+
+### 3.5 시뮬레이션
+`FleetSimulationContext`/`fleet-simulation.ts` 의 `serviceType === "CLEANING"` 분기(초기 phase, nextCustomer/currentDispatch 이동, 시동 알림 대상) → **cleaning-family(SEQUENTIAL∪ROUND)** 체크로. `ServiceType` 타입(프론트 시뮬)도 5값 또는 family 헬퍼로.
+
+---
+
+## 4. 데이터 흐름 / 영향
+- enum 값 in-place 교체 → 타입 참조는 무변경, **값 분기 지점만** 패밀리/신규값으로 갱신.
+- **V36 마이그레이션**(값 매핑 + 제약 재생성 + default) — 재기동 시 Flyway 적용. 엔티티 enum 과 DB 제약 값 일치 필수(불일치 시 기존 행 로드/검증 실패).
+
+## 5. 검증
+- 백엔드 `compileJava + compileTestJava`, 프론트 `typecheck + lint + build`.
+- 프로덕션 QA: 지도 필터 6칩 동작(콜/단일/순차/왕복/기타) + 카운트 갱신, 차량 편집폼 운영 방식 5옵션, 시동 알림(순차/왕복 차량) 정상, 시스템 배차(콜·단일 차량만 자동 배정).
+
+## 6. 비범위 재확인
+타입명/컬럼명 리네임, 시스템배차 CALL 전용 좁히기, 마커 declutter/범례, 관리 테이블 필터는 이 스펙에 포함하지 않는다.


### PR DESCRIPTION
## 릴리스 내용
차량 분류를 **배차 동작 방식 5종**으로 재정의 (#385).
- `CALL`(콜 배차)/`SINGLE`(단일 배차)/`SEQUENTIAL`(순차 배차)/`ROUND`(왕복 배차)/`OTHER`(기타)
- 지도 필터 6칩, 차량 편집폼 5옵션, 상세 "운영 방식" 라벨
- 분기 로직 패밀리 매핑으로 시동알림·청소 시뮬·시스템배차 동작 보존

## ⚠️ 배포 영향 — DB 마이그레이션
- **V36** (`rebrand_bikes_service_type_to_operating_mode`): 기존 `bikes.service_type` 값 매핑(`DELIVERY→SINGLE`, `CLEANING→SEQUENTIAL`, `OTHER` 유지) + `ck_bikes_service_type` 제약 재생성 + default `SINGLE`.
- **api 재기동 시 Flyway 자동 적용.** 마이그레이션 성공 = 재기동 성공.

## 검증 완료
- 백엔드 compileJava + compileTestJava, 프론트 typecheck + lint + build
- 코드 리뷰 (패밀리 매핑·마이그레이션·systemDispatch 정합성)

## 릴리스 후 QA
지도 필터 6칩 + 카운트 / 차량 편집폼 5옵션 / 시동알림(순차·왕복) / 시스템배차(콜·단일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)