### PR TITLE
차량 상세 패널이 하단 탭 라인과 겹치지 않도록 수정

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1082,7 +1082,10 @@ textarea { padding-top: 10px; min-height: 96px; }
   right: 16px;
   width: 360px;
   max-width: calc(100% - 32px);
-  max-height: calc(100% - 32px);
+  /* 하단 차량/충전소/팁 탭 라인(접혀 있어도 항상 보임, z-index 110 으로 패널
+     위를 덮음 ~40px)과 겹치지 않도록 그 위에서 멈춘다 = top 16px + 탭바·여백
+     56px. 패널이 펼쳐지면 --bottom-open 이 30vh 컨텐츠만큼 추가로 비킨다. */
+  max-height: calc(100% - 72px);
   overflow: auto;
   padding: 20px 24px;
   border-radius: 12px;
@@ -1094,7 +1097,7 @@ textarea { padding-top: 10px; min-height: 96px; }
   z-index: 50;
   pointer-events: auto;
 }
-.vehicle-floating-panel--bottom-open { max-height: calc(70vh - 32px); }
+.vehicle-floating-panel--bottom-open { max-height: calc(100% - 30vh - 72px); }
 .vehicle-floating-panel h3 { margin: 0; font-size: 16px; }
 .vehicle-floating-panel-header {
   display: flex;


### PR DESCRIPTION
@
## 문제
지도에서 차량 상세 플로팅 패널이 하단의 **차량/충전소/팁 탭 라인**과 겹쳤습니다. 패널은 `top:16px` + `max-height: calc(100% - 32px)` 라서 화면 바닥 ~16px까지 늘어나는데, 탭바(`.bottom-map-panel-tabbar`)는 접혀 있어도 항상 바닥에 떠 있고 `z-index:110`(패널 50보다 높음)이라 패널 하단을 덮었습니다. 기존 `--bottom-open` 보정은 패널이 *펼쳐졌을 때*만 적용돼 접힌 상태의 겹침은 미처리였습니다.

## 수정
플로팅 패널이 두 상태 모두에서 탭 라인 위에서 멈추도록 max-height cap 조정:
- 접힘: `calc(100% - 72px)` (top 16px + 탭바·여백 56px 확보)
- 펼침(`--bottom-open`): `calc(100% - 30vh - 72px)` (30vh 컨텐츠까지 추가로 비킴)

CSS만 변경. lint/build 통과.

## QA (배포 후)
지도 → 차량 행 선택 → 차량 상세 패널 하단이 탭 라인 위에서 끝나는지, 하단 패널 펼침/접힘 모두에서 안 겹치는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@