### PR TITLE
업로드 미리보기: '변경 없음' 행 목록에서 제외

### DIFF
--- a/development/front-admin-web/components/management/BulkPreviewModal.css
+++ b/development/front-admin-web/components/management/BulkPreviewModal.css
@@ -126,6 +126,12 @@
   background: color-mix(in srgb, #ef4444 14%, var(--color-surface));
 }
 
+.bulk-preview-empty {
+  padding: 28px 12px;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
 .bulk-preview-actions {
   display: flex;
   justify-content: flex-end;

--- a/development/front-admin-web/components/management/BulkPreviewModal.tsx
+++ b/development/front-admin-web/components/management/BulkPreviewModal.tsx
@@ -13,6 +13,8 @@ interface BulkPreviewModalProps {
 
 export function BulkPreviewModal({ response, onConfirm, onCancel, loading = false }: BulkPreviewModalProps) {
   const { rows, summary } = response;
+  // "변경 없음" 행은 검토 가치가 없어 리스트에서 제외 — 요약 카운트로만 표시.
+  const visibleRows = rows.filter((row) => row.status !== "UNCHANGED");
 
   return (
     <div className="bulk-preview-overlay">
@@ -39,15 +41,21 @@ export function BulkPreviewModal({ response, onConfirm, onCancel, loading = fals
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
-                <tr key={row.rowNumber} className={`bulk-preview-row-${row.status}`}>
-                  <td>{row.rowNumber}</td>
-                  <td>{statusLabel(row.status)}</td>
-                  <td>{row.key}</td>
-                  <td>{row.changes.join(', ')}</td>
-                  <td>{row.errorMessage ?? ''}</td>
+              {visibleRows.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="bulk-preview-empty">변경/신규/오류 항목 없음 (모두 변경 없음)</td>
                 </tr>
-              ))}
+              ) : (
+                visibleRows.map((row) => (
+                  <tr key={row.rowNumber} className={`bulk-preview-row-${row.status}`}>
+                    <td>{row.rowNumber}</td>
+                    <td>{statusLabel(row.status)}</td>
+                    <td>{row.key}</td>
+                    <td>{row.changes.join(', ')}</td>
+                    <td>{row.errorMessage ?? ''}</td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
업로드 미리보기 표에서 검토 가치 없는 '변경 없음'(UNCHANGED) 행을 리스트에서 제외 — 변경/신규/오류 행만 표시. 요약 카운트(변경 없음 N)는 유지. 전부 변경 없음이면 안내 문구.

## 영향
- 프론트 전용(BulkPreviewModal). 차량/라이더/매칭 미리보기 공통 적용

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 미리보기에 변경 없음 행 미표시, 변경/신규/오류만 노출