### PR TITLE
레이아웃: 상단 유틸리티(테마·비밀번호·로그아웃)를 좌측 레일 하단으로 통합

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -237,6 +237,20 @@ button, input, select, textarea { font: inherit; }
   color: var(--baemin-mint);
   background: color-mix(in srgb, var(--baemin-mint) 14%, transparent);
 }
+/* 레일 하단 유틸리티 그룹(테마/비밀번호/로그아웃) — margin-top:auto 로 맨
+   아래에 붙이고, nav 와 얇은 구분선으로 분리. 버튼들은 .sidebar-link 라
+   위 레일 규칙(아이콘+라벨 세로 스택)을 그대로 따른다. */
+.app-rail-utility {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding-top: 12px;
+  border-top: 1px solid var(--rm-overlay-line-strong);
+}
+.app-rail-utility .top-actions-form { margin: 0; display: flex; justify-content: center; }
 
 /* Content + map offsets when rail is present. */
 .app-frame.has-rail .app-main { margin-left: var(--rail-width); }

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -56,22 +56,21 @@ export async function AppShell({ children }: { children: ReactNode }) {
       {serviceOpsSessionActive ? (
         <aside className="app-rail" aria-label="기본 메뉴">
           <SidebarPrimaryNav items={NAV} />
-        </aside>
-      ) : null}
-      <div className="top-actions" aria-label="유틸리티">
-        <ThemeToggle />
-        {serviceOpsSessionActive ? (
-          <>
+          <div className="app-rail-utility" aria-label="유틸리티">
+            <ThemeToggle />
             <PasswordChangeButton />
             <LogoutButton />
-          </>
-        ) : (
+          </div>
+        </aside>
+      ) : (
+        <div className="top-actions" aria-label="유틸리티">
+          <ThemeToggle />
           <a className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
             <span className="sidebar-icon" aria-hidden="true">↗</span>
             <span className="sidebar-label">관리자 로그인</span>
           </a>
-        )}
-      </div>
+        </div>
+      )}
       <main className="app-main">{children}</main>
     </div>
   );


### PR DESCRIPTION
## Summary
로그인 상태에서 우상단에 떠 있던 다크모드 토글 · 비밀번호 변경 · 로그아웃 버튼을 **좌측 레일 하단**으로 통합.

- 레일 = 상단 내비(지도/자원/업무/정비) + 하단 유틸리티 그룹(테마·비밀번호·로그아웃), `margin-top:auto`로 맨 아래 정렬 + 얇은 구분선
- 세 버튼은 이미 `.sidebar-link` 구조라 레일의 아이콘+라벨 세로 스택 스타일을 그대로 적용 (통일성)
- 비로그인(로그인 페이지)은 레일이 없으므로 기존 우상단 top-actions(테마 + 로그인 링크) 유지

## 영향
- 프론트 전용 (AppShell + globals.css). 동작/엔드포인트 무변경

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 우상단 버튼 사라지고 좌측 레일 맨 아래에 테마/비밀번호/로그아웃, 각 동작 정상