### PR TITLE
정비 관리: 4섹션 → 단일 테이블 + 휠/엔진 필터

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1121,8 +1121,14 @@ textarea { padding-top: 10px; min-height: 96px; }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
 /* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
    각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
-.maintenance-panel { display: flex; flex-direction: column; gap: 24px; }
-.maintenance-panel-toolbar { display: flex; justify-content: flex-end; }
+.maintenance-panel { display: flex; flex-direction: column; gap: 16px; }
+.maintenance-panel-toolbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.maintenance-filters { display: flex; gap: 20px; flex-wrap: wrap; }
+.maintenance-filter-group { display: flex; align-items: center; gap: 6px; }
+.maintenance-filter-group-label { font-size: 12px; color: var(--color-text-muted); margin-right: 2px; }
+.maintenance-filter-chip { min-height: 32px; padding: 0 12px; border: 1px solid var(--color-border); border-radius: 8px; background: transparent; color: var(--color-text-secondary); font-size: 13px; font-weight: 500; font-family: inherit; cursor: pointer; }
+.maintenance-filter-chip:hover { border-color: var(--color-border-strong); }
+.maintenance-filter-chip[aria-pressed="true"] { background: var(--baemin-mint); color: var(--color-text-on-mint); border-color: transparent; }
 .maintenance-panel-section { display: flex; flex-direction: column; gap: 8px; }
 .maintenance-panel-section-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .maintenance-panel-section-title { margin: 0; font-size: 13px; font-weight: 700; color: var(--color-text-muted); letter-spacing: .04em; text-transform: uppercase; }

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -10,57 +10,111 @@ import type {
 } from "@/lib/services/service-ops-api";
 
 /**
- * `/management/maintenance` 의 정비 카탈로그 편집 패널. 4개 카테고리 섹션
- * (2륜전기 / 2륜내연 / 4륜전기 / 4륜내연) 으로 나눠서 품목을 보여준다.
+ * `/management/maintenance` 의 정비 카탈로그 편집 패널. 단일 테이블 + 상단
+ * 휠(전체/2륜/4륜) · 엔진(전체/전기/내연) 필터. 항목은 categories(다중) 를
+ * 보유하며, 선택한 휠 × 엔진 교차곱과 하나라도 겹치면 표시된다.
  *
- * 한 품목이 여러 카테고리에 속할 수 있으며, 해당 섹션 모두에 중복 표시된다.
- * 각 행 클릭 시 상세 다이얼로그가 열리고 거기서 수정 모드로 전환.
+ * 행 클릭 시 상세 다이얼로그, "+ 항목 추가" 로 생성 다이얼로그.
  */
+type WheelFilter = "ALL" | "TWO_WHEEL" | "FOUR_WHEEL";
+type EngineFilter = "ALL" | "ELECTRIC" | "ICE";
+
 export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMaintenanceItem> }) {
   const [activeRow, setActiveRow] = useState<ServiceOpsMaintenanceItem | null>(null);
   const [creating, setCreating] = useState(false);
+  const [wheel, setWheel] = useState<WheelFilter>("ALL");
+  const [engine, setEngine] = useState<EngineFilter>("ALL");
 
   const sorted = useMemo(
     () => [...items].sort((a, b) => a.name.localeCompare(b.name, "ko")),
     [items]
   );
 
+  const visible = useMemo(() => {
+    const wheels: ("TWO_WHEEL" | "FOUR_WHEEL")[] =
+      wheel === "ALL" ? ["TWO_WHEEL", "FOUR_WHEEL"] : [wheel];
+    const engines: ("ELECTRIC" | "ICE")[] =
+      engine === "ALL" ? ["ELECTRIC", "ICE"] : [engine];
+    const target = new Set<ServiceOpsMaintenanceCategory>();
+    for (const w of wheels) for (const e of engines) {
+      target.add(`${w}_${e}` as ServiceOpsMaintenanceCategory);
+    }
+    return sorted.filter((item) => item.categories.some((c) => target.has(c)));
+  }, [sorted, wheel, engine]);
+
   const openRow = (item: ServiceOpsMaintenanceItem) => {
     setCreating(false);
     setActiveRow(item);
-  };
-  const openCreate = () => {
-    setActiveRow(null);
-    setCreating(true);
   };
   const close = () => {
     setActiveRow(null);
     setCreating(false);
   };
 
-  const sections: { category: ServiceOpsMaintenanceCategory; title: string }[] = [
-    { category: "TWO_WHEEL_ELECTRIC", title: "2륜 전기" },
-    { category: "TWO_WHEEL_ICE", title: "2륜 내연" },
-    { category: "FOUR_WHEEL_ELECTRIC", title: "4륜 전기" },
-    { category: "FOUR_WHEEL_ICE", title: "4륜 내연" }
-  ];
-
   return (
     <div className="maintenance-panel">
       <div className="maintenance-panel-toolbar">
-        <button type="button" className="button-primary" onClick={openCreate}>
+        <div className="maintenance-filters">
+          <div className="maintenance-filter-group">
+            <span className="maintenance-filter-group-label">휠</span>
+            <FilterChip label="전체" active={wheel === "ALL"} onClick={() => setWheel("ALL")} />
+            <FilterChip label="2륜" active={wheel === "TWO_WHEEL"} onClick={() => setWheel("TWO_WHEEL")} />
+            <FilterChip label="4륜" active={wheel === "FOUR_WHEEL"} onClick={() => setWheel("FOUR_WHEEL")} />
+          </div>
+          <div className="maintenance-filter-group">
+            <span className="maintenance-filter-group-label">엔진</span>
+            <FilterChip label="전체" active={engine === "ALL"} onClick={() => setEngine("ALL")} />
+            <FilterChip label="전기" active={engine === "ELECTRIC"} onClick={() => setEngine("ELECTRIC")} />
+            <FilterChip label="내연" active={engine === "ICE"} onClick={() => setEngine("ICE")} />
+          </div>
+        </div>
+        <button type="button" className="button-primary" onClick={() => { setActiveRow(null); setCreating(true); }}>
           + 항목 추가
         </button>
       </div>
 
-      {sections.map(({ category, title }) => (
-        <Section
-          key={category}
-          title={title}
-          items={sorted.filter((i) => i.categories.includes(category))}
-          onActivate={openRow}
-        />
-      ))}
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <colgroup>
+            <col style={{ width: "48px" }} />
+            <col />
+            <col style={{ width: "240px" }} />
+            <col style={{ width: "140px" }} />
+          </colgroup>
+          <thead>
+            <tr>
+              <th aria-label="삭제" />
+              <th>품목</th>
+              <th>분류</th>
+              <th>교환주기</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="table-empty-cell">해당 조건의 정비 항목 없음</td>
+              </tr>
+            ) : (
+              visible.map((item) => (
+                <tr key={item.id} className="table-row-clickable" onClick={() => openRow(item)}>
+                  <td onClick={(event) => event.stopPropagation()}>
+                    <DeleteMaintenanceItemButton itemId={item.id} itemName={item.name} />
+                  </td>
+                  <td>{item.name}</td>
+                  <td>
+                    <div className="maintenance-chip-row">
+                      {sortCategories(item.categories).map((c) => (
+                        <span key={c} className="maintenance-chip">{categoryLabel(c)}</span>
+                      ))}
+                    </div>
+                  </td>
+                  <td>{renderCycle(item)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
 
       <MaintenanceItemDetailDialog
         key={activeRow?.id ?? (creating ? "create" : "none")}
@@ -72,57 +126,11 @@ export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMai
   );
 }
 
-function Section({
-  title,
-  items,
-  onActivate
-}: {
-  title: string;
-  items: ReadonlyArray<ServiceOpsMaintenanceItem>;
-  onActivate: (item: ServiceOpsMaintenanceItem) => void;
-}) {
+function FilterChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
   return (
-    <section className="maintenance-panel-section">
-      <h3 className="maintenance-panel-section-title">{title}</h3>
-      <div className="table-card">
-        <table className="table" style={{ tableLayout: "fixed" }}>
-          <colgroup>
-            <col style={{ width: "48px" }} />
-            <col />
-            <col style={{ width: "160px" }} />
-          </colgroup>
-          <thead>
-            <tr>
-              <th aria-label="삭제" />
-              <th>품목</th>
-              <th>교환주기</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.length === 0 ? (
-              <tr>
-                <td colSpan={3} className="table-empty-cell">
-                  데이터 없음
-                </td>
-              </tr>
-            ) : null}
-            {items.map((item) => (
-              <tr
-                key={item.id}
-                className="table-row-clickable"
-                onClick={() => onActivate(item)}
-              >
-                <td onClick={(event) => event.stopPropagation()}>
-                  <DeleteMaintenanceItemButton itemId={item.id} itemName={item.name} />
-                </td>
-                <td>{item.name}</td>
-                <td>{renderCycle(item)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
+    <button type="button" className="maintenance-filter-chip" aria-pressed={active} onClick={onClick}>
+      {label}
+    </button>
   );
 }
 
@@ -130,4 +138,26 @@ function renderCycle(item: ServiceOpsMaintenanceItem): ReactNode {
   if (item.cycleKm !== null && item.cycleKm > 0) return `${item.cycleKm.toLocaleString()} km`;
   if (item.cycleMonths !== null && item.cycleMonths > 0) return `${item.cycleMonths}개월`;
   return <span className="muted">—</span>;
+}
+
+const CATEGORY_ORDER: ServiceOpsMaintenanceCategory[] = [
+  "TWO_WHEEL_ELECTRIC",
+  "TWO_WHEEL_ICE",
+  "FOUR_WHEEL_ELECTRIC",
+  "FOUR_WHEEL_ICE"
+];
+
+function sortCategories(
+  cats: ReadonlyArray<ServiceOpsMaintenanceCategory>
+): ServiceOpsMaintenanceCategory[] {
+  return CATEGORY_ORDER.filter((c) => cats.includes(c));
+}
+
+function categoryLabel(c: ServiceOpsMaintenanceCategory): string {
+  switch (c) {
+    case "TWO_WHEEL_ELECTRIC": return "2륜 전기";
+    case "TWO_WHEEL_ICE": return "2륜 내연";
+    case "FOUR_WHEEL_ELECTRIC": return "4륜 전기";
+    case "FOUR_WHEEL_ICE": return "4륜 내연";
+  }
 }


### PR DESCRIPTION
## Summary
정비 카탈로그를 4개 분류 섹션에서 **단일 테이블 + 상단 필터**로 통합.

- 필터: **휠(전체/2륜/4륜)** · **엔진(전체/전기/내연)** 칩 (단일 선택, 민트 활성)
- 선택한 휠 × 엔진 교차곱과 항목의 categories가 하나라도 겹치면 표시 (전체/전체 = 전부)
- 표 컬럼: 삭제 / 품목 / **분류(칩)** / 교환주기. 품명순, 기존 max-height 내부 스크롤
- "+ 항목 추가" 버튼은 상단 유지. 다이얼로그/데이터 모델 무변경

## 영향
- 프론트 전용(MaintenancePanel + globals.css). 백엔드/마이그레이션 무변경

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 단일 표, 휠/엔진 필터 동작, 분류 칩, 전체 조합