### PR TITLE
Task C②: 지도 하단 '배송' 상태 탭

### DIFF
--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -188,6 +188,12 @@ export async function listDispatchOrdersAction(
   return client.listDispatchOrders(bikeId).catch(() => []);
 }
 
+export async function listActiveDispatchOrdersAction(): Promise<ServiceOpsDispatchOrder[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listActiveDispatchOrders().catch(() => []);
+}
+
 export async function completeDispatchOrderAction(
   id: string
 ): Promise<{ ok: true } | { ok: false; error: string }> {

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1574,6 +1574,30 @@ textarea { padding-top: 10px; min-height: 96px; }
   text-align: center;
 }
 
+/* ── 배송 탭 (DeliveryStatusPanel) ──────────────────────────────────
+   dispatch-queue-* / delivery-meta 클래스를 그대로 재사용하고,
+   차량별 그룹 간격과 헤더만 추가로 정의한다. */
+.delivery-status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.delivery-status-vehicle-group {
+  padding: 10px 12px;
+  border: 1px solid var(--rm-line-subtle);
+  border-radius: var(--rm-radius-md);
+  background: var(--rm-bg-panel);
+}
+
+.delivery-status-vehicle-header {
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--rm-text-primary);
+  letter-spacing: .01em;
+}
+
 /* 전체화면 모드일 때 page-container 의 기본 패딩/스크롤을 제거해 지도가
    viewport 전체를 채우도록. */
 .page-container--fullscreen {

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
+import { DeliveryStatusPanel } from "@/components/overview/DeliveryStatusPanel";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
   FrontendVehicle,
@@ -14,7 +15,7 @@ import type { StationDataResult } from "@/lib/services/station-data";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 
-type BottomTab = "vehicles" | "stations" | "tips";
+type BottomTab = "vehicles" | "stations" | "delivery" | "tips";
 
 export interface BottomMapPanelProps {
   /** 패널 열림 상태 — 부모가 제어 (controlled). */
@@ -63,14 +64,14 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
   return (
     <div className={`bottom-map-panel${open ? " bottom-map-panel--open" : ""}`}>
       <div className="bottom-map-panel-tabbar">
-        {(["vehicles", "stations", "tips"] as BottomTab[]).map((tab) => (
+        {(["vehicles", "stations", "delivery", "tips"] as BottomTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
             className={`bottom-map-panel-tab${activeTab === tab && open ? " is-active" : ""}`}
             onClick={() => handleTabClick(tab)}
           >
-            {tab === "vehicles" ? "차량" : tab === "stations" ? "충전소" : "팁"}
+            {tab === "vehicles" ? "차량" : tab === "stations" ? "충전소" : tab === "delivery" ? "배송" : "팁"}
           </button>
         ))}
         {open && (
@@ -110,6 +111,9 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
               )}
               <StationsPanel data={props.stationData} />
             </>
+          )}
+          {activeTab === "delivery" && (
+            <DeliveryStatusPanel vehicles={props.visibleVehicles} />
           )}
           {activeTab === "tips" && (
             props.tipContent ?? (

--- a/development/front-admin-web/components/overview/DeliveryStatusPanel.tsx
+++ b/development/front-admin-web/components/overview/DeliveryStatusPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { listActiveDispatchOrdersAction } from "@/app/dispatch/actions";
+import type { FrontendVehicle, ServiceOpsDispatchOrder } from "@/lib/services/service-ops-api";
+
+interface DeliveryStatusPanelProps {
+  vehicles: ReadonlyArray<FrontendVehicle>;
+}
+
+/**
+ * 전체화면 지도 하단 패널의 "배송" 탭 콘텐츠.
+ *
+ * 마운트 시 `listActiveDispatchOrdersAction()` 으로 ASSIGNED 상태의 전체 배차를
+ * 받아 bikeId 별로 그룹화한 뒤, 차량번호와 함께 현재 배차 + 대기 목록을 보여준다.
+ * 읽기 전용 상태 뷰이므로 완료/취소 버튼은 없다.
+ */
+export function DeliveryStatusPanel({ vehicles }: DeliveryStatusPanelProps) {
+  const [orders, setOrders] = useState<ServiceOpsDispatchOrder[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listActiveDispatchOrdersAction().then((next) => {
+      if (cancelled) return;
+      setOrders(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // bikeId → plateNumber 조회 맵 (id 가 있는 차량만).
+  const plateByBikeId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const v of vehicles) {
+      if (v.id) map.set(v.id, v.plateNumber);
+    }
+    return map;
+  }, [vehicles]);
+
+  // bikeId 별 그룹화 및 sequence 정렬.
+  const groups = useMemo(() => {
+    if (!orders) return null;
+    const byBike = new Map<string, ServiceOpsDispatchOrder[]>();
+    for (const o of orders) {
+      if (!o.bikeId) continue;
+      const existing = byBike.get(o.bikeId);
+      if (existing) {
+        existing.push(o);
+      } else {
+        byBike.set(o.bikeId, [o]);
+      }
+    }
+    // 각 그룹 내 sequence 오름차순 정렬.
+    const result: Array<{ bikeId: string; plate: string; orders: ServiceOpsDispatchOrder[] }> = [];
+    for (const [bikeId, groupOrders] of byBike.entries()) {
+      const plate = plateByBikeId.get(bikeId) ?? "(미상)";
+      result.push({
+        bikeId,
+        plate,
+        orders: [...groupOrders].sort((a, b) => a.sequence - b.sequence)
+      });
+    }
+    // 차량번호 순으로 정렬.
+    result.sort((a, b) => a.plate.localeCompare(b.plate, "ko"));
+    return result;
+  }, [orders, plateByBikeId]);
+
+  if (orders === null) {
+    return (
+      <div className="delivery-status-panel">
+        <p className="muted">불러오는 중…</p>
+      </div>
+    );
+  }
+
+  if (!groups || groups.length === 0) {
+    return (
+      <div className="delivery-status-panel">
+        <div className="bottom-map-panel-placeholder">진행 중인 배송 없음</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="delivery-status-panel">
+      {groups.map(({ bikeId, plate, orders: groupOrders }) => {
+        const [current, ...waiting] = groupOrders;
+        return (
+          <div key={bikeId} className="delivery-status-vehicle-group">
+            <div className="delivery-status-vehicle-header">{plate}</div>
+
+            {/* 현재 배차 */}
+            <div className="dispatch-queue-current">
+              <span className="dispatch-queue-tag">현재 배차</span>
+              <ReadonlyDispatchOrderRow order={current} />
+            </div>
+
+            {/* 대기 목록 */}
+            {waiting.length > 0 && (
+              <div className="dispatch-queue-waiting">
+                <span className="dispatch-queue-tag muted">대기 {waiting.length}건</span>
+                <ul className="dispatch-queue-list">
+                  {waiting.map((order) => (
+                    <li key={order.id} className="dispatch-queue-item">
+                      <ReadonlyDispatchOrderRow order={order} compact />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * 읽기 전용 배차 주문 행 — VehicleDetailDialog 의 DispatchOrderRow 와 동일한
+ * delivery-meta 마크업을 재사용하되 액션 버튼(완료/취소)을 제외한다.
+ * `compact` 가 true 이면 대기 목록용으로 고객명+주소만 간략히 표시한다.
+ */
+function ReadonlyDispatchOrderRow({
+  order,
+  compact = false
+}: {
+  order: ServiceOpsDispatchOrder;
+  compact?: boolean;
+}) {
+  return (
+    <div className="dispatch-order-row">
+      <dl className="delivery-meta">
+        <div className="delivery-meta-row">
+          <dt>고객 이름</dt>
+          <dd>
+            {order.customerName || "—"}
+            {order.kind ? (
+              <span
+                className={`dispatch-kind-badge dispatch-kind-badge--${order.kind === "PICKUP" ? "pickup" : "delivery"}`}
+              >
+                {order.kind === "PICKUP" ? "수거" : "배송"}
+              </span>
+            ) : null}
+          </dd>
+        </div>
+        {!compact && (
+          <div className="delivery-meta-row">
+            <dt>연락처</dt>
+            <dd>{order.customerPhone || "—"}</dd>
+          </div>
+        )}
+        {!compact && order.originAddress ? (
+          <div className="delivery-meta-row">
+            <dt>출발지</dt>
+            <dd>{order.originAddress}</dd>
+          </div>
+        ) : null}
+        <div className="delivery-meta-row">
+          <dt>주소</dt>
+          <dd>{order.address || "—"}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1273,6 +1273,7 @@ export type ServiceOpsApiClient = {
 
   // ── Dispatch orders (배차) ──
   listDispatchOrders: (bikeId: string) => Promise<ServiceOpsDispatchOrder[]>;
+  listActiveDispatchOrders: () => Promise<ServiceOpsDispatchOrder[]>;
   completeDispatchOrder: (id: string) => Promise<ServiceOpsDispatchOrder>;
   cancelDispatchOrder: (id: string) => Promise<void>;
   previewDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
@@ -1884,6 +1885,8 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     // ── Dispatch orders (배차) ──
     listDispatchOrders: (bikeId) =>
       request<ServiceOpsDispatchOrder[]>("/dispatch-orders", { method: "GET" }, { bikeId }),
+    listActiveDispatchOrders: () =>
+      request<ServiceOpsDispatchOrder[]>("/dispatch-orders/active", { method: "GET" }),
     completeDispatchOrder: (id) =>
       request<ServiceOpsDispatchOrder>(
         `/dispatch-orders/${encodeURIComponent(id)}/complete`,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
@@ -28,6 +28,12 @@ public class DispatchOrderReadController {
         return dispatchOrderReadService.listByBike(bikeId);
     }
 
+    /** 배송 상태 탭: 차량 배정된 활성(ASSIGNED) 배차 전체. */
+    @GetMapping("/active")
+    List<DispatchOrderReadResponse> activeOrders() {
+        return dispatchOrderReadService.listActiveAssigned();
+    }
+
     @GetMapping("/calls/offered")
     List<DispatchOrderReadResponse> offeredCalls() {
         return deliveryCallService.listOffered();

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
@@ -25,6 +25,13 @@ public class DispatchOrderReadService {
                 .toList();
     }
 
+    /** 배송 상태 탭: 차량 배정된 활성(ASSIGNED) 배차 전체. 프론트가 차량별로 묶는다. */
+    public List<DispatchOrderReadResponse> listActiveAssigned() {
+        return dispatchOrderRepository.findByStatusAndDeletedAtIsNull(DispatchOrderStatus.ASSIGNED).stream()
+                .map(DispatchOrderReadResponse::from)
+                .toList();
+    }
+
     public Optional<DispatchOrderReadResponse> currentByBike(UUID bikeId) {
         return dispatchOrderRepository
                 .findByBikeIdAndStatusAndDeletedAtIsNullOrderBySequenceAsc(bikeId, DispatchOrderStatus.ASSIGNED)


### PR DESCRIPTION
@
## Task C ② — 배송 상태 파악 탭
지도 하단 패널에 **배송** 탭(4번째)을 추가해 차량별 현재/대기 배송을 한눈에 봅니다.

## 변경
**백엔드 (마이그레이션 없음)**
- `GET /api/v1/dispatch-orders/active` — ASSIGNED 배차 전체 반환 (`DispatchOrderReadService.listActiveAssigned`, 기존 `findByStatusAndDeletedAtIsNull` 재사용)

**프론트엔드**
- `listActiveDispatchOrders` 클라이언트 + `listActiveDispatchOrdersAction`
- 새 `DeliveryStatusPanel`: 활성 배차를 차량별 그룹 → 차량번호 + 현재 배차(최소 순번: 고객/연락처/출발지/목적지/수거·배송 배지) + 대기 N건 목록. 읽기 전용(완료/취소 없음). 출발지(①)도 표시
- `BottomMapPanel`: 차량/충전소/**배송**/팁 4탭

## 검증
- 백엔드 compileJava 통과 / 프론트 typecheck·lint·build 통과

## QA (배포 후)
지도 하단 배송 탭 → 배차 있는 차량별 현재/대기 표시, 배차 없으면 "진행 중인 배송 없음".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@