### PR TITLE
릴리스: 지도 UI 정리 (상단 필터/대수 제거 + 차량 상세 유지·겹침 방지)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1094,6 +1094,7 @@ textarea { padding-top: 10px; min-height: 96px; }
   z-index: 50;
   pointer-events: auto;
 }
+.vehicle-floating-panel--bottom-open { max-height: calc(70vh - 32px); }
 .vehicle-floating-panel h3 { margin: 0; font-size: 16px; }
 .vehicle-floating-panel-header {
   display: flex;

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -68,12 +68,15 @@ const STATUS_TO_CODE: Record<FrontendVehicle["status"], ServiceOpsBikeOperationS
 export function VehicleDetailDialog({
   row,
   insuranceOptions,
-  onClose
+  onClose,
+  bottomPanelOpen
 }: {
   row: VehicleDetailRow | null;
   /** 보험 select / 체크박스 선택지. PRIMARY + ADDON 구분 포함. */
   insuranceOptions: ReadonlyArray<InsuranceOption>;
   onClose: () => void;
+  /** 하단 패널이 열려 있을 때 true — floating panel 높이를 줄여 겹침 방지. */
+  bottomPanelOpen?: boolean;
 }) {
   const [mode, setMode] = useState<"view" | "edit">("view");
   // 현재 부착 단말기 정보. row 가 바뀔 때마다 lazy fetch — 미부착(null) /
@@ -170,7 +173,7 @@ export function VehicleDetailDialog({
   return (
     <div
       ref={panelRef}
-      className="vehicle-floating-panel"
+      className={`vehicle-floating-panel${bottomPanelOpen ? " vehicle-floating-panel--bottom-open" : ""}`}
       role="dialog"
       aria-label="차량 상세"
       aria-modal="false"

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
@@ -80,12 +80,6 @@ export function VehiclesPanel({
   // 지도 헤더 필터가 차량 필터의 단일 소스다. FullscreenMapHost 가 이미
   // 필터링한 `visibleVehicles` 를 `data.vehicles` 로 받아 그대로 렌더한다.
   const visibleVehicles = data.vehicles;
-
-  // 탭 언마운트(다른 탭으로 전환) 시 선택 상태도 해제. 마커 클릭 / 행 클릭
-  // 으로 잡힌 selectedBikeId 가 다른 탭에서 잔존하지 않게.
-  useEffect(() => {
-    return () => setSelectedBikeId(null);
-  }, [setSelectedBikeId]);
 
   return (
     <div className="vehicles-panel">

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -17,6 +17,9 @@ import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-s
 type BottomTab = "vehicles" | "stations" | "tips";
 
 export interface BottomMapPanelProps {
+  /** 패널 열림 상태 — 부모가 제어 (controlled). */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   // vehicles tab — VehiclesPanel 은 `data: VehicleDataResult` 전체를 받는다
   // (notice 뿐 아니라 source 필드까지 필요).
   vehicleData: VehicleDataResult;
@@ -45,43 +48,43 @@ export interface BottomMapPanelProps {
  * `tipContent` 로 주입되기 전까지 placeholder 만 표시한다.
  */
 export function BottomMapPanel(props: BottomMapPanelProps) {
+  const { open, onOpenChange } = props;
   const [activeTab, setActiveTab] = useState<BottomTab>("vehicles");
-  const [panelOpen, setPanelOpen] = useState(false);
 
   const handleTabClick = (tab: BottomTab) => {
-    if (activeTab === tab && panelOpen) {
-      setPanelOpen(false);
+    if (activeTab === tab && open) {
+      onOpenChange(false);
     } else {
       setActiveTab(tab);
-      setPanelOpen(true);
+      onOpenChange(true);
     }
   };
 
   return (
-    <div className={`bottom-map-panel${panelOpen ? " bottom-map-panel--open" : ""}`}>
+    <div className={`bottom-map-panel${open ? " bottom-map-panel--open" : ""}`}>
       <div className="bottom-map-panel-tabbar">
         {(["vehicles", "stations", "tips"] as BottomTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
-            className={`bottom-map-panel-tab${activeTab === tab && panelOpen ? " is-active" : ""}`}
+            className={`bottom-map-panel-tab${activeTab === tab && open ? " is-active" : ""}`}
             onClick={() => handleTabClick(tab)}
           >
             {tab === "vehicles" ? "차량" : tab === "stations" ? "충전소" : "팁"}
           </button>
         ))}
-        {panelOpen && (
+        {open && (
           <button
             type="button"
             className="bottom-map-panel-collapse"
-            onClick={() => setPanelOpen(false)}
+            onClick={() => onOpenChange(false)}
             aria-label="패널 닫기"
           >
             ▼
           </button>
         )}
       </div>
-      {panelOpen && (
+      {open && (
         <div className="bottom-map-panel-content">
           {activeTab === "vehicles" && (
             <>

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -10,20 +10,6 @@ import { useFleetSimulation } from "@/components/overview/FleetSimulationContext
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import { useTrailWaypoints } from "@/components/overview/use-trail-waypoints";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
-import {
-  applyRiderFilters,
-  applyStationFilters,
-  applyVehicleFilters,
-  DEFAULT_RIDER_FILTERS,
-  DEFAULT_STATION_FILTERS,
-  DEFAULT_VEHICLE_FILTERS,
-  type RiderFilterState,
-  type StationFilterState,
-  type VehicleFilterState
-} from "@/components/overview/filter-compute";
-import { RiderFilterControls } from "@/components/overview/RiderFilterControls";
-import { StationFilterControls } from "@/components/overview/StationFilterControls";
-import { VehicleFilterControls } from "@/components/overview/VehicleFilterControls";
 import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import { OverviewMapSearch, type OverviewMapSearchMatch } from "@/components/overview/OverviewMapSearch";
 import { NotificationBell } from "@/components/layout/NotificationBell";
@@ -100,18 +86,11 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     stationPins,
     tipPins,
     vehicles,
-    riders,
-    stations,
     bikeActiveRiderById,
     riderInfoById,
     deviceUidByBikeId,
-    maintenanceSummaryByBike,
     educationTypeByRiderId,
-    riderActiveBikeId,
-    riderActiveBikePlate,
     riderActiveContractById,
-    insuredRiderIds,
-    ignitionStatusByBikeId,
     riderAllInsurancesByRiderId,
     insuranceItemById,
     insuranceOptions,
@@ -125,14 +104,10 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
   // 팁 선택 상태 — 지도 보라 마커 클릭과 하단 팁 패널 행 클릭이 공유한다.
   // 마커 클릭 → setSelectedTipId → TipsPanel 행 하이라이트. 행 클릭 → 동일.
   const [selectedTipId, setSelectedTipId] = useState<string | null>(null);
+  const [bottomPanelOpen, setBottomPanelOpen] = useState(false);
 
-  const [vehicleFilters, setVehicleFilters] = useState<VehicleFilterState>(DEFAULT_VEHICLE_FILTERS);
-  const [riderFilters, setRiderFilters] = useState<RiderFilterState>(DEFAULT_RIDER_FILTERS);
-  const [stationFilters, setStationFilters] = useState<StationFilterState>(DEFAULT_STATION_FILTERS);
   const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
-  // 필터 바 펼침/접힘. 기본 접힘 — 지도가 최대한 넓게 보이도록.
-  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const { seedBikePins } = useFleetSimulation();
 
@@ -166,87 +141,23 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     [vehicles, serviceTypeFilter]
   );
 
-  const visibleVehicles = useMemo(
-    () =>
-      applyVehicleFilters({
-        vehicles: serviceTypeFilteredVehicles,
-        filters: vehicleFilters,
-        bikePinById,
-        deviceUidByBikeId,
-        maintenanceSummaryByBike
-      }),
-    [serviceTypeFilteredVehicles, vehicleFilters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike]
-  );
+  const visibleVehicles = serviceTypeFilteredVehicles;
 
-  const visibleRiders = useMemo(
-    () =>
-      applyRiderFilters({
-        riders,
-        filters: riderFilters,
-        educationTypeByRiderId,
-        riderActiveBikeId,
-        riderActiveBikePlate,
-        riderActiveContractById,
-        insuredRiderIds,
-        ignitionStatusByBikeId
-      }),
-    [
-      riders,
-      riderFilters,
-      educationTypeByRiderId,
-      riderActiveBikeId,
-      riderActiveBikePlate,
-      riderActiveContractById,
-      insuredRiderIds,
-      ignitionStatusByBikeId
-    ]
-  );
-
-  const visibleStations = useMemo(
-    () => applyStationFilters({ stations, filters: stationFilters }),
-    [stations, stationFilters]
-  );
-
-  // 라이더 필터가 defaults 면 라이더 매핑 거치지 않고 차량 후보 그대로 통과
-  // (의도된 비차단 동작). 필드 비교를 명시적으로 — onChange 마다 spread 라
-  // reference equality 한 번에 의존할 수 없으므로.
-  const riderFilterIsDefault =
-    riderFilters.query.trim() === "" &&
-    riderFilters.education === "ALL" &&
-    riderFilters.assignment === "ALL" &&
-    riderFilters.contractCategory === "ALL" &&
-    riderFilters.insurance === "ALL" &&
-    riderFilters.ignition === "ALL";
-
-  const visibleBikePins = useMemo(() => {
-    const allowedBikeIds = new Set<string>();
-    if (riderFilterIsDefault) {
-      for (const vehicle of visibleVehicles) {
-        const key = vehicle.id ?? vehicle.slug;
-        if (key) allowedBikeIds.add(key);
-      }
-    } else {
-      const ridersWithBikes = new Set<string>();
-      for (const rider of visibleRiders) {
-        const riderKey = rider.id ?? rider.slug;
-        const bikeId = riderActiveBikeId?.get(riderKey);
-        if (bikeId) ridersWithBikes.add(bikeId);
-      }
-      for (const vehicle of visibleVehicles) {
-        const key = vehicle.id ?? vehicle.slug;
-        if (key && ridersWithBikes.has(key)) allowedBikeIds.add(key);
-      }
+  const visibleVehicleIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const v of visibleVehicles) {
+      const key = v.id ?? v.slug;
+      if (key) ids.add(key);
     }
-    return overlaidBikePins.filter((pin) => allowedBikeIds.has(pin.bikeId));
-  }, [visibleVehicles, visibleRiders, riderFilterIsDefault, riderActiveBikeId, overlaidBikePins]);
+    return ids;
+  }, [visibleVehicles]);
 
-  const visibleStationPins = useMemo(() => {
-    const allowed = new Set<string>();
-    for (const station of visibleStations) {
-      if (station.id) allowed.add(station.id);
-    }
-    return stationPins.filter((pin) => allowed.has(pin.stationId));
-  }, [visibleStations, stationPins]);
+  const visibleBikePins = useMemo(
+    () => overlaidBikePins.filter((pin) => visibleVehicleIds.has(pin.bikeId)),
+    [overlaidBikePins, visibleVehicleIds]
+  );
+
+  const visibleStationPins = useMemo(() => [...stationPins], [stationPins]);
 
   const targetLocation = useMemo(() => {
     if (searchOverride) {
@@ -303,60 +214,14 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
   return (
     <div className="fullscreen-map-overlay" role="main" aria-label="운영 지도">
       <header className="fullscreen-map-header">
-        {/* 필터 바를 다시 노출하는 헤더 버튼. 필터가 열려 있을 때도 같은 버튼이
-            존재하며 클릭으로 닫을 수 있다. */}
-        <button
-          type="button"
-          className={filtersOpen ? "fullscreen-map-filter-reopen fullscreen-map-filter-reopen--active" : "fullscreen-map-filter-reopen"}
-          onClick={() => setFiltersOpen((v) => !v)}
-          aria-pressed={filtersOpen}
-          title={filtersOpen ? "필터 숨기기" : "필터 보기"}
-        >
-          필터
-        </button>
         <OverviewMapSearch
           bikePins={overlaidBikePins}
           stationPins={stationPins}
           onSelect={handleSearchSelect}
         />
         <ServiceTypeFilterTabs value={serviceTypeFilter} onChange={setServiceTypeFilter} />
-        <span className="fullscreen-map-counts">
-          {visibleBikePins.length}대 차량 · {visibleStationPins.length}개 충전소
-        </span>
         <NotificationBell />
       </header>
-      {filtersOpen ? (
-        <div className="fullscreen-map-filter-bar">
-          <VehicleFilterControls
-            filters={vehicleFilters}
-            onChange={setVehicleFilters}
-            layout="horizontal"
-            hideSearch
-            count={{ visible: visibleVehicles.length, total: serviceTypeFilteredVehicles.length }}
-          />
-          <RiderFilterControls
-            filters={riderFilters}
-            onChange={setRiderFilters}
-            layout="horizontal"
-            hideSearch
-          />
-          <StationFilterControls
-            filters={stationFilters}
-            onChange={setStationFilters}
-            layout="horizontal"
-            hideSearch
-          />
-          <button
-            type="button"
-            className="fullscreen-map-filter-bar-close"
-            onClick={() => setFiltersOpen(false)}
-            title="필터 숨기기"
-            aria-label="필터 바 닫기"
-          >
-            ✕
-          </button>
-        </div>
-      ) : null}
       <main className="fullscreen-map-canvas">
         <MapShell
           bikePins={[...visibleBikePins]}
@@ -374,8 +239,11 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           row={detailRow}
           insuranceOptions={insuranceOptions ?? []}
           onClose={() => setSelectedBikeId(null)}
+          bottomPanelOpen={bottomPanelOpen}
         />
         <BottomMapPanel
+          open={bottomPanelOpen}
+          onOpenChange={setBottomPanelOpen}
           vehicleData={vehicleData}
           visibleVehicles={visibleVehicles}
           bikeActiveRiderById={bikeActiveRiderById ?? new Map()}


### PR DESCRIPTION
## 릴리스 내용 (프론트 UI, 마이그레이션 없음)
- **#433**: 지도 상단 필터 토글·상세 필터바·차량/충전소 대수 카운트 제거(검색·서비스유형 탭·알림벨 유지), 차량 tab 접어도 차량 상세 유지, 하단 패널과 상세 겹침 방지

## 배포 영향
- 프론트 빌드만 갱신. 마커 필터는 서비스유형 탭만 남음

## Test Plan
- [x] typecheck + lint + build
- [ ] 프로덕션 QA: 상단바 정리, 차량 상세 유지, 하단 패널 비겹침

🤖 Generated with [Claude Code](https://claude.com/claude-code)