### PR TITLE
자원 관리: 차량 표 운영 상태 컬럼 제거

### DIFF
--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -21,11 +21,6 @@ function EngineTypeBadge({ value }: { value?: string | null }) {
   return <span>{value === "ELECTRIC" ? "전기" : "내연"}</span>;
 }
 
-function OperationStatusBadge({ status }: { status: FrontendVehicle["status"] }) {
-  const cls = status === "운행" ? "status-badge status-badge-green" : "status-badge status-badge-gray";
-  return <span className={cls}>{status}</span>;
-}
-
 export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [vehicles, setVehicles] = useState<FrontendVehicle[]>([]);
@@ -82,17 +77,16 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>휠타입</th>
               <th>동력</th>
               <th>IMEI</th>
-              <th>운영 상태</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={4} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : vehicles.length === 0 ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">차량 없음</td>
+                <td colSpan={4} className="table-empty-cell">차량 없음</td>
               </tr>
             ) : (
               vehicles.map((v) => (
@@ -101,7 +95,6 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td><WheelTypeBadge value={v.wheelType} /></td>
                   <td><EngineTypeBadge value={v.engineType} /></td>
                   <td>{v.imei ?? <span className="muted">—</span>}</td>
-                  <td><OperationStatusBadge status={v.status} /></td>
                 </tr>
               ))
             )}


### PR DESCRIPTION
자원 관리 차량 표에서 '운영 상태' 컬럼 제거 — 차량번호/휠타입/동력/IMEI만 표시. OperationStatusBadge 미사용 제거, colSpan 5→4. 프론트 전용, typecheck/lint/build 통과.

참고: IMEI는 현재 13대 전부 DB null이라 지도 상세·자원 관리 모두 '—'로 동일(데이터 미등록). 코드 불일치 아님 — 엑셀 D열/차량별 입력으로 채워짐.