### PR TITLE
업무 관리 라벨 통일 (콜/순차/왕복 배차)

### DIFF
--- a/development/front-admin-web/app/management/operations/page.tsx
+++ b/development/front-admin-web/app/management/operations/page.tsx
@@ -8,9 +8,9 @@ import { listVehiclesAction } from "@/app/management/vehicles/actions";
 export const dynamic = "force-dynamic";
 
 const SECTIONS = [
-  { id: "mgmt-dispatch", label: "배차" },
-  { id: "mgmt-stroller", label: "유모차" },
-  { id: "mgmt-baemin", label: "배민 콜" }
+  { id: "mgmt-baemin", label: "콜 배차" },
+  { id: "mgmt-dispatch", label: "순차 배차" },
+  { id: "mgmt-stroller", label: "왕복 배차" }
 ];
 
 export default async function ManagementOperationsPage() {
@@ -28,14 +28,14 @@ export default async function ManagementOperationsPage() {
   return (
     <div className="management-page">
       <ManagementSectionNav sections={SECTIONS} />
+      <section id="mgmt-baemin" className="management-anchor">
+        <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
+      </section>
       <section id="mgmt-dispatch" className="management-anchor">
         <DispatchPanel exportUrl="/api/management/dispatch/export" />
       </section>
       <section id="mgmt-stroller" className="management-anchor">
         <StrollerRoundPanel initialRound={activeRound} />
-      </section>
-      <section id="mgmt-baemin" className="management-anchor">
-        <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
       </section>
     </div>
   );

--- a/development/front-admin-web/components/management/BaeminCallPanel.tsx
+++ b/development/front-admin-web/components/management/BaeminCallPanel.tsx
@@ -93,7 +93,7 @@ export function BaeminCallPanel({
       {/* ── header ─────────────────────────────────────────────────────── */}
       <div className="mgmt-panel-header">
         <div className="mgmt-panel-header-left">
-          <span className="mgmt-panel-title">배민 콜</span>
+          <span className="mgmt-panel-title">콜 배차</span>
           {offered.length > 0 && (
             <span className="mgmt-panel-count">{offered.length}</span>
           )}

--- a/development/front-admin-web/components/management/DispatchPanel.tsx
+++ b/development/front-admin-web/components/management/DispatchPanel.tsx
@@ -106,7 +106,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
     <div className="management-panel">
       <div className="mgmt-panel-header">
         <div className="mgmt-panel-header-left">
-          <span className="mgmt-panel-title">배차</span>
+          <span className="mgmt-panel-title">순차 배차</span>
         </div>
         <div className="mgmt-panel-header-actions">
           <a href={exportUrl} target="_blank" rel="noreferrer">
@@ -165,7 +165,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
       {preview ? (
         <div className="bulk-preview-overlay">
           <div className="bulk-preview-modal">
-            <h2 className="bulk-preview-title">배차 업로드 미리보기</h2>
+            <h2 className="bulk-preview-title">순차 배차 업로드 미리보기</h2>
 
             <div className="bulk-preview-summary">
               <span className="bulk-preview-summary-new">신규 {preview.summary.new}</span>

--- a/development/front-admin-web/components/management/StrollerRoundPanel.tsx
+++ b/development/front-admin-web/components/management/StrollerRoundPanel.tsx
@@ -17,7 +17,7 @@ import type {
 import "./BulkPreviewModal.css";
 
 /**
- * /management 유모차 라운드 섹션.
+ * /management 왕복 배차(라운드) 섹션.
  *
  * 업로드 플로우는 DispatchPanel 과 동일하게 HYBRID 다:
  *   파일 선택 → `previewDispatchAction`(서버에서 파싱 + 지오코딩) → 미리보기
@@ -117,7 +117,7 @@ export function StrollerRoundPanel({
       const result = await createRoundAction(applyRows);
       if (result.ok) {
         setPreview(null);
-        setNotice("유모차 라운드가 생성되었습니다.");
+        setNotice("왕복 배차 라운드가 생성되었습니다.");
         await reloadRound();
       } else {
         setError(result.error);
@@ -170,7 +170,7 @@ export function StrollerRoundPanel({
     <div className="management-panel">
       <div className="mgmt-panel-header">
         <div className="mgmt-panel-header-left">
-          <span className="mgmt-panel-title">유모차 라운드</span>
+          <span className="mgmt-panel-title">왕복 배차</span>
           <span className={`stroller-round-status-badge stroller-round-status-badge--${statusVariant}`}>
             {statusLabel}
           </span>
@@ -230,7 +230,7 @@ export function StrollerRoundPanel({
       {preview ? (
         <div className="bulk-preview-overlay">
           <div className="bulk-preview-modal">
-            <h2 className="bulk-preview-title">유모차 라운드 업로드 미리보기</h2>
+            <h2 className="bulk-preview-title">왕복 배차 업로드 미리보기</h2>
 
             <div className="bulk-preview-summary">
               <span className="bulk-preview-summary-new">신규 {preview.summary.new}</span>

--- a/docs/superpowers/plans/2026-06-12-operations-naming-consistency.md
+++ b/docs/superpowers/plans/2026-06-12-operations-naming-consistency.md
@@ -1,0 +1,120 @@
+# 업무 관리 섹션 네이밍 통일 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 업무 관리 라벨을 콜 배차 / 순차 배차 / 왕복 배차로 통일·정렬. 프론트 문구만, 마이그레이션 없음.
+
+**Tech Stack:** Next.js, TypeScript. 브랜치 `cc-operations-naming` (이미 생성됨). 경로 `development/front-admin-web`. Bash 절대경로 cd.
+
+**매핑:** BaeminCallPanel=콜 배차, DispatchPanel=순차 배차, StrollerRoundPanel=왕복 배차. 앵커 id·동작 어휘(라운드/콜/수거·배송/순번) 유지.
+
+---
+
+### Task 1: 라벨·순서·제목 문구 변경
+
+**Files:**
+- Modify: `app/management/operations/page.tsx`
+- Modify: `components/management/BaeminCallPanel.tsx`
+- Modify: `components/management/DispatchPanel.tsx`
+- Modify: `components/management/StrollerRoundPanel.tsx`
+
+- [ ] **Step 1: operations 페이지 SECTIONS + 렌더 순서**
+
+`app/management/operations/page.tsx`의 `SECTIONS` 배열을 콜→순차→왕복 순으로 교체:
+```tsx
+const SECTIONS = [
+  { id: "mgmt-baemin", label: "콜 배차" },
+  { id: "mgmt-dispatch", label: "순차 배차" },
+  { id: "mgmt-stroller", label: "왕복 배차" }
+];
+```
+그리고 `<section>` 렌더 순서도 동일하게 재정렬(콜→순차→왕복):
+```tsx
+      <section id="mgmt-baemin" className="management-anchor">
+        <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
+      </section>
+      <section id="mgmt-dispatch" className="management-anchor">
+        <DispatchPanel exportUrl="/api/management/dispatch/export" />
+      </section>
+      <section id="mgmt-stroller" className="management-anchor">
+        <StrollerRoundPanel initialRound={activeRound} />
+      </section>
+```
+(import·데이터 로딩·props 그대로. 앵커 id 유지.)
+
+- [ ] **Step 2: BaeminCallPanel 제목**
+
+`components/management/BaeminCallPanel.tsx`: `<span className="mgmt-panel-title">배민 콜</span>` → `<span className="mgmt-panel-title">콜 배차</span>`. (다른 "콜" 문구 — "콜 등록"/"콜이 등록되었습니다"/"수락 대기 중인 콜"/"배차 방식" — 유지.)
+
+- [ ] **Step 3: DispatchPanel 제목 + 미리보기**
+
+`components/management/DispatchPanel.tsx`:
+- `<span className="mgmt-panel-title">배차</span>` → `<span className="mgmt-panel-title">순차 배차</span>`
+- `<h2 className="bulk-preview-title">배차 업로드 미리보기</h2>` → `<h2 className="bulk-preview-title">순차 배차 업로드 미리보기</h2>`
+- notice `배차 ${result.applied}건 적용 완료`는 유지(일반 동작 문구).
+
+- [ ] **Step 4: StrollerRoundPanel 제목 + 미리보기 + 알림**
+
+`components/management/StrollerRoundPanel.tsx`:
+- `<span className="mgmt-panel-title">유모차 라운드</span>` → `<span className="mgmt-panel-title">왕복 배차</span>`
+- `<h2 className="bulk-preview-title">유모차 라운드 업로드 미리보기</h2>` → `<h2 className="bulk-preview-title">왕복 배차 업로드 미리보기</h2>`
+- `setNotice("유모차 라운드가 생성되었습니다.")` → `setNotice("왕복 배차 라운드가 생성되었습니다.")`
+- 파일 상단 주석 "유모차 라운드 섹션" → "왕복 배차(라운드) 섹션"(선택).
+- "진행 라운드 없음"/"라운드 생성"/stage 등 라운드 메커니즘 문구는 유지.
+
+- [ ] **Step 5: typecheck + lint + build**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+```
+Expected: 전부 통과.
+
+- [ ] **Step 6: 잔존 확인 + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && grep -rn "배민\|유모차" development/front-admin-web/components/management/BaeminCallPanel.tsx development/front-admin-web/components/management/StrollerRoundPanel.tsx development/front-admin-web/components/management/DispatchPanel.tsx development/front-admin-web/app/management/operations/page.tsx || echo "no brand/domain labels left"
+git add development/front-admin-web/app/management/operations/page.tsx development/front-admin-web/components/management/BaeminCallPanel.tsx development/front-admin-web/components/management/DispatchPanel.tsx development/front-admin-web/components/management/StrollerRoundPanel.tsx && git commit -m "feat(mgmt): unify operations labels (콜/순차/왕복 배차) + reorder"
+```
+(주석 외 사용자 표시 '배민/유모차' 잔존 0 기대. Co-Authored-By 라인 포함.)
+
+---
+
+### Task 2: 최종 검증 + PR
+
+- [ ] **Step 1: 검증**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && (git diff dev --name-only | grep -i "db/migration" && echo MIGRATION || echo "no migration")
+```
+Expected: 통과, 마이그레이션 0.
+
+- [ ] **Step 2: PR (→ dev)**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git push -u origin cc-operations-naming && gh pr create --base dev --title "업무 관리 라벨 통일 (콜/순차/왕복 배차)" --body "$(cat <<'EOF'
+## Summary
+- 업무 관리 섹션을 콜 배차 / 순차 배차 / 왕복 배차로 통일·재정렬 (기존 배차/유모차/배민 콜 — 기능·도메인·브랜드 혼재 해소)
+- 매핑: 배민 콜→콜 배차, 배차→순차 배차, 유모차 라운드→왕복 배차
+- 점프 내비 라벨·순서 + 패널 제목 + 업로드 미리보기 제목 + 라운드 생성 알림 정리
+- 앵커 id·serviceType·서버액션·동작 어휘(라운드/콜/수거·배송) 유지
+
+## 배포 영향
+- 프론트 문구만, **마이그레이션 없음**.
+
+## Test Plan
+- [x] typecheck + lint + build, 마이그레이션 0
+- [ ] 프로덕션 QA: 업무 관리 내비/제목 = 콜·순차·왕복 배차 순서·라벨, 기능 정상
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec 커버리지:** SECTIONS 라벨+순서(Step1), 3 패널 제목/미리보기/알림(Step2-4), 검증·PR(Task2). ✓ 앵커 id·동작 어휘 유지. ✓ 마이그레이션 없음.
+
+**2. 플레이스홀더 스캔:** 모든 문구 변경이 before→after 구체 명시. 잔존 grep 검증 포함.
+
+**3. 타입/이름 일관성:** 매핑 일관(콜=배민, 순차=배차, 왕복=유모차). 앵커 id 변경 없음(mgmt-baemin/dispatch/stroller 유지) → 섹션 내비 href·section id 일치. 패널 props 무변경.

--- a/docs/superpowers/specs/2026-06-12-operations-naming-consistency-design.md
+++ b/docs/superpowers/specs/2026-06-12-operations-naming-consistency-design.md
@@ -1,0 +1,48 @@
+# 업무 관리 섹션 네이밍 통일 (콜/순차/왕복 배차) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 업무 관리 3개 섹션의 라벨을 기능·도메인·브랜드 혼재(배차/유모차/배민 콜)에서 **운영 방식 축(콜 배차 / 순차 배차 / 왕복 배차)**으로 통일하고 그 순서로 정렬한다.
+
+**Architecture:** 프론트 표시 문구만 변경 — 섹션 점프 내비 라벨, 패널 제목, 업로드 미리보기 제목, 패널 내 브랜드/도메인 문구. 앵커 id·serviceType enum·서버액션·라우트 무변경. 마이그레이션 없음.
+
+**Tech Stack:** Next.js, TypeScript.
+
+**매핑:** BaeminCallPanel→**콜 배차**(CALL), DispatchPanel→**순차 배차**(SINGLE+SEQUENTIAL, 순번 0=단일 포괄), StrollerRoundPanel→**왕복 배차**(ROUND).
+
+**비범위:** 백엔드/enum/라우트/기능, 지도 필터 칩(이미 정렬됨), 메커니즘 어휘(라운드/콜/수거·배송/순번).
+
+---
+
+## 1. operations 페이지 (`app/management/operations/page.tsx`)
+- `SECTIONS` 라벨 + `<section>` 렌더 순서를 **콜 배차 → 순차 배차 → 왕복 배차**로:
+  - `{ id: "mgmt-baemin", label: "콜 배차" }` → BaeminCallPanel
+  - `{ id: "mgmt-dispatch", label: "순차 배차" }` → DispatchPanel
+  - `{ id: "mgmt-stroller", label: "왕복 배차" }` → StrollerRoundPanel
+- 앵커 id(`mgmt-baemin`/`mgmt-dispatch`/`mgmt-stroller`)는 **유지**(내부 식별자). 라벨·순서만 변경. 데이터 로딩·패널 props 그대로.
+
+## 2. BaeminCallPanel
+- `mgmt-panel-title` "배민 콜" → **"콜 배차"**.
+- 본문 "콜 등록"/"콜이 등록되었습니다"/"수락 대기 중인 콜"/"배차 방식" 등 **콜·배차 동작 어휘는 유지**(브랜드 단어 "배민"만 제거 — 현재 배민은 제목에만 존재).
+
+## 3. DispatchPanel
+- `mgmt-panel-title` "배차" → **"순차 배차"**.
+- 업로드 미리보기 `bulk-preview-title` "배차 업로드 미리보기" → **"순차 배차 업로드 미리보기"**.
+- notice "배차 N건 적용 완료"는 일반 동작 문구라 유지.
+
+## 4. StrollerRoundPanel
+- `mgmt-panel-title` "유모차 라운드" → **"왕복 배차"**.
+- 업로드 미리보기 "유모차 라운드 업로드 미리보기" → **"왕복 배차 업로드 미리보기"**.
+- notice "유모차 라운드가 생성되었습니다." → **"왕복 배차 라운드가 생성되었습니다."** (브랜드/도메인 '유모차' 제거, 메커니즘 '라운드' 유지).
+- 파일 상단 주석의 "유모차 라운드 섹션"은 "왕복 배차(라운드) 섹션"으로 정리(선택, 혼선 방지).
+
+## 5. 데이터 흐름 / 영향
+- 순수 표시 문구. API·serviceType·앵커 id·동작 무변경.
+- 영향: `operations/page.tsx`, `BaeminCallPanel.tsx`, `DispatchPanel.tsx`, `StrollerRoundPanel.tsx`.
+
+## 6. 검증
+- 프론트 `typecheck + lint + build`.
+- 프로덕션 QA: 업무 관리 점프 내비 = 콜 배차/순차 배차/왕복 배차 순서·라벨, 각 패널 제목·미리보기 제목 일치, 라운드 생성 알림 문구 정리. 기능(업로드/콜 등록/라운드)은 그대로.
+
+## 7. 비범위 재확인
+백엔드/enum/라우트/기능, 지도 필터, 동작 어휘(라운드/콜/수거·배송)는 변경하지 않는다.


### PR DESCRIPTION
## Summary
업무 관리 섹션을 콜 배차 / 순차 배차 / 왕복 배차로 통일·재정렬 (기존 배차/유모차/배민 콜의 기능·도메인·브랜드 혼재 해소).
- 배민 콜→콜 배차, 배차→순차 배차, 유모차 라운드→왕복 배차
- 점프 내비 라벨·순서 + 패널 제목 + 업로드 미리보기 제목 + 라운드 생성 알림
- 앵커 id·serviceType·서버액션·동작 어휘(라운드/콜/수거·배송) 유지

## 배포 영향
- 프론트 문구만, 마이그레이션 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)