### PR TITLE
릴리스: 차량 상세 IMEI/단말기 ID 비우기 수정 (#438)

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -320,8 +320,12 @@ export async function updateVehicleFromOverviewAction(
       modelName: optionalText(formData.get("modelName")),
       engineType,
       serviceType,
-      imei: optionalText(formData.get("imei")),
-      terminalId: optionalText(formData.get("terminalId"))
+      // 상세 폼은 IMEI / 단말기 ID 입력을 항상 렌더하므로 빈 칸 = "지우기" 의도.
+      // optionalText 면 빈 칸이 null 로 가서 backend 의 "null=변경 안 함" 분기에
+      // 걸려 기존 값이 안 지워진다. requiredText 로 빈 문자열("")을 보내 backend
+      // 의 isBlank()→null 경로(=clear)를 타게 한다.
+      imei: requiredText(formData.get("imei")),
+      terminalId: requiredText(formData.get("terminalId"))
     });
     if (nextStatus && nextStatus !== currentStatus) {
       await client.changeVehicleOperationStatus(vehicleId, {


### PR DESCRIPTION
@
## 릴리스 내용
[#438](https://github.com/EVNSolution/thundercrew-domain/pull/438) — 차량 상세 편집에서 IMEI/단말기 ID를 빈 칸으로 저장하면 기존 값이 안 지워지던 문제 수정 (프론트 `requiredText` 로 빈 문자열 전송 → 백엔드 clear 경로).

## 배포 영향
- 프론트엔드만 변경(DB 마이그레이션 없음). 머지 시 aws-ec2-deploy 자동 실행.

## QA (배포 후)
차량 상세 단말기 ID 입력→저장→반영, 비우기→저장→`—` 확인. 직전 QA로 99아9999에 남은 `QA-T-001` 정리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@