### PR TITLE
매칭 벌크: 9컬럼 템플릿 정렬 + 날짜 포맷 + 서비스유형 연결

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractBulkService.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.contract.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.bulk.BulkApplyResponse;
 import com.thundercrew.opsapi.common.bulk.BulkPreviewResponse;
@@ -64,8 +65,11 @@ public class ContractBulkService {
         long skipped = 0;
         for (List<String> cols : rows) {
             try {
+                // 9-column layout:
+                // col0=차량번호, col1=서비스유형, col2=라이더이름, col3=연락처,
+                // col4=계약형태, col5=인수방식, col6=시작일, col7=종료일, col8=검증결과
                 String plate = cell(cols, 0);
-                String phone = cell(cols, 2);
+                String phone = cell(cols, 3);
                 if (plate.isBlank() || phone.isBlank()) {
                     skipped++;
                     continue;
@@ -76,8 +80,8 @@ public class ContractBulkService {
                     skipped++;
                     continue;
                 }
-                ContractCategory category = parseCategory(cell(cols, 3));
-                ContractReturnType returnType = parseReturnType(cell(cols, 4));
+                ContractCategory category = parseCategory(cell(cols, 4));
+                ContractReturnType returnType = parseReturnType(cell(cols, 5));
                 Optional<ContractTemplate> template = templateRepository
                         .findFirstByCategoryAndReturnTypeAndEnabledTrueAndDeletedAtIsNull(
                                 category, returnType);
@@ -85,12 +89,20 @@ public class ContractBulkService {
                     skipped++;
                     continue;
                 }
-                Instant startAt = parseDate(cell(cols, 5));
+                Instant startAt = parseDate(cell(cols, 6));
                 if (startAt == null) {
                     skipped++;
                     continue;
                 }
-                Instant endAt = parseDate(cell(cols, 6));
+                Instant endAt = parseDate(cell(cols, 7));
+
+                // Wire 서비스유형 (col1) → update bike's serviceType if recognized
+                BikeServiceType st = parseServiceType(cell(cols, 1));
+                if (st != null) {
+                    bike.get().updateBasicProfile(null, null, null, null, st, null);
+                    bikeRepository.save(bike.get());
+                }
+
                 Optional<RiderBikeContract> existing = contractRepository
                         .findActiveByBikeIdAndRiderId(bike.get().getId(), rider.get().getId());
                 if (existing.isPresent()) {
@@ -131,23 +143,30 @@ public class ContractBulkService {
             String returnTypeLabel = template.getReturnType() == ContractReturnType.TAKEOVER
                     ? "인수형" : "반납형";
 
+            // 9-column layout matching the template:
+            // col0=차량번호, col1=서비스유형, col2=라이더이름, col3=연락처,
+            // col4=계약형태, col5=인수방식, col6=시작일(YYYY-MM-DD), col7=종료일(YYYY-MM-DD), col8=검증결과
             rows.add(List.of(
-                    bike.getPlateNumber(),
-                    rider.getName(),
-                    rider.getPhoneNumber(),
-                    categoryLabel,
-                    returnTypeLabel,
-                    c.getStartAt().toString(),
-                    c.getEndAt() != null ? c.getEndAt().toString() : "",
-                    "N"));
+                    bike.getPlateNumber(),                                                                           // col0 차량번호
+                    serviceTypeLabel(bike.getServiceType()),                                                         // col1 서비스 유형
+                    rider.getName(),                                                                                 // col2 라이더 이름
+                    rider.getPhoneNumber(),                                                                          // col3 연락처
+                    categoryLabel,                                                                                   // col4 계약형태
+                    returnTypeLabel,                                                                                 // col5 인수방식
+                    LocalDate.ofInstant(c.getStartAt(), ZoneOffset.UTC).toString(),                                  // col6 시작일
+                    c.getEndAt() != null ? LocalDate.ofInstant(c.getEndAt(), ZoneOffset.UTC).toString() : "",       // col7 종료일
+                    ""));                                                                                            // col8 검증 결과 (blank)
         }
         return ExcelExporter.export(ContractBulkService.class, "matching-template.xlsx",
                 DATA_START_ROW, rows);
     }
 
     private BulkRowResult evaluateRow(List<String> cols, int rowNum) {
+        // 9-column layout:
+        // col0=차량번호, col1=서비스유형, col2=라이더이름, col3=연락처,
+        // col4=계약형태, col5=인수방식, col6=시작일, col7=종료일, col8=검증결과
         String plate = cell(cols, 0);
-        String phone = cell(cols, 2);
+        String phone = cell(cols, 3);
         String key = plate + " / " + phone;
         if (plate.isBlank() || phone.isBlank()) {
             return BulkRowResult.error(rowNum, key, "차량번호 또는 연락처 없음");
@@ -161,16 +180,16 @@ public class ContractBulkService {
             if (rider.isEmpty()) {
                 return BulkRowResult.error(rowNum, key, "라이더 없음: " + phone);
             }
-            ContractCategory category = parseCategory(cell(cols, 3));
-            ContractReturnType returnType = parseReturnType(cell(cols, 4));
+            ContractCategory category = parseCategory(cell(cols, 4));
+            ContractReturnType returnType = parseReturnType(cell(cols, 5));
             Optional<ContractTemplate> template = templateRepository
                     .findFirstByCategoryAndReturnTypeAndEnabledTrueAndDeletedAtIsNull(
                             category, returnType);
             if (template.isEmpty()) {
                 return BulkRowResult.error(rowNum, key,
-                        "계약 템플릿 없음: " + cell(cols, 3) + "/" + cell(cols, 4));
+                        "계약 템플릿 없음: " + cell(cols, 4) + "/" + cell(cols, 5));
             }
-            if (parseDate(cell(cols, 5)) == null) {
+            if (parseDate(cell(cols, 6)) == null) {
                 return BulkRowResult.error(rowNum, key, "시작일 없음");
             }
             Optional<RiderBikeContract> existing = contractRepository
@@ -182,8 +201,8 @@ public class ContractBulkService {
             if (!existing.get().getContractTemplateId().equals(template.get().getId())) {
                 changes.add("template");
             }
-            Instant newStart = parseDate(cell(cols, 5));
-            Instant newEnd = parseDate(cell(cols, 6));
+            Instant newStart = parseDate(cell(cols, 6));
+            Instant newEnd = parseDate(cell(cols, 7));
             if (!existing.get().getStartAt().equals(newStart)) changes.add("startAt");
             if (existing.get().getEndAt() == null
                     ? newEnd != null
@@ -196,6 +215,28 @@ public class ContractBulkService {
         } catch (IllegalArgumentException e) {
             return BulkRowResult.error(rowNum, key, e.getMessage());
         }
+    }
+
+    private static BikeServiceType parseServiceType(String val) {
+        if (val == null || val.isBlank()) return null;
+        return switch (val.trim()) {
+            case "콜 배차", "콜" -> BikeServiceType.CALL;
+            case "단일 배차", "단일" -> BikeServiceType.SINGLE;
+            case "순차 배차", "순차" -> BikeServiceType.SEQUENTIAL;
+            case "왕복 배차", "왕복" -> BikeServiceType.ROUND;
+            case "기타" -> BikeServiceType.OTHER;
+            default -> null;
+        };
+    }
+
+    private static String serviceTypeLabel(BikeServiceType t) {
+        return switch (t) {
+            case CALL -> "콜 배차";
+            case SINGLE -> "단일 배차";
+            case SEQUENTIAL -> "순차 배차";
+            case ROUND -> "왕복 배차";
+            case OTHER -> "기타";
+        };
     }
 
     private ContractCategory parseCategory(String val) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
@@ -82,8 +82,9 @@ class ContractBulkApiTests extends PostgresContainerSupport {
 
     @Test
     void previewNewContract() throws Exception {
+        // 9-col layout: plate, serviceType, riderName, phone, category, returnType, start, end, validationResult
         MockMultipartFile file = buildContractExcel(
-                "12가3456", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "N");
+                "12가3456", "단일 배차", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
 
         mockMvc.perform(multipart("/api/v1/contracts/bulk-preview")
                         .file(file)
@@ -96,7 +97,7 @@ class ContractBulkApiTests extends PostgresContainerSupport {
     @Test
     void previewErrorWhenBikeNotFound() throws Exception {
         MockMultipartFile file = buildContractExcel(
-                "99나9999", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "N");
+                "99나9999", "단일 배차", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
 
         mockMvc.perform(multipart("/api/v1/contracts/bulk-preview")
                         .file(file)
@@ -109,7 +110,7 @@ class ContractBulkApiTests extends PostgresContainerSupport {
     @Test
     void previewErrorWhenRiderNotFound() throws Exception {
         MockMultipartFile file = buildContractExcel(
-                "12가3456", "김철수", "010-9999-9999", "구독", "인수형", "2026-07-01", "2027-06-30", "N");
+                "12가3456", "단일 배차", "김철수", "010-9999-9999", "구독", "인수형", "2026-07-01", "2027-06-30", "");
 
         mockMvc.perform(multipart("/api/v1/contracts/bulk-preview")
                         .file(file)
@@ -121,7 +122,7 @@ class ContractBulkApiTests extends PostgresContainerSupport {
     @Test
     void applyCreatesContract() throws Exception {
         MockMultipartFile file = buildContractExcel(
-                "12가3456", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "N");
+                "12가3456", "단일 배차", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
 
         mockMvc.perform(multipart("/api/v1/contracts/bulk-apply")
                         .file(file)
@@ -133,7 +134,7 @@ class ContractBulkApiTests extends PostgresContainerSupport {
     @Test
     void applySkipsInvalidRow() throws Exception {
         MockMultipartFile file = buildContractExcel(
-                "99나9999", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "N");
+                "99나9999", "단일 배차", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
 
         mockMvc.perform(multipart("/api/v1/contracts/bulk-apply")
                         .file(file)
@@ -141,6 +142,40 @@ class ContractBulkApiTests extends PostgresContainerSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.applied").value(0))
                 .andExpect(jsonPath("$.skipped").value(1));
+    }
+
+    @Test
+    void applyUpdatesServiceTypeWhenRecognized() throws Exception {
+        // col1 = "콜 배차" → bike's serviceType should be updated to CALL
+        MockMultipartFile file = buildContractExcel(
+                "12가3456", "콜 배차", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
+
+        mockMvc.perform(multipart("/api/v1/contracts/bulk-apply")
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applied").value(1));
+
+        String serviceType = jdbcTemplate.queryForObject(
+                "select service_type from bikes where id = ?", String.class, BIKE_ID);
+        org.assertj.core.api.Assertions.assertThat(serviceType).isEqualTo("CALL");
+    }
+
+    @Test
+    void applyLeavesServiceTypeUnchangedWhenBlank() throws Exception {
+        // col1 blank → serviceType stays SINGLE (the seeded value)
+        MockMultipartFile file = buildContractExcel(
+                "12가3456", "", "홍길동", "010-1234-5678", "구독", "인수형", "2026-07-01", "2027-06-30", "");
+
+        mockMvc.perform(multipart("/api/v1/contracts/bulk-apply")
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applied").value(1));
+
+        String serviceType = jdbcTemplate.queryForObject(
+                "select service_type from bikes where id = ?", String.class, BIKE_ID);
+        org.assertj.core.api.Assertions.assertThat(serviceType).isEqualTo("SINGLE");
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────
@@ -157,24 +192,30 @@ class ContractBulkApiTests extends PostgresContainerSupport {
         return m.group(1);
     }
 
+    /**
+     * Builds a 9-column matching Excel row aligned to the template layout:
+     * col0=차량번호, col1=서비스유형, col2=라이더이름, col3=연락처,
+     * col4=계약형태, col5=인수방식, col6=시작일(YYYY-MM-DD), col7=종료일(YYYY-MM-DD), col8=검증결과
+     */
     private MockMultipartFile buildContractExcel(
-            String plate, String riderName, String phone,
+            String plate, String serviceType, String riderName, String phone,
             String category, String returnType,
-            String startAt, String endAt, String insurance) throws Exception {
+            String startAt, String endAt, String validationResult) throws Exception {
         XSSFWorkbook wb = new XSSFWorkbook();
         Sheet sheet = wb.createSheet();
         sheet.createRow(0);
         sheet.createRow(1);
         sheet.createRow(2);
         Row row = sheet.createRow(3); // DATA_START_ROW = 3
-        row.createCell(0).setCellValue(plate);
-        row.createCell(1).setCellValue(riderName);
-        row.createCell(2).setCellValue(phone);
-        row.createCell(3).setCellValue(category);
-        row.createCell(4).setCellValue(returnType);
-        row.createCell(5).setCellValue(startAt);
-        row.createCell(6).setCellValue(endAt);
-        row.createCell(7).setCellValue(insurance);
+        row.createCell(0).setCellValue(plate);           // 차량번호
+        row.createCell(1).setCellValue(serviceType);     // 서비스 유형
+        row.createCell(2).setCellValue(riderName);       // 라이더 이름
+        row.createCell(3).setCellValue(phone);           // 연락처
+        row.createCell(4).setCellValue(category);        // 계약형태
+        row.createCell(5).setCellValue(returnType);      // 인수방식
+        row.createCell(6).setCellValue(startAt);         // 시작일
+        row.createCell(7).setCellValue(endAt);           // 종료일
+        row.createCell(8).setCellValue(validationResult); // 검증 결과
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         wb.write(out);
         wb.close();


### PR DESCRIPTION
## Summary
자원 관리 벌크 정합성 감사 결과, 매칭(계약) 업로드/내려받기 라운드트립이 깨져 있던 것을 수정.

- **컬럼 정렬**: 파서/export가 8컬럼(서비스유형 누락)으로 9컬럼 템플릿과 한 칸씩 어긋나 있던 것을 템플릿 기준으로 정렬 — 연락처 lookup을 col2→**col3**, 계약형태 col4, 인수방식 col5, 시작일 col6, 종료일 col7
- **날짜 포맷**: export가 `Instant.toString()`(...Z)라 파서(`LocalDate.parse`, YYYY-MM-DD)와 불일치 → 내려받기 파일 재업로드 시 시작일 파싱 실패로 전멸하던 것 → export를 **YYYY-MM-DD**로
- **서비스유형 연결**: 매칭 col1(서비스유형)을 차량 serviceType에 반영(콜/단일/순차/왕복/기타 라벨, 미인식/공백은 기존값 유지). export도 차량 serviceType 라벨 출력. ("서비스 타입은 매칭에서" 결정 반영)
- 계약 테스트: 9컬럼 레이아웃·날짜·serviceType 갱신 검증 추가

## 참고 (이번 변경 외)
- 차량 벌크: 라운드트립 정상 → 변경 없음(4컬럼 유지 결정)
- 라이더 벌크: export/파서 모두 3값(온라인/오프라인/미완료) 일치라 round-trip 동작. 템플릿 헤더 라벨만 "(완료/미완료)"로 오해 소지 — 별도 cosmetic 수정 대상

## 영향
- 백엔드 전용. 마이그레이션 없음. 매칭 업로드/내려받기 동작 변경

## Test Plan
- [x] compileJava + compileTestJava (9컬럼·날짜·serviceType 계약 테스트)
- [ ] 프로덕션 QA: 매칭 내려받기→업로드 라운드트립, 손-입력 템플릿 업로드, 서비스유형 반영