### PR TITLE
fix: 합성 핀(미추적 차량)에 wheelType 반영 — 4륜 박스트럭 마커 수정

### DIFF
--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -122,6 +122,7 @@ export function generatePinsForUntrackedVehicles(
         batteryStatus: sim.batteryStatus === "HEALTHY" ? "NORMAL" : sim.batteryStatus,
         pinLabel: vehicle.plateNumber,
         serviceType: vehicle.serviceType ?? "SINGLE",
+        wheelType: vehicle.wheelType ?? undefined,
         nextCustomerLat: null,
         nextCustomerLng: null,
         currentDispatchCustomerName: null,


### PR DESCRIPTION
## 문제 (QA에서 발견)
4륜으로 등록한 차량(77나7777)도 지도 마커가 오토바이로 표시. DB·백엔드 핀 경로·프론트 아이콘 분기 모두 정상이었는데도 안 됐음.

## 근본 원인
prod엔 실제 GPS 디바이스가 없어 지도 핀이 전부 `generatePinsForUntrackedVehicles`(dashboard-dummy-bikes.ts)로 클라이언트 합성됨(`telemetrySource: "SIMULATED"`). 이 합성 함수가 `serviceType`은 복사하면서 **`wheelType`을 누락** → `pin.wheelType` 항상 undefined → `bikeIconSvg`의 FOUR_WHEEL 분기 미발동. (휠타입 기능 플랜이 이 합성 경로를 놓침.)

## 수정
합성 핀에 `wheelType: vehicle.wheelType ?? undefined` 추가. 프론트 전용, 마이그레이션 없음.

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 4륜 차량(77나7777) 마커 = 박스트럭

🤖 Generated with [Claude Code](https://claude.com/claude-code)