### PR TITLE
자원 관리: 표 최대 높이 + 내부 스크롤

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -286,8 +286,10 @@ button, input, select, textarea { font: inherit; }
   margin: 0 auto;
   padding: 88px 24px 96px;
 }
-/* /management 테이블은 내부 고정-높이 스크롤을 쓰지 않고 페이지 전체로 스크롤한다. */
-.management-panel .table-card { height: auto; overflow-y: visible; }
+/* /management 테이블은 행이 많아져도 페이지가 무한정 길어지지 않도록 카드별
+   최대 높이 + 내부 세로 스크롤. 행이 적으면 내용만큼만 차지(max-height). 헤더는
+   `.table thead th { position: sticky }` 로 스크롤 중에도 고정. */
+.management-panel .table-card { height: auto; max-height: 440px; overflow-y: auto; }
 .management-panel .vehicles-table-scroll { max-height: none; overflow-y: visible; }
 .management-section-nav {
   position: sticky;


### PR DESCRIPTION
## Summary
자원 관리(차량/라이더/매칭) 표가 행이 많아지면 페이지가 무한정 길어지던 문제 수정.

- 기존 `.management-panel .table-card { height:auto; overflow-y:visible }`(스크롤 끔)을 → `max-height: 440px; overflow-y: auto`로 변경
- 행 적으면 내용만큼만 차지, 많으면 카드 내부에서 세로 스크롤. 헤더는 기존 `thead th { position: sticky }`로 스크롤 중에도 고정
- CSS 1줄 변경 (지도쪽 vehicles-table-scroll은 무관, 미변경)

## 영향
- 프론트(globals.css) 전용

## Test Plan
- [x] build
- [ ] 프로덕션 QA: 자원 관리 각 표가 일정 높이에서 내부 스크롤, 헤더 고정