### PR TITLE
Task C④: 순차 재시동 서버 알림(영속화) + 다음 목적지

### DIFF
--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -8,8 +8,10 @@ import {
   type DispatchBulkApplyRow,
   type DispatchBulkPreviewRow,
   type DispatchBulkSummary,
+  type ReignitionNotificationCreateInput,
   type ServiceOpsDispatchOrder,
-  type ServiceOpsDispatchRound
+  type ServiceOpsDispatchRound,
+  type ServiceOpsReignitionNotification
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 import { geocodeAddress } from "@/lib/services/ncp-geocoder";
@@ -324,4 +326,27 @@ export async function listOfferedCallsAction(): Promise<ServiceOpsDispatchOrder[
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
   if (!client) return [];
   return client.listOfferedCalls().catch(() => []);
+}
+
+// ── Re-ignition notifications ──
+
+/**
+ * 시동 ON 이벤트를 서버에 기록한다 (fire-and-forget). 인증 없거나 실패해도 무시.
+ */
+export async function recordReignitionNotificationAction(
+  input: ReignitionNotificationCreateInput
+): Promise<void> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return;
+  await client.recordReignitionNotification(input).catch(() => undefined);
+}
+
+/**
+ * 최근 re-ignition 알림 목록을 반환한다 (앱 로드 시 벨 초기화용).
+ * 미인증 또는 오류 시 빈 배열 반환.
+ */
+export async function listReignitionNotificationsAction(): Promise<ServiceOpsReignitionNotification[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listReignitionNotifications().catch(() => []);
 }

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -4,9 +4,12 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useState,
   type ReactNode,
 } from "react";
+
+import { listReignitionNotificationsAction } from "@/app/dispatch/actions";
 
 export type IgnitionNotification = {
   id: string;
@@ -34,6 +37,29 @@ const NotificationContext = createContext<NotificationContextValue | null>(null)
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<IgnitionNotification[]>([]);
   const [readCount, setReadCount] = useState(0);
+
+  // 앱 로드 시 서버에서 최근 re-ignition 알림을 가져와 벨을 초기화한다.
+  // 서버 레코드 id 는 클라이언트 생성 id 와 충돌하지 않으므로 dedup 불필요.
+  useEffect(() => {
+    listReignitionNotificationsAction().then((records) => {
+      if (records.length === 0) return;
+      const seeded: IgnitionNotification[] = records.map((r) => ({
+        id: r.id,
+        plateNumber: r.plateNumber,
+        startedAt: new Date(r.occurredAt).getTime(),
+        customerName: r.nextCustomerName ?? undefined,
+        address: r.nextAddress ?? undefined,
+      }));
+      // newest-first — server returns newest first, so reverse for oldest-first
+      // then cap to 20 via the same logic as addNotification.
+      setNotifications((prev) => {
+        if (prev.length > 0) return prev; // already has live notifications, skip seed
+        const combined = [...seeded].reverse(); // convert newest-first → oldest-first
+        return combined.length > 20 ? combined.slice(-20) : combined;
+      });
+      setReadCount(0);
+    }).catch(() => undefined);
+  }, []);
 
   const addNotification = useCallback((n: Omit<IgnitionNotification, "id">) => {
     const id = `${n.plateNumber}-${n.startedAt}-${Math.random().toString(36).slice(2, 7)}`;

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+import { recordReignitionNotificationAction } from "@/app/dispatch/actions";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
 /**
@@ -166,6 +167,15 @@ export function FleetSimulationProvider({
         customerName: pin?.currentDispatchCustomerName ?? undefined,
         address: pin?.currentDispatchAddress ?? undefined,
         kind: pin?.currentDispatchKind ?? undefined,
+      });
+      void recordReignitionNotificationAction({
+        bikeId,
+        plateNumber,
+        occurredAt: new Date(state.ignitionOnAt).toISOString(),
+        nextCustomerName: pin?.currentDispatchCustomerName ?? null,
+        nextAddress: pin?.currentDispatchAddress ?? null,
+        nextLatitude: pin?.currentDispatchLatitude ?? null,
+        nextLongitude: pin?.currentDispatchLongitude ?? null,
       });
       const key = dispatchKeyOf(pin);
       if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1134,6 +1134,30 @@ export type DispatchBulkApplyRequest = {
   rows: DispatchBulkApplyRow[];
 };
 
+// ── Re-ignition notification types ──
+
+export type ServiceOpsReignitionNotification = {
+  id: string;
+  bikeId: string;
+  plateNumber: string;
+  occurredAt: string;
+  nextCustomerName: string | null;
+  nextAddress: string | null;
+  nextLatitude: number | null;
+  nextLongitude: number | null;
+  createdAt: string;
+};
+
+export type ReignitionNotificationCreateInput = {
+  bikeId: string;
+  plateNumber: string;
+  occurredAt: string;
+  nextCustomerName?: string | null;
+  nextAddress?: string | null;
+  nextLatitude?: number | null;
+  nextLongitude?: number | null;
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
@@ -1292,6 +1316,10 @@ export type ServiceOpsApiClient = {
   offerCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
   acceptCall: (orderId: string, bikeId: string) => Promise<ServiceOpsDispatchOrder>;
   listOfferedCalls: () => Promise<ServiceOpsDispatchOrder[]>;
+
+  // ── Re-ignition notifications ──
+  recordReignitionNotification: (input: ReignitionNotificationCreateInput) => Promise<ServiceOpsReignitionNotification>;
+  listReignitionNotifications: () => Promise<ServiceOpsReignitionNotification[]>;
 };
 
 type ServiceOpsApiOptions = {
@@ -1975,6 +2003,15 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       }),
     listOfferedCalls: () =>
       request<ServiceOpsDispatchOrder[]>("/dispatch-orders/calls/offered", { method: "GET" }),
+
+    // ── Re-ignition notifications ──
+    recordReignitionNotification: (input) =>
+      request<ServiceOpsReignitionNotification>("/reignition-notifications", {
+        body: JSON.stringify(input),
+        method: "POST"
+      }),
+    listReignitionNotifications: () =>
+      request<ServiceOpsReignitionNotification[]>("/reignition-notifications", { method: "GET" }),
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationCommandController.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationCreateRequest;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.ReignitionNotificationCommandService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reignition-notifications")
+public class ReignitionNotificationCommandController {
+
+    private final ReignitionNotificationCommandService reignitionNotificationCommandService;
+
+    public ReignitionNotificationCommandController(ReignitionNotificationCommandService reignitionNotificationCommandService) {
+        this.reignitionNotificationCommandService = reignitionNotificationCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<ReignitionNotificationReadResponse> record(
+            @Valid @RequestBody ReignitionNotificationCreateRequest req) {
+        ReignitionNotificationReadResponse response = reignitionNotificationCommandService.record(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationReadController.java
@@ -1,0 +1,24 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.ReignitionNotificationReadService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reignition-notifications")
+public class ReignitionNotificationReadController {
+
+    private final ReignitionNotificationReadService reignitionNotificationReadService;
+
+    public ReignitionNotificationReadController(ReignitionNotificationReadService reignitionNotificationReadService) {
+        this.reignitionNotificationReadService = reignitionNotificationReadService;
+    }
+
+    @GetMapping
+    List<ReignitionNotificationReadResponse> listRecent() {
+        return reignitionNotificationReadService.listRecent();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/ReignitionNotification.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/ReignitionNotification.java
@@ -1,0 +1,79 @@
+package com.thundercrew.opsapi.notification.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reignition_notifications")
+public class ReignitionNotification extends DisplaySequencedEntity {
+
+    @Column(name = "bike_id", nullable = false)
+    private UUID bikeId;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String plateNumber;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "next_customer_name", columnDefinition = "text")
+    private String nextCustomerName;
+
+    @Column(name = "next_address", columnDefinition = "text")
+    private String nextAddress;
+
+    @Column(name = "next_latitude")
+    private Double nextLatitude;
+
+    @Column(name = "next_longitude")
+    private Double nextLongitude;
+
+    public static ReignitionNotification create(UUID bikeId, String plateNumber, Instant occurredAt,
+                                                String nextCustomerName, String nextAddress,
+                                                Double nextLatitude, Double nextLongitude) {
+        ReignitionNotification notification = new ReignitionNotification();
+        notification.bikeId = bikeId;
+        notification.plateNumber = plateNumber;
+        notification.occurredAt = occurredAt;
+        notification.nextCustomerName = nextCustomerName;
+        notification.nextAddress = nextAddress;
+        notification.nextLatitude = nextLatitude;
+        notification.nextLongitude = nextLongitude;
+        return notification;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public String getPlateNumber() {
+        return plateNumber;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public String getNextCustomerName() {
+        return nextCustomerName;
+    }
+
+    public String getNextAddress() {
+        return nextAddress;
+    }
+
+    public Double getNextLatitude() {
+        return nextLatitude;
+    }
+
+    public Double getNextLongitude() {
+        return nextLongitude;
+    }
+
+    protected ReignitionNotification() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationCreateRequest.java
@@ -1,0 +1,16 @@
+package com.thundercrew.opsapi.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReignitionNotificationCreateRequest(
+        @NotNull UUID bikeId,
+        @NotBlank String plateNumber,
+        @NotNull Instant occurredAt,
+        String nextCustomerName,
+        String nextAddress,
+        Double nextLatitude,
+        Double nextLongitude
+) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationReadResponse.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.notification.dto;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReignitionNotificationReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        String plateNumber,
+        Instant occurredAt,
+        String nextCustomerName,
+        String nextAddress,
+        Double nextLatitude,
+        Double nextLongitude,
+        Instant createdAt
+) {
+    public static ReignitionNotificationReadResponse from(ReignitionNotification notification) {
+        return new ReignitionNotificationReadResponse(
+                notification.getId(),
+                notification.getIdx(),
+                notification.getBikeId(),
+                notification.getPlateNumber(),
+                notification.getOccurredAt(),
+                notification.getNextCustomerName(),
+                notification.getNextAddress(),
+                notification.getNextLatitude(),
+                notification.getNextLongitude(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/ReignitionNotificationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/ReignitionNotificationRepository.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.notification.repository;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReignitionNotificationRepository extends JpaRepository<ReignitionNotification, UUID> {
+
+    List<ReignitionNotification> findTop50ByDeletedAtIsNullOrderByOccurredAtDesc();
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationCommandService.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationCreateRequest;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.ReignitionNotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReignitionNotificationCommandService {
+
+    private final ReignitionNotificationRepository reignitionNotificationRepository;
+
+    public ReignitionNotificationCommandService(ReignitionNotificationRepository reignitionNotificationRepository) {
+        this.reignitionNotificationRepository = reignitionNotificationRepository;
+    }
+
+    public ReignitionNotificationReadResponse record(ReignitionNotificationCreateRequest req) {
+        ReignitionNotification notification = ReignitionNotification.create(
+                req.bikeId(),
+                req.plateNumber(),
+                req.occurredAt(),
+                req.nextCustomerName(),
+                req.nextAddress(),
+                req.nextLatitude(),
+                req.nextLongitude()
+        );
+        ReignitionNotification saved = reignitionNotificationRepository.save(notification);
+        return ReignitionNotificationReadResponse.from(saved);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationReadService.java
@@ -1,0 +1,24 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.ReignitionNotificationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ReignitionNotificationReadService {
+
+    private final ReignitionNotificationRepository reignitionNotificationRepository;
+
+    public ReignitionNotificationReadService(ReignitionNotificationRepository reignitionNotificationRepository) {
+        this.reignitionNotificationRepository = reignitionNotificationRepository;
+    }
+
+    public List<ReignitionNotificationReadResponse> listRecent() {
+        return reignitionNotificationRepository.findTop50ByDeletedAtIsNullOrderByOccurredAtDesc().stream()
+                .map(ReignitionNotificationReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V41__create_reignition_notifications.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V41__create_reignition_notifications.sql
@@ -1,0 +1,18 @@
+create table reignition_notifications (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    plate_number text not null,
+    occurred_at timestamptz not null,
+    next_customer_name text,
+    next_address text,
+    next_latitude double precision,
+    next_longitude double precision,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+create index idx_reignition_notifications_occurred_at on reignition_notifications (occurred_at desc);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -113,7 +113,8 @@ class ArchitectureBoundaryTests {
                         || isDeviceApiSyncCommand(method)
                         || isTestVehicleCommand(method)
                         || isTestRiderCommand(method)
-                        || isTestMatchingCommand(method)) {
+                        || isTestMatchingCommand(method)
+                        || isReignitionNotificationCommand(method)) {
                     return;
                 }
 
@@ -155,7 +156,8 @@ class ArchitectureBoundaryTests {
                         && !isDeviceApiSyncCommand(method)
                         && !isTestVehicleCommand(method)
                         && !isTestRiderCommand(method)
-                        && !isTestMatchingCommand(method)) {
+                        && !isTestMatchingCommand(method)
+                        && !isReignitionNotificationCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -311,6 +313,11 @@ class ArchitectureBoundaryTests {
                 "com.thundercrew.opsapi.testmatching.matching.controller.TestMatchingCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isReignitionNotificationCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.notification.controller.ReignitionNotificationCommandController");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReignitionNotificationApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReignitionNotificationApiContractTests.java
@@ -1,0 +1,197 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ReignitionNotificationApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from reignition_notifications");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① POST /api/v1/reignition-notifications → 201, fields persisted including next-destination
+    @Test
+    void postReturns201WithAllNextDestinationFields() throws Exception {
+        String occurredAt = "2026-06-16T10:00:00Z";
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0001",
+                                  "occurredAt": "%s",
+                                  "nextCustomerName": "홍길동",
+                                  "nextAddress": "서울 강남구 역삼동 123",
+                                  "nextLatitude": 37.4987,
+                                  "nextLongitude": 127.0276
+                                }
+                                """.formatted(BIKE_ID, occurredAt)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.plateNumber").value("서울CC-0001"))
+                .andExpect(jsonPath("$.occurredAt").value(occurredAt))
+                .andExpect(jsonPath("$.nextCustomerName").value("홍길동"))
+                .andExpect(jsonPath("$.nextAddress").value("서울 강남구 역삼동 123"))
+                .andExpect(jsonPath("$.nextLatitude").value(37.4987))
+                .andExpect(jsonPath("$.nextLongitude").value(127.0276))
+                .andExpect(jsonPath("$.createdAt").isString());
+    }
+
+    // ② POST then GET list returns the event (ordered by occurredAt desc), next-destination fields visible
+    @Test
+    void getListReturnsRecentEventWithNextDestinationFields() throws Exception {
+        String occurredAt = "2026-06-16T09:00:00Z";
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0001",
+                                  "occurredAt": "%s",
+                                  "nextCustomerName": "김철수",
+                                  "nextAddress": "서울 마포구 합정동 456",
+                                  "nextLatitude": 37.5503,
+                                  "nextLongitude": 126.9142
+                                }
+                                """.formatted(BIKE_ID, occurredAt)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$[0].plateNumber").value("서울CC-0001"))
+                .andExpect(jsonPath("$[0].occurredAt").value(occurredAt))
+                .andExpect(jsonPath("$[0].nextCustomerName").value("김철수"))
+                .andExpect(jsonPath("$[0].nextAddress").value("서울 마포구 합정동 456"))
+                .andExpect(jsonPath("$[0].nextLatitude").value(37.5503))
+                .andExpect(jsonPath("$[0].nextLongitude").value(126.9142));
+    }
+
+    // ③ POST without next-destination fields (nullable) → 201
+    @Test
+    void postWithNullNextDestinationFieldsReturns201() throws Exception {
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0002",
+                                  "occurredAt": "2026-06-16T08:00:00Z"
+                                }
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nextCustomerName").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextAddress").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextLatitude").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextLongitude").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    // ④ Two events posted: GET list is ordered occurredAt desc
+    @Test
+    void getListOrdersByOccurredAtDesc() throws Exception {
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s","plateNumber":"서울CC-0001","occurredAt":"2026-06-16T07:00:00Z"}
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s","plateNumber":"서울CC-0002","occurredAt":"2026-06-16T08:00:00Z"}
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].plateNumber").value("서울CC-0002"))
+                .andExpect(jsonPath("$[1].plateNumber").value("서울CC-0001"));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        Assertions.assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
@
## Task C ④ — 순차 재시동 서버 알림
재시동 알림이 클라이언트 전용(벨/토스트)이라 새로고침 시 사라지고 다른 운영자에게 안 보였습니다. **서버에 영속화**합니다.

## 변경
**백엔드 (신규 `notification` 슬라이스, V41)**
- `reignition_notifications` 테이블 (base 컬럼은 dispatch_orders 패턴과 동일)
- 엔티티/리포지토리(`findTop50…OrderByOccurredAtDesc`)/read·command 서비스/read(GET)·command(POST) 컨트롤러 `/api/v1/reignition-notifications` — 차량·plate·occurredAt + 다음 목적지(고객/주소/좌표)
- ArchitectureBoundaryTests: 신규 command 컨트롤러 allow-list 등록(`isReignitionNotificationCommand`, dispatch와 동일한 owner-class 매칭). 신규 컨트롤러가 새 위반을 추가하지 않음 확인.

**프론트엔드**
- 클라이언트 + 타입(record/list), `recordReignitionNotificationAction`(fire-and-forget) + `listReignitionNotificationsAction`
- `FleetSimulationContext`: 순차/왕복 재시동 시 기존 벨과 함께 현재 배차 목적지로 서버 이벤트 POST(dedup 가드 동일 분기 → 재시동당 1회)
- `NotificationContext`: 마운트 시 서버 이벤트로 벨 시드 → 새로고침에도 유지

## 검증
- 백엔드 compileJava/compileTestJava 통과, ArchUnit 신규 컨트롤러 정상 allow-list (통합테스트는 Docker 미가용 환경 사유로 미실행)
- 프론트 typecheck/lint/build 통과

## 배포 영향
- **V41** 신규 테이블 (additive). API 재기동 시 Flyway 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@