### PR TITLE
릴리스: 정비 테이블 내부 스크롤 제거 + 휠/엔진 컬럼

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1122,6 +1122,9 @@ textarea { padding-top: 10px; min-height: 96px; }
 /* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
    각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
 .maintenance-panel { display: flex; flex-direction: column; gap: 16px; }
+/* 단일 테이블 + 필터라 고정-높이 내부 스크롤 불필요 — 내용만큼 펼치고
+   페이지 스크롤을 쓴다(헤더는 thead sticky 로 페이지 스크롤에 고정). */
+.maintenance-panel .table-card { height: auto; overflow: visible; }
 .maintenance-panel-toolbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
 .maintenance-filters { display: flex; gap: 20px; flex-wrap: wrap; }
 .maintenance-filter-group { display: flex; align-items: center; gap: 6px; }

--- a/development/front-admin-web/components/management/MaintenancePanel.tsx
+++ b/development/front-admin-web/components/management/MaintenancePanel.tsx
@@ -78,21 +78,23 @@ export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMai
           <colgroup>
             <col style={{ width: "48px" }} />
             <col />
-            <col style={{ width: "240px" }} />
+            <col style={{ width: "110px" }} />
+            <col style={{ width: "110px" }} />
             <col style={{ width: "140px" }} />
           </colgroup>
           <thead>
             <tr>
               <th aria-label="삭제" />
               <th>품목</th>
-              <th>분류</th>
+              <th>휠</th>
+              <th>엔진</th>
               <th>교환주기</th>
             </tr>
           </thead>
           <tbody>
             {visible.length === 0 ? (
               <tr>
-                <td colSpan={4} className="table-empty-cell">해당 조건의 정비 항목 없음</td>
+                <td colSpan={5} className="table-empty-cell">해당 조건의 정비 항목 없음</td>
               </tr>
             ) : (
               visible.map((item) => (
@@ -101,13 +103,8 @@ export function MaintenancePanel({ items }: { items: ReadonlyArray<ServiceOpsMai
                     <DeleteMaintenanceItemButton itemId={item.id} itemName={item.name} />
                   </td>
                   <td>{item.name}</td>
-                  <td>
-                    <div className="maintenance-chip-row">
-                      {sortCategories(item.categories).map((c) => (
-                        <span key={c} className="maintenance-chip">{categoryLabel(c)}</span>
-                      ))}
-                    </div>
-                  </td>
+                  <td>{wheelText(item.categories)}</td>
+                  <td>{engineText(item.categories)}</td>
                   <td>{renderCycle(item)}</td>
                 </tr>
               ))
@@ -140,24 +137,16 @@ function renderCycle(item: ServiceOpsMaintenanceItem): ReactNode {
   return <span className="muted">—</span>;
 }
 
-const CATEGORY_ORDER: ServiceOpsMaintenanceCategory[] = [
-  "TWO_WHEEL_ELECTRIC",
-  "TWO_WHEEL_ICE",
-  "FOUR_WHEEL_ELECTRIC",
-  "FOUR_WHEEL_ICE"
-];
-
-function sortCategories(
-  cats: ReadonlyArray<ServiceOpsMaintenanceCategory>
-): ServiceOpsMaintenanceCategory[] {
-  return CATEGORY_ORDER.filter((c) => cats.includes(c));
+function wheelText(cats: ReadonlyArray<ServiceOpsMaintenanceCategory>): ReactNode {
+  const parts: string[] = [];
+  if (cats.some((c) => c.startsWith("TWO_WHEEL"))) parts.push("2륜");
+  if (cats.some((c) => c.startsWith("FOUR_WHEEL"))) parts.push("4륜");
+  return parts.length > 0 ? parts.join(" · ") : <span className="muted">—</span>;
 }
 
-function categoryLabel(c: ServiceOpsMaintenanceCategory): string {
-  switch (c) {
-    case "TWO_WHEEL_ELECTRIC": return "2륜 전기";
-    case "TWO_WHEEL_ICE": return "2륜 내연";
-    case "FOUR_WHEEL_ELECTRIC": return "4륜 전기";
-    case "FOUR_WHEEL_ICE": return "4륜 내연";
-  }
+function engineText(cats: ReadonlyArray<ServiceOpsMaintenanceCategory>): ReactNode {
+  const parts: string[] = [];
+  if (cats.some((c) => c.endsWith("ELECTRIC"))) parts.push("전기");
+  if (cats.some((c) => c.endsWith("ICE"))) parts.push("내연");
+  return parts.length > 0 ? parts.join(" · ") : <span className="muted">—</span>;
 }


### PR DESCRIPTION
## 릴리스 내용 (프론트 UI, 마이그레이션 없음)
- **#423**: 정비 단일 테이블의 고정-높이 내부 스크롤 제거 → 내용만큼 펼침(페이지 스크롤, thead sticky)
- **#424**: 분류 칩 컬럼 → 휠(2륜/4륜) + 엔진(전기/내연) 두 컬럼으로 분리

## 배포 영향
- 프론트 빌드만 갱신. 백엔드/마이그레이션/동작 무변경

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 정비 테이블 페이지 스크롤, 휠/엔진 컬럼 표시, 필터 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)