### PR TITLE
릴리스: 정비 다이얼로그 분류 힌트 문구 정정

### DIFF
--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -110,7 +110,7 @@ export function MaintenanceItemDetailDialog({
           <div className="maintenance-axis-group">
             <div className="maintenance-axis-head">
               <span className="maintenance-axis-title">분류</span>
-              <span className="maintenance-axis-hint">휠 × 엔진 — 안 고른 축은 전체 적용</span>
+              <span className="maintenance-axis-hint">휠 × 엔진 (각각 1개 이상 선택)</span>
             </div>
             <div className="maintenance-axis-row">
               <span className="maintenance-axis-row-label">휠</span>


### PR DESCRIPTION
## 릴리스 내용
- **#413**: 정비 다이얼로그 분류 힌트를 "휠 × 엔진 — 안 고른 축은 전체 적용"(와일드카드 제거로 사실과 다름) → "휠 × 엔진 (각각 1개 이상 선택)"으로 정정

## 배포 영향
- 프론트 텍스트 1줄. 마이그레이션/백엔드/동작 무변경

## Test Plan
- [x] typecheck + lint
- [ ] 프로덕션: 추가 다이얼로그 힌트 문구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)