### PR TITLE
릴리스: 정비 관리 페이지 + 휠타입×엔진 2축 카탈로그

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -503,11 +503,14 @@ export async function setVehicleOperationStatusFromOverviewAction(
 // 추가/수정/삭제. backend V22 의 maintenance-items endpoint 를 그대로 호출.
 // ============================================================================
 
-import type { ServiceOpsMaintenanceAppliesTo } from "@/lib/services/service-ops-api";
+import type {
+  ServiceOpsMaintenanceAppliesTo,
+  ServiceOpsMaintenanceWheelApplies
+} from "@/lib/services/service-ops-api";
 
 export async function createMaintenanceItemAction(formData: FormData): Promise<void> {
   if (!serviceOpsApiConfigured()) {
-    redirect("/?tab=maintenance");
+    redirect("/management/maintenance");
   }
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
@@ -516,25 +519,27 @@ export async function createMaintenanceItemAction(formData: FormData): Promise<v
 
   const name = requiredText(formData.get("name"));
   if (!name) {
-    redirect("/?tab=maintenance&status=maintenance-item-missing-name");
+    redirect("/management/maintenance?status=maintenance-item-missing-name");
   }
   const appliesTo = parseAppliesTo(formData.get("appliesTo"));
   if (!appliesTo) {
-    redirect("/?tab=maintenance&status=maintenance-item-invalid-applies-to");
+    redirect("/management/maintenance?status=maintenance-item-invalid-applies-to");
   }
   const cycleKm = optionalInteger(formData.get("cycleKm"));
   const cycleMonths = optionalInteger(formData.get("cycleMonths"));
   const cycleLabel = optionalText(formData.get("cycleLabel"));
   if (cycleKm === null && cycleMonths === null && !cycleLabel) {
     // 백엔드 check 제약과 동일 정책 — 최소 한 종류의 cycle 표현은 있어야 한다.
-    redirect("/?tab=maintenance&status=maintenance-item-cycle-required");
+    redirect("/management/maintenance?status=maintenance-item-cycle-required");
   }
+  const appliesToWheel = parseAppliesToWheel(formData.get("appliesToWheel"));
   const parentItemId = optionalText(formData.get("parentItemId"));
   const displayOrder = optionalInteger(formData.get("displayOrder"));
   try {
     await client.createMaintenanceItem({
       name,
       appliesTo,
+      appliesToWheel,
       parentItemId,
       cycleKm,
       cycleMonths,
@@ -543,10 +548,10 @@ export async function createMaintenanceItemAction(formData: FormData): Promise<v
       memo: optionalText(formData.get("memo"))
     });
   } catch {
-    redirect("/?tab=maintenance&status=maintenance-item-create-error");
+    redirect("/management/maintenance?status=maintenance-item-create-error");
   }
-  revalidatePath("/");
-  redirect("/?tab=maintenance");
+  revalidatePath("/management/maintenance");
+  redirect("/management/maintenance");
 }
 
 export async function updateMaintenanceItemAction(
@@ -554,7 +559,7 @@ export async function updateMaintenanceItemAction(
   formData: FormData
 ): Promise<void> {
   if (!serviceOpsApiConfigured()) {
-    redirect("/?tab=maintenance");
+    redirect("/management/maintenance");
   }
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
@@ -562,11 +567,13 @@ export async function updateMaintenanceItemAction(
   }
   const name = optionalText(formData.get("name"));
   const appliesTo = parseAppliesTo(formData.get("appliesTo"));
+  const appliesToWheel = parseAppliesToWheel(formData.get("appliesToWheel"));
   // 모든 필드 optional; cycle 들은 명시적 null (빈 입력) 도 그대로 반영.
   try {
     await client.updateMaintenanceItem(itemId, {
       name,
       appliesTo: appliesTo ?? null,
+      appliesToWheel: appliesToWheel ?? null,
       parentItemId: optionalText(formData.get("parentItemId")),
       cycleKm: optionalInteger(formData.get("cycleKm")),
       cycleMonths: optionalInteger(formData.get("cycleMonths")),
@@ -576,15 +583,15 @@ export async function updateMaintenanceItemAction(
       memo: optionalText(formData.get("memo"))
     });
   } catch {
-    redirect("/?tab=maintenance&status=maintenance-item-update-error");
+    redirect("/management/maintenance?status=maintenance-item-update-error");
   }
-  revalidatePath("/");
-  redirect("/?tab=maintenance");
+  revalidatePath("/management/maintenance");
+  redirect("/management/maintenance");
 }
 
 export async function deleteMaintenanceItemAction(itemId: string): Promise<void> {
   if (!serviceOpsApiConfigured()) {
-    redirect("/?tab=maintenance");
+    redirect("/management/maintenance");
   }
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) {
@@ -593,16 +600,22 @@ export async function deleteMaintenanceItemAction(itemId: string): Promise<void>
   try {
     await client.deleteMaintenanceItem(itemId);
   } catch {
-    redirect("/?tab=maintenance&status=maintenance-item-delete-error");
+    redirect("/management/maintenance?status=maintenance-item-delete-error");
   }
-  revalidatePath("/");
-  redirect("/?tab=maintenance");
+  revalidatePath("/management/maintenance");
+  redirect("/management/maintenance");
 }
 
 function parseAppliesTo(value: FormDataEntryValue | null): ServiceOpsMaintenanceAppliesTo | null {
   const text = String(value ?? "").trim();
   if (text === "ELECTRIC" || text === "ICE" || text === "BOTH") return text;
   return null;
+}
+
+function parseAppliesToWheel(value: FormDataEntryValue | null): ServiceOpsMaintenanceWheelApplies {
+  const text = String(value ?? "").trim();
+  if (text === "TWO_WHEEL" || text === "FOUR_WHEEL" || text === "BOTH") return text;
+  return "BOTH";
 }
 
 function parseOptionalBoolean(value: FormDataEntryValue | null): boolean | null {

--- a/development/front-admin-web/app/management/maintenance/page.tsx
+++ b/development/front-admin-web/app/management/maintenance/page.tsx
@@ -1,0 +1,14 @@
+import { MaintenancePanel } from "@/components/management/MaintenancePanel";
+import { loadMaintenanceDataset } from "@/lib/services/vehicle-maintenance-data";
+
+export const dynamic = "force-dynamic";
+
+export default async function ManagementMaintenancePage() {
+  const { items } = await loadMaintenanceDataset();
+
+  return (
+    <div className="management-page">
+      <MaintenancePanel items={items} />
+    </div>
+  );
+}

--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -144,16 +144,21 @@ export default async function RootPage({
     ignitionStatusByBikeId.set(pin.bikeId, pin.ignitionStatus);
   }
   // 차량 탭 "정비 상태" 필터가 임박/지연 차량을 골라낼 때 참조. bikeId →
-  // {hasOverdue, hasDueSoon, overallStatus}. 차량별 engineType 으로 적용
-  // catalog 를 분기해 catalog × records 의 매트릭스를 한 번에 derive.
+  // {hasOverdue, hasDueSoon, overallStatus}. 차량별 engineType + wheelType 으로
+  // 적용 catalog 를 분기해 catalog × records 의 매트릭스를 한 번에 derive.
   const bikeEngineTypeById = new Map<string, "ELECTRIC" | "ICE">();
   for (const vehicle of vehicleData.vehicles) {
     if (vehicle.id) bikeEngineTypeById.set(vehicle.id, vehicle.engineType ?? "ELECTRIC");
   }
+  const bikeWheelTypeById = new Map<string, "TWO_WHEEL" | "FOUR_WHEEL">();
+  for (const vehicle of vehicleData.vehicles) {
+    if (vehicle.id) bikeWheelTypeById.set(vehicle.id, vehicle.wheelType ?? "TWO_WHEEL");
+  }
   const maintenanceSummaryByBike = summarizeMaintenanceByBike(
     maintenanceData.items,
     maintenanceData.records,
-    bikeEngineTypeById
+    bikeEngineTypeById,
+    bikeWheelTypeById
   );
 
   // IMEI=-1 차량 식별: deviceUid 가 "-1" 이거나 "-1-" 으로 시작하는 bikeId 를 추출.

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -36,6 +36,15 @@ const NAV: SidebarNavItem[] = [
         <path d="M9 4V3h6v1M8.5 10h7M8.5 14h7M8.5 18h4" />
       </svg>
     )
+  },
+  {
+    href: "/management/maintenance",
+    label: "정비 관리",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 0 5.4-5.4l-2.5 2.5-2.5-.7-.7-2.5 2.4-2.3z" />
+      </svg>
+    )
   }
 ];
 

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -50,6 +50,7 @@ export function MaintenanceItemDetailDialog({
         <div className="detail-row-grid">
           <DetailField label="품목" value={row.name} />
           <DetailField label="적용" value={appliesToLabel(row.appliesTo)} />
+          <DetailField label="휠타입" value={wheelAppliesLabel(row.appliesToWheel)} />
           <DetailField label="교환주기 (km)" value={row.cycleKm !== null ? `${row.cycleKm.toLocaleString()} km` : "—"} />
           <DetailField label="교환주기 (개월)" value={row.cycleMonths !== null ? `${row.cycleMonths}개월` : "—"} />
           <DetailField label="라벨" value={row.cycleLabel ?? "—"} />
@@ -72,6 +73,14 @@ export function MaintenanceItemDetailDialog({
             <select name="appliesTo" defaultValue={row.appliesTo}>
               <option value="ELECTRIC">전기</option>
               <option value="ICE">내연</option>
+              <option value="BOTH">공통</option>
+            </select>
+          </label>
+          <label>
+            휠타입
+            <select name="appliesToWheel" defaultValue={row.appliesToWheel ?? "BOTH"}>
+              <option value="TWO_WHEEL">2륜</option>
+              <option value="FOUR_WHEEL">4륜</option>
               <option value="BOTH">공통</option>
             </select>
           </label>
@@ -131,6 +140,12 @@ function DetailField({ label, value }: { label: string; value: string }) {
 function appliesToLabel(value: ServiceOpsMaintenanceItem["appliesTo"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
+  return "공통";
+}
+
+function wheelAppliesLabel(value: ServiceOpsMaintenanceItem["appliesToWheel"]): string {
+  if (value === "TWO_WHEEL") return "2륜";
+  if (value === "FOUR_WHEEL") return "4륜";
   return "공통";
 }
 

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, type ReactNode } from "react";
 
 import { DeleteMaintenanceItemButton } from "@/components/management/DeleteMaintenanceItemButton";
 import { MaintenanceItemDetailDialog } from "@/components/management/MaintenanceItemDetailDialog";
-import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+import type { ServiceOpsMaintenanceItem, ServiceOpsMaintenanceWheelApplies } from "@/lib/services/service-ops-api";
 
 /**
  * `/?tab=maintenance` 의 정비 카탈로그 편집 패널. 세 섹션(전기 전용 / 내연
@@ -67,6 +67,7 @@ function Section({
             <col style={{ width: "48px" }} />
             <col />
             <col style={{ width: "140px" }} />
+            <col style={{ width: "64px" }} />
             <col style={{ width: "120px" }} />
             <col style={{ width: "72px" }} />
           </colgroup>
@@ -75,6 +76,7 @@ function Section({
               <th aria-label="삭제" />
               <th>품목</th>
               <th>교환주기</th>
+              <th>휠</th>
               <th>그룹 부모</th>
               <th>활성</th>
             </tr>
@@ -82,7 +84,7 @@ function Section({
           <tbody>
             {items.length === 0 ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">
+                <td colSpan={6} className="table-empty-cell">
                   데이터 없음
                 </td>
               </tr>
@@ -105,6 +107,7 @@ function Section({
                     {item.name}
                   </td>
                   <td>{renderCycle(item)}</td>
+                  <td><span className="muted">{wheelLabel(item.appliesToWheel)}</span></td>
                   <td>{parent ? parent.name : <span className="muted">—</span>}</td>
                   <td>{item.enabled ? "ON" : <span className="muted">OFF</span>}</td>
                 </tr>
@@ -123,4 +126,10 @@ function renderCycle(item: ServiceOpsMaintenanceItem): ReactNode {
   if (item.cycleMonths !== null && item.cycleMonths > 0) return `${item.cycleMonths}개월`;
   // 그룹 부모: cycle 세 값 모두 비어 있는 헤더 행.
   return <span className="muted">— (그룹)</span>;
+}
+
+function wheelLabel(w: ServiceOpsMaintenanceWheelApplies): string {
+  if (w === "TWO_WHEEL") return "2륜";
+  if (w === "FOUR_WHEEL") return "4륜";
+  return "공통";
 }

--- a/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
+++ b/development/front-admin-web/components/management/vehicle-maintenance-derive.ts
@@ -159,15 +159,18 @@ const STATUS_PRIORITY: Record<MaintenanceStatus, number> = {
 
 /**
  * bikeId → 그 차량의 정비 상태 요약 map. 전체 데이터셋(items + records) 와
- * engineType-별 catalog 매핑을 받아 한 번에 계산.
+ * engineType-별, wheelType-별 catalog 매핑을 받아 한 번에 계산.
  *
  * `bikeEngineTypeById` — 차량 ID 가 ICE/ELECTRIC 중 어느 catalog 를 봐야 하는지.
  *   엔트리 없으면 ELECTRIC 으로 fallback (V21 default 정책과 일치).
+ * `bikeWheelTypeById` — 차량 ID 가 TWO_WHEEL/FOUR_WHEEL 중 어느 catalog 를 봐야
+ *   하는지. 엔트리 없으면 TWO_WHEEL 로 fallback (백엔드 NOT NULL default 와 일치).
  */
 export function summarizeMaintenanceByBike(
   items: ReadonlyArray<ServiceOpsMaintenanceItem>,
   records: ReadonlyArray<ServiceOpsVehicleMaintenanceRecord>,
   bikeEngineTypeById: Map<string, "ELECTRIC" | "ICE">,
+  bikeWheelTypeById: Map<string, "TWO_WHEEL" | "FOUR_WHEEL">,
   now: Date = new Date()
 ): Map<string, VehicleMaintenanceSummary> {
   // engineType 별 적용 catalog 두 묶음 미리 분리.
@@ -176,6 +179,14 @@ export function summarizeMaintenanceByBike(
   );
   const iceItems = items.filter(
     (item) => item.appliesTo === "ICE" || item.appliesTo === "BOTH"
+  );
+
+  // wheelType 별 적용 catalog 두 묶음 미리 분리.
+  const twoWheelItems = items.filter(
+    (item) => item.appliesToWheel === "TWO_WHEEL" || item.appliesToWheel === "BOTH"
+  );
+  const fourWheelItems = items.filter(
+    (item) => item.appliesToWheel === "FOUR_WHEEL" || item.appliesToWheel === "BOTH"
   );
 
   // bikeId → records 그룹핑.
@@ -189,7 +200,12 @@ export function summarizeMaintenanceByBike(
   // bikeEngineTypeById 에 등장한 모든 차량에 대해 요약 계산.
   const result = new Map<string, VehicleMaintenanceSummary>();
   for (const [bikeId, engineType] of bikeEngineTypeById) {
-    const applicableItems = engineType === "ICE" ? iceItems : electricItems;
+    const engineItems = engineType === "ICE" ? iceItems : electricItems;
+    const wheelType = bikeWheelTypeById.get(bikeId) ?? "TWO_WHEEL";
+    const wheelItems = wheelType === "FOUR_WHEEL" ? fourWheelItems : twoWheelItems;
+    // 엔진 조건 AND 휠 조건 동시 충족 품목만 이 차량에 적용.
+    const engineItemIds = new Set(engineItems.map((item) => item.id));
+    const applicableItems = wheelItems.filter((item) => engineItemIds.has(item.id));
     const bikeRecords = recordsByBike.get(bikeId) ?? [];
     // 다음 단계에선 servicedAt desc 정렬 가정 — recordsByBike push 순서가
     // 백엔드 응답(이미 정렬됨) 그대로라 별도 정렬 안 함.

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -261,6 +261,7 @@ export type MaintenanceRecordCreateInput = {
 export type MaintenanceItemCreateInput = {
   name: string;
   appliesTo: ServiceOpsMaintenanceAppliesTo;
+  appliesToWheel: ServiceOpsMaintenanceWheelApplies;
   parentItemId?: string | null;
   cycleKm?: number | null;
   cycleMonths?: number | null;
@@ -272,6 +273,7 @@ export type MaintenanceItemCreateInput = {
 export type MaintenanceItemUpdateInput = {
   name?: string | null;
   appliesTo?: ServiceOpsMaintenanceAppliesTo | null;
+  appliesToWheel?: ServiceOpsMaintenanceWheelApplies | null;
   parentItemId?: string | null;
   cycleKm?: number | null;
   cycleMonths?: number | null;

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -220,11 +220,14 @@ export type ServiceOpsBikeOperationStatusHistory = {
 
 export type ServiceOpsMaintenanceAppliesTo = "ELECTRIC" | "ICE" | "BOTH";
 
+export type ServiceOpsMaintenanceWheelApplies = "TWO_WHEEL" | "FOUR_WHEEL" | "BOTH";
+
 export type ServiceOpsMaintenanceItem = {
   id: string;
   idx: number | null;
   name: string;
   appliesTo: ServiceOpsMaintenanceAppliesTo;
+  appliesToWheel: ServiceOpsMaintenanceWheelApplies;
   parentItemId: string | null;
   cycleKm: number | null;
   cycleMonths: number | null;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
@@ -29,6 +29,10 @@ public class MaintenanceItem extends DisplaySequencedEntity {
     @Column(name = "applies_to", nullable = false, length = 20)
     private MaintenanceAppliesTo appliesTo;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "applies_to_wheel", nullable = false, length = 20)
+    private MaintenanceWheelApplies appliesToWheel;
+
     @Column(name = "parent_item_id")
     private UUID parentItemId;
 
@@ -53,6 +57,7 @@ public class MaintenanceItem extends DisplaySequencedEntity {
     public static MaintenanceItem create(
             String name,
             MaintenanceAppliesTo appliesTo,
+            MaintenanceWheelApplies appliesToWheel,
             UUID parentItemId,
             Integer cycleKm,
             Integer cycleMonths,
@@ -63,6 +68,7 @@ public class MaintenanceItem extends DisplaySequencedEntity {
         MaintenanceItem item = new MaintenanceItem();
         item.name = name;
         item.appliesTo = appliesTo;
+        item.appliesToWheel = appliesToWheel;
         item.parentItemId = parentItemId;
         item.cycleKm = cycleKm;
         item.cycleMonths = cycleMonths;
@@ -76,6 +82,7 @@ public class MaintenanceItem extends DisplaySequencedEntity {
     public void updateCatalog(
             String name,
             MaintenanceAppliesTo appliesTo,
+            MaintenanceWheelApplies appliesToWheel,
             UUID parentItemId,
             Integer cycleKm,
             Integer cycleMonths,
@@ -89,6 +96,9 @@ public class MaintenanceItem extends DisplaySequencedEntity {
         }
         if (appliesTo != null) {
             this.appliesTo = appliesTo;
+        }
+        if (appliesToWheel != null) {
+            this.appliesToWheel = appliesToWheel;
         }
         // parentItemId / cycle 들은 명시적으로 null 로 보내는 케이스(그룹 분리,
         // cycle 변경 등) 가 있으므로 null 도 그대로 수용. 호출 측이 partial
@@ -115,6 +125,10 @@ public class MaintenanceItem extends DisplaySequencedEntity {
 
     public MaintenanceAppliesTo getAppliesTo() {
         return appliesTo;
+    }
+
+    public MaintenanceWheelApplies getAppliesToWheel() {
+        return appliesToWheel;
     }
 
     public UUID getParentItemId() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceWheelApplies.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceWheelApplies.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.maintenance.domain;
+
+/** 정비 항목의 휠타입 적용 축. 엔진 축(MaintenanceAppliesTo)과 직교. */
+public enum MaintenanceWheelApplies {
+    TWO_WHEEL,   // 2륜 전용
+    FOUR_WHEEL,  // 4륜 전용
+    BOTH         // 공통(양쪽)
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.maintenance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceWheelApplies;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -12,6 +13,7 @@ import java.util.UUID;
 public record MaintenanceItemCreateRequest(
         @NotBlank @Size(max = 100) String name,
         @NotNull MaintenanceAppliesTo appliesTo,
+        @NotNull MaintenanceWheelApplies appliesToWheel,
         UUID parentItemId,
         @PositiveOrZero Integer cycleKm,
         @PositiveOrZero Integer cycleMonths,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.maintenance.dto;
 
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceWheelApplies;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -10,6 +11,7 @@ public record MaintenanceItemReadResponse(
         Long idx,
         String name,
         MaintenanceAppliesTo appliesTo,
+        MaintenanceWheelApplies appliesToWheel,
         UUID parentItemId,
         Integer cycleKm,
         Integer cycleMonths,
@@ -26,6 +28,7 @@ public record MaintenanceItemReadResponse(
                 item.getIdx(),
                 item.getName(),
                 item.getAppliesTo(),
+                item.getAppliesToWheel(),
                 item.getParentItemId(),
                 item.getCycleKm(),
                 item.getCycleMonths(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.maintenance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceWheelApplies;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public record MaintenanceItemUpdateRequest(
         @Size(max = 100) String name,
         MaintenanceAppliesTo appliesTo,
+        MaintenanceWheelApplies appliesToWheel,
         UUID parentItemId,
         @PositiveOrZero Integer cycleKm,
         @PositiveOrZero Integer cycleMonths,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/repository/MaintenanceItemRepository.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.maintenance.repository;
 
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceItem;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceWheelApplies;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,5 +25,13 @@ public interface MaintenanceItemRepository extends Repository<MaintenanceItem, U
      */
     List<MaintenanceItem> findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(
             List<MaintenanceAppliesTo> appliesTo
+    );
+
+    /**
+     * 차량 단위 catalog 조회 — 엔진 축 + 휠 축 동시 필터.
+     * bike.engineType 과 bike.wheelType 모두 적용. 각 in-list 는 서비스 측에서 구성.
+     */
+    List<MaintenanceItem> findByAppliesToInAndAppliesToWheelInAndDeletedAtIsNullOrderByDisplayOrderAsc(
+            List<MaintenanceAppliesTo> appliesTo, List<MaintenanceWheelApplies> appliesToWheel
     );
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
@@ -46,6 +46,7 @@ public class MaintenanceCommandService {
         MaintenanceItem item = MaintenanceItem.create(
                 request.name(),
                 request.appliesTo(),
+                request.appliesToWheel(),
                 request.parentItemId(),
                 request.cycleKm(),
                 request.cycleMonths(),
@@ -66,6 +67,7 @@ public class MaintenanceCommandService {
         item.updateCatalog(
                 request.name(),
                 request.appliesTo(),
+                request.appliesToWheel(),
                 request.parentItemId(),
                 request.cycleKm(),
                 request.cycleMonths(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -2,10 +2,12 @@ package com.thundercrew.opsapi.maintenance.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
 import com.thundercrew.opsapi.bike.domain.BikeEngineType;
+import com.thundercrew.opsapi.bike.domain.BikeWheelType;
 import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceAppliesTo;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceWheelApplies;
 import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
 import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
 import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
@@ -61,8 +63,11 @@ public class MaintenanceReadService {
         List<MaintenanceAppliesTo> appliesTo = bike.getEngineType() == BikeEngineType.ELECTRIC
                 ? List.of(MaintenanceAppliesTo.ELECTRIC, MaintenanceAppliesTo.BOTH)
                 : List.of(MaintenanceAppliesTo.ICE, MaintenanceAppliesTo.BOTH);
+        List<MaintenanceWheelApplies> appliesToWheel = bike.getWheelType() == BikeWheelType.FOUR_WHEEL
+                ? List.of(MaintenanceWheelApplies.FOUR_WHEEL, MaintenanceWheelApplies.BOTH)
+                : List.of(MaintenanceWheelApplies.TWO_WHEEL, MaintenanceWheelApplies.BOTH);
         return itemRepository
-                .findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo)
+                .findByAppliesToInAndAppliesToWheelInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo, appliesToWheel)
                 .stream()
                 .map(MaintenanceItemReadResponse::from)
                 .toList();

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceReadService.java
@@ -53,9 +53,9 @@ public class MaintenanceReadService {
     }
 
     /**
-     * 한 차량의 정비 catalog — 그 차량의 engineType 에 적용 가능한 품목만.
-     * ELECTRIC 차량은 (ELECTRIC + BOTH), ICE 는 (ICE + BOTH). 정렬은
-     * displayOrder 오름차순으로 사진 표 순서 유지.
+     * 한 차량의 정비 catalog — 그 차량의 engineType AND wheelType 에 적용 가능한 품목만.
+     * 엔진: ELECTRIC→(ELECTRIC+BOTH), ICE→(ICE+BOTH). 휠: FOUR_WHEEL→(FOUR_WHEEL+BOTH),
+     * TWO_WHEEL→(TWO_WHEEL+BOTH). 두 축 모두 매치하는 품목만. 정렬은 displayOrder 오름차순.
      */
     public List<MaintenanceItemReadResponse> listItemsForBike(UUID bikeId) {
         Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)

--- a/development/service-ops-api/src/main/resources/db/migration/V37__add_maintenance_applies_to_wheel.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V37__add_maintenance_applies_to_wheel.sql
@@ -1,0 +1,8 @@
+-- 휠 축 추가. 기존 항목은 기본 'BOTH'(전 휠 적용). add-column + check 동시 —
+-- 기존 행이 모두 default 'BOTH' 라 check 위반 없음(값-재브랜드 아님).
+alter table maintenance_items
+    add column applies_to_wheel varchar(20) not null default 'BOTH';
+
+alter table maintenance_items
+    add constraint ck_maintenance_items_applies_to_wheel
+        check (applies_to_wheel in ('TWO_WHEEL', 'FOUR_WHEEL', 'BOTH'));

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/MaintenanceItemApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/MaintenanceItemApiContractTests.java
@@ -1,0 +1,265 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MaintenanceItemApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID  = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from vehicle_maintenance_records");
+        jdbcTemplate.update("delete from maintenance_items where parent_item_id is not null");
+        jdbcTemplate.update("delete from maintenance_items");
+        jdbcTemplate.update("delete from bike_device_installations");
+        jdbcTemplate.update("delete from devices");
+        jdbcTemplate.update("delete from bike_equipments");
+        jdbcTemplate.update("delete from equipment_types");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from bike_operation_status_histories");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    // -----------------------------------------------------------------------
+    // create / update persists appliesToWheel
+    // -----------------------------------------------------------------------
+
+    @Test
+    void createItemPersistsAppliesToWheel() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/maintenance-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"브레이크 패드(앞)",
+                                  "appliesTo":"BOTH",
+                                  "appliesToWheel":"TWO_WHEEL",
+                                  "cycleKm":4000,
+                                  "displayOrder":10
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.appliesToWheel").value("TWO_WHEEL"))
+                .andReturn();
+
+        // verify DB value
+        UUID id = UUID.fromString(extractId(result));
+        String wheel = jdbcTemplate.queryForObject(
+                "select applies_to_wheel from maintenance_items where id = ?",
+                String.class, id);
+        assertThat(wheel).isEqualTo("TWO_WHEEL");
+    }
+
+    @Test
+    void updateItemPersistsAppliesToWheel() throws Exception {
+        // seed an item with TWO_WHEEL
+        UUID itemId = UUID.randomUUID();
+        seedItem(itemId, "타이어(앞)", "BOTH", "TWO_WHEEL", 15000, 10);
+
+        mockMvc.perform(patch("/api/v1/maintenance-items/{id}", itemId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "appliesToWheel":"FOUR_WHEEL"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appliesToWheel").value("FOUR_WHEEL"));
+
+        String wheel = jdbcTemplate.queryForObject(
+                "select applies_to_wheel from maintenance_items where id = ?",
+                String.class, itemId);
+        assertThat(wheel).isEqualTo("FOUR_WHEEL");
+    }
+
+    @Test
+    void updateItemLeavesAppliesToWheelUnchangedWhenNotProvided() throws Exception {
+        UUID itemId = UUID.randomUUID();
+        seedItem(itemId, "타이어(앞)", "BOTH", "TWO_WHEEL", 15000, 10);
+
+        mockMvc.perform(patch("/api/v1/maintenance-items/{id}", itemId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":"타이어(앞) 수정"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appliesToWheel").value("TWO_WHEEL"));
+    }
+
+    // -----------------------------------------------------------------------
+    // 2-axis filter: listItemsForBike
+    // -----------------------------------------------------------------------
+
+    /**
+     * 2륜·전기 바이크 → engine ∈ {ELECTRIC,BOTH} AND wheel ∈ {TWO_WHEEL,BOTH}.
+     *
+     * 시드:
+     *   A  (ELECTRIC, TWO_WHEEL)  → 포함 ✓
+     *   B  (ICE,      FOUR_WHEEL) → 제외 ✗ (엔진 불일치, 휠 불일치)
+     *   C  (BOTH,     BOTH)       → 포함 ✓
+     *   D  (ELECTRIC, BOTH)       → 포함 ✓
+     *   E  (BOTH,     TWO_WHEEL)  → 포함 ✓
+     *   F  (ELECTRIC, FOUR_WHEEL) → 제외 ✗ (엔진 일치, 휠 불일치)
+     *   G  (ICE,      TWO_WHEEL)  → 제외 ✗ (엔진 불일치, 휠 일치)
+     */
+    @Test
+    void listItemsForBikeFiltersOnBothEngineAndWheelAxes() throws Exception {
+        UUID itemA = seedItem(UUID.randomUUID(), "A 전기+2륜",  "ELECTRIC", "TWO_WHEEL",  1000, 1);
+        UUID itemB = seedItem(UUID.randomUUID(), "B ICE+4륜",   "ICE",      "FOUR_WHEEL", 2000, 2);
+        UUID itemC = seedItem(UUID.randomUUID(), "C BOTH+BOTH", "BOTH",     "BOTH",       3000, 3);
+        UUID itemD = seedItem(UUID.randomUUID(), "D 전기+BOTH", "ELECTRIC", "BOTH",       4000, 4);
+        UUID itemE = seedItem(UUID.randomUUID(), "E BOTH+2륜",  "BOTH",     "TWO_WHEEL",  5000, 5);
+        UUID itemF = seedItem(UUID.randomUUID(), "F 전기+4륜",  "ELECTRIC", "FOUR_WHEEL", 6000, 6);
+        UUID itemG = seedItem(UUID.randomUUID(), "G ICE+2륜",   "ICE",      "TWO_WHEEL",  7000, 7);
+
+        // 2륜·전기 바이크
+        seedBike(BIKE_ID, "ELECTRIC", "TWO_WHEEL");
+
+        MvcResult result = mockMvc.perform(get("/api/v1/bikes/{bikeId}/maintenance-items", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+
+        // 포함
+        assertThat(body).contains(itemA.toString()); // ELECTRIC + TWO_WHEEL
+        assertThat(body).contains(itemC.toString()); // BOTH     + BOTH
+        assertThat(body).contains(itemD.toString()); // ELECTRIC + BOTH
+        assertThat(body).contains(itemE.toString()); // BOTH     + TWO_WHEEL
+
+        // 제외
+        assertThat(body).doesNotContain(itemB.toString()); // ICE      + FOUR_WHEEL
+        assertThat(body).doesNotContain(itemF.toString()); // ELECTRIC + FOUR_WHEEL
+        assertThat(body).doesNotContain(itemG.toString()); // ICE      + TWO_WHEEL
+    }
+
+    @Test
+    void listItemsForFourWheelElectricBikeFiltersCorrectly() throws Exception {
+        UUID itemA = seedItem(UUID.randomUUID(), "A 전기+4륜",  "ELECTRIC", "FOUR_WHEEL", 1000, 1);
+        UUID itemB = seedItem(UUID.randomUUID(), "B 전기+2륜",  "ELECTRIC", "TWO_WHEEL",  2000, 2);
+        UUID itemC = seedItem(UUID.randomUUID(), "C BOTH+4륜",  "BOTH",     "FOUR_WHEEL", 3000, 3);
+        UUID itemD = seedItem(UUID.randomUUID(), "D BOTH+BOTH", "BOTH",     "BOTH",       4000, 4);
+        UUID itemE = seedItem(UUID.randomUUID(), "E ICE+4륜",   "ICE",      "FOUR_WHEEL", 5000, 5);
+
+        // 4륜·전기 바이크
+        seedBike(BIKE_ID, "ELECTRIC", "FOUR_WHEEL");
+
+        MvcResult result = mockMvc.perform(get("/api/v1/bikes/{bikeId}/maintenance-items", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+
+        assertThat(body).contains(itemA.toString()); // ELECTRIC + FOUR_WHEEL
+        assertThat(body).contains(itemC.toString()); // BOTH     + FOUR_WHEEL
+        assertThat(body).contains(itemD.toString()); // BOTH     + BOTH
+
+        assertThat(body).doesNotContain(itemB.toString()); // ELECTRIC + TWO_WHEEL
+        assertThat(body).doesNotContain(itemE.toString()); // ICE      + FOUR_WHEEL
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    /** Seeds a maintenance item. Returns its id. */
+    private UUID seedItem(UUID id, String name, String appliesTo, String appliesToWheel,
+                          int cycleKm, int displayOrder) {
+        jdbcTemplate.update("""
+                insert into maintenance_items
+                    (id, name, applies_to, applies_to_wheel, cycle_km, display_order, enabled)
+                values (?, ?, ?, ?, ?, ?, true)
+                """, id, name, appliesTo, appliesToWheel, cycleKm, displayOrder);
+        return id;
+    }
+
+    private void seedBike(UUID id, String engineType, String wheelType) {
+        jdbcTemplate.update("""
+                insert into bikes
+                    (id, plate_number, vin, model_name, engine_type, wheel_type, service_type, operation_status, memo)
+                values (?, ?, ?, 'Thunder M1', ?, ?, 'SINGLE', 'READY', 'fixture bike')
+                """, id,
+                "서울A-" + id.toString().substring(0, 4),
+                "VIN-" + id.toString().substring(0, 8),
+                engineType, wheelType);
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private String extractId(MvcResult result) throws Exception {
+        Matcher matcher = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"")
+                .matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-12-maintenance-page-wheel-axis.md
+++ b/docs/superpowers/plans/2026-06-12-maintenance-page-wheel-axis.md
@@ -1,0 +1,293 @@
+# 정비 관리 페이지 + 휠타입×엔진 2축 카탈로그 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 정비 카탈로그 편집을 `/management/maintenance`(좌측 레일 4번째)로 되살리고, 분류를 엔진(전기/내연) + **휠(2륜/4륜)** 2축으로 확장.
+
+**Architecture:** `MaintenanceItem`에 휠 축 `appliesToWheel` 독립 컬럼 추가(엔진 `appliesTo` 유지). 차량 적용 = 엔진 AND 휠 매치. V37 add-column(기본 BOTH). 편집기 안 A(엔진 3섹션 + 휠 배지/select).
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA, Next.js, TS. 브랜치 `cc-maintenance-page`(생성됨). Bash 절대경로 cd. 백엔드 게이트 compileJava compileTestJava(계약테스트 Docker→CI). 프론트 typecheck/lint/build.
+
+**현재 핵심(탐색 확인):**
+- `MaintenanceItem.create(name, appliesTo, parentItemId, cycleKm, cycleMonths, cycleLabel, displayOrder, memo)` (line 53) + `updateCatalog(name, appliesTo, parentItemId, cycleKm, cycleMonths, cycleLabel, displayOrder, enabled, memo)` (line 78). 필드 `appliesTo`(line 30).
+- `MaintenanceReadService.listItemsForBike` → `itemRepository.findByAppliesToInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo)`.
+- `MaintenanceCommandService.createItem`/`updateItem` (lines 45/63) 가 `request.appliesTo()` 전달.
+- DTO: `MaintenanceItemReadResponse`(record, `from`), `MaintenanceItemCreateRequest`(@NotNull appliesTo), `MaintenanceItemUpdateRequest`.
+- 프론트: `MaintenancePanel`(엔진 3섹션 filter, line 30-38), `MaintenanceItemDetailDialog`(appliesTo select line 72-76), `app/actions.ts` create/update/delete maintenance actions(+`parseAppliesTo`, redirect `/?tab=maintenance`), `ServiceOpsMaintenanceItem` 타입, `vehicle-maintenance-data.ts`(loadMaintenanceDataset = 전체 items), `summarizeMaintenanceByBike`(engine map) + `app/page.tsx` 호출부, `AppShell` NAV(3항목).
+- 차량 상세 번들 = `client.listMaintenanceItemsForBike(bikeId)`(백엔드 필터) → deriveMaintenanceRows 무변경.
+
+---
+
+### Task 1: 백엔드 — 휠 축 (enum + 엔티티 + V37 + 필터 + DTO + 테스트)
+
+**Files:**
+- Create: `.../maintenance/domain/MaintenanceWheelApplies.java`
+- Create: `.../resources/db/migration/V37__add_maintenance_applies_to_wheel.sql`
+- Modify: `.../maintenance/domain/MaintenanceItem.java`
+- Modify: `.../maintenance/repository/MaintenanceItemRepository.java`
+- Modify: `.../maintenance/service/MaintenanceReadService.java`
+- Modify: `.../maintenance/service/MaintenanceCommandService.java`
+- Modify: `.../maintenance/dto/MaintenanceItemReadResponse.java`, `MaintenanceItemCreateRequest.java`, `MaintenanceItemUpdateRequest.java`
+- Test: maintenance 계약 테스트
+
+- [ ] **Step 1: enum**
+
+`MaintenanceWheelApplies.java`:
+```java
+package com.thundercrew.opsapi.maintenance.domain;
+
+/** 정비 항목의 휠타입 적용 축. 엔진 축(MaintenanceAppliesTo)과 직교. */
+public enum MaintenanceWheelApplies {
+    TWO_WHEEL,   // 2륜 전용
+    FOUR_WHEEL,  // 4륜 전용
+    BOTH         // 공통(양쪽)
+}
+```
+
+- [ ] **Step 2: V37 마이그레이션**
+
+`V37__add_maintenance_applies_to_wheel.sql`:
+```sql
+-- 휠 축 추가. 기존 항목은 기본 'BOTH'(전 휠 적용). add-column + check 동시 —
+-- 기존 행이 모두 default 'BOTH' 라 check 위반 없음(값-재브랜드 아님).
+alter table maintenance_items
+    add column applies_to_wheel varchar(20) not null default 'BOTH';
+
+alter table maintenance_items
+    add constraint ck_maintenance_items_applies_to_wheel
+        check (applies_to_wheel in ('TWO_WHEEL', 'FOUR_WHEEL', 'BOTH'));
+```
+
+- [ ] **Step 3: 엔티티**
+
+`MaintenanceItem.java`: 
+- 필드 추가: `@Enumerated(EnumType.STRING) @Column(name = "applies_to_wheel", nullable = false, length = 20) private MaintenanceWheelApplies appliesToWheel;` (appliesTo 필드 옆).
+- `create(...)` 팩토리에 파라미터 `MaintenanceWheelApplies appliesToWheel` 추가(appliesTo 다음) + `item.appliesToWheel = appliesToWheel;`.
+- `updateCatalog(...)`에 파라미터 `MaintenanceWheelApplies appliesToWheel` 추가(appliesTo 다음) + `if (appliesToWheel != null) { this.appliesToWheel = appliesToWheel; }` (기존 appliesTo 패턴 따라).
+- getter `getAppliesToWheel()` 추가.
+
+- [ ] **Step 4: 리포지토리**
+
+`MaintenanceItemRepository.java`: 메서드 추가:
+```java
+    List<MaintenanceItem> findByAppliesToInAndAppliesToWheelInAndDeletedAtIsNullOrderByDisplayOrderAsc(
+            List<MaintenanceAppliesTo> appliesTo, List<MaintenanceWheelApplies> appliesToWheel);
+```
+(import `MaintenanceWheelApplies`.)
+
+- [ ] **Step 5: 차량별 필터**
+
+`MaintenanceReadService.listItemsForBike`: 휠 목록 추가 + 새 쿼리 사용:
+```java
+        List<MaintenanceAppliesTo> appliesTo = bike.getEngineType() == BikeEngineType.ELECTRIC
+                ? List.of(MaintenanceAppliesTo.ELECTRIC, MaintenanceAppliesTo.BOTH)
+                : List.of(MaintenanceAppliesTo.ICE, MaintenanceAppliesTo.BOTH);
+        List<MaintenanceWheelApplies> appliesToWheel = bike.getWheelType() == BikeWheelType.FOUR_WHEEL
+                ? List.of(MaintenanceWheelApplies.FOUR_WHEEL, MaintenanceWheelApplies.BOTH)
+                : List.of(MaintenanceWheelApplies.TWO_WHEEL, MaintenanceWheelApplies.BOTH);
+        return itemRepository
+                .findByAppliesToInAndAppliesToWheelInAndDeletedAtIsNullOrderByDisplayOrderAsc(appliesTo, appliesToWheel)
+                .stream().map(MaintenanceItemReadResponse::from).toList();
+```
+(import `MaintenanceWheelApplies`, `BikeWheelType`. `Bike.getWheelType()` 존재 확인 — wheelType NOT NULL default TWO_WHEEL.)
+
+- [ ] **Step 6: DTO**
+
+- `MaintenanceItemReadResponse`: record에 `MaintenanceWheelApplies appliesToWheel` 추가 + `from(item)`에 `item.getAppliesToWheel()` 매핑.
+- `MaintenanceItemCreateRequest`: `@NotNull MaintenanceWheelApplies appliesToWheel` 추가.
+- `MaintenanceItemUpdateRequest`: `MaintenanceWheelApplies appliesToWheel`(nullable) 추가.
+
+- [ ] **Step 7: CommandService 전달**
+
+`MaintenanceCommandService.createItem`: `MaintenanceItem.create(... request.appliesTo(), request.appliesToWheel(), ...)`. `updateItem`: `item.updateCatalog(... request.appliesTo(), request.appliesToWheel(), ...)`. (파라미터 위치 = 엔티티 시그니처와 일치하게.)
+
+- [ ] **Step 8: 컴파일 + 계약 테스트**
+
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava -q
+```
+계약 테스트(`grep -rln "maintenance-items\|listItemsForBike\|MaintenanceItemCreate" src/test/java`): 기존 create 요청에 appliesToWheel 누락 시 @NotNull 422 → 기존 테스트에 `appliesToWheel` 추가. 신규: 2륜·전기 / 4륜·내연 / 공통 항목 시드 후 `GET /api/v1/bikes/{id}/maintenance-items`가 차량 (엔진,휠) 조합 + 공통만 반환하는지(예: 2륜·전기 차량 → 2륜·전기 항목 + ELECTRIC/BOTH×TWO_WHEEL/BOTH 교집합). create/update가 appliesToWheel 저장.
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+```
+
+- [ ] **Step 9: 커밋**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/service-ops-api/src development/service-ops-api/src/main/resources/db/migration && git commit -m "feat(maintenance): wheel-type axis (appliesToWheel) + V37 + per-bike filter"
+```
+Co-Authored-By 라인 포함.
+
+---
+
+### Task 2: 프론트 — 타입 + 데이터 로더 + 정비 페이지 + 레일
+
+**Files:**
+- Modify: `lib/services/service-ops-api.ts`
+- Create: `app/management/maintenance/page.tsx`
+- Modify: `components/layout/AppShell.tsx`
+- (확인) `lib/services/vehicle-maintenance-data.ts` (전체 카탈로그 로더 재사용)
+
+- [ ] **Step 1: 타입**
+
+`service-ops-api.ts`: `export type ServiceOpsMaintenanceWheelApplies = "TWO_WHEEL" | "FOUR_WHEEL" | "BOTH";`. `ServiceOpsMaintenanceItem`에 `appliesToWheel: ServiceOpsMaintenanceWheelApplies;` 추가. create/update 메서드의 payload 타입/바디에 `appliesToWheel` 포함(기존 appliesTo 옆 — 메서드 READ 후 추가).
+
+- [ ] **Step 2: 정비 페이지**
+
+`app/management/maintenance/page.tsx`:
+```tsx
+import { MaintenancePanel } from "@/components/management/MaintenancePanel";
+import { loadMaintenanceDataset } from "@/lib/services/vehicle-maintenance-data";
+
+export const dynamic = "force-dynamic";
+
+export default async function ManagementMaintenancePage() {
+  const dataset = await loadMaintenanceDataset();
+  return (
+    <div className="management-page">
+      <MaintenancePanel items={dataset.items} />
+    </div>
+  );
+}
+```
+(`loadMaintenanceDataset`가 전체 `maintenance-items`를 반환하는지 READ로 확인 — `vehicle-maintenance-data.ts`에 `loadMaintenanceDataset`/유사 함수 존재. 함수명·반환형이 다르면 맞춰서. 미인증/오류 시 빈 items 폴백.)
+
+- [ ] **Step 3: 레일 4번째 항목**
+
+`AppShell.tsx` `NAV` 배열에 추가(업무 관리 다음):
+```tsx
+  {
+    href: "/management/maintenance",
+    label: "정비 관리",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 0 5.4-5.4l-2.5 2.5-2.5-.7-.7-2.5 2.4-2.3z" />
+      </svg>
+    )
+  }
+```
+
+- [ ] **Step 4: typecheck + lint + 커밋**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/lib/services/service-ops-api.ts development/front-admin-web/app/management/maintenance development/front-admin-web/components/layout/AppShell.tsx && git commit -m "feat(maintenance): /management/maintenance page + rail entry + wheel type"
+```
+(typecheck 실패가 MaintenancePanel/Dialog의 appliesToWheel 미반영(Task 3 대상)이면 그 파일 내부 에러는 Task 3에서 — 이 태스크 파일 내부 에러 0 목표. 단 MaintenancePanel을 페이지가 마운트하므로 빌드 통과 위해 Task 3와 함께 typecheck/lint가 깔끔해야 할 수 있음 — 그 경우 Task 3 먼저 끝낸 뒤 함께 검증. 안전하게: 이 태스크의 typecheck는 신규 페이지/타입/레일만 보고, 전체 통과는 Task 3 말미 + Task 5에서 보장.) Co-Authored-By 포함.
+
+---
+
+### Task 3: 프론트 — 편집기 휠 축 (배지 + select + 액션)
+
+**Files:**
+- Modify: `components/management/MaintenancePanel.tsx`
+- Modify: `components/management/MaintenanceItemDetailDialog.tsx`
+- Modify: `app/actions.ts`
+
+- [ ] **Step 1: MaintenancePanel 휠 배지**
+
+엔진 3섹션(전기/내연/공통) 유지. 각 항목 행에 휠타입 배지/셀 추가 — `item.appliesToWheel` → 라벨(TWO_WHEEL=2륜, FOUR_WHEEL=4륜, BOTH=공통). 행 렌더 구조(READ)에 배지 span 또는 컬럼 추가. 헬퍼 `wheelLabel(appliesToWheel)`.
+
+- [ ] **Step 2: MaintenanceItemDetailDialog 휠 select**
+
+생성·수정 폼의 `appliesTo` select 아래에 **휠타입 select** 추가:
+```tsx
+<label>휠타입
+  <select name="appliesToWheel" defaultValue={row?.appliesToWheel ?? "BOTH"}>
+    <option value="TWO_WHEEL">2륜</option>
+    <option value="FOUR_WHEEL">4륜</option>
+    <option value="BOTH">공통</option>
+  </select>
+</label>
+```
+(기존 appliesTo select 마크업 패턴 따라. 생성 모드 기본 BOTH.)
+
+- [ ] **Step 3: 서버액션**
+
+`app/actions.ts`:
+- `parseAppliesToWheel(value)` 헬퍼 추가(`parseAppliesTo` 패턴 — "TWO_WHEEL"|"FOUR_WHEEL"|"BOTH" 검증).
+- `createMaintenanceItemAction`/`updateMaintenanceItemAction`: 폼에서 `appliesToWheel` 파싱해 client.createMaintenanceItem/updateMaintenanceItem payload에 포함.
+- create/update/delete 액션의 redirect `/?tab=maintenance` → `/management/maintenance` (전부).
+
+- [ ] **Step 4: typecheck + lint + build + 커밋**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/MaintenancePanel.tsx development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx development/front-admin-web/app/actions.ts && git commit -m "feat(maintenance): editor wheel-type badge + select + action wiring"
+```
+Co-Authored-By 포함. Expected: 전부 통과.
+
+---
+
+### Task 4: 프론트 — 요약 derive 엔진+휠 확장
+
+**Files:**
+- Modify: `components/management/vehicle-maintenance-derive.ts`
+- Modify: `app/page.tsx`
+
+- [ ] **Step 1: summarizeMaintenanceByBike 휠 반영**
+
+`summarizeMaintenanceByBike`: 현재 `bikeEngineTypeById: Map<string,"ELECTRIC"|"ICE">`로 엔진만 필터. 휠 맵 파라미터 추가:
+```ts
+export function summarizeMaintenanceByBike(
+  items, records,
+  bikeEngineTypeById: Map<string, "ELECTRIC" | "ICE">,
+  bikeWheelTypeById: Map<string, "TWO_WHEEL" | "FOUR_WHEEL">,
+  now = new Date()
+)
+```
+필터를 엔진(ELECTRIC→ELECTRIC|BOTH, ICE→ICE|BOTH) **AND** 휠(FOUR_WHEEL→FOUR_WHEEL|BOTH, else TWO_WHEEL|BOTH)로. 차량별 `applicableItems` = engine 매치 ∩ wheel 매치.
+
+- [ ] **Step 2: app/page.tsx 호출부**
+
+`summarizeMaintenanceByBike` 호출부에 `bikeWheelTypeById` 맵 구성·전달(차량 목록에서 `wheelType` 추출, 미상 시 TWO_WHEEL fallback — 백엔드 기본과 일치). engine 맵 구성 코드 옆에 추가.
+
+- [ ] **Step 3: typecheck + lint + build + 커밋**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && git add development/front-admin-web/components/management/vehicle-maintenance-derive.ts development/front-admin-web/app/page.tsx && git commit -m "feat(maintenance): summary keys by engine + wheel"
+```
+Co-Authored-By 포함.
+
+---
+
+### Task 5: 최종 검증 + PR
+
+- [ ] **Step 1: 풀 검증**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/service-ops-api && ./gradlew compileJava compileTestJava -q
+cd /c/Users/user/repositories/clever/thundercrew-domain/development/front-admin-web && npm run typecheck && npm run lint && npm run build
+cd /c/Users/user/repositories/clever/thundercrew-domain && (git diff dev --name-only | grep -i "db/migration") && echo "V37 present" 
+```
+Expected: 백엔드/프론트 통과, V37 마이그레이션 1개(add-column), 빌드에 `/management/maintenance` 라우트.
+
+- [ ] **Step 2: PR (→ dev)**
+```bash
+cd /c/Users/user/repositories/clever/thundercrew-domain && git push -u origin cc-maintenance-page && gh pr create --base dev --title "정비 관리 페이지 + 휠타입×엔진 2축 카탈로그" --body "$(cat <<'EOF'
+## Summary
+- 좌측 레일 4번째 "정비 관리" → /management/maintenance (미마운트였던 카탈로그 편집기 복구)
+- 정비 분류를 엔진(전기/내연) + **휠(2륜/4륜)** 2축으로: MaintenanceItem.appliesToWheel(BOTH 포함) 추가
+- 차량별 정비 = 엔진 매치 AND 휠 매치 (listItemsForBike), 차량 상세 자동 반영
+- 편집기: 엔진 3섹션 유지 + 휠 배지/select. 요약 derive 엔진+휠 확장
+
+## 배포 영향
+- **V37 마이그레이션**: maintenance_items에 applies_to_wheel 컬럼 add (기본 'BOTH', check). add-column이라 안전(기존 행 BOTH로 채움, V36식 값-재브랜드 아님). 재기동 시 Flyway 적용.
+
+## Test Plan
+- [x] 백엔드 compileJava + compileTestJava, 프론트 typecheck+lint+build, V37 add-column
+- [ ] 계약 테스트(CI): (엔진,휠) 조합 필터
+- [ ] 프로덕션 QA: 레일 정비 관리→페이지, 항목 생성/수정 엔진+휠 지정, 휠 배지, 차량 상세 정비가 (엔진,휠) 조합만
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec 커버리지:** enum/엔티티/V37/repo/필터/DTO/command/테스트(T1), 타입·페이지·레일(T2), 편집기 배지·select·액션·redirect(T3), 요약 derive(T4), 검증·PR(T5). ✓ 차량상세 derive 무변경(백엔드 필터). ✓
+
+**2. 플레이스홀더 스캔:** enum/migration/필터/페이지/레일SVG/select 완전 코드. "READ 후 패턴 따라"(panel 행 구조, dialog select 마크업, 데이터로더 함수명, create/update payload)는 코드베이스 의존 — 대상·방법 구체. placeholder 아님.
+
+**3. 타입/이름 일관성:** 백엔드 `MaintenanceWheelApplies{TWO_WHEEL,FOUR_WHEEL,BOTH}` ↔ 프론트 `ServiceOpsMaintenanceWheelApplies` 동일 3값. 컬럼 `applies_to_wheel` ↔ 필드 `appliesToWheel` ↔ DTO/타입/폼 name="appliesToWheel" 일관. repo 메서드명 = 필터 쿼리 시그니처. listItemsForBike 휠 필터 ↔ 차량 상세 자동.
+
+**구현자 주의:** V37은 add-column+check(기존 행 default 'BOTH'라 안전) — V36식 UPDATE-before-DROP 아님. `MaintenanceItem.create`/`updateCatalog` 파라미터 위치에 appliesToWheel를 appliesTo 바로 다음으로 일관 삽입(엔티티·CommandService·CreateRequest 매핑 위치 정렬). 차량상세 deriveMaintenanceRows는 손대지 말 것(백엔드 필터로 충분). Task2 중간 typecheck는 Task3 미완으로 실패할 수 있음 — 전체 통과는 T3·T5에서 보장.

--- a/docs/superpowers/specs/2026-06-12-maintenance-page-wheel-axis-design.md
+++ b/docs/superpowers/specs/2026-06-12-maintenance-page-wheel-axis-design.md
@@ -1,0 +1,58 @@
+# 정비 관리 페이지 + 휠타입×엔진 2축 카탈로그 Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan derived from this spec.
+
+**Goal:** 정비 카탈로그(항목·주기) 편집을 좌측 레일의 **정비 관리** 페이지(`/management/maintenance`)로 되살리고, 분류 기준을 엔진 축(전기/내연)만에서 **휠타입(2륜/4륜) × 엔진(전기/내연) 2축**으로 확장한다.
+
+**Architecture:** `MaintenanceItem`에 휠 축(`appliesToWheel`) 독립 컬럼 추가(엔진 축 `appliesTo` 유지). 차량별 적용 = 엔진 매치 AND 휠 매치. 미마운트 편집기 `MaintenancePanel`을 신규 라우트에 마운트 + 레일 4번째 항목. V37 add-column(기본 BOTH) → 안전.
+
+**Tech Stack:** Spring Boot (Java 21), Flyway, JPA, Next.js App Router, TypeScript.
+
+**비범위:** 정비 이력 기록 UI(기존 유지), 정비 알림, 4조합 단일 enum(2축 독립 채택), serviceType 연계.
+
+---
+
+## 1. 백엔드 — 휠 축 추가
+
+`com.thundercrew.opsapi.maintenance`:
+- **신규 enum** `MaintenanceWheelApplies { TWO_WHEEL, FOUR_WHEEL, BOTH }` (엔진 `MaintenanceAppliesTo`와 대칭).
+- **`MaintenanceItem`**: 필드 `appliesToWheel`(EnumType.STRING, varchar(20), NOT NULL) 추가. 팩토리/생성자에 반영.
+- **V37 마이그레이션** `V37__add_maintenance_applies_to_wheel.sql`:
+  ```sql
+  alter table maintenance_items add column applies_to_wheel varchar(20) not null default 'BOTH';
+  alter table maintenance_items add constraint ck_maintenance_items_applies_to_wheel
+      check (applies_to_wheel in ('TWO_WHEEL', 'FOUR_WHEEL', 'BOTH'));
+  ```
+  (기본 'BOTH'로 기존 항목 전 휠 적용. add-column + check 동시 — 기존 행이 모두 default 'BOTH'라 check 위반 없음. V36 같은 값-재브랜드 아님.)
+- **차량별 필터** `MaintenanceReadService.listItemsForBike`: 엔진 목록(전기→ELECTRIC,BOTH / 내연→ICE,BOTH) + 휠 목록(2륜→TWO_WHEEL,BOTH / 4륜→FOUR_WHEEL,BOTH) **둘 다** 매치하는 항목만. `Bike.getWheelType()` 사용. Repository에 `findByAppliesToInAndAppliesToWheelInAndDeletedAtIsNull...OrderByDisplayOrderAsc` 추가(또는 기존 쿼리 확장).
+- **DTO**: `MaintenanceItemReadResponse`/`MaintenanceItemCreateRequest`/`MaintenanceItemUpdateRequest`에 `appliesToWheel`(생성은 `@NotNull`, 수정은 nullable) 추가.
+- **테스트**: 2륜·전기 / 4륜·내연 / 공통(BOTH) 조합 시드 → `listItemsForBike`가 차량의 (엔진,휠) 조합에 맞는 항목만(+공통) 반환. create/update가 appliesToWheel 저장.
+
+## 2. 프론트 — 정비 관리 페이지 + 레일
+
+- **신규 라우트** `app/management/maintenance/page.tsx`: 카탈로그 SSR 로드(기존 데이터 로더 재사용 — 전체 `maintenance-items` 목록) + `<MaintenancePanel items={...} />` 마운트. `export const dynamic = "force-dynamic"`.
+- **AppShell 레일**: NAV에 4번째 `{ href: "/management/maintenance", label: "정비 관리", icon: <정비 SVG> }` 추가. active 판정 기존 로직(startsWith) 그대로.
+
+## 3. 프론트 — 편집기 (안 A: 엔진 3섹션 + 휠 배지/필드)
+
+- **`MaintenancePanel`**: 기존 엔진 3섹션(전기 전용 / 내연 전용 / 공통) 유지. 각 항목 행에 **휠타입 배지/컬럼**(2륜/4륜/공통) 추가.
+- **`MaintenanceItemDetailDialog`**: 생성·수정 폼에 **휠타입 select**(2륜/4륜/공통) 추가.
+- **서버액션**(`app/actions.ts`) `createMaintenanceItemAction`/`updateMaintenanceItemAction`: `appliesToWheel` 폼 파싱(`parseAppliesToWheel`)·전달. redirect를 stale `/?tab=maintenance` → **`/management/maintenance`** 로 수정(create/update/delete 모두).
+- **클라이언트 타입** `ServiceOpsMaintenanceItem` + 신규 `ServiceOpsMaintenanceWheelApplies = "TWO_WHEEL" | "FOUR_WHEEL" | "BOTH"` + create/update 메서드 payload에 `appliesToWheel` 추가.
+
+## 4. 프론트 — 차량 상세 / 요약 derive
+- **차량 상세**: 번들 items는 `listMaintenanceItemsForBike`(백엔드, §1에서 엔진+휠 필터됨) → `deriveMaintenanceRows` **무변경**(이미 필터된 항목만 받음).
+- **요약** `summarizeMaintenanceByBike`(app/page.tsx): 현재 `bikeEngineTypeById: Map<id,engine>`로 엔진만 필터. → `Map<id,{engine,wheel}>`(또는 wheel 맵 추가)로 확장해 엔진+휠 필터. `app/page.tsx` 호출부에서 각 bike의 wheelType 전달.
+
+## 5. 데이터 흐름
+```
+정비 관리 페이지 → maintenance-items 전체 → MaintenancePanel(엔진 섹션 + 휠 배지) → 생성/수정(엔진+휠 select) → CRUD API(appliesTo + appliesToWheel)
+차량 상세 → listMaintenanceItemsForBike(엔진∈{차량엔진,BOTH} AND 휠∈{차량휠,BOTH}) → derive(무변경)
+```
+
+## 6. 검증
+- 백엔드 `compileJava + compileTestJava`(2축 필터 계약 테스트). 프론트 `typecheck + lint + build`.
+- 프로덕션 QA: 레일 "정비 관리" → 페이지 진입, 항목 생성/수정 시 엔진+휠 지정, 항목 행에 휠 배지, 차량 상세 정비가 차량의 (엔진,휠) 조합 항목만 노출. **마이그레이션 V37(add-column) 재기동 적용.**
+
+## 7. 비범위 재확인
+정비 이력 기록 UI, 정비 알림, 단일 4조합 enum, serviceType 연계는 포함하지 않는다.


### PR DESCRIPTION
## 릴리스 내용
정비 카탈로그를 좌측 레일 **정비 관리**(`/management/maintenance`) 페이지로 복구하고, 분류를 엔진(전기/내연) + **휠(2륜/4륜)** 2축으로 확장.

- `MaintenanceItem.appliesToWheel`(TWO_WHEEL/FOUR_WHEEL/BOTH) 추가 — 엔진 축과 직교
- 차량별 정비 = 엔진 매치 **AND** 휠 매치 (백엔드 `listItemsForBike` 필터)
- 편집기: 엔진 3섹션 + 휠 배지/select, 요약 derive 엔진∩휠 교집합
- 좌측 레일 4번째 정비 관리 항목, 액션 redirect 정리

(상세: #404)

## ⚠️ 배포 영향 — 마이그레이션
- **V37** `maintenance_items.applies_to_wheel` 컬럼 add (NOT NULL DEFAULT 'BOTH' + CHECK).
- 순수 add-column → 기존 행은 'BOTH'로 backfill, CHECK 위반 없음. V36식 값-재브랜드/DROP 순서 위험 **없음**.
- API 재기동 시 Flyway 자동 적용.

## Test Plan
- [x] 백엔드 compileJava + compileTestJava (2축 필터 계약 테스트)
- [x] 프론트 typecheck + lint + build
- [ ] 프로덕션 QA (배포 후): 레일 정비 관리 진입, 항목 생성/수정 엔진+휠 지정, 목록 휠 배지, 차량 상세가 (엔진,휠) 조합 항목만 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)