### PR TITLE
[릴리스] 합성 핀 wheelType 반영 (4륜 박스트럭 마커 수정)

### DIFF
--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -122,6 +122,7 @@ export function generatePinsForUntrackedVehicles(
         batteryStatus: sim.batteryStatus === "HEALTHY" ? "NORMAL" : sim.batteryStatus,
         pinLabel: vehicle.plateNumber,
         serviceType: vehicle.serviceType ?? "SINGLE",
+        wheelType: vehicle.wheelType ?? undefined,
         nextCustomerLat: null,
         nextCustomerLng: null,
         currentDispatchCustomerName: null,


### PR DESCRIPTION
## 릴리스 내용 (#394)
미추적 차량의 합성 지도 핀에 wheelType 누락을 수정. 4륜 차량 마커가 박스트럭으로 표시되도록. 프론트 전용, 마이그레이션 없음.

## 배포 영향
- 프론트 빌드만. 재기동만으로 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)