### PR TITLE
정비 테이블: 고정-높이 내부 스크롤 제거

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1122,6 +1122,9 @@ textarea { padding-top: 10px; min-height: 96px; }
 /* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
    각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
 .maintenance-panel { display: flex; flex-direction: column; gap: 16px; }
+/* 단일 테이블 + 필터라 고정-높이 내부 스크롤 불필요 — 내용만큼 펼치고
+   페이지 스크롤을 쓴다(헤더는 thead sticky 로 페이지 스크롤에 고정). */
+.maintenance-panel .table-card { height: auto; overflow: visible; }
 .maintenance-panel-toolbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
 .maintenance-filters { display: flex; gap: 20px; flex-wrap: wrap; }
 .maintenance-filter-group { display: flex; align-items: center; gap: 6px; }


### PR DESCRIPTION
단일 테이블+필터 전환(#421) 이후 240px 내부 스크롤 박스가 불필요 → `.maintenance-panel .table-card`를 height:auto/overflow:visible 로 펼침. 페이지 스크롤 사용, 헤더는 thead sticky 유지. 정비 페이지에만 스코프(다른 .table-card 무관). 프론트 CSS 1줄, build 통과.