### PR TITLE
정비 다이얼로그: 분류 힌트 문구 정정

### DIFF
--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -110,7 +110,7 @@ export function MaintenanceItemDetailDialog({
           <div className="maintenance-axis-group">
             <div className="maintenance-axis-head">
               <span className="maintenance-axis-title">분류</span>
-              <span className="maintenance-axis-hint">휠 × 엔진 — 안 고른 축은 전체 적용</span>
+              <span className="maintenance-axis-hint">휠 × 엔진 (각각 1개 이상 선택)</span>
             </div>
             <div className="maintenance-axis-row">
               <span className="maintenance-axis-row-label">휠</span>


### PR DESCRIPTION
QA에서 발견 — 와일드카드 제거(#411) 후에도 다이얼로그 힌트가 "휠 × 엔진 — 안 고른 축은 전체 적용"로 남아 동작과 모순. → "휠 × 엔진 (각각 1개 이상 선택)"로 정정.

프론트 텍스트 1줄. typecheck/lint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)