### PR TITLE
정비 다이얼로그: 와일드카드 제거 + 중앙 정렬 보정

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -509,8 +509,8 @@ const MAINTENANCE_WHEELS = ["TWO_WHEEL", "FOUR_WHEEL"] as const;
 const MAINTENANCE_ENGINES = ["ELECTRIC", "ICE"] as const;
 
 // 분류는 휠(2륜/4륜) × 엔진(전기/내연) 두 축의 교차곱으로 만든다.
-// 한 축을 안 고르면 그 축은 전체로 간주(와일드카드) — 예: 2륜만 고르면
-// 2륜전기·2륜내연 둘 다. 결과는 항상 1개 이상.
+// 와일드카드 없음 — 선택된 휠·엔진만 교차한다. 한 축이라도 비면 결과는 빈
+// 배열(클라이언트가 제출 자체를 막고, create 액션은 빈 배열을 거른다).
 function categoriesFromAxes(
   wheelValues: FormDataEntryValue[],
   engineValues: FormDataEntryValue[]
@@ -519,11 +519,9 @@ function categoriesFromAxes(
   const engineSet = new Set(engineValues.map((v) => String(v)));
   const wheels = MAINTENANCE_WHEELS.filter((w) => wheelSet.has(w));
   const engines = MAINTENANCE_ENGINES.filter((e) => engineSet.has(e));
-  const effWheels = wheels.length > 0 ? wheels : [...MAINTENANCE_WHEELS];
-  const effEngines = engines.length > 0 ? engines : [...MAINTENANCE_ENGINES];
   const out: ServiceOpsMaintenanceCategory[] = [];
-  for (const w of effWheels) {
-    for (const e of effEngines) {
+  for (const w of wheels) {
+    for (const e of engines) {
       out.push(`${w}_${e}` as ServiceOpsMaintenanceCategory);
     }
   }
@@ -544,6 +542,9 @@ export async function createMaintenanceItemAction(formData: FormData): Promise<v
     redirect("/management/maintenance?status=maintenance-item-missing-name");
   }
   const categories = categoriesFromAxes(formData.getAll("wheels"), formData.getAll("engines"));
+  if (categories.length === 0) {
+    redirect("/management/maintenance?status=maintenance-item-invalid-applies-to");
+  }
   const cycleKm = optionalInteger(formData.get("cycleKm"));
   const cycleMonths = optionalInteger(formData.get("cycleMonths"));
   if (cycleKm === null && cycleMonths === null) {

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1124,8 +1124,14 @@ textarea { padding-top: 10px; min-height: 96px; }
 .maintenance-axis-toggle:hover { border-color: var(--color-border-strong); }
 .maintenance-axis-toggle[aria-pressed="true"] { background: var(--baemin-mint); color: var(--color-text-on-mint); border-color: transparent; }
 .maintenance-axis-preview { margin: 8px 0 0; font-size: 12px; color: var(--baemin-mint); }
+.maintenance-axis-preview-empty { color: var(--color-text-muted); }
 .maintenance-chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 2px; }
 .maintenance-chip { font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 999px; background: var(--color-surface-mint); color: var(--color-text-primary); border: 1px solid var(--color-border-mint); }
+
+/* 정비 다이얼로그 중앙 정렬 — transform 기반 대신 네이티브 모달 정석
+   (inset:0 + margin:auto) 로 보정해 위치 어긋남을 없앤다. */
+.overview-create-dialog.maintenance-dialog { top: auto; left: auto; transform: none; inset: 0; margin: auto; }
+.button-primary:disabled, .button-neutral:disabled { opacity: .45; cursor: not-allowed; }
 
 /* 차량 floating panel 의 view 모드 — field grid / 정비 섹션 / 액션 버튼 세
    블록을 위에서 아래로 쌓는다. 정비 섹션을 grid 안에 두면 IMEI 오른쪽 셀로

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -48,6 +48,7 @@ export function MaintenanceItemDetailDialog({
     : updateMaintenanceItemAction.bind(null, row!.id);
 
   const previewCategories = effectiveCategories(wheels, engines);
+  const categoriesValid = previewCategories.length > 0;
 
   const toggleWheel = (w: WheelAxis) =>
     setWheels((prev) => toggle(prev, w));
@@ -125,9 +126,15 @@ export function MaintenanceItemDetailDialog({
                 <AxisToggle label="내연" active={engines.has("ICE")} onClick={() => toggleEngine("ICE")} />
               </div>
             </div>
-            <p className="maintenance-axis-preview">
-              → 적용: {sortCategories(previewCategories).map(categoryLabel).join(" · ")}
-            </p>
+            {categoriesValid ? (
+              <p className="maintenance-axis-preview">
+                → 적용: {sortCategories(previewCategories).map(categoryLabel).join(" · ")}
+              </p>
+            ) : (
+              <p className="maintenance-axis-preview maintenance-axis-preview-empty">
+                휠과 엔진을 각각 1개 이상 선택하세요
+              </p>
+            )}
             {[...wheels].map((w) => (
               <input key={`w-${w}`} type="hidden" name="wheels" value={w} />
             ))}
@@ -167,7 +174,7 @@ export function MaintenanceItemDetailDialog({
             >
               취소
             </button>
-            <button type="submit" className="button-primary">
+            <button type="submit" className="button-primary" disabled={!categoriesValid}>
               {isCreate ? "추가" : "저장"}
             </button>
           </div>
@@ -213,16 +220,14 @@ function axesFromCategories(cats: ReadonlyArray<ServiceOpsMaintenanceCategory>):
   return { wheels, engines };
 }
 
-// 와일드카드 전개 — 안 고른 축은 전체. 결과는 항상 1개 이상.
+// 선택된 휠 × 엔진 교차곱. 한 축이라도 비면 빈 배열(= 미선택, 제출 불가).
 function effectiveCategories(
   wheels: Set<WheelAxis>,
   engines: Set<EngineAxis>
 ): ServiceOpsMaintenanceCategory[] {
-  const w: WheelAxis[] = wheels.size > 0 ? [...wheels] : ["TWO_WHEEL", "FOUR_WHEEL"];
-  const e: EngineAxis[] = engines.size > 0 ? [...engines] : ["ELECTRIC", "ICE"];
   const out: ServiceOpsMaintenanceCategory[] = [];
-  for (const ww of w) {
-    for (const ee of e) {
+  for (const ww of wheels) {
+    for (const ee of engines) {
       out.push(`${ww}_${ee}` as ServiceOpsMaintenanceCategory);
     }
   }


### PR DESCRIPTION
## Summary
직전 다이얼로그 재디자인(#410)에 대한 후속 수정.

- **분류 와일드카드 제거**: "안 고른 축 전체 적용" 폐지. 휠·엔진을 **각각 1개 이상** 선택해야 분류가 생김. 미선택 시 추가/저장 버튼 비활성 + "휠과 엔진을 각각 1개 이상 선택하세요" 안내
- **다이얼로그 중앙 정렬 보정**: transform 기반 → `inset:0 + margin:auto`(네이티브 모달 정석)으로 위치 어긋남 수정 (정비 다이얼로그에만 스코프)

## 영향
- 프론트 전용. 분류 데이터 모델/백엔드 무변경

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 다이얼로그 중앙 표시, 휠/엔진 미선택 시 제출 비활성, 2륜+전기·내연 → 2륜전기·2륜내연 저장