### PR TITLE
정비 관리: 상세 보기 핵심 필드만 노출

### DIFF
--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -58,13 +58,8 @@ export function MaintenanceItemDetailDialog({
         <div className="detail-row-grid">
           <DetailField label="품목" value={row!.name} />
           <DetailField label="적용" value={appliesToLabel(row!.appliesTo)} />
-          <DetailField label="휠타입" value={wheelAppliesLabel(row!.appliesToWheel)} />
           <DetailField label="교환주기 (km)" value={row!.cycleKm !== null ? `${row!.cycleKm.toLocaleString()} km` : "—"} />
           <DetailField label="교환주기 (개월)" value={row!.cycleMonths !== null ? `${row!.cycleMonths}개월` : "—"} />
-          <DetailField label="라벨" value={row!.cycleLabel ?? "—"} />
-          <DetailField label="그룹 부모" value={parentLabel(row!, parentOptions)} />
-          <DetailField label="활성" value={row!.enabled ? "ON" : "OFF"} />
-          <DetailField label="정렬" value={String(row!.displayOrder)} />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>닫기</button>
             <button type="button" className="button-primary" onClick={() => setMode("edit")}>수정</button>
@@ -151,19 +146,4 @@ function appliesToLabel(value: ServiceOpsMaintenanceItem["appliesTo"]): string {
   if (value === "ELECTRIC") return "전기";
   if (value === "ICE") return "내연";
   return "공통";
-}
-
-function wheelAppliesLabel(value: ServiceOpsMaintenanceItem["appliesToWheel"]): string {
-  if (value === "TWO_WHEEL") return "2륜";
-  if (value === "FOUR_WHEEL") return "4륜";
-  return "공통";
-}
-
-function parentLabel(
-  row: ServiceOpsMaintenanceItem,
-  options: ReadonlyArray<ServiceOpsMaintenanceItem>
-): string {
-  if (!row.parentItemId) return "—";
-  const parent = options.find((option) => option.id === row.parentItemId);
-  return parent?.name ?? "—";
 }


### PR DESCRIPTION
## Summary
정비 품목 상세 보기(읽기 전용)를 핵심 필드만 남기도록 정리.

- **제거**: 휠타입 / 라벨 / 그룹 부모 / 활성 / 정렬(displayOrder)
- **유지**: 품목 / 적용 / 교환주기(km) / 교환주기(개월)
- 조건부 숨김이 아니라 필드 자체 삭제

제거된 정보는 손실 없음 — 휠/그룹부모/활성은 목록 표에 그대로 노출되고, 전부 수정 폼에서 입력 가능. 사용하지 않게 된 헬퍼(wheelAppliesLabel, parentLabel) 제거.

## 영향
- 프론트 전용, 상세 보기 모드만. 수정 폼·목록·필터 무변경.

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 상세 보기에 품목/적용/교환주기만 노출