### PR TITLE
릴리스: 자원 관리 표 엑셀 정합 + 운영상태 제거 + 시뮬 IMEI 기준

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -157,13 +157,14 @@ export default async function RootPage({
     bikeCategoryById
   );
 
-  // IMEI=-1 차량 식별: deviceUid 가 "-1" 이거나 "-1-" 으로 시작하는 bikeId 를 추출.
-  // "-1-{prefix}" 형식은 차량별 독립 가상 단말기를 위해 고유하게 생성된 uid.
-  // 실제 IMEI 는 15자리 숫자라서 "-1" 패턴과 절대 겹치지 않음.
+  // 시뮬레이션 대상 식별: 차량 IMEI(Bike.imei) 가 "-" 로 시작하면 가상(시뮬)
+  // 차량으로 본다. 실제 IMEI 는 15자리 숫자라 "-" 와 절대 겹치지 않으므로,
+  // 운영자가 자원 관리/엑셀에서 IMEI 를 "-1" 등으로 넣은 차량만 시뮬 후보다.
+  // IMEI 가 비어 있는(미등록) 실차는 매칭되어도 시뮬되지 않는다.
   const imeiMinusOneBikeIds: string[] = [];
-  for (const [bikeId, uid] of deviceMap.deviceUidByBikeId) {
-    if (uid === "-1" || uid.startsWith("-1-")) {
-      imeiMinusOneBikeIds.push(bikeId);
+  for (const vehicle of vehicleData.vehicles) {
+    if (vehicle.id && vehicle.imei && vehicle.imei.startsWith("-")) {
+      imeiMinusOneBikeIds.push(vehicle.id);
     }
   }
 

--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -9,13 +9,30 @@ import {
   bulkApplyMatchingAction,
   listMatchingAction
 } from "@/app/management/matching/actions";
-import type { ServiceOpsRiderBikeContract } from "@/lib/services/service-ops-api";
+import type {
+  ServiceOpsRiderBikeContract,
+  ServiceOpsContractCategory,
+  ServiceOpsContractReturnType,
+} from "@/lib/services/service-ops-api";
 
 function ContractStatusBadge({ contract }: { contract: ServiceOpsRiderBikeContract }) {
   if (contract.terminatedAt) {
     return <span className="status-badge status-badge-gray">종료</span>;
   }
   return <span className="status-badge status-badge-green">진행 중</span>;
+}
+
+function categoryLabel(category?: ServiceOpsContractCategory | null): React.ReactNode {
+  if (category === "SUBSCRIPTION") return "구독";
+  if (category === "RENTAL") return "렌탈";
+  if (category === "CUSTOM") return "기타";
+  return <span className="muted">—</span>;
+}
+
+function returnTypeLabel(returnType?: ServiceOpsContractReturnType | null): React.ReactNode {
+  if (returnType === "TAKEOVER") return "인수형";
+  if (returnType === "RETURN") return "반납형";
+  return <span className="muted">—</span>;
 }
 
 export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
@@ -71,8 +88,10 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
           <thead>
             <tr>
               <th>차량번호</th>
-              <th>라이더명</th>
+              <th>라이더 이름</th>
               <th>연락처</th>
+              <th>계약형태</th>
+              <th>인수방식</th>
               <th>시작일</th>
               <th>종료일</th>
               <th>상태</th>
@@ -81,11 +100,11 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={8} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : contracts.length === 0 ? (
               <tr>
-                <td colSpan={6} className="table-empty-cell">계약 없음</td>
+                <td colSpan={8} className="table-empty-cell">계약 없음</td>
               </tr>
             ) : (
               contracts.map((c) => (
@@ -93,6 +112,8 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td>{c.plateNumber ?? <span className="muted">—</span>}</td>
                   <td>{c.riderName ?? <span className="muted">—</span>}</td>
                   <td>{c.riderPhoneNumber ?? <span className="muted">—</span>}</td>
+                  <td>{categoryLabel(c.category)}</td>
+                  <td>{returnTypeLabel(c.returnType)}</td>
                   <td>{c.startAt.slice(0, 10)}</td>
                   <td>{c.endAt ? c.endAt.slice(0, 10) : <span className="muted">—</span>}</td>
                   <td><ContractStatusBadge contract={c} /></td>

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -72,8 +72,8 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
             <tr>
               <th>이름</th>
               <th>연락처</th>
-              <th>훈련 상태</th>
-              <th>팀명</th>
+              <th>교육이수</th>
+              <th>팀</th>
             </tr>
           </thead>
           <tbody>

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -21,11 +21,6 @@ function EngineTypeBadge({ value }: { value?: string | null }) {
   return <span>{value === "ELECTRIC" ? "전기" : "내연"}</span>;
 }
 
-function OperationStatusBadge({ status }: { status: FrontendVehicle["status"] }) {
-  const cls = status === "운행" ? "status-badge status-badge-green" : "status-badge status-badge-gray";
-  return <span className={cls}>{status}</span>;
-}
-
 export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
   const router = useRouter();
   const [vehicles, setVehicles] = useState<FrontendVehicle[]>([]);
@@ -82,17 +77,16 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>휠타입</th>
               <th>동력</th>
               <th>IMEI</th>
-              <th>운영 상태</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={4} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : vehicles.length === 0 ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">차량 없음</td>
+                <td colSpan={4} className="table-empty-cell">차량 없음</td>
               </tr>
             ) : (
               vehicles.map((v) => (
@@ -101,7 +95,6 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td><WheelTypeBadge value={v.wheelType} /></td>
                   <td><EngineTypeBadge value={v.engineType} /></td>
                   <td>{v.imei ?? <span className="muted">—</span>}</td>
-                  <td><OperationStatusBadge status={v.status} /></td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -74,8 +74,8 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
           <thead>
             <tr>
               <th>차량번호</th>
-              <th>휠타입</th>
-              <th>동력</th>
+              <th>구분</th>
+              <th>엔진</th>
               <th>IMEI</th>
             </tr>
           </thead>

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -357,6 +357,9 @@ export type ServiceOpsRiderBikeContract = {
   /** Denormalized from Rider — populated in list responses. */
   riderName?: string | null;
   riderPhoneNumber?: string | null;
+  /** Denormalized from ContractTemplate — populated in list responses. */
+  category?: ServiceOpsContractCategory | null;
+  returnType?: ServiceOpsContractReturnType | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
@@ -1,5 +1,7 @@
 package com.thundercrew.opsapi.contract.dto;
 
+import com.thundercrew.opsapi.contract.domain.ContractCategory;
+import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
 import java.time.Instant;
 import java.util.UUID;
@@ -20,6 +22,8 @@ public record RiderBikeContractReadResponse(
         String plateNumber,
         String riderName,
         String riderPhoneNumber,
+        ContractCategory category,
+        ContractReturnType returnType,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -52,17 +56,21 @@ public record RiderBikeContractReadResponse(
                 null,
                 null,
                 null,
+                null,
+                null,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );
     }
 
-    /** Used by the list endpoint to include denormalized bike/rider fields. */
+    /** Used by the list endpoint to include denormalized bike/rider/template fields. */
     public static RiderBikeContractReadResponse from(
             RiderBikeContract contract,
             String plateNumber,
             String riderName,
-            String riderPhoneNumber
+            String riderPhoneNumber,
+            ContractCategory category,
+            ContractReturnType returnType
     ) {
         return new RiderBikeContractReadResponse(
                 contract.getId(),
@@ -80,6 +88,8 @@ public record RiderBikeContractReadResponse(
                 plateNumber,
                 riderName,
                 riderPhoneNumber,
+                category,
+                returnType,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/ContractTemplateRepository.java
@@ -3,6 +3,8 @@ package com.thundercrew.opsapi.contract.repository;
 import com.thundercrew.opsapi.contract.domain.ContractCategory;
 import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import com.thundercrew.opsapi.contract.domain.ContractTemplate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -22,6 +24,8 @@ public interface ContractTemplateRepository extends Repository<ContractTemplate,
     boolean existsByNameAndIdNotAndDeletedAtIsNull(String name, UUID id);
 
     ContractTemplate save(ContractTemplate template);
+
+    List<ContractTemplate> findAllByIdIn(Collection<UUID> ids);
 
     Optional<ContractTemplate> findFirstByCategoryAndReturnTypeAndEnabledTrueAndDeletedAtIsNull(
             ContractCategory category, ContractReturnType returnType);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
@@ -4,6 +4,7 @@ import com.thundercrew.opsapi.bike.domain.Bike;
 import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.domain.ContractTemplate;
 import com.thundercrew.opsapi.contract.dto.ContractTemplateReadResponse;
 import com.thundercrew.opsapi.contract.dto.RiderBikeContractReadResponse;
 import com.thundercrew.opsapi.contract.repository.ContractTemplateRepository;
@@ -61,19 +62,28 @@ public class ContractReadService {
                 .map(com.thundercrew.opsapi.contract.domain.RiderBikeContract::getRiderId)
                 .collect(Collectors.toSet());
 
+        Set<UUID> templateIds = page.getContent().stream()
+                .map(com.thundercrew.opsapi.contract.domain.RiderBikeContract::getContractTemplateId)
+                .collect(Collectors.toSet());
+
         Map<UUID, Bike> bikeMap = bikeRepository.findAllByIdIn(bikeIds).stream()
                 .collect(Collectors.toMap(Bike::getId, b -> b));
         Map<UUID, Rider> riderMap = riderRepository.findAllByIdIn(riderIds).stream()
                 .collect(Collectors.toMap(Rider::getId, r -> r));
+        Map<UUID, ContractTemplate> templateMap = contractTemplateRepository.findAllByIdIn(templateIds).stream()
+                .collect(Collectors.toMap(ContractTemplate::getId, t -> t));
 
         return PageResponse.of(page.map(contract -> {
             Bike bike = bikeMap.get(contract.getBikeId());
             Rider rider = riderMap.get(contract.getRiderId());
+            ContractTemplate template = templateMap.get(contract.getContractTemplateId());
             return RiderBikeContractReadResponse.from(
                     contract,
                     bike != null ? bike.getPlateNumber() : null,
                     rider != null ? rider.getName() : null,
-                    rider != null ? rider.getPhoneNumber() : null
+                    rider != null ? rider.getPhoneNumber() : null,
+                    template != null ? template.getCategory() : null,
+                    template != null ? template.getReturnType() : null
             );
         }));
     }


### PR DESCRIPTION
## 릴리스 내용
- **#431 표↔엑셀 정합**: 차량(휠타입→구분, 동력→엔진), 라이더(훈련 상태→교육이수, 팀명→팀), 매칭(라이더 이름 + 계약형태·인수방식 컬럼 추가, 백엔드 denormalize)
- **#430 시뮬 기준 변경**: 시뮬 대상을 차량 IMEI(Bike.imei)가 '-'로 시작하는 차량으로 (단말기 deviceUid -1 → 명시적 IMEI 접두 마커). IMEI 미등록/실차는 시뮬 제외
- **#429 운영 상태 컬럼 제거**: 자원 관리 차량 표 정리

## 배포 영향
- 백엔드(계약 read denormalize) + 프론트. 마이그레이션 없음
- ⚠️ #430으로 배포 직후 시뮬 0대 → 시뮬 차량은 IMEI를 '-1' 등으로 설정해야 함(준비된 업로드 파일 있음)

## Test Plan
- [x] 백엔드 compileJava + compileTestJava, 프론트 typecheck+lint+build
- [ ] 프로덕션 QA: 표 헤더(구분/엔진/교육이수/팀), 매칭 계약형태·인수방식, IMEI '-1' 차량만 시뮬

🤖 Generated with [Claude Code](https://claude.com/claude-code)