### PR TITLE
차량 상세에서 IMEI/단말기 ID 비우기(clear) 동작 수정

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -320,8 +320,12 @@ export async function updateVehicleFromOverviewAction(
       modelName: optionalText(formData.get("modelName")),
       engineType,
       serviceType,
-      imei: optionalText(formData.get("imei")),
-      terminalId: optionalText(formData.get("terminalId"))
+      // 상세 폼은 IMEI / 단말기 ID 입력을 항상 렌더하므로 빈 칸 = "지우기" 의도.
+      // optionalText 면 빈 칸이 null 로 가서 backend 의 "null=변경 안 함" 분기에
+      // 걸려 기존 값이 안 지워진다. requiredText 로 빈 문자열("")을 보내 backend
+      // 의 isBlank()→null 경로(=clear)를 타게 한다.
+      imei: requiredText(formData.get("imei")),
+      terminalId: requiredText(formData.get("terminalId"))
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {


### PR DESCRIPTION
@
## 문제 (QA 중 발견)
prod QA에서 차량 상세 편집으로 단말기 ID를 입력→저장하면 정상 반영되지만, **값을 비워 저장하면 기존 값이 안 지워졌습니다.** 상세 폼은 IMEI/단말기 ID 입력을 항상 렌더하므로 빈 칸 = "지우기" 의도인데:
- 프론트가 `optionalText("")` → `null` 전송
- 백엔드 `update()` 는 `null` 을 "변경 안 함"으로 처리
→ 빈 칸이 백엔드에 도달하지 못해 clear 불가. (엑셀 벌크는 `""`→null 로 정상 clear 되어 동작이 비일관)

## 수정
`updateVehicleFromOverviewAction` 에서 imei/terminalId 를 `requiredText` 로 전송(빈 칸이면 `""`). 백엔드 `if (req != null) setX(isBlank()?null:req)` 의 isBlank→null(=clear) 경로를 타게 함. 값이 있으면 기존대로 반영.

CSS/로직 외 영향 없음, 프론트 typecheck/lint/build 통과.

## QA (배포 후)
차량 상세 → IMEI/단말기 ID 입력 후 저장 → 반영 확인 → 다시 비우고 저장 → 자원 관리에서 `—` 로 비워지는지 확인. (직전 QA로 99아9999에 남은 `QA-T-001` 도 이 수정 배포 후 정리 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@