### PR TITLE
정비 관리: 항목 추가 기능

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1107,6 +1107,7 @@ textarea { padding-top: 10px; min-height: 96px; }
    각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
 .maintenance-panel { display: flex; flex-direction: column; gap: 24px; }
 .maintenance-panel-section { display: flex; flex-direction: column; gap: 8px; }
+.maintenance-panel-section-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .maintenance-panel-section-title { margin: 0; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }
 .maintenance-panel-indent { color: var(--color-text-muted); margin-right: 4px; }
 

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -2,9 +2,12 @@
 
 import { useCallback, useRef, useState } from "react";
 
-import { updateMaintenanceItemAction } from "@/app/actions";
+import { createMaintenanceItemAction, updateMaintenanceItemAction } from "@/app/actions";
 import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
-import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
+import type {
+  ServiceOpsMaintenanceAppliesTo,
+  ServiceOpsMaintenanceItem
+} from "@/lib/services/service-ops-api";
 
 /**
  * 정비 카탈로그 행의 상세 + 수정 다이얼로그. 다른 detail dialog 들과 같은
@@ -16,26 +19,31 @@ import type { ServiceOpsMaintenanceItem } from "@/lib/services/service-ops-api";
  */
 export function MaintenanceItemDetailDialog({
   row,
+  createEngine = null,
   parentOptions,
   onClose
 }: {
   row: ServiceOpsMaintenanceItem | null;
+  createEngine?: ServiceOpsMaintenanceAppliesTo | null;
   parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const [mode, setMode] = useState<"view" | "edit">("view");
-  useScrollLockedDialog(dialogRef, row !== null);
+  const isCreate = row === null && createEngine !== null;
+  // 생성 모드는 바로 폼, 기존 항목은 보기 → 수정 토글.
+  const [mode, setMode] = useState<"view" | "edit">(isCreate ? "edit" : "view");
+  useScrollLockedDialog(dialogRef, row !== null || createEngine !== null);
 
   const handleClose = useCallback(() => {
     onClose();
   }, [onClose]);
 
-  if (!row) return null;
+  if (!row && !isCreate) return null;
 
-  const boundUpdate = updateMaintenanceItemAction.bind(null, row.id);
+  const formAction = isCreate ? createMaintenanceItemAction : updateMaintenanceItemAction.bind(null, row!.id);
+  // 그룹 부모 후보: 최상위 항목만(자기 자신 제외). 생성 모드는 제외할 자기 자신이 없다.
   const eligibleParents = parentOptions.filter(
-    (option) => option.id !== row.id && option.parentItemId === null
+    (option) => option.parentItemId === null && (row ? option.id !== row.id : true)
   );
 
   return (
@@ -45,32 +53,32 @@ export function MaintenanceItemDetailDialog({
       onClose={onClose}
       onCancel={onClose}
     >
-      <h3>정비 품목 상세</h3>
-      {mode === "view" ? (
+      <h3>{isCreate ? "정비 품목 추가" : "정비 품목 상세"}</h3>
+      {!isCreate && mode === "view" ? (
         <div className="detail-row-grid">
-          <DetailField label="품목" value={row.name} />
-          <DetailField label="적용" value={appliesToLabel(row.appliesTo)} />
-          <DetailField label="휠타입" value={wheelAppliesLabel(row.appliesToWheel)} />
-          <DetailField label="교환주기 (km)" value={row.cycleKm !== null ? `${row.cycleKm.toLocaleString()} km` : "—"} />
-          <DetailField label="교환주기 (개월)" value={row.cycleMonths !== null ? `${row.cycleMonths}개월` : "—"} />
-          <DetailField label="라벨" value={row.cycleLabel ?? "—"} />
-          <DetailField label="그룹 부모" value={parentLabel(row, parentOptions)} />
-          <DetailField label="활성" value={row.enabled ? "ON" : "OFF"} />
-          <DetailField label="정렬" value={String(row.displayOrder)} />
+          <DetailField label="품목" value={row!.name} />
+          <DetailField label="적용" value={appliesToLabel(row!.appliesTo)} />
+          <DetailField label="휠타입" value={wheelAppliesLabel(row!.appliesToWheel)} />
+          <DetailField label="교환주기 (km)" value={row!.cycleKm !== null ? `${row!.cycleKm.toLocaleString()} km` : "—"} />
+          <DetailField label="교환주기 (개월)" value={row!.cycleMonths !== null ? `${row!.cycleMonths}개월` : "—"} />
+          <DetailField label="라벨" value={row!.cycleLabel ?? "—"} />
+          <DetailField label="그룹 부모" value={parentLabel(row!, parentOptions)} />
+          <DetailField label="활성" value={row!.enabled ? "ON" : "OFF"} />
+          <DetailField label="정렬" value={String(row!.displayOrder)} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>닫기</button>
             <button type="button" className="button-primary" onClick={() => setMode("edit")}>수정</button>
           </div>
         </div>
       ) : (
-        <form action={boundUpdate}>
+        <form action={formAction}>
           <label>
             품목
-            <input name="name" defaultValue={row.name} maxLength={100} required />
+            <input name="name" defaultValue={row?.name ?? ""} maxLength={100} required />
           </label>
           <label>
             적용
-            <select name="appliesTo" defaultValue={row.appliesTo}>
+            <select name="appliesTo" defaultValue={row?.appliesTo ?? createEngine ?? "BOTH"}>
               <option value="ELECTRIC">전기</option>
               <option value="ICE">내연</option>
               <option value="BOTH">공통</option>
@@ -78,7 +86,7 @@ export function MaintenanceItemDetailDialog({
           </label>
           <label>
             휠타입
-            <select name="appliesToWheel" defaultValue={row.appliesToWheel ?? "BOTH"}>
+            <select name="appliesToWheel" defaultValue={row?.appliesToWheel ?? "BOTH"}>
               <option value="TWO_WHEEL">2륜</option>
               <option value="FOUR_WHEEL">4륜</option>
               <option value="BOTH">공통</option>
@@ -86,19 +94,19 @@ export function MaintenanceItemDetailDialog({
           </label>
           <label>
             교환주기 (km)
-            <input name="cycleKm" type="number" min={0} defaultValue={row.cycleKm ?? ""} placeholder="비우면 km 기준 없음" />
+            <input name="cycleKm" type="number" min={0} defaultValue={row?.cycleKm ?? ""} placeholder="비우면 km 기준 없음" />
           </label>
           <label>
             교환주기 (개월)
-            <input name="cycleMonths" type="number" min={0} defaultValue={row.cycleMonths ?? ""} placeholder="비우면 개월 기준 없음" />
+            <input name="cycleMonths" type="number" min={0} defaultValue={row?.cycleMonths ?? ""} placeholder="비우면 개월 기준 없음" />
           </label>
           <label>
             라벨 (자유 텍스트)
-            <input name="cycleLabel" defaultValue={row.cycleLabel ?? ""} maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
+            <input name="cycleLabel" defaultValue={row?.cycleLabel ?? ""} maxLength={50} placeholder="예: 6~7개월 / 12개월 이상" />
           </label>
           <label>
             그룹 부모
-            <select name="parentItemId" defaultValue={row.parentItemId ?? ""}>
+            <select name="parentItemId" defaultValue={row?.parentItemId ?? ""}>
               <option value="">없음</option>
               {eligibleParents.map((option) => (
                 <option key={option.id} value={option.id}>
@@ -109,18 +117,20 @@ export function MaintenanceItemDetailDialog({
           </label>
           <label>
             정렬
-            <input name="displayOrder" type="number" min={0} defaultValue={row.displayOrder} />
+            <input name="displayOrder" type="number" min={0} defaultValue={row?.displayOrder ?? ""} />
           </label>
-          <label>
-            활성
-            <select name="enabled" defaultValue={row.enabled ? "true" : "false"}>
-              <option value="true">ON</option>
-              <option value="false">OFF</option>
-            </select>
-          </label>
+          {!isCreate ? (
+            <label>
+              활성
+              <select name="enabled" defaultValue={row!.enabled ? "true" : "false"}>
+                <option value="true">ON</option>
+                <option value="false">OFF</option>
+              </select>
+            </label>
+          ) : null}
           <div className="overview-create-dialog-actions">
-            <button type="button" className="button-neutral" onClick={() => setMode("view")}>취소</button>
-            <button type="submit" className="button-primary">저장</button>
+            <button type="button" className="button-neutral" onClick={isCreate ? handleClose : () => setMode("view")}>취소</button>
+            <button type="submit" className="button-primary">{isCreate ? "추가" : "저장"}</button>
           </div>
         </form>
       )}

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -4,7 +4,11 @@ import { useMemo, useState, type ReactNode } from "react";
 
 import { DeleteMaintenanceItemButton } from "@/components/management/DeleteMaintenanceItemButton";
 import { MaintenanceItemDetailDialog } from "@/components/management/MaintenanceItemDetailDialog";
-import type { ServiceOpsMaintenanceItem, ServiceOpsMaintenanceWheelApplies } from "@/lib/services/service-ops-api";
+import type {
+  ServiceOpsMaintenanceAppliesTo,
+  ServiceOpsMaintenanceItem,
+  ServiceOpsMaintenanceWheelApplies
+} from "@/lib/services/service-ops-api";
 
 /**
  * `/?tab=maintenance` 의 정비 카탈로그 편집 패널. 세 섹션(전기 전용 / 내연
@@ -21,6 +25,7 @@ import type { ServiceOpsMaintenanceItem, ServiceOpsMaintenanceWheelApplies } fro
  */
 export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMaintenanceItem> }) {
   const [activeRow, setActiveRow] = useState<ServiceOpsMaintenanceItem | null>(null);
+  const [createEngine, setCreateEngine] = useState<ServiceOpsMaintenanceAppliesTo | null>(null);
 
   const sorted = useMemo(
     () => [...items].sort((a, b) => a.displayOrder - b.displayOrder),
@@ -31,17 +36,31 @@ export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMai
   const ice = sorted.filter((item) => item.appliesTo === "ICE");
   const both = sorted.filter((item) => item.appliesTo === "BOTH");
 
+  const openRow = (item: ServiceOpsMaintenanceItem) => {
+    setCreateEngine(null);
+    setActiveRow(item);
+  };
+  const openCreate = (engine: ServiceOpsMaintenanceAppliesTo) => {
+    setActiveRow(null);
+    setCreateEngine(engine);
+  };
+  const close = () => {
+    setActiveRow(null);
+    setCreateEngine(null);
+  };
+
   return (
     <div className="maintenance-panel">
-      <Section title="전기 전용" items={electric} parentOptions={sorted} onActivate={setActiveRow} />
-      <Section title="내연 전용" items={ice} parentOptions={sorted} onActivate={setActiveRow} />
-      <Section title="공통 (양쪽 적용)" items={both} parentOptions={sorted} onActivate={setActiveRow} />
+      <Section title="전기 전용" appliesTo="ELECTRIC" items={electric} parentOptions={sorted} onActivate={openRow} onCreate={openCreate} />
+      <Section title="내연 전용" appliesTo="ICE" items={ice} parentOptions={sorted} onActivate={openRow} onCreate={openCreate} />
+      <Section title="공통 (양쪽 적용)" appliesTo="BOTH" items={both} parentOptions={sorted} onActivate={openRow} onCreate={openCreate} />
 
       <MaintenanceItemDetailDialog
-        key={activeRow?.id ?? "none"}
+        key={activeRow?.id ?? (createEngine ? `create-${createEngine}` : "none")}
         row={activeRow}
+        createEngine={createEngine}
         parentOptions={sorted}
-        onClose={() => setActiveRow(null)}
+        onClose={close}
       />
     </div>
   );
@@ -49,18 +68,27 @@ export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMai
 
 function Section({
   title,
+  appliesTo,
   items,
   parentOptions,
-  onActivate
+  onActivate,
+  onCreate
 }: {
   title: string;
+  appliesTo: ServiceOpsMaintenanceAppliesTo;
   items: ReadonlyArray<ServiceOpsMaintenanceItem>;
   parentOptions: ReadonlyArray<ServiceOpsMaintenanceItem>;
   onActivate: (item: ServiceOpsMaintenanceItem) => void;
+  onCreate: (appliesTo: ServiceOpsMaintenanceAppliesTo) => void;
 }) {
   return (
     <section className="maintenance-panel-section">
-      <h3 className="maintenance-panel-section-title">{title}</h3>
+      <div className="maintenance-panel-section-head">
+        <h3 className="maintenance-panel-section-title">{title}</h3>
+        <button type="button" className="button-neutral" onClick={() => onCreate(appliesTo)}>
+          + 항목 추가
+        </button>
+      </div>
       <div className="table-card">
         <table className="table" style={{ tableLayout: "fixed" }}>
           <colgroup>


### PR DESCRIPTION
## Summary
정비 관리 페이지에 **신규 항목 추가** UI를 연결. (백엔드/서버액션/클라이언트는 이미 존재했으나 호출할 버튼이 없었음 — QA 중 발견)

- 각 섹션(전기 전용 / 내연 전용 / 공통) 헤더에 **+ 항목 추가** 버튼
- 클릭 시 해당 섹션의 엔진이 미리 선택된 빈 생성 폼 다이얼로그(`정비 품목 추가`)
- 다이얼로그에 생성 모드 추가: `createMaintenanceItemAction` 바인딩, 활성 필드는 생성 시 숨김(백엔드 기본값), 취소 시 닫기

## 영향
- 프론트 전용. 마이그레이션/백엔드 변경 없음.

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 섹션별 추가 버튼 → 폼 → 저장 시 새 항목 생성, 엔진 프리필 확인