### PR TITLE
단일/순차 배차 분리 (순번 컬럼)

### DIFF
--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -38,6 +38,7 @@ function extractError(err: unknown): string {
 export type DispatchPreviewRow = DispatchBulkPreviewRow & {
   latitude?: number;
   longitude?: number;
+  sequence?: number | null;
 };
 
 export type DispatchPreviewResult =
@@ -91,6 +92,60 @@ export async function applyDispatchAction(
   try {
     const result = await client.applyDispatchOrders(rows);
     revalidatePath("/management");
+    revalidatePath("/");
+    return { ok: true, applied: result.applied };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function previewSequentialDispatchAction(formData: FormData): Promise<DispatchPreviewResult> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) return { ok: false, error: "업로드할 파일이 없습니다." };
+
+  try {
+    const preview = await client.previewSequentialDispatchOrders(file);
+
+    // NEW 행만 지오코딩. 변환 실패 시 해당 행을 ERROR 로 강등하고 사유를 남긴다 —
+    // 좌표 없이 apply 로 넘기면 backend 가 거부하므로 미리보기에서 걸러준다.
+    const rows: DispatchPreviewRow[] = await Promise.all(
+      preview.rows.map(async (row): Promise<DispatchPreviewRow> => {
+        if (row.status !== "NEW") return row;
+        const coords = await geocodeAddress(row.address);
+        if (!coords) {
+          return { ...row, status: "ERROR", message: "주소 변환 실패" };
+        }
+        return { ...row, latitude: coords.latitude, longitude: coords.longitude };
+      })
+    );
+
+    // 지오코딩 강등으로 NEW/ERROR 집계가 바뀌므로 summary 를 다시 센다.
+    const newCount = rows.filter((r) => r.status === "NEW").length;
+    const errorCount = rows.filter((r) => r.status === "ERROR").length;
+    const summary: DispatchBulkSummary = {
+      total: rows.length,
+      new: newCount,
+      error: errorCount
+    };
+
+    return { ok: true, rows, summary };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function applySequentialDispatchAction(
+  rows: DispatchBulkApplyRow[]
+): Promise<{ ok: true; applied: number } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+
+  try {
+    const result = await client.applySequentialDispatchOrders(rows);
+    revalidatePath("/management/operations");
     revalidatePath("/");
     return { ok: true, applied: result.applied };
   } catch (err) {

--- a/development/front-admin-web/app/management/operations/page.tsx
+++ b/development/front-admin-web/app/management/operations/page.tsx
@@ -1,4 +1,5 @@
 import { DispatchPanel } from "@/components/management/DispatchPanel";
+import { SequentialDispatchPanel } from "@/components/management/SequentialDispatchPanel";
 import { StrollerRoundPanel } from "@/components/management/StrollerRoundPanel";
 import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
 import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
@@ -9,7 +10,8 @@ export const dynamic = "force-dynamic";
 
 const SECTIONS = [
   { id: "mgmt-baemin", label: "콜 배차" },
-  { id: "mgmt-dispatch", label: "순차 배차" },
+  { id: "mgmt-dispatch", label: "단일 배차" },
+  { id: "mgmt-sequential", label: "순차 배차" },
   { id: "mgmt-stroller", label: "왕복 배차" }
 ];
 
@@ -33,6 +35,9 @@ export default async function ManagementOperationsPage() {
       </section>
       <section id="mgmt-dispatch" className="management-anchor">
         <DispatchPanel exportUrl="/api/management/dispatch/export" />
+      </section>
+      <section id="mgmt-sequential" className="management-anchor">
+        <SequentialDispatchPanel exportUrl="/api/management/dispatch/export" />
       </section>
       <section id="mgmt-stroller" className="management-anchor">
         <StrollerRoundPanel initialRound={activeRound} />

--- a/development/front-admin-web/components/management/SequentialDispatchPanel.tsx
+++ b/development/front-admin-web/components/management/SequentialDispatchPanel.tsx
@@ -4,24 +4,24 @@ import React, { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import {
-  previewDispatchAction,
-  applyDispatchAction,
+  previewSequentialDispatchAction,
+  applySequentialDispatchAction,
   type DispatchPreviewRow
 } from "@/app/dispatch/actions";
 import type { DispatchBulkApplyRow, DispatchBulkSummary } from "@/lib/services/service-ops-api";
 import "./BulkPreviewModal.css";
 
 /**
- * /management 배차 섹션. 업로드 플로우는 HYBRID 다:
- *   파일 선택 → `previewDispatchAction`(서버에서 파싱 + 지오코딩) → 미리보기
- *   모달 → 확인 시 NEW 행만 `applyDispatchAction(rows)`(JSON).
+ * /management 순차 배차 섹션. 업로드 플로우는 HYBRID 다:
+ *   파일 선택 → `previewSequentialDispatchAction`(서버에서 파싱 + 지오코딩) → 미리보기
+ *   모달 → 확인 시 NEW 행만 `applySequentialDispatchAction(rows)`(JSON).
+ *
+ * 단일 배차(DispatchPanel)와 동일한 플로우지만 엑셀에 순번(sequence) 컬럼이
+ * 포함되어 있으며, apply 시 sequence 를 함께 전달한다.
  *
  * 지오코딩이 server action 안에서 끝나므로 이 client component 는 좌표를 만지지
  * 않고 받은 행을 그대로 표시/전달만 한다. apply 는 excel 재업로드가 아니라 좌표
  * 포함 JSON 이라 공용 `ExcelImportButton`/`BulkPreviewModal` 대신 전용 모달을 쓴다.
- *
- * 현재 ASSIGNED 배차 목록 list-all 엔드포인트가 없어(클라이언트는 bikeId 별
- * 조회만 제공) 테이블은 비워두고 업로드/내려받기에 집중한다.
  */
 
 interface DispatchPreviewState {
@@ -29,7 +29,7 @@ interface DispatchPreviewState {
   summary: DispatchBulkSummary;
 }
 
-export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
+export function SequentialDispatchPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<DispatchPreviewState | null>(null);
@@ -46,7 +46,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
     try {
       const fd = new FormData();
       fd.append("file", file);
-      const result = await previewDispatchAction(fd);
+      const result = await previewSequentialDispatchAction(fd);
       if (result.ok) {
         setPreview({ rows: result.rows, summary: result.summary });
       } else {
@@ -75,12 +75,13 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
         customerPhone: r.customerPhone,
         address: r.address,
         latitude: r.latitude,
-        longitude: r.longitude
+        longitude: r.longitude,
+        sequence: r.sequence ?? undefined
       }));
 
     setLoading(true);
     try {
-      const result = await applyDispatchAction(applyRows);
+      const result = await applySequentialDispatchAction(applyRows);
       if (result.ok) {
         setPreview(null);
         setNotice(`배차 ${result.applied}건 적용 완료`);
@@ -106,7 +107,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
     <div className="management-panel">
       <div className="mgmt-panel-header">
         <div className="mgmt-panel-header-left">
-          <span className="mgmt-panel-title">단일 배차</span>
+          <span className="mgmt-panel-title">순차 배차</span>
         </div>
         <div className="mgmt-panel-header-actions">
           <a href={exportUrl} target="_blank" rel="noreferrer">
@@ -155,7 +156,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
           <tbody>
             <tr>
               <td colSpan={5} className="table-empty-cell">
-                업로드한 배차는 라이더 앱 / 대시보드에서 확인하세요.
+                업로드한 배차는 라이더 앱 / 대시보드에서 확인하세요. (엑셀에 순번 컬럼 포함 — 차량별 방문 순서)
               </td>
             </tr>
           </tbody>
@@ -165,7 +166,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
       {preview ? (
         <div className="bulk-preview-overlay">
           <div className="bulk-preview-modal">
-            <h2 className="bulk-preview-title">단일 배차 업로드 미리보기</h2>
+            <h2 className="bulk-preview-title">순차 배차 업로드 미리보기</h2>
 
             <div className="bulk-preview-summary">
               <span className="bulk-preview-summary-new">신규 {preview.summary.new}</span>
@@ -183,6 +184,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
                     <th>고객명</th>
                     <th>연락처</th>
                     <th>배송지주소</th>
+                    <th>순번</th>
                     <th>좌표</th>
                     <th>비고</th>
                   </tr>
@@ -196,6 +198,7 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
                       <td>{row.customerName}</td>
                       <td>{row.customerPhone}</td>
                       <td>{row.address}</td>
+                      <td>{row.sequence ?? "—"}</td>
                       <td>
                         {row.latitude != null && row.longitude != null
                           ? `${row.latitude.toFixed(5)}, ${row.longitude.toFixed(5)}`

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1099,6 +1099,7 @@ export type DispatchBulkPreviewRow = {
   address: string;
   status: DispatchBulkPreviewRowStatus;
   message: string | null;
+  sequence?: number | null;
 };
 
 export type DispatchBulkSummary = {
@@ -1121,6 +1122,7 @@ export type DispatchBulkApplyRow = {
   address: string;
   latitude: number;
   longitude: number;
+  sequence?: number;
 };
 
 /** bulk-apply 요청 body — backend 가 `{ rows: [...] }` 로 받음. */
@@ -1271,6 +1273,8 @@ export type ServiceOpsApiClient = {
   cancelDispatchOrder: (id: string) => Promise<void>;
   previewDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
   applyDispatchOrders: (rows: DispatchBulkApplyRow[]) => Promise<BulkApplyResponse>;
+  previewSequentialDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
+  applySequentialDispatchOrders: (rows: DispatchBulkApplyRow[]) => Promise<BulkApplyResponse>;
   getDispatchOrdersExportUrl: () => string;
 
   // ── Dispatch round (라운드) ──
@@ -1893,6 +1897,18 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     },
     applyDispatchOrders: (rows) =>
       request<BulkApplyResponse>("/dispatch-orders/bulk-apply", {
+        body: JSON.stringify({ rows } satisfies DispatchBulkApplyRequest),
+        method: "POST"
+      }),
+    previewSequentialDispatchOrders: (file) => {
+      const form = file instanceof FormData ? file : new FormData();
+      if (!(file instanceof FormData)) {
+        form.append("file", file);
+      }
+      return request<DispatchBulkPreviewResponse>("/dispatch-orders/bulk-preview-sequential", { method: "POST", body: form });
+    },
+    applySequentialDispatchOrders: (rows) =>
+      request<BulkApplyResponse>("/dispatch-orders/bulk-apply-sequential", {
         body: JSON.stringify({ rows } satisfies DispatchBulkApplyRequest),
         method: "POST"
       }),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
@@ -73,6 +73,16 @@ public class DispatchOrderCommandController {
         return dispatchOrderBulkService.apply(request);
     }
 
+    @PostMapping("/bulk-preview-sequential")
+    DispatchBulkPreviewResponse bulkPreviewSequential(@RequestPart("file") MultipartFile file) throws IOException {
+        return dispatchOrderBulkService.previewSequential(file.getInputStream());
+    }
+
+    @PostMapping("/bulk-apply-sequential")
+    BulkApplyResponse bulkApplySequential(@Valid @RequestBody DispatchBulkApplyRequest request) {
+        return dispatchOrderBulkService.applySequential(request);
+    }
+
     @PostMapping("/calls/system")
     DispatchOrderReadResponse systemCall(@Valid @RequestBody DeliveryCallCreateRequest request) {
         return deliveryCallService.systemDispatch(request.customerName(), request.customerPhone(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchBulkApplyRow.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchBulkApplyRow.java
@@ -22,5 +22,6 @@ public record DispatchBulkApplyRow(
         @NotBlank @Size(max = 255) String customerPhone,
         @NotBlank @Size(max = 2000) String address,
         @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
-        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude
+        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude,
+        Long sequence
 ) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchBulkPreviewRow.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchBulkPreviewRow.java
@@ -17,6 +17,7 @@ import java.util.UUID;
  * @param customerName  고객명
  * @param customerPhone 연락처
  * @param address       배송지주소 (frontend geocodes this before apply)
+ * @param sequence      순번 (sequential variant only); null for single-dispatch rows
  * @param status        NEW for valid rows, ERROR for invalid ones (never UPDATE/UNCHANGED)
  * @param message       human-readable reason for ERROR rows; null otherwise
  */
@@ -27,19 +28,34 @@ public record DispatchBulkPreviewRow(
         String customerName,
         String customerPhone,
         String address,
+        Integer sequence,
         BulkRowStatus status,
         String message
 ) {
     public static DispatchBulkPreviewRow newRow(int rowNumber, String plateNumber, UUID bikeId,
                                                 String customerName, String customerPhone, String address) {
         return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
-                customerName, customerPhone, address, BulkRowStatus.NEW, null);
+                customerName, customerPhone, address, null, BulkRowStatus.NEW, null);
     }
 
     public static DispatchBulkPreviewRow error(int rowNumber, String plateNumber, UUID bikeId,
                                                String customerName, String customerPhone, String address,
                                                String message) {
         return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
-                customerName, customerPhone, address, BulkRowStatus.ERROR, message);
+                customerName, customerPhone, address, null, BulkRowStatus.ERROR, message);
+    }
+
+    public static DispatchBulkPreviewRow newRowSeq(int rowNumber, String plateNumber, UUID bikeId,
+                                                   String customerName, String customerPhone, String address,
+                                                   Integer sequence) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, sequence, BulkRowStatus.NEW, null);
+    }
+
+    public static DispatchBulkPreviewRow errorSeq(int rowNumber, String plateNumber, UUID bikeId,
+                                                  String customerName, String customerPhone, String address,
+                                                  Integer sequence, String message) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, sequence, BulkRowStatus.ERROR, message);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderBulkService.java
@@ -15,6 +15,7 @@ import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,6 +98,68 @@ public class DispatchOrderBulkService {
                 .toList();
         return ExcelExporter.export(DispatchOrderBulkService.class, "dispatch-template.xlsx",
                 DATA_START_ROW, rows);
+    }
+
+    /** 순차 배차 미리보기. 컬럼: [0]차량번호 [1]고객명 [2]연락처 [3]배송지주소 [4]순번. */
+    public DispatchBulkPreviewResponse previewSequential(InputStream excelStream) throws IOException {
+        List<List<String>> rows = ExcelParser.parseRows(excelStream, DATA_START_ROW);
+        List<DispatchBulkPreviewRow> results = new ArrayList<>();
+        int rowNum = DATA_START_ROW + 1;
+        for (List<String> cols : rows) {
+            results.add(evaluateSequentialRow(cols, rowNum++));
+        }
+        return DispatchBulkPreviewResponse.of(results);
+    }
+
+    /** 차량별 순번 오름차순 정렬 후 큐에 append (순번=정렬 키, 저장 sequence 는 append 연속값). */
+    @Transactional
+    public BulkApplyResponse applySequential(DispatchBulkApplyRequest request) {
+        long applied = 0;
+        List<DispatchBulkApplyRow> ordered = request.rows().stream()
+                .sorted(Comparator
+                        .comparing(DispatchBulkApplyRow::bikeId)
+                        .thenComparing(r -> r.sequence() == null ? Long.MAX_VALUE : r.sequence()))
+                .toList();
+        for (DispatchBulkApplyRow row : ordered) {
+            commandService.appendForBike(row.bikeId(), row.customerName(), row.customerPhone(),
+                    row.address(), row.latitude(), row.longitude());
+            applied++;
+        }
+        return new BulkApplyResponse(applied, 0);
+    }
+
+    private DispatchBulkPreviewRow evaluateSequentialRow(List<String> cols, int rowNum) {
+        String plate = cell(cols, 0);
+        String customerName = cell(cols, 1);
+        String customerPhone = cell(cols, 2);
+        String address = cell(cols, 3);
+        String seqRaw = cell(cols, 4);
+
+        if (plate.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, null, customerName, customerPhone, address, null, "차량번호 없음");
+        }
+        Optional<Bike> bike = bikeRepository.findByPlateNumberAndDeletedAtIsNull(plate);
+        if (bike.isEmpty()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, null, customerName, customerPhone, address, null, "차량 없음: " + plate);
+        }
+        UUID bikeId = bike.get().getId();
+        if (customerName.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "고객명 없음");
+        }
+        if (customerPhone.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "연락처 없음");
+        }
+        if (address.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "배송지주소 없음");
+        }
+        Integer sequence;
+        try {
+            sequence = Integer.parseInt(seqRaw.trim());
+        } catch (NumberFormatException ex) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null,
+                    seqRaw.isBlank() ? "순번 없음" : "순번 형식 오류: " + seqRaw);
+        }
+        return DispatchBulkPreviewRow.newRowSeq(rowNum, plate, bikeId, customerName, customerPhone, address, sequence);
     }
 
     private DispatchBulkPreviewRow evaluateRow(List<String> cols, int rowNum) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
@@ -229,6 +229,78 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$.summary.total").value(2));
     }
 
+    // ⑦ bulk-preview-sequential: 순번 컬럼 있는 엑셀 → NEW rows에 sequence 포함, 잘못된 순번 행 → ERROR
+    @Test
+    void bulkPreviewSequentialReturnsSequenceOnNewRowsAndErrorOnInvalidSequence() throws Exception {
+        byte[] xlsx = buildSequentialWorkbook(
+                new String[]{BIKE_PLATE, "순차고객A", "010-1111-2222", "순차 주소 A", "2"},
+                new String[]{BIKE_PLATE, "순차고객B", "010-3333-4444", "순차 주소 B", "1"},
+                new String[]{BIKE_PLATE, "순번없음", "010-5555-6666", "주소 C", ""},
+                new String[]{BIKE_PLATE, "순번오류", "010-7777-8888", "주소 D", "abc"});
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "upload-seq.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", xlsx);
+
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/bulk-preview-sequential")
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows.length()").value(4))
+                .andExpect(jsonPath("$.rows[0].status").value("NEW"))
+                .andExpect(jsonPath("$.rows[0].sequence").value(2))
+                .andExpect(jsonPath("$.rows[0].customerName").value("순차고객A"))
+                .andExpect(jsonPath("$.rows[1].status").value("NEW"))
+                .andExpect(jsonPath("$.rows[1].sequence").value(1))
+                .andExpect(jsonPath("$.rows[1].customerName").value("순차고객B"))
+                .andExpect(jsonPath("$.rows[2].status").value("ERROR"))
+                .andExpect(jsonPath("$.rows[2].message").value("순번 없음"))
+                .andExpect(jsonPath("$.rows[3].status").value("ERROR"))
+                .andExpect(jsonPath("$.rows[3].message").value("순번 형식 오류: abc"))
+                .andExpect(jsonPath("$.summary.new").value(2))
+                .andExpect(jsonPath("$.summary.error").value(2))
+                .andExpect(jsonPath("$.summary.total").value(4));
+    }
+
+    // ⑧ bulk-apply-sequential: 순번 역순으로 전송 → 차량 큐에 순번 오름차순으로 append
+    @Test
+    void bulkApplySequentialAppendsBikeQueueInSequenceOrder() throws Exception {
+        // 순번을 역순(3,1,2)으로 전송 → 실제 저장 sequence 는 1,2,3 (순번 오름차순 append 결과)
+        String body = """
+                {
+                  "rows": [
+                    {"bikeId":"%1$s","customerName":"순차C","customerPhone":"010-3333-3333",
+                     "address":"주소 C","latitude":37.50,"longitude":127.00,"sequence":3},
+                    {"bikeId":"%1$s","customerName":"순차A","customerPhone":"010-1111-1111",
+                     "address":"주소 A","latitude":37.50,"longitude":127.00,"sequence":1},
+                    {"bikeId":"%1$s","customerName":"순차B","customerPhone":"010-2222-2222",
+                     "address":"주소 B","latitude":37.50,"longitude":127.00,"sequence":2}
+                  ]
+                }
+                """.formatted(BIKE_ID);
+
+        mockMvc.perform(post("/api/v1/dispatch-orders/bulk-apply-sequential")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applied").value(3))
+                .andExpect(jsonPath("$.skipped").value(0));
+
+        // 큐 조회: appendForBike 는 순번 오름차순으로 호출되었으므로 저장 sequence 1→A, 2→B, 3→C
+        mockMvc.perform(get("/api/v1/dispatch-orders")
+                        .param("bikeId", BIKE_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].customerName").value("순차A"))
+                .andExpect(jsonPath("$[0].sequence").value(1))
+                .andExpect(jsonPath("$[1].customerName").value("순차B"))
+                .andExpect(jsonPath("$[1].sequence").value(2))
+                .andExpect(jsonPath("$[2].customerName").value("순차C"))
+                .andExpect(jsonPath("$[2].sequence").value(3));
+    }
+
     // ⑦ dashboard map-state: ASSIGNED 배차 생성 후 해당 핀에 dispatchQueueCount>=1, currentDispatchCustomerName 설정
     @Test
     void dashboardMapStateExposesCurrentDispatchAndQueueCountForBike() throws Exception {
@@ -278,6 +350,30 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
             // header row at index DATA_START_ROW - 1 (1); index 0 left blank like the template title row
             Row header = sheet.createRow(DATA_START_ROW - 1);
             String[] headers = {"차량번호", "고객명", "연락처", "배송지주소"};
+            for (int c = 0; c < headers.length; c++) {
+                header.createCell(c).setCellValue(headers[c]);
+            }
+            int rowIdx = DATA_START_ROW;
+            for (String[] cols : dataRows) {
+                Row row = sheet.createRow(rowIdx++);
+                for (int c = 0; c < cols.length; c++) {
+                    row.createCell(c).setCellValue(cols[c]);
+                }
+            }
+            wb.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    /**
+     * Build an .xlsx upload for sequential bulk preview: 5 columns
+     * [0]=차량번호 [1]=고객명 [2]=연락처 [3]=배송지주소 [4]=순번.
+     */
+    private byte[] buildSequentialWorkbook(String[]... dataRows) throws Exception {
+        try (Workbook wb = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = wb.createSheet("dispatch-seq");
+            Row header = sheet.createRow(DATA_START_ROW - 1);
+            String[] headers = {"차량번호", "고객명", "연락처", "배송지주소", "순번"};
             for (int c = 0; c < headers.length; c++) {
                 header.createCell(c).setCellValue(headers[c]);
             }

--- a/docs/superpowers/plans/2026-06-12-sequential-dispatch-split.md
+++ b/docs/superpowers/plans/2026-06-12-sequential-dispatch-split.md
@@ -1,0 +1,312 @@
+# 단일 배차 / 순차 배차 분리 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 배차 업로드를 단일 배차(순번 없음=현행)와 순차 배차(순번 컬럼)로 분리. 업무 관리 = 콜/단일/순차/왕복 4패널. `DispatchOrder.sequence` 재사용 → 마이그레이션 없음.
+
+**Architecture:** 기존 single 배차 벌크는 그대로, `-sequential` 변형(엔드포인트/서비스/패널) 추가. 순번 = 차량별 정렬 키(저장은 append). 단일 라벨 정정(순차 배차→단일 배차).
+
+**Tech Stack:** Spring Boot (Java 21), POI, Next.js, TS. 브랜치 `cc-sequential-dispatch`(생성됨). Bash 절대경로 cd. 백엔드 게이트 `compileJava compileTestJava`(계약테스트 Docker→CI). 프론트 `typecheck && lint && build`.
+
+**현재 핵심:**
+- 백엔드 엔드포인트(`DispatchOrderCommandController`, `/api/v1/dispatch-orders`): `POST /bulk-preview`→`bulkService.preview`, `POST /bulk-apply`→`bulkService.apply`.
+- `evaluateRow(cols,rowNum)`: cols[0]차량번호 [1]고객명 [2]연락처 [3]배송지주소. `cell(cols,idx)` 안전 접근.
+- `apply`: 행마다 `commandService.appendForBike(bikeId,name,phone,addr,lat,lng)`(순번 자동).
+- 프론트: client `previewDispatchOrders(file)`/`applyDispatchOrders(rows)`; actions `previewDispatchAction`/`applyDispatchAction`; `DispatchPanel`.
+
+---
+
+### Task 1: 백엔드 순차 변형 (DTO + 서비스 + 엔드포인트 + 테스트)
+
+**Files:**
+- Modify: `.../dispatch/dto/DispatchBulkPreviewRow.java`
+- Modify: `.../dispatch/dto/DispatchBulkApplyRow.java`
+- Modify: `.../dispatch/service/DispatchOrderBulkService.java`
+- Modify: `.../dispatch/controller/DispatchOrderCommandController.java`
+- Test: dispatch bulk 계약 테스트
+
+- [ ] **Step 1: Preview DTO에 순번**
+
+`DispatchBulkPreviewRow.java`: 레코드에 `Integer sequence`(null 허용) 추가. 기존 두 팩토리(`newRow`/`error`)는 `null`을 넘기게 수정하고, 순차용 팩토리 추가:
+```java
+public record DispatchBulkPreviewRow(
+        int rowNumber, String plateNumber, UUID bikeId,
+        String customerName, String customerPhone, String address,
+        Integer sequence,
+        BulkRowStatus status, String message
+) {
+    public static DispatchBulkPreviewRow newRow(int rowNumber, String plateNumber, UUID bikeId,
+                                                String customerName, String customerPhone, String address) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, null, BulkRowStatus.NEW, null);
+    }
+    public static DispatchBulkPreviewRow error(int rowNumber, String plateNumber, UUID bikeId,
+                                               String customerName, String customerPhone, String address, String message) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, null, BulkRowStatus.ERROR, message);
+    }
+    public static DispatchBulkPreviewRow newRowSeq(int rowNumber, String plateNumber, UUID bikeId,
+                                                   String customerName, String customerPhone, String address, Integer sequence) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, sequence, BulkRowStatus.NEW, null);
+    }
+    public static DispatchBulkPreviewRow errorSeq(int rowNumber, String plateNumber, UUID bikeId,
+                                                  String customerName, String customerPhone, String address, Integer sequence, String message) {
+        return new DispatchBulkPreviewRow(rowNumber, plateNumber, bikeId,
+                customerName, customerPhone, address, sequence, BulkRowStatus.ERROR, message);
+    }
+}
+```
+
+- [ ] **Step 2: Apply DTO에 순번**
+
+`DispatchBulkApplyRow.java`: 레코드에 `Long sequence`(nullable, 검증 애너테이션 없음) 추가 — 마지막 컴포넌트. 단일 경로는 null, 순차 경로는 값. (`@JsonIgnoreProperties(ignoreUnknown=true)` 유지.)
+```java
+public record DispatchBulkApplyRow(
+        @NotNull UUID bikeId,
+        @NotBlank @Size(max = 255) String customerName,
+        @NotBlank @Size(max = 255) String customerPhone,
+        @NotBlank @Size(max = 2000) String address,
+        @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude,
+        Long sequence
+) {}
+```
+
+- [ ] **Step 3: 서비스 — previewSequential + applySequential**
+
+`DispatchOrderBulkService.java`에 추가(기존 `preview`/`apply`/`evaluateRow`/`cell` 무변경):
+```java
+    /** 순차 배차 미리보기. 컬럼: [0]차량번호 [1]고객명 [2]연락처 [3]배송지주소 [4]순번. */
+    public DispatchBulkPreviewResponse previewSequential(InputStream excelStream) throws IOException {
+        List<List<String>> rows = ExcelParser.parseRows(excelStream, DATA_START_ROW);
+        List<DispatchBulkPreviewRow> results = new ArrayList<>();
+        int rowNum = DATA_START_ROW + 1;
+        for (List<String> cols : rows) {
+            results.add(evaluateSequentialRow(cols, rowNum++));
+        }
+        return DispatchBulkPreviewResponse.of(results);
+    }
+
+    /** 차량별로 순번 오름차순 정렬 후 큐에 append (순번=정렬 키, 저장 sequence 는 append 연속값). */
+    @Transactional
+    public BulkApplyResponse applySequential(DispatchBulkApplyRequest request) {
+        long applied = 0;
+        List<DispatchBulkApplyRow> ordered = request.rows().stream()
+                .sorted(java.util.Comparator
+                        .comparing(DispatchBulkApplyRow::bikeId)
+                        .thenComparing(r -> r.sequence() == null ? Long.MAX_VALUE : r.sequence()))
+                .toList();
+        for (DispatchBulkApplyRow row : ordered) {
+            commandService.appendForBike(row.bikeId(), row.customerName(), row.customerPhone(),
+                    row.address(), row.latitude(), row.longitude());
+            applied++;
+        }
+        return new BulkApplyResponse(applied, 0);
+    }
+
+    private DispatchBulkPreviewRow evaluateSequentialRow(List<String> cols, int rowNum) {
+        String plate = cell(cols, 0);
+        String customerName = cell(cols, 1);
+        String customerPhone = cell(cols, 2);
+        String address = cell(cols, 3);
+        String seqRaw = cell(cols, 4);
+
+        if (plate.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, null, customerName, customerPhone, address, null, "차량번호 없음");
+        }
+        Optional<Bike> bike = bikeRepository.findByPlateNumberAndDeletedAtIsNull(plate);
+        if (bike.isEmpty()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, null, customerName, customerPhone, address, null, "차량 없음: " + plate);
+        }
+        UUID bikeId = bike.get().getId();
+        if (customerName.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "고객명 없음");
+        }
+        if (customerPhone.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "연락처 없음");
+        }
+        if (address.isBlank()) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null, "배송지주소 없음");
+        }
+        Integer sequence;
+        try {
+            sequence = Integer.parseInt(seqRaw.trim());
+        } catch (NumberFormatException ex) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bikeId, customerName, customerPhone, address, null,
+                    seqRaw.isBlank() ? "순번 없음" : "순번 형식 오류: " + seqRaw);
+        }
+        return DispatchBulkPreviewRow.newRowSeq(rowNum, plate, bikeId, customerName, customerPhone, address, sequence);
+    }
+```
+(import 필요: `java.util.Comparator`는 정규화 위해 상단 import 추가 권장. `appendForBike` 시그니처 = (bikeId,name,phone,address,lat,lng) — READ로 재확인.)
+
+- [ ] **Step 4: 컨트롤러 — 순차 엔드포인트**
+
+`DispatchOrderCommandController.java`: 기존 `/bulk-preview`·`/bulk-apply` 아래에 추가:
+```java
+    @PostMapping("/bulk-preview-sequential")
+    DispatchBulkPreviewResponse bulkPreviewSequential(@RequestPart("file") MultipartFile file) throws IOException {
+        return dispatchOrderBulkService.previewSequential(file.getInputStream());
+    }
+
+    @PostMapping("/bulk-apply-sequential")
+    BulkApplyResponse bulkApplySequential(@Valid @RequestBody DispatchBulkApplyRequest request) {
+        return dispatchOrderBulkService.applySequential(request);
+    }
+```
+(`/api/v1/dispatch-orders`는 arch allow-list 기존 커버. import 필요 없으면 그대로.)
+
+- [ ] **Step 5: 컴파일 + 계약 테스트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+```
+기존 dispatch bulk 계약 테스트 찾기: `grep -rln "bulk-preview\|bulk-apply\|DispatchBulkApply\|previewSequential" src/test/java`. 순차 테스트 추가: (a) 순차 preview가 순번 파싱(정상→NEW+sequence, 순번 누락/비정수→ERROR), (b) applySequential이 한 차량의 행을 순번 순서(예: 입력 순번 3,1,2 → 큐 1,2,3)로 큐 생성 — 차량 큐 조회로 검증. 단일 경로 테스트 회귀 없음(DispatchBulkApplyRow에 sequence 추가돼도 기존 테스트의 행 생성이 컴파일되게 — 기존 테스트가 positional 생성이면 sequence 인자 추가 필요, named/builder면 무변경; READ 후 맞출 것).
+
+- [ ] **Step 6: compileJava compileTestJava + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src && git commit -m "feat(dispatch): sequential bulk variant (순번 column) + endpoints"
+```
+Co-Authored-By 라인 포함.
+
+---
+
+### Task 2: 프론트 클라이언트 + 서버액션 + 타입
+
+**Files:**
+- Modify: `development/front-admin-web/lib/services/service-ops-api.ts`
+- Modify: `development/front-admin-web/app/dispatch/actions.ts`
+
+- [ ] **Step 1: 클라이언트 타입 + 메서드**
+
+`service-ops-api.ts`:
+- `DispatchBulkApplyRow`(TS, 라인 ~1117) 에 `sequence?: number` 추가.
+- `DispatchBulkPreviewResponse`의 row 타입(또는 해당 row 타입)에 `sequence?: number | null` 추가(미리보기 순번 표시용). 실제 타입명 grep으로 확인.
+- 클라이언트 인터페이스(라인 ~1272)와 구현에 추가:
+```ts
+  previewSequentialDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
+  applySequentialDispatchOrders: (rows: DispatchBulkApplyRow[]) => Promise<BulkApplyResponse>;
+```
+구현은 기존 `previewDispatchOrders`/`applyDispatchOrders` 복제 + 경로만 `-sequential`:
+```ts
+    previewSequentialDispatchOrders: (file) => {
+      const form = file instanceof FormData ? file : toFileForm(file);   // 기존 preview 구현의 form 구성 그대로
+      return request<DispatchBulkPreviewResponse>("/dispatch-orders/bulk-preview-sequential", { method: "POST", body: form });
+    },
+    applySequentialDispatchOrders: (rows) =>
+      request<BulkApplyResponse>("/dispatch-orders/bulk-apply-sequential", { method: "POST", body: JSON.stringify({ rows }) ... }),
+```
+(기존 `previewDispatchOrders`/`applyDispatchOrders` 구현을 READ해서 form/headers/JSON 직렬화 방식 그대로 복제 — 경로만 변경.)
+
+- [ ] **Step 2: 서버액션**
+
+`app/dispatch/actions.ts`:
+- `DispatchPreviewRow` 타입에 `sequence?: number | null` 추가(미리보기 순번 노출용).
+- `previewSequentialDispatchAction(formData)`: `previewDispatchAction` 복제, `client.previewDispatchOrders` → `client.previewSequentialDispatchOrders`. 지오코딩·summary 로직 동일.
+- `applySequentialDispatchAction(rows)`: `applyDispatchAction` 복제, `client.applyDispatchOrders` → `client.applySequentialDispatchOrders`. `revalidatePath("/management/operations")`, `("/")`.
+
+- [ ] **Step 3: typecheck + lint + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/app/dispatch/actions.ts && git commit -m "feat(dispatch): sequential bulk client methods + server actions"
+```
+Co-Authored-By 라인 포함.
+
+---
+
+### Task 3: 순차 패널 + 단일 라벨 정정 + operations 4패널
+
+**Files:**
+- Create: `development/front-admin-web/components/management/SequentialDispatchPanel.tsx`
+- Modify: `development/front-admin-web/components/management/DispatchPanel.tsx`
+- Modify: `development/front-admin-web/app/management/operations/page.tsx`
+
+- [ ] **Step 1: SequentialDispatchPanel 신규**
+
+`DispatchPanel.tsx`를 READ해서 그대로 복제하되:
+- 컴포넌트명 `SequentialDispatchPanel`.
+- `previewDispatchAction`/`applyDispatchAction` → `previewSequentialDispatchAction`/`applySequentialDispatchAction` import·호출.
+- apply rows 매핑 시 `sequence: row.sequence` 포함(미리보기 행의 순번을 apply row로 전달).
+- 제목 `mgmt-panel-title` = "순차 배차", 미리보기 제목 "순차 배차 업로드 미리보기".
+- 미리보기 테이블에 **순번 컬럼** 추가(`<th>순번</th>` + `row.sequence`). 안내 문구에 "엑셀에 순번 컬럼 포함(차량별 방문 순서)".
+- 차량 큐 안내 테이블 헤더(차량/고객/연락처/배송지/순번)는 DispatchPanel과 동일 유지.
+
+- [ ] **Step 2: DispatchPanel 단일 라벨 정정**
+
+`DispatchPanel.tsx`: `mgmt-panel-title` "순차 배차" → **"단일 배차"**, 미리보기 "순차 배차 업로드 미리보기" → **"단일 배차 업로드 미리보기"**. (동작·액션 무변경.)
+
+- [ ] **Step 3: operations 페이지 4섹션**
+
+`app/management/operations/page.tsx`:
+- import에 `SequentialDispatchPanel` 추가.
+- `SECTIONS` = 4개:
+```tsx
+const SECTIONS = [
+  { id: "mgmt-baemin", label: "콜 배차" },
+  { id: "mgmt-dispatch", label: "단일 배차" },
+  { id: "mgmt-sequential", label: "순차 배차" },
+  { id: "mgmt-stroller", label: "왕복 배차" }
+];
+```
+- `<section>` 렌더에 순차 섹션 추가(단일 다음):
+```tsx
+      <section id="mgmt-sequential" className="management-anchor">
+        <SequentialDispatchPanel exportUrl="/api/management/dispatch/export" />
+      </section>
+```
+(콜=BaeminCallPanel, 단일=DispatchPanel, 순차=SequentialDispatchPanel, 왕복=StrollerRoundPanel 순. exportUrl은 DispatchPanel과 동일 재사용 — 순차도 같은 export면 그대로, 아니면 SequentialDispatchPanel이 export 버튼 없이 업로드만 두어도 됨. DispatchPanel 구조 따라 맞출 것.)
+
+- [ ] **Step 4: typecheck + lint + build + 커밋**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/SequentialDispatchPanel.tsx development/front-admin-web/components/management/DispatchPanel.tsx development/front-admin-web/app/management/operations/page.tsx && git commit -m "feat(mgmt): sequential dispatch panel + 단일 라벨 정정 + operations 4 sections"
+```
+Co-Authored-By 라인 포함.
+
+---
+
+### Task 4: 최종 검증 + PR
+
+- [ ] **Step 1: 풀 검증**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && (git diff dev --name-only | grep -i "db/migration" && echo MIGRATION || echo "no migration")
+```
+Expected: 백엔드/프론트 통과, 마이그레이션 0, operations에 4섹션.
+
+- [ ] **Step 2: PR (→ dev)**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git push -u origin cc-sequential-dispatch && gh pr create --base dev --title "단일/순차 배차 분리 (순번 컬럼)" --body "$(cat <<'EOF'
+## Summary
+- 배차 업로드를 단일(순번 없음=현행)/순차(순번 컬럼)로 분리. 업무 관리 = 콜/단일/순차/왕복 4패널
+- 백엔드: `bulk-preview-sequential`/`bulk-apply-sequential`(5컬럼 순번 파싱, 차량별 순번 정렬 append). DispatchBulkApplyRow/PreviewRow에 sequence
+- 프론트: SequentialDispatchPanel(순번 컬럼) + 순차 클라이언트/액션. DispatchPanel "순차 배차"→"단일 배차" 정정
+- 순번 = 차량별 정렬 키(저장 sequence 는 append). DispatchOrder.sequence 재사용 → **마이그레이션 없음**, 단일 경로 무변경
+
+## Test Plan
+- [x] 백엔드 compileJava + compileTestJava, 프론트 typecheck+lint+build, 마이그레이션 0
+- [ ] 계약 테스트(CI): 순차 preview 순번 파싱, apply 큐 순번 정렬
+- [ ] 프로덕션 QA: 업무 관리 4패널, 순차 엑셀(순번) 업로드→미리보기 순번→적용 큐 순번 순, 단일 현행
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec 커버리지:** 백엔드 순차(DTO/서비스/엔드포인트/테스트, T1), 프론트 클라이언트·액션(T2), 순차 패널+단일 정정+4섹션(T3), 검증·PR(T4). ✓ 마이그레이션 없음, 단일 경로 무변경. ✓
+
+**2. 플레이스홀더 스캔:** 백엔드 신규 메서드/엔드포인트/DTO 완전 코드. 프론트는 "DispatchPanel/기존 client 메서드 READ 후 복제 + 경로/액션/제목/순번컬럼만 변경" — 기존 코드 의존이라 구체 지시. exportUrl·form 구성은 기존 구현 따름.
+
+**3. 타입/이름 일관성:** 백엔드 `previewSequential`/`applySequential` ↔ 엔드포인트 `-sequential` ↔ 프론트 client `previewSequentialDispatchOrders`/`applySequentialDispatchOrders` ↔ 액션 `previewSequentialDispatchAction`/`applySequentialDispatchAction`. `sequence` 필드 백엔드(Long/Integer)·프론트(number) 일관. 앵커 id: 단일=mgmt-dispatch(기존), 순차=mgmt-sequential(신규), 콜=mgmt-baemin, 왕복=mgmt-stroller.
+
+**구현자 주의:** `DispatchBulkApplyRow`에 sequence 추가 시 기존 단일 테스트/프론트가 positional 생성이면 인자 추가 필요(READ 후 확인) — named/object면 무변경. 단일 경로의 `apply`(append)·preview(4컬럼)·DispatchPanel 동작은 절대 바꾸지 말 것(라벨만). 순번은 정렬 키일 뿐 DispatchOrder.sequence에 raw 저장 안 함.

--- a/docs/superpowers/specs/2026-06-12-sequential-dispatch-split-design.md
+++ b/docs/superpowers/specs/2026-06-12-sequential-dispatch-split-design.md
@@ -1,0 +1,60 @@
+# 단일 배차 / 순차 배차 분리 (순번 컬럼) Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 업무 관리의 배차 업로드를 **단일 배차**(순번 없음 = 현재 동작)와 **순차 배차**(순번 컬럼으로 순서 지정)로 분리해, 업무 관리 = 콜/단일/순차/왕복 4패널로 지도 필터와 정렬한다.
+
+**핵심 정의(사용자 확정):** 둘 다 1:N(차량→목적지 큐). 차이는 **순번 컬럼/순서 지정 유무** 하나뿐.
+- **단일 배차** = 현재 `DispatchPanel` 그대로 (엑셀 `[차량번호, 고객명, 연락처, 배송지주소]`, 순번 입력 없음, append).
+- **순차 배차** = 신규 (엑셀에 `순번` 추가 → 차량별 순번 정렬해 큐 append).
+
+**Architecture:** 기존 배차 벌크(single) 경로는 그대로 두고, `-sequential` 변형(preview/apply 엔드포인트 + 서비스 메서드 + 패널)을 추가. `DispatchOrder.sequence` 컬럼 재사용 → **마이그레이션 없음**.
+
+**Tech Stack:** Spring Boot (Java 21), POI(ExcelParser), Next.js, TypeScript.
+
+**비범위:** 콜/왕복 패널 변경, N:N, serviceType별 차량 제약(차량번호로 아무 차량 허용), 재업로드 교체 시맨틱(현행 append 유지), 다운로드 템플릿 파일.
+
+---
+
+## 1. 라벨 정정 (단일)
+- 직전 네이밍 작업에서 `DispatchPanel`을 "순차 배차"로 바꿨으나, 정의상 **현재 패널(순번 없음)=단일 배차**가 맞음. `DispatchPanel`의 `mgmt-panel-title`·미리보기 제목·operations 섹션 라벨을 **"단일 배차"**로 정정. 동작·엔드포인트 무변경.
+
+## 2. 백엔드 — 순차 변형
+
+`com.thundercrew.opsapi.dispatch`:
+
+- **DTO**:
+  - `DispatchBulkApplyRow`에 `Long sequence`(nullable) 추가 — 단일 경로는 null, 순차 경로는 값 보유. (또는 순차 전용 row DTO. 재사용 권장.)
+  - `DispatchBulkPreviewRow`에 순번 표시 필드(`Integer sequence` 또는 문자열) 추가 — 순차 미리보기에서 노출.
+- **`DispatchOrderBulkService`**:
+  - `previewSequential(InputStream)` — 엑셀 5컬럼 `[차량번호, 고객명, 연락처, 배송지주소, 순번]` 파싱·검증. 순번 비정수/누락은 ERROR 행. (단일 `preview`는 4컬럼 그대로.)
+  - `applySequential(DispatchBulkApplyRequest)` — 차량별로 `sequence` 오름차순 정렬 후 `commandService.appendForBike(...)` 순서대로 호출(순번=정렬 키, 저장 sequence는 append 연속값 — 기존 큐와 충돌 없음). 단일 `apply`는 현행대로 행 순서 append.
+- **`DispatchOrderCommandController`** (`/api/v1/dispatch-orders`, arch allow-list 기존 커버):
+  - `POST /bulk-preview-sequential` → `previewSequential`.
+  - `POST /bulk-apply-sequential` → `applySequential`.
+  - 기존 `/bulk-preview`·`/bulk-apply`(단일)는 무변경.
+- **테스트**: 순차 preview가 순번 파싱(정상/누락→ERROR), apply가 차량별 큐를 순번 순서로 생성(예: 순번 2,1,3 → 큐 1,2,3 순). 단일 경로 회귀 없음.
+
+## 3. 프론트 — 순차 패널 + 단일 정정
+
+`development/front-admin-web`:
+
+- **service-ops-api 클라이언트**: `previewSequentialDispatchOrders(file)` / `applySequentialDispatchOrders(rows)` 추가(`-sequential` 엔드포인트 호출). 순차 row 타입에 `sequence` 포함.
+- **서버액션** (`app/dispatch/actions.ts`): `previewSequentialDispatchAction` / `applySequentialDispatchAction` 추가(단일 액션 패턴 복제, 지오코딩 동일). `revalidatePath("/management/operations")`, `("/")`.
+- **신규 `SequentialDispatchPanel`** (`components/management/`): `DispatchPanel` 복제 기반 — 업로드 → 순차 preview(테이블에 순번 컬럼 노출) → apply. 제목 "순차 배차", 미리보기 "순차 배차 업로드 미리보기". 안내 문구에 "엑셀에 순번 컬럼 포함(차량별 방문 순서)".
+- **`DispatchPanel`**: 제목·미리보기 "순차 배차" → **"단일 배차"** 정정(§1).
+- **operations 페이지**: SECTIONS·렌더 = **콜 배차 / 단일 배차 / 순차 배차 / 왕복 배차** 4개. 신규 앵커 id `mgmt-sequential`(순차). 기존 `mgmt-dispatch`(단일)·`mgmt-baemin`(콜)·`mgmt-stroller`(왕복) 유지.
+
+## 4. 데이터 흐름
+```
+단일: 엑셀[차량,고객,연락처,배송지] → bulk-preview → 지오코딩 → bulk-apply(append) → 차량 큐(순서 무의미)
+순차: 엑셀[…,순번] → bulk-preview-sequential → 지오코딩 → bulk-apply-sequential(차량별 순번 정렬 append) → 차량 큐(순번 순)
+```
+- DispatchOrder 1건 = 차량+목적지+sequence. 모델·테이블 무변경.
+
+## 5. 검증
+- 백엔드 `compileJava + compileTestJava`(순차 계약 테스트 포함). 프론트 `typecheck + lint + build`.
+- 프로덕션 QA: 업무 관리 4패널(콜/단일/순차/왕복), 순차 엑셀(순번 포함) 업로드→미리보기 순번 노출→적용 시 차량 큐가 순번 순서, 단일은 현행대로. **마이그레이션 없음.**
+
+## 6. 비범위 재확인
+콜/왕복 변경, N:N, serviceType 제약, 재업로드 교체, 템플릿 파일은 포함하지 않는다.


### PR DESCRIPTION
## Summary
- 배차 업로드를 단일(순번 없음=현행) / 순차(순번 컬럼)로 분리. 업무 관리 = 콜/단일/순차/왕복 4패널
- 백엔드: `bulk-preview-sequential`/`bulk-apply-sequential` (5컬럼 순번 파싱, 차량별 순번 정렬 append) + DispatchBulkApplyRow/PreviewRow에 sequence + 계약 테스트(순번 파싱, 큐 3,1,2→1,2,3)
- 프론트: SequentialDispatchPanel(순번 컬럼) + 순차 클라이언트/서버액션. DispatchPanel "순차 배차"→"단일 배차" 정정
- 순번 = 차량별 정렬 키(저장 sequence는 append). DispatchOrder.sequence 재사용 → **마이그레이션 없음**, 단일 경로 무변경

## Test Plan
- [x] 백엔드 compileJava + compileTestJava, 프론트 typecheck+lint+build, 마이그레이션 0
- [ ] 계약 테스트(CI/Docker)
- [ ] 프로덕션 QA: 업무 관리 4패널, 순차 엑셀(순번) 업로드→미리보기 순번→적용 큐 순번 순, 단일 현행

🤖 Generated with [Claude Code](https://claude.com/claude-code)