### PR TITLE
[릴리스] 휠타입별 지도 마커 아이콘 (2륜/4륜)

### DIFF
--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -466,7 +466,7 @@ export function MapShell({
       incomingIds.add(pin.bikeId);
       const position = new naver.maps.LatLng(pin.latitude, pin.longitude);
       const isSelected = pin.bikeId === selectedBikeId;
-      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected, pin.currentDispatchCustomerName, pin.connectionStatus, pin.ignitionStatus);
+      const html = bikeMarkerHtml(pin.pinLabel ?? pin.plateNumber, showLabel, pin.servicePhase, pin.deliveryCount, pin.ignitionOnAt, pin.serviceType, isSelected, pin.currentDispatchCustomerName, pin.connectionStatus, pin.ignitionStatus, pin.wheelType);
       // 배지는 icon wrapper(overflow:visible) 안에 position:absolute 로 내장되므로
       // icon.size 는 아이콘 자체 크기(28×28) 고정. 배지는 visually 아래로 넘침.
       const icon = {
@@ -806,8 +806,20 @@ function ignitionBubbleMarkup(customerName?: string | null): string {
 // 공통 SVG attribute. stroke 기반 line-art 가 currentColor 를 따라간다.
 const ICON_SVG_PROPS = `width="${ICON_PX}" height="${ICON_PX}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
 
-/** 배달 스쿠터 silhouette — 앞·뒤 바퀴 + 핸들 + 좌석 + 후방 배달박스. */
-function bikeIconSvg(): string {
+/** 배달 스쿠터 silhouette — 앞·뒤 바퀴 + 핸들 + 좌석 + 후방 배달박스. 4륜이면 box-truck. */
+function bikeIconSvg(wheelType?: string): string {
+  if (wheelType === "FOUR_WHEEL") {
+    return `<svg ${ICON_SVG_PROPS}>
+    <path d="M2.5 16 V7.5 H13 V16"/>
+    <path d="M13 10.5 H16.5 L20.5 13.5 V16 H13"/>
+    <path d="M2.5 16 H4.3"/>
+    <path d="M8.2 16 H14.8"/>
+    <path d="M18.7 16 H20.5"/>
+    <path d="M16.5 10.7 V13.5 H20.2"/>
+    <circle cx="6.3" cy="17.6" r="1.9"/>
+    <circle cx="16.8" cy="17.6" r="1.9"/>
+  </svg>`;
+  }
   return `<svg ${ICON_SVG_PROPS}>
     <circle cx="6" cy="18" r="2"/>
     <circle cx="18" cy="18" r="2"/>
@@ -895,7 +907,8 @@ function bikeMarkerHtml(
   selected?: boolean,
   currentDispatchCustomerName?: string | null,
   connectionStatus?: string,
-  ignitionStatus?: string
+  ignitionStatus?: string,
+  wheelType?: string
 ): string {
   const badge =
     servicePhase != null
@@ -911,7 +924,7 @@ function bikeMarkerHtml(
   const showBubble = isCleaningServiceType(serviceType) && ignitionOnAt != null && Date.now() - ignitionOnAt < 4_000;
   const bubble = showBubble ? ignitionBubbleMarkup(currentDispatchCustomerName) : "";
   const extras = badgeArea + bubble;
-  const wrapped = markerWrapper(bikeIconSvg(), "--rm-accent", extras, selected);
+  const wrapped = markerWrapper(bikeIconSvg(wheelType), "--rm-accent", extras, selected);
   if (!showLabel) return wrapped;
   return (
     `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">` +

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -685,6 +685,7 @@ export type ServiceOpsDashboardBikePin = {
   batteryStatus: string;
   pinLabel: string;
   serviceType?: ServiceOpsBikeServiceType;
+  wheelType?: ServiceOpsBikeWheelType;
   nextCustomerName?: string | null;
   nextCustomerPhone?: string | null;
   nextCustomerLat?: number | string | null;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/dto/DashboardMapStateResponse.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.dashboard.dto;
 
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.domain.BikeWheelType;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrderKind;
 import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
 import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
@@ -50,6 +51,7 @@ public record DashboardMapStateResponse(
             String batteryStatus,
             String pinLabel,
             BikeServiceType serviceType,
+            BikeWheelType wheelType,
             String nextCustomerName,
             String nextCustomerPhone,
             BigDecimal nextCustomerLat,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/repository/DashboardMapQueryRepository.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.dashboard.repository;
 
 import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
 import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.domain.BikeWheelType;
 import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
 import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
 import java.math.BigDecimal;
@@ -40,6 +41,7 @@ public class DashboardMapQueryRepository {
                     b.model_name,
                     b.operation_status,
                     b.service_type,
+                    b.wheel_type,
                     active_rider.rider_name,
                     cs.device_id,
                     cs.last_received_at,
@@ -105,6 +107,7 @@ public class DashboardMapQueryRepository {
                 rs.getString("model_name"),
                 BikeOperationStatus.valueOf(rs.getString("operation_status")),
                 BikeServiceType.valueOf(rs.getString("service_type")),
+                BikeWheelType.valueOf(rs.getString("wheel_type")),
                 rs.getString("rider_name"),
                 rs.getObject("device_id", UUID.class),
                 rs.getTimestamp("last_received_at").toInstant(),
@@ -145,6 +148,7 @@ public class DashboardMapQueryRepository {
             String modelName,
             BikeOperationStatus operationStatus,
             BikeServiceType serviceType,
+            BikeWheelType wheelType,
             String activeRiderName,
             UUID deviceId,
             Instant lastReceivedAt,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
@@ -116,6 +116,7 @@ public class DashboardMapStateService {
                 batteryStatus,
                 bikePinLabel(row),
                 row.serviceType(),
+                row.wheelType(),
                 row.nextCustomerName(),
                 row.nextCustomerPhone(),
                 row.nextCustomerLat(),

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardMapApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DashboardMapApiContractTests.java
@@ -84,7 +84,7 @@ class DashboardMapApiContractTests extends PostgresContainerSupport {
         Instant now = Instant.now();
         seedRider(RIDER_ID, "김지도", "010-1111-2222");
         seedBike(ONLINE_BIKE_ID, "서울T-2001", "VIN-DASH-001", "IN_SERVICE");
-        seedBike(STALE_BIKE_ID, "서울T-2002", "VIN-DASH-002", "READY");
+        seedBikeWithWheelType(STALE_BIKE_ID, "서울T-2002", "VIN-DASH-002", "READY", "FOUR_WHEEL");
         seedBike(NO_STATE_BIKE_ID, "서울T-2003", "VIN-DASH-003", "IN_SERVICE");
         seedActiveContract(CONTRACT_ID, RIDER_ID, ONLINE_BIKE_ID, now.minusSeconds(3600));
         insertCurrentState(ONLINE_BIKE_ID, DEVICE_ID, now.minusSeconds(60), "ON", "12.30", "44.00");
@@ -117,6 +117,8 @@ class DashboardMapApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$.bikePins[0].batteryStatus").value("LOW"))
                 .andExpect(jsonPath("$.bikePins[1].connectionStatus").value("ONLINE"))
                 .andExpect(jsonPath("$.bikePins[1].batteryStatus").value("CRITICAL"))
+                .andExpect(jsonPath("$.bikePins[0].wheelType").value("TWO_WHEEL"))
+                .andExpect(jsonPath("$.bikePins[1].wheelType").value("FOUR_WHEEL"))
                 .andExpect(jsonPath("$.stationPins[0].stationId").value(STATION_ID.toString()))
                 .andExpect(jsonPath("$.stationPins[0].pinLabel").value("강남 스테이션 5/12"))
                 .andExpect(jsonPath("$.stationPins[0].availableBatteryLabel").value("5/12"))
@@ -184,6 +186,13 @@ class DashboardMapApiContractTests extends PostgresContainerSupport {
                 insert into bikes (id, plate_number, vin, model_name, operation_status)
                 values (?, ?, ?, 'Thunder M1', ?)
                 """, id, plateNumber, vin, operationStatus);
+    }
+
+    private void seedBikeWithWheelType(UUID id, String plateNumber, String vin, String operationStatus, String wheelType) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, wheel_type)
+                values (?, ?, ?, 'Thunder M1', ?, ?)
+                """, id, plateNumber, vin, operationStatus, wheelType);
     }
 
     private void seedActiveContract(UUID id, UUID riderId, UUID bikeId, Instant startAt) {

--- a/docs/superpowers/plans/2026-06-12-wheeltype-marker-icon.md
+++ b/docs/superpowers/plans/2026-06-12-wheeltype-marker-icon.md
@@ -1,0 +1,159 @@
+# 휠타입별 지도 마커 아이콘 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 지도 차량 마커를 `wheelType` 으로 분기 — `TWO_WHEEL`→오토바이(현행), `FOUR_WHEEL`→박스트럭.
+
+**Architecture:** `bikes.wheel_type`(이미 존재)를 대시보드 핀 DTO까지 전달하고 프론트 `bikeIconSvg(wheelType)`에서 분기. 마이그레이션 없음.
+
+**Tech Stack:** Spring Boot (Java 21), JDBC, Next.js, TypeScript, NCP Maps.
+
+**작업 경로:** 백엔드 `development/service-ops-api`, 프론트 `development/front-admin-web`. Bash 절대경로 cd (cwd 매 호출 리셋). 브랜치 `cc-wheeltype-marker` 체크아웃(이미 생성됨). 계약 테스트 Docker 필요 → 컴파일만 로컬 게이트. 프론트 `npm run typecheck && lint && build`.
+
+---
+
+### Task 1: 백엔드 — wheelType을 대시보드 핀까지 전달
+
+**Files:**
+- Modify: `.../dashboard/repository/DashboardMapQueryRepository.java`
+- Modify: `.../dashboard/dto/DashboardMapStateResponse.java`
+- Modify: `.../dashboard/service/DashboardMapStateService.java`
+- Test: 대시보드 계약 테스트
+
+- [ ] **Step 1: 쿼리 SELECT + 매핑 + BikePinRow**
+
+`DashboardMapQueryRepository.java`:
+- `findCurrentBikeStates` SQL의 `b.service_type,` 다음 줄에 `b.wheel_type,` 추가.
+- `mapBikePinRow`에서 `BikeServiceType.valueOf(rs.getString("service_type")),` 다음에 `BikeWheelType.valueOf(rs.getString("wheel_type")),` 추가.
+- `BikePinRow` record에서 `BikeServiceType serviceType,` 다음에 `BikeWheelType wheelType,` 추가.
+- import 추가: `import com.thundercrew.opsapi.bike.domain.BikeWheelType;`
+
+- [ ] **Step 2: BikePin DTO 필드**
+
+`DashboardMapStateResponse.java`의 `BikePin` record에서 `BikeServiceType serviceType,` 다음에 `BikeWheelType wheelType,` 추가. import `com.thundercrew.opsapi.bike.domain.BikeWheelType;` 추가(없으면).
+
+- [ ] **Step 3: toBikePin 전달**
+
+`DashboardMapStateService.java` `toBikePin`의 `new BikePin(...)` 에서 `row.serviceType(),` 다음에 `row.wheelType(),` 추가. (import `BikeWheelType` 불필요 — 값 패스스루. 컴파일 에러면 추가.)
+
+- [ ] **Step 4: 컴파일**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: 계약 테스트 단언**
+
+`grep -rln "DashboardMapApiContractTests\|map-state\|BikePin" src/test/java` 에서 대시보드 핀 테스트를 찾아, 시드 차량의 `wheel_type`(기본 'TWO_WHEEL'; 한 차량은 `'FOUR_WHEEL'`로 명시 시드)에 따라 핀 응답 `bikePins[n].wheelType` 가 `"TWO_WHEEL"`/`"FOUR_WHEEL"` 로 노출되는지 단언 추가. 기존 핀 필드 단언은 유지. 시드 insert에 `wheel_type` 컬럼이 빠져 있으면 NOT NULL DEFAULT 라 자동 'TWO_WHEEL' — 4륜 검증용으로 한 행만 명시 지정.
+
+- [ ] **Step 6: 컴파일(main+test) + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src/main/java/com/thundercrew/opsapi/dashboard development/service-ops-api/src/test/java && git commit -m "feat(map): expose bike wheelType on dashboard pin"
+```
+Co-Authored-By 라인 포함.
+
+---
+
+### Task 2: 프론트 — 핀 타입 + 아이콘 분기
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/service-ops-api.ts`
+- Modify: `development/front-admin-web/components/dashboard/MapShell.tsx`
+
+- [ ] **Step 1: 핀 타입에 wheelType**
+
+`service-ops-api.ts` `ServiceOpsDashboardBikePin` 의 `serviceType?: ServiceOpsBikeServiceType;` 다음에 `wheelType?: ServiceOpsBikeWheelType;` 추가. (`ServiceOpsBikeWheelType = "TWO_WHEEL" | "FOUR_WHEEL"` 이미 존재.) `FrontendDashboardBikePin`은 `Omit<ServiceOpsDashboardBikePin, ...>` 인데 wheelType이 Omit 목록에 없으므로 자동 포함 — grep으로 Omit 목록 확인하고 wheelType이 없으면 그대로 둠.
+
+- [ ] **Step 2: bikeIconSvg 분기**
+
+`MapShell.tsx` `bikeIconSvg()` 를 인자 받게 변경:
+```ts
+function bikeIconSvg(wheelType?: string): string {
+  if (wheelType === "FOUR_WHEEL") {
+    return `<svg ${ICON_SVG_PROPS}>
+    <path d="M2.5 16 V7.5 H13 V16"/>
+    <path d="M13 10.5 H16.5 L20.5 13.5 V16 H13"/>
+    <path d="M2.5 16 H4.3"/>
+    <path d="M8.2 16 H14.8"/>
+    <path d="M18.7 16 H20.5"/>
+    <path d="M16.5 10.7 V13.5 H20.2"/>
+    <circle cx="6.3" cy="17.6" r="1.9"/>
+    <circle cx="16.8" cy="17.6" r="1.9"/>
+  </svg>`;
+  }
+  return `<svg ${ICON_SVG_PROPS}>
+    <circle cx="6" cy="18" r="2"/>
+    <circle cx="18" cy="18" r="2"/>
+    <path d="M6 16 L7 10"/>
+    <path d="M7 10 L10 8"/>
+    <path d="M7 10 H13 L16 14"/>
+    <path d="M8 16 H16"/>
+    <rect x="13" y="4" width="7" height="6" rx="0.75"/>
+    <path d="M13 6.5 H20"/>
+  </svg>`;
+}
+```
+(기존 오토바이 path는 현재 `bikeIconSvg` 본문 그대로 — READ해서 정확히 옮길 것. `ICON_SVG_PROPS` 래퍼 동일 사용.)
+
+- [ ] **Step 3: bikeMarkerHtml에 wheelType 전달**
+
+`bikeMarkerHtml(...)` 시그니처에 `wheelType?: string` 인자 추가(끝쪽, `ignitionStatus` 뒤). 본문에서 `markerWrapper(bikeIconSvg(), ...)` → `markerWrapper(bikeIconSvg(wheelType), ...)`. 호출부(약 라인 468) `bikeMarkerHtml(..., pin.connectionStatus, pin.ignitionStatus)` 끝에 `, pin.wheelType` 추가.
+
+- [ ] **Step 4: typecheck + lint + build + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/components/dashboard/MapShell.tsx && git commit -m "feat(map): wheel-type marker icon (2륜 bike / 4륜 box truck)"
+```
+Co-Authored-By 라인 포함. Expected: 전부 통과.
+
+---
+
+### Task 3: 최종 검증 + PR
+
+- [ ] **Step 1: 풀 검증**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && (git diff dev --name-only | grep -i "db/migration" && echo "MIGRATION!" || echo "no migration (의도대로)")
+```
+Expected: 백엔드/프론트 성공, 마이그레이션 0.
+
+- [ ] **Step 2: PR (→ dev)**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git push -u origin cc-wheeltype-marker && gh pr create --base dev --title "휠타입별 지도 마커 아이콘 (2륜 오토바이 / 4륜 박스트럭)" --body "$(cat <<'EOF'
+## Summary
+- 대시보드 핀에 `wheelType` 노출(백엔드 쿼리→BikePinRow→BikePin DTO)
+- 프론트 `bikeIconSvg(wheelType)` 분기: FOUR_WHEEL → 박스트럭, 그 외 → 오토바이
+- 시뮬 차량은 spread로 wheelType 자동 상속
+
+## 배포 영향
+- **마이그레이션 없음** (wheel_type 컬럼 기존). 재기동만으로 적용.
+
+## Test Plan
+- [x] 백엔드 compileJava + compileTestJava
+- [x] 프론트 typecheck + lint + build, 마이그레이션 0
+- [ ] 계약 테스트(CI): 핀 wheelType 노출
+- [ ] 프로덕션 QA: 4륜(청소차) 마커 = 박스트럭, 2륜(배송) = 오토바이
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec 커버리지:** 백엔드 전달(쿼리/BikePinRow/BikePin/toBikePin) Task1, 계약테스트 Task1 Step5, 프론트 타입+아이콘 분기+배선 Task2, 검증·PR Task3. ✓ 마이그레이션 없음. ✓
+
+**2. 플레이스홀더 스캔:** 박스트럭 SVG·분기 함수·필드 추가 위치 전부 구체적. Task1 Step5(테스트)·Task2 Step1(Omit 확인)은 grep 후 대상 한정 — placeholder 아님.
+
+**3. 타입/이름 일관성:** `wheelType`을 각 record의 `serviceType` 바로 뒤에 일관 삽입(BikePinRow·BikePin DTO·mapBikePinRow·toBikePin 네 곳 모두 serviceType 다음). `BikeWheelType{TWO_WHEEL,FOUR_WHEEL}` ↔ 프론트 `ServiceOpsBikeWheelType="TWO_WHEEL"|"FOUR_WHEEL"` ↔ `bikeIconSvg`의 `=== "FOUR_WHEEL"` 일치. `bikeMarkerHtml(wheelType)` ↔ 호출부 `pin.wheelType` 일관.
+
+**구현자 주의:** 박스트럭/오토바이 SVG는 동일 `ICON_SVG_PROPS` 래퍼·viewBox(0 0 24)를 써야 크기·앵커가 맞음. 기존 오토바이 path는 현재 `bikeIconSvg`에서 그대로 옮길 것. 충전소/팁 아이콘은 건드리지 말 것.

--- a/docs/superpowers/specs/2026-06-12-wheeltype-marker-icon-design.md
+++ b/docs/superpowers/specs/2026-06-12-wheeltype-marker-icon-design.md
@@ -1,0 +1,56 @@
+# 휠타입별 지도 마커 아이콘 (2륜 오토바이 / 4륜 박스트럭) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 지도 차량 마커 아이콘을 차량의 `wheelType`에 따라 분기한다 — `TWO_WHEEL` → 기존 오토바이, `FOUR_WHEEL` → 박스트럭(물류차량) 아이콘.
+
+**Architecture:** `bikes.wheel_type`(이미 존재, `NOT NULL DEFAULT 'TWO_WHEEL'`)를 대시보드 핀까지 전달하고, 프론트 `bikeIconSvg(wheelType)`에서 아이콘을 분기한다. 마이그레이션 없음.
+
+**Tech Stack:** Spring Boot (Java 21), JPA/JDBC, Next.js, TypeScript, NCP Maps.
+
+**비범위:** 충전소/팁 마커 아이콘, 관리 테이블 행 아이콘, 휠타입 기반 필터, 새 컬럼/마이그레이션.
+
+---
+
+## 1. 백엔드 — wheelType을 대시보드 핀까지 전달
+
+`com.thundercrew.opsapi.dashboard`:
+
+- **`DashboardMapQueryRepository.findCurrentBikeStates`**: bike pin SELECT에 `b.wheel_type` 추가. `mapBikePinRow`에서 `BikeWheelType.valueOf(rs.getString("wheel_type"))` 매핑.
+- **`BikePinRow`** record: `BikeWheelType wheelType` 필드 추가.
+- **`DashboardMapStateService.toBikePin`**: `BikePin` 생성 시 `row.wheelType()` 전달.
+- **`DashboardMapStateResponse.BikePin`** record: `BikeWheelType wheelType` 필드 추가(JSON 직렬화 → `"TWO_WHEEL"`/`"FOUR_WHEEL"`).
+- 요약 카운트·다른 핀 로직 무변경. (`BikeWheelType` enum 이미 존재: `{TWO_WHEEL, FOUR_WHEEL}`.)
+
+## 2. 프론트 — 타입 + 아이콘 분기
+
+`development/front-admin-web`:
+
+- **`service-ops-api.ts`**: `ServiceOpsDashboardBikePin`에 `wheelType?: ServiceOpsBikeWheelType` 추가(이미 `ServiceOpsBikeWheelType = "TWO_WHEEL" | "FOUR_WHEEL"` 존재). `FrontendDashboardBikePin`은 Omit 대상이 아니므로 자동 포함 — 확인.
+- **`MapShell.tsx`**:
+  - `bikeIconSvg()` → `bikeIconSvg(wheelType?: string)`로 변경. `wheelType === "FOUR_WHEEL"` 이면 박스트럭 SVG, 그 외(undefined 포함) 기존 오토바이 SVG 반환.
+  - 박스트럭 SVG(viewBox 0 0 24 24, 기존 `ICON_SVG_PROPS` 스타일 재사용):
+    ```
+    <path d="M2.5 16 V7.5 H13 V16"/>
+    <path d="M13 10.5 H16.5 L20.5 13.5 V16 H13"/>
+    <path d="M2.5 16 H4.3"/>
+    <path d="M8.2 16 H14.8"/>
+    <path d="M18.7 16 H20.5"/>
+    <path d="M16.5 10.7 V13.5 H20.2"/>
+    <circle cx="6.3" cy="17.6" r="1.9"/>
+    <circle cx="16.8" cy="17.6" r="1.9"/>
+    ```
+  - `bikeMarkerHtml`에서 `markerWrapper(bikeIconSvg(...), ...)` 호출 시 `wheelType`을 받아 전달. `bikeMarkerHtml` 시그니처에 `wheelType?: string` 인자 추가 + 호출부(약 라인 468)에서 `pin.wheelType` 전달.
+
+## 3. 동작 / 엣지
+- `wheel_type` NOT NULL DEFAULT TWO_WHEEL → null 없음. 방어적으로 `FOUR_WHEEL`이 아니면 오토바이.
+- 시뮬 차량(`useSimulatedBikePins`): raw 핀을 `{ ...pin }` spread하므로 `wheelType` 자동 상속. 시뮬 코드 변경 불필요.
+- 선택 halo / 상태 칩 / 배송 배지 / 라벨 등 마커의 나머지 로직 무변경.
+
+## 4. 검증
+- 백엔드 `compileJava + compileTestJava`. 대시보드 계약 테스트에 wheelType 노출 단언 추가(2륜·4륜 시드 → 핀 응답 `wheelType` 확인).
+- 프론트 `typecheck + lint + build`.
+- 프로덕션 QA: 4륜 차량(청소차) 마커가 박스트럭 아이콘으로, 2륜(배송)은 오토바이로 표시.
+
+## 5. 비범위 재확인
+충전소/팁 아이콘, 관리 테이블 아이콘, 휠타입 필터, 마이그레이션은 포함하지 않는다.


### PR DESCRIPTION
## 릴리스 내용 (#392)
지도 차량 마커를 휠타입으로 분기 — 2륜=오토바이, 4륜=박스트럭. 대시보드 핀에 wheelType 노출 + 프론트 아이콘 분기.

## 배포 영향
- **마이그레이션 없음** (wheel_type 컬럼 기존). 재기동만으로 적용.

## 릴리스 후 QA
4륜(청소차) 마커 = 박스트럭, 2륜(배송) = 오토바이

🤖 Generated with [Claude Code](https://claude.com/claude-code)