### PR TITLE
[핫픽스] V36 마이그레이션 순서 — 구 CHECK 제약 먼저 제거

### DIFF
--- a/development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V36__rebrand_bikes_service_type_to_operating_mode.sql
@@ -1,9 +1,15 @@
+-- 구 CHECK 제약을 먼저 제거한다.
+-- (구 제약은 'DELIVERY'/'CLEANING'/'OTHER' 만 허용하므로, 제거 전에 신규 값으로 UPDATE 하면
+--  제약 위반(SQLSTATE 23514)으로 마이그레이션이 실패한다. 반드시 DROP → UPDATE → ADD 순서여야 한다.)
+alter table bikes drop constraint if exists ck_bikes_service_type;
+
 -- 기존 분류 → 운영 방식 매핑 (OTHER 는 유지)
 update bikes set service_type = 'SINGLE'     where service_type = 'DELIVERY';
 update bikes set service_type = 'SEQUENTIAL' where service_type = 'CLEANING';
--- check 제약 재생성
-alter table bikes drop constraint ck_bikes_service_type;
+
+-- 신규 운영 방식 값으로 CHECK 제약 재생성
 alter table bikes add constraint ck_bikes_service_type
     check (service_type in ('CALL', 'SINGLE', 'SEQUENTIAL', 'ROUND', 'OTHER'));
+
 -- 컬럼 기본값 변경 (기존 default 'DELIVERY')
 alter table bikes alter column service_type set default 'SINGLE';


### PR DESCRIPTION
## 문제 (프로덕션 다운)
릴리스(#386) 후 prod api 가 부팅 실패 → 로그인 불가. 원인: V36 가 구 CHECK 제약(`ck_bikes_service_type in (DELIVERY,CLEANING,OTHER)`)을 **제거하기 전에** `service_type` 을 신규 값(`SINGLE`/`SEQUENTIAL`)으로 UPDATE → `SQLSTATE 23514` 제약 위반 → Flyway 롤백 → Spring Boot 부팅 실패 크래시 루프.

```
ERROR: new row for relation "bikes" violates check constraint "ck_bikes_service_type"
Location : V36__...sql  Line: 2
Changes successfully rolled back.  /  Current version of schema: 35
```

## 수정
순서를 `DROP (if exists) → UPDATE → ADD 신규 제약 → set default` 으로 변경. (`if exists` 로 재실행 안전성 확보.)

## 복구 영향
- Flyway 가 실패한 V36 을 **완전 롤백**(스키마 v35 유지, 실패 마커 없음, 데이터 구 값 그대로) → 수정 V36 재배포 시 깨끗하게 적용. **수동 flyway repair 불필요.**
- 재배포(=이 핫픽스 dev→main 머지) 후 api 정상 부팅 → 로그인 복구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)