### PR TITLE
릴리스: 레일 유틸리티 통합 + 자원 표 스크롤 + 미리보기 다크모드 수정

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -237,6 +237,20 @@ button, input, select, textarea { font: inherit; }
   color: var(--baemin-mint);
   background: color-mix(in srgb, var(--baemin-mint) 14%, transparent);
 }
+/* 레일 하단 유틸리티 그룹(테마/비밀번호/로그아웃) — margin-top:auto 로 맨
+   아래에 붙이고, nav 와 얇은 구분선으로 분리. 버튼들은 .sidebar-link 라
+   위 레일 규칙(아이콘+라벨 세로 스택)을 그대로 따른다. */
+.app-rail-utility {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding-top: 12px;
+  border-top: 1px solid var(--rm-overlay-line-strong);
+}
+.app-rail-utility .top-actions-form { margin: 0; display: flex; justify-content: center; }
 
 /* Content + map offsets when rail is present. */
 .app-frame.has-rail .app-main { margin-left: var(--rail-width); }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -286,8 +286,10 @@ button, input, select, textarea { font: inherit; }
   margin: 0 auto;
   padding: 88px 24px 96px;
 }
-/* /management 테이블은 내부 고정-높이 스크롤을 쓰지 않고 페이지 전체로 스크롤한다. */
-.management-panel .table-card { height: auto; overflow-y: visible; }
+/* /management 테이블은 행이 많아져도 페이지가 무한정 길어지지 않도록 카드별
+   최대 높이 + 내부 세로 스크롤. 행이 적으면 내용만큼만 차지(max-height). 헤더는
+   `.table thead th { position: sticky }` 로 스크롤 중에도 고정. */
+.management-panel .table-card { height: auto; max-height: 440px; overflow-y: auto; }
 .management-panel .vehicles-table-scroll { max-height: none; overflow-y: visible; }
 .management-section-nav {
   position: sticky;

--- a/development/front-admin-web/components/layout/AppShell.tsx
+++ b/development/front-admin-web/components/layout/AppShell.tsx
@@ -56,22 +56,21 @@ export async function AppShell({ children }: { children: ReactNode }) {
       {serviceOpsSessionActive ? (
         <aside className="app-rail" aria-label="기본 메뉴">
           <SidebarPrimaryNav items={NAV} />
-        </aside>
-      ) : null}
-      <div className="top-actions" aria-label="유틸리티">
-        <ThemeToggle />
-        {serviceOpsSessionActive ? (
-          <>
+          <div className="app-rail-utility" aria-label="유틸리티">
+            <ThemeToggle />
             <PasswordChangeButton />
             <LogoutButton />
-          </>
-        ) : (
+          </div>
+        </aside>
+      ) : (
+        <div className="top-actions" aria-label="유틸리티">
+          <ThemeToggle />
           <a className="sidebar-link" href="/login" title="관리자 로그인" aria-label="관리자 로그인">
             <span className="sidebar-icon" aria-hidden="true">↗</span>
             <span className="sidebar-label">관리자 로그인</span>
           </a>
-        )}
-      </div>
+        </div>
+      )}
       <main className="app-main">{children}</main>
     </div>
   );

--- a/development/front-admin-web/components/management/BulkPreviewModal.css
+++ b/development/front-admin-web/components/management/BulkPreviewModal.css
@@ -44,29 +44,29 @@
 .bulk-preview-summary-unchanged {
   padding: 3px 10px;
   border-radius: 999px;
-  background: #f5f5f5;
-  color: #555;
+  background: var(--color-bg-muted);
+  color: var(--color-text-secondary);
 }
 
 .bulk-preview-summary-update {
   padding: 3px 10px;
   border-radius: 999px;
-  background: #fffbe6;
-  color: #854d0e;
+  background: color-mix(in srgb, #f59e0b 18%, var(--color-surface));
+  color: #d97706;
 }
 
 .bulk-preview-summary-new {
   padding: 3px 10px;
   border-radius: 999px;
-  background: #f6ffed;
-  color: #166534;
+  background: color-mix(in srgb, #22c55e 18%, var(--color-surface));
+  color: #16a34a;
 }
 
 .bulk-preview-summary-error {
   padding: 3px 10px;
   border-radius: 999px;
-  background: #fff1f0;
-  color: #991b1b;
+  background: color-mix(in srgb, #ef4444 18%, var(--color-surface));
+  color: #ef4444;
 }
 
 .bulk-preview-summary-total {
@@ -111,19 +111,19 @@
 }
 
 .bulk-preview-row-UNCHANGED {
-  background: #f5f5f5;
+  background: transparent;
 }
 
 .bulk-preview-row-UPDATE {
-  background: #fffbe6;
+  background: color-mix(in srgb, #f59e0b 12%, var(--color-surface));
 }
 
 .bulk-preview-row-NEW {
-  background: #f6ffed;
+  background: color-mix(in srgb, #22c55e 12%, var(--color-surface));
 }
 
 .bulk-preview-row-ERROR {
-  background: #fff1f0;
+  background: color-mix(in srgb, #ef4444 14%, var(--color-surface));
 }
 
 .bulk-preview-actions {


### PR DESCRIPTION
## 릴리스 내용 (프론트 UI, 마이그레이션 없음)
- **#415**: 상단 우측 유틸리티(다크모드·비밀번호 변경·로그아웃)를 좌측 레일 하단으로 통합
- **#416**: 자원 관리(차량/라이더/매칭) 표에 최대 높이 + 내부 스크롤(헤더 sticky) — 행 많아도 페이지 안 길어짐
- **#417**: 업로드 미리보기 모달이 다크 테마에서 행이 안 보이던 문제 수정(테마 대응 색)

## 배포 영향
- 프론트 빌드만 갱신. 마이그레이션/백엔드/동작 무변경

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: ① 레일 하단 테마/비밀번호/로그아웃 ② 자원 표 스크롤 ③ 업로드 미리보기 행 가독성

🤖 Generated with [Claude Code](https://claude.com/claude-code)