### PR TITLE
릴리스: 순차 재시동 ETA(③) + 서버 알림 영속화(④, V41)

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -11,6 +11,7 @@ import {
   type BikeNextCustomerUpsertInput,
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
+  type AuditLogCreateInput,
   serviceOpsApiConfigured,
   ServiceOpsApiError
 } from "@/lib/services/service-ops-api";
@@ -700,6 +701,65 @@ export async function setVehicleIgnitionBlockFromDashboardAction(
   }
 
   revalidatePath("/");
+}
+
+/**
+ * 감사 로그를 DB에 기록하는 fire-and-forget 서버 액션.
+ * 실패해도 호출자에게 영향을 주지 않는다.
+ */
+export async function recordAuditLogAction(input: AuditLogCreateInput): Promise<void> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return;
+  await client.recordAuditLog(input).catch(() => undefined);
+}
+
+/**
+ * 차량 상세 패널 VIEW 모드에서 운행 상태를 인라인으로 변경하는 서버 액션.
+ * redirect 없이 결과를 반환하므로 호출자가 UI 를 즉시 업데이트할 수 있다.
+ */
+export async function changeVehicleOperationStatusInlineAction(
+  vehicleId: string,
+  nextStatus: ServiceOpsBikeOperationStatus,
+  currentStatus: ServiceOpsBikeOperationStatus
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (nextStatus === currentStatus) return { ok: true };
+
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, error: "서비스 API 가 설정되어 있지 않습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) {
+    return { ok: false, error: "session-required" };
+  }
+
+  try {
+    await client.changeVehicleOperationStatus(vehicleId, {
+      operationStatus: nextStatus,
+      reason: "OPERATOR_INLINE_EDIT"
+    });
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+
+  // fire-and-forget audit log
+  void recordAuditLogAction({
+    entityType: "BIKE_OPERATION_STATUS",
+    entityId: vehicleId,
+    field: "operationStatus",
+    oldValue: currentStatus,
+    newValue: nextStatus
+  });
+
+  revalidatePath("/");
+  revalidatePath("/management");
+  return { ok: true };
+}
+
+function extractError(err: unknown): string {
+  if (err instanceof ServiceOpsApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return "알 수 없는 오류가 발생했습니다.";
 }
 
 export async function setVehicleIgnitionBlockFromOverviewAction(

--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -8,8 +8,10 @@ import {
   type DispatchBulkApplyRow,
   type DispatchBulkPreviewRow,
   type DispatchBulkSummary,
+  type ReignitionNotificationCreateInput,
   type ServiceOpsDispatchOrder,
-  type ServiceOpsDispatchRound
+  type ServiceOpsDispatchRound,
+  type ServiceOpsReignitionNotification
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 import { geocodeAddress } from "@/lib/services/ncp-geocoder";
@@ -324,4 +326,27 @@ export async function listOfferedCallsAction(): Promise<ServiceOpsDispatchOrder[
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
   if (!client) return [];
   return client.listOfferedCalls().catch(() => []);
+}
+
+// ── Re-ignition notifications ──
+
+/**
+ * 시동 ON 이벤트를 서버에 기록한다 (fire-and-forget). 인증 없거나 실패해도 무시.
+ */
+export async function recordReignitionNotificationAction(
+  input: ReignitionNotificationCreateInput
+): Promise<void> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return;
+  await client.recordReignitionNotification(input).catch(() => undefined);
+}
+
+/**
+ * 최근 re-ignition 알림 목록을 반환한다 (앱 로드 시 벨 초기화용).
+ * 미인증 또는 오류 시 빈 배열 반환.
+ */
+export async function listReignitionNotificationsAction(): Promise<ServiceOpsReignitionNotification[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listReignitionNotifications().catch(() => []);
 }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -836,6 +836,12 @@ textarea { padding-top: 10px; min-height: 96px; }
   color: var(--rm-accent);
 }
 .dispatch-queue-tag.muted { color: var(--color-text-muted); }
+.dispatch-next-eta {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.dispatch-next-eta strong { color: var(--rm-accent); font-weight: 700; }
 .dispatch-queue-waiting { margin-top: 12px; }
 .dispatch-queue-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .dispatch-order-row {

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -953,6 +953,11 @@ textarea { padding-top: 10px; min-height: 96px; }
 .detail-field { display: grid; gap: 2px; min-width: 0; }
 .detail-field-label { color: var(--color-text-secondary); font-size: 12px; }
 .detail-field-value { color: var(--color-text-primary); font-size: 14px; font-weight: 700; overflow-wrap: anywhere; }
+/* 차량 상세 VIEW 모드 인라인 운영 상태 select — detail-field-value 와 동일한
+   타이포그래피를 유지하면서 border + 패딩만 더해 컨트롤임을 표시. */
+.detail-field-inline-select { width: 100%; font-size: 14px; font-weight: 700; font-family: inherit; color: var(--color-text-primary); background: var(--color-bg-soft); border: 0; border-radius: 6px; box-shadow: 0 0 0 1px var(--color-border); padding: 2px 6px; min-height: 26px; cursor: pointer; }
+.detail-field-inline-select:hover { box-shadow: 0 0 0 1px var(--color-border-strong); }
+.detail-field-inline-select:disabled { opacity: 0.55; cursor: not-allowed; }
 /* 시동 방지 같은 binary 운영자 토글. 좌측이 OFF(허용), 우측이 ON(차단). 칩 안의
    thumb 이 좌/우로 이동하면서 시각적으로 상태를 표현. mint 액센트(차단 = 위험)
    는 light=blue / dark=mint 토큰을 그대로 따른다. */

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -4,9 +4,12 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useState,
   type ReactNode,
 } from "react";
+
+import { listReignitionNotificationsAction } from "@/app/dispatch/actions";
 
 export type IgnitionNotification = {
   id: string;
@@ -34,6 +37,29 @@ const NotificationContext = createContext<NotificationContextValue | null>(null)
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<IgnitionNotification[]>([]);
   const [readCount, setReadCount] = useState(0);
+
+  // 앱 로드 시 서버에서 최근 re-ignition 알림을 가져와 벨을 초기화한다.
+  // 서버 레코드 id 는 클라이언트 생성 id 와 충돌하지 않으므로 dedup 불필요.
+  useEffect(() => {
+    listReignitionNotificationsAction().then((records) => {
+      if (records.length === 0) return;
+      const seeded: IgnitionNotification[] = records.map((r) => ({
+        id: r.id,
+        plateNumber: r.plateNumber,
+        startedAt: new Date(r.occurredAt).getTime(),
+        customerName: r.nextCustomerName ?? undefined,
+        address: r.nextAddress ?? undefined,
+      }));
+      // newest-first — server returns newest first, so reverse for oldest-first
+      // then cap to 20 via the same logic as addNotification.
+      setNotifications((prev) => {
+        if (prev.length > 0) return prev; // already has live notifications, skip seed
+        const combined = [...seeded].reverse(); // convert newest-first → oldest-first
+        return combined.length > 20 ? combined.slice(-20) : combined;
+      });
+      setReadCount(0);
+    }).catch(() => undefined);
+  }, []);
 
   const addNotification = useCallback((n: Omit<IgnitionNotification, "id">) => {
     const id = `${n.plateNumber}-${n.startedAt}-${Math.random().toString(36).slice(2, 7)}`;

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type ChangeEvent, type ReactNode } from "react";
 
 import { PlateNumberInput } from "@/components/management/PlateNumberInput";
 import {
@@ -9,7 +9,9 @@ import {
   type MaintenanceStatus
 } from "@/components/management/vehicle-maintenance-derive";
 import {
+  changeVehicleOperationStatusInlineAction,
   markVehicleMaintenanceServicedAction,
+  recordAuditLogAction,
   setRiderInsuranceFromVehicleAction,
   updateVehicleFromOverviewAction
 } from "@/app/actions";
@@ -202,7 +204,10 @@ export function VehicleDetailDialog({
             <DetailField label="구분" value={engineTypeLabel(vehicle.engineType)} />
             <DetailField label="운영 방식" value={serviceTypeLabel(vehicle.serviceType)} />
             <DetailField label="모델명" value={vehicle.model || "—"} />
-            <DetailField label="운영 상태" value={vehicle.status} />
+            <OperationStatusInlineField
+              vehicleId={vehicleId}
+              currentOperationStatus={currentOperationStatus}
+            />
             <DetailField label="이름" value={row.riderName ?? "—"} />
             <DetailField label="연락처" value={row.riderPhone ?? "—"} />
             <DetailField label="IMEI" value={vehicle.imei || "—"} />
@@ -332,6 +337,54 @@ function DetailField({ label, value }: { label: string; value: string }) {
     <div className="detail-field">
       <span className="detail-field-label">{label}</span>
       <span className="detail-field-value">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * VIEW 모드에서 운행 상태를 인라인으로 변경하는 select 컨트롤.
+ * 변경 즉시 서버 액션을 호출하고, 실패 시 이전 값으로 되돌린다.
+ */
+function OperationStatusInlineField({
+  vehicleId,
+  currentOperationStatus
+}: {
+  vehicleId: string;
+  currentOperationStatus: ServiceOpsBikeOperationStatus;
+}) {
+  const [selected, setSelected] = useState<ServiceOpsBikeOperationStatus>(currentOperationStatus);
+  const [pending, startTransition] = useTransition();
+
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const next = e.currentTarget.value as ServiceOpsBikeOperationStatus;
+    const prev = selected;
+    setSelected(next);
+    startTransition(async () => {
+      const result = await changeVehicleOperationStatusInlineAction(vehicleId, next, prev);
+      if (!result.ok) {
+        if (result.error === "session-required") {
+          window.location.href = "/login?status=session-required";
+          return;
+        }
+        window.alert("운행 상태 변경에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+        setSelected(prev);
+      }
+    });
+  };
+
+  return (
+    <div className="detail-field">
+      <span className="detail-field-label">운영 상태</span>
+      <select
+        className="detail-field-inline-select"
+        value={selected}
+        onChange={handleChange}
+        disabled={pending}
+        aria-label="운영 상태 변경"
+      >
+        <option value="READY">대기</option>
+        <option value="IN_SERVICE">운행</option>
+      </select>
     </div>
   );
 }
@@ -560,6 +613,13 @@ function MaintenanceRowView({
       // alert 으로 알리는 정도 — 더 정교한 toast 는 추후.
       const result = await markVehicleMaintenanceServicedAction(vehicleId, fd);
       if (result.ok) {
+        void recordAuditLogAction({
+          entityType: "MAINTENANCE",
+          entityId: vehicleId,
+          field: row.item.name,
+          oldValue: null,
+          newValue: "교환 완료"
+        });
         onChanged();
       } else if (result.reason === "session-required") {
         window.location.href = "/login?status=session-required";
@@ -649,11 +709,14 @@ function renderStatusBadge(row: DerivedMaintenanceRow, telemetryOffline: boolean
 // ============================================================================
 
 /**
- * 차량 상세 패널 내 보험 섹션.
+ * 차량 상세 패널 내 보험 섹션 — 항상 인라인 편집 모드.
  *
- * 보험 데이터는 라이더에 귀속 — riderId 가 없으면 편집 불가. view 모드에서는
- * PRIMARY 상품명 + ADDON 뱃지를 보여주고, "편집" 버튼으로 edit 모드 전환.
- * edit 모드는 차량 수정 form 과 별도 `<form>` 을 써서 nested form 회피.
+ * 편집/취소/저장 버튼 흐름을 제거하고 PRIMARY select 와 ADDON 체크박스를
+ * 직접 렌더링한다. 변경이 생기면 즉시 form.requestSubmit() 으로 서버 액션을
+ * 호출하고, 성공 후 감사 로그를 fire-and-forget 으로 남긴다.
+ *
+ * 보험 데이터는 라이더에 귀속 — riderId 가 없으면 편집 불가.
+ * 차량 수정 form 과 nested form 충돌을 피하기 위해 별도 `<form>` 사용.
  */
 function InsuranceSection({
   riderId,
@@ -668,20 +731,10 @@ function InsuranceSection({
   addonInsurances: ReadonlyArray<{ id: string; itemId: string }>;
   insuranceOptions: ReadonlyArray<InsuranceOption>;
 }) {
-  const [editing, setEditing] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
 
   const primaryOptions = insuranceOptions.filter((o) => !o.category || o.category === "PRIMARY");
   const addonOptions = insuranceOptions.filter((o) => o.category === "ADDON");
-
-  const insuranceLabelById = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const o of insuranceOptions) map.set(o.id, o.label);
-    return map;
-  }, [insuranceOptions]);
-
-  const primaryLabel = currentPrimaryInsuranceItemId
-    ? (insuranceLabelById.get(currentPrimaryInsuranceItemId) ?? null)
-    : null;
 
   const addonItemIds = useMemo(
     () => new Set(addonInsurances.map((a) => a.itemId)),
@@ -697,52 +750,39 @@ function InsuranceSection({
     );
   }
 
-  if (!editing) {
-    return (
-      <section className="insurance-section">
-        <h4>보험</h4>
-        <div className="insurance-view">
-          <div className="insurance-field">
-            <span className="insurance-field-label">기본</span>
-            <span className="insurance-field-value">
-              {primaryLabel ?? <span className="muted">—</span>}
-            </span>
-          </div>
-          {addonInsurances.length > 0 ? (
-            <div className="insurance-field">
-              <span className="insurance-field-label">추가</span>
-              <span className="insurance-field-value insurance-addons">
-                {addonInsurances.map((addon) => {
-                  const label = insuranceLabelById.get(addon.itemId) ?? addon.itemId;
-                  return (
-                    <span key={addon.id} className="insurance-addon-badge">
-                      {label}
-                    </span>
-                  );
-                })}
-              </span>
-            </div>
-          ) : null}
-          <button
-            type="button"
-            className="button-neutral insurance-edit-btn"
-            onClick={() => setEditing(true)}
-          >
-            편집
-          </button>
-        </div>
-      </section>
-    );
-  }
-
-  // edit 모드 — 차량 수정 form 과 별도 form 으로 nested form 회피.
-  // server action 은 onSubmit 완료 후 redirect 를 태우므로 remount → editing 초기화.
   const boundAction = setRiderInsuranceFromVehicleAction.bind(null, riderId);
+
+  const handlePrimaryChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newValue = e.currentTarget.value || null;
+    const oldValue = currentPrimaryInsuranceItemId;
+    // fire audit before submit (values captured in closure)
+    void recordAuditLogAction({
+      entityType: "RIDER_INSURANCE",
+      entityId: riderId,
+      field: "primaryInsurance",
+      oldValue,
+      newValue
+    });
+    formRef.current?.requestSubmit();
+  };
+
+  const handleAddonChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const changedItemId = e.currentTarget.value;
+    const isChecked = e.currentTarget.checked;
+    void recordAuditLogAction({
+      entityType: "RIDER_INSURANCE",
+      entityId: riderId,
+      field: "addonInsurance",
+      oldValue: isChecked ? null : changedItemId,
+      newValue: isChecked ? changedItemId : null
+    });
+    formRef.current?.requestSubmit();
+  };
 
   return (
     <section className="insurance-section">
       <h4>보험</h4>
-      <form className="insurance-form" action={boundAction}>
+      <form ref={formRef} className="insurance-form" action={boundAction}>
         {/* 서버 액션의 diff 판단에 필요한 현재 상태 hidden 필드 */}
         <input type="hidden" name="currentPrimaryInsuranceId" value={currentPrimaryInsuranceId ?? ""} />
         <input type="hidden" name="currentPrimaryInsuranceItemId" value={currentPrimaryInsuranceItemId ?? ""} />
@@ -751,7 +791,11 @@ function InsuranceSection({
         ))}
         <label className="insurance-form-field">
           <span className="insurance-form-label">기본 보험</span>
-          <select name="primaryInsuranceItemId" defaultValue={currentPrimaryInsuranceItemId ?? ""}>
+          <select
+            name="primaryInsuranceItemId"
+            defaultValue={currentPrimaryInsuranceItemId ?? ""}
+            onChange={handlePrimaryChange}
+          >
             <option value="">없음</option>
             {primaryOptions.map((o) => (
               <option key={o.id} value={o.id}>
@@ -771,6 +815,7 @@ function InsuranceSection({
                     name="addonInsuranceItemId"
                     value={o.id}
                     defaultChecked={addonItemIds.has(o.id)}
+                    onChange={handleAddonChange}
                   />
                   {o.label}
                 </label>
@@ -778,14 +823,6 @@ function InsuranceSection({
             </div>
           </div>
         ) : null}
-        <div className="insurance-form-actions">
-          <button type="button" className="button-neutral" onClick={() => setEditing(false)}>
-            취소
-          </button>
-          <button type="submit" className="button-primary">
-            저장
-          </button>
-        </div>
       </form>
     </section>
   );

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -27,7 +27,7 @@ import type {
   ServiceOpsBikeServiceType,
   ServiceOpsDispatchOrder
 } from "@/lib/services/service-ops-api";
-import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
+import { approxDistanceKm, isCleaningServiceType, MOVING_SPEED_KPH } from "@/lib/services/fleet-simulation";
 import type { SimulatedBikeState, ServiceType } from "@/lib/services/fleet-simulation";
 import type { VehicleDeviceResult } from "@/lib/services/vehicle-device-data";
 import type { VehicleMaintenanceBundle } from "@/lib/services/vehicle-maintenance-data";
@@ -212,7 +212,13 @@ export function VehicleDetailDialog({
             bikeId={vehicleIdForFetch ?? null}
             state={simState}
           />
-          {vehicleIdForFetch && <DispatchQueueSection bikeId={vehicleIdForFetch} />}
+          {vehicleIdForFetch && (
+            <DispatchQueueSection
+              bikeId={vehicleIdForFetch}
+              currentPosition={simState?.position ?? null}
+              isSequential={isCleaningServiceType(vehicle.serviceType)}
+            />
+          )}
           <TelemetrySection current={overlaidCurrent} loading={maintenance === null} />
           <InsuranceSection
             riderId={row.riderId}
@@ -881,7 +887,17 @@ function formatRemaining(ms: number): string {
  * 두 액션 모두 `{ ok } | { ok:false, error }` 를 반환 — 성공 시 큐 재페치, 실패 시
  * error 노출. MaintenanceRowView 의 startTransition + 재페치 패턴을 미러링.
  */
-function DispatchQueueSection({ bikeId }: { bikeId: string }) {
+function DispatchQueueSection({
+  bikeId,
+  currentPosition,
+  isSequential
+}: {
+  bikeId: string;
+  /** 차량 현재 위치 (시뮬 position). 다음 목적지 거리·ETA 계산에 사용. null 이면 미표시. */
+  currentPosition?: { lat: number; lng: number } | null;
+  /** 순차/왕복(cleaning family) 일 때만 다음 목적지 거리·ETA 를 보여준다. */
+  isSequential?: boolean;
+}) {
   const [orders, setOrders] = useState<ServiceOpsDispatchOrder[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   // 큐 재페치 트리거 — 완료/취소 성공 후 +1 하면 아래 useEffect 가 다시 발화.
@@ -952,6 +968,9 @@ function DispatchQueueSection({ bikeId }: { bikeId: string }) {
       <div className="dispatch-queue-current">
         <span className="dispatch-queue-tag">현재 배차</span>
         <DispatchOrderRow order={current} pending={pending} onComplete={runAction} onCancel={runAction} />
+        {isSequential && currentPosition
+          ? renderNextDestinationEta(currentPosition, { lat: current.latitude, lng: current.longitude })
+          : null}
       </div>
 
       {/* ── 대기 목록 ── */}
@@ -968,6 +987,28 @@ function DispatchQueueSection({ bikeId }: { bikeId: string }) {
         </div>
       )}
     </section>
+  );
+}
+
+/**
+ * 순차/왕복 배차의 "다음 목적지까지 거리 + 예상 도착시간". 목적지 도달 → 시동
+ * 종료 → 재시동 흐름에서 운영자가 다음 목적지가 얼마나 남았는지 한눈에 보도록
+ * 현재 배차(가장 낮은 sequence) 목적지에 대해 계산한다. 거리는 좌표 근사
+ * (approxDistanceKm), ETA 는 거리 ÷ MOVING_SPEED_KPH(30km/h).
+ */
+function renderNextDestinationEta(
+  from: { lat: number; lng: number },
+  to: { lat: number; lng: number }
+): ReactNode {
+  const distanceKm = approxDistanceKm(from, to);
+  const etaMin = Math.max(1, Math.round((distanceKm / MOVING_SPEED_KPH) * 60));
+  const arrival = new Date(Date.now() + etaMin * 60_000);
+  const hh = String(arrival.getHours()).padStart(2, "0");
+  const mm = String(arrival.getMinutes()).padStart(2, "0");
+  return (
+    <p className="dispatch-next-eta">
+      다음 목적지까지 <strong>{distanceKm.toFixed(1)} km</strong> · 예상 {etaMin}분 ({hh}:{mm} 도착)
+    </p>
   );
 }
 

--- a/development/front-admin-web/components/overview/FleetSimulationContext.tsx
+++ b/development/front-admin-web/components/overview/FleetSimulationContext.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/services/fleet-simulation";
 import { useNotifications } from "@/components/layout/NotificationContext";
 import type { FrontendDashboardBikePin } from "@/lib/services/service-ops-api";
+import { recordReignitionNotificationAction } from "@/app/dispatch/actions";
 import { fetchOsrmRoute } from "@/lib/services/osrm";
 
 /**
@@ -166,6 +167,15 @@ export function FleetSimulationProvider({
         customerName: pin?.currentDispatchCustomerName ?? undefined,
         address: pin?.currentDispatchAddress ?? undefined,
         kind: pin?.currentDispatchKind ?? undefined,
+      });
+      void recordReignitionNotificationAction({
+        bikeId,
+        plateNumber,
+        occurredAt: new Date(state.ignitionOnAt).toISOString(),
+        nextCustomerName: pin?.currentDispatchCustomerName ?? null,
+        nextAddress: pin?.currentDispatchAddress ?? null,
+        nextLatitude: pin?.currentDispatchLatitude ?? null,
+        nextLongitude: pin?.currentDispatchLongitude ?? null,
       });
       const key = dispatchKeyOf(pin);
       if (key) lastDepartedDispatchKeyRef.current.set(bikeId, key);

--- a/development/front-admin-web/lib/services/fleet-simulation.ts
+++ b/development/front-admin-web/lib/services/fleet-simulation.ts
@@ -91,7 +91,7 @@ function randomSeoulPoint(random: () => number = Math.random): { lat: number; ln
   };
 }
 
-function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+export function approxDistanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
   const dLat = (b.lat - a.lat) * 111;
   const dLng = (b.lng - a.lng) * 88;
   return Math.sqrt(dLat * dLat + dLng * dLng);

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1158,6 +1158,28 @@ export type ReignitionNotificationCreateInput = {
   nextLongitude?: number | null;
 };
 
+// ── Audit log ──
+
+export type ServiceOpsAuditLog = {
+  id: string;
+  entityType: string;
+  entityId: string;
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+  actor: string | null;
+  occurredAt: string;
+  createdAt: string;
+};
+
+export type AuditLogCreateInput = {
+  entityType: string;
+  entityId: string;
+  field: string;
+  oldValue?: string | null;
+  newValue?: string | null;
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
@@ -1320,6 +1342,10 @@ export type ServiceOpsApiClient = {
   // ── Re-ignition notifications ──
   recordReignitionNotification: (input: ReignitionNotificationCreateInput) => Promise<ServiceOpsReignitionNotification>;
   listReignitionNotifications: () => Promise<ServiceOpsReignitionNotification[]>;
+
+  // ── Audit logs ──
+  recordAuditLog: (input: AuditLogCreateInput) => Promise<ServiceOpsAuditLog>;
+  listAuditLogs: (entityId?: string) => Promise<ServiceOpsAuditLog[]>;
 };
 
 type ServiceOpsApiOptions = {
@@ -2012,6 +2038,19 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       }),
     listReignitionNotifications: () =>
       request<ServiceOpsReignitionNotification[]>("/reignition-notifications", { method: "GET" }),
+
+    // ── Audit logs ──
+    recordAuditLog: (input) =>
+      request<ServiceOpsAuditLog>("/audit-logs", {
+        body: JSON.stringify(input),
+        method: "POST"
+      }),
+    listAuditLogs: (entityId) =>
+      request<ServiceOpsAuditLog[]>(
+        "/audit-logs",
+        { method: "GET" },
+        entityId !== undefined ? { entityId } : undefined
+      ),
   };
 }
 

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1134,6 +1134,30 @@ export type DispatchBulkApplyRequest = {
   rows: DispatchBulkApplyRow[];
 };
 
+// ── Re-ignition notification types ──
+
+export type ServiceOpsReignitionNotification = {
+  id: string;
+  bikeId: string;
+  plateNumber: string;
+  occurredAt: string;
+  nextCustomerName: string | null;
+  nextAddress: string | null;
+  nextLatitude: number | null;
+  nextLongitude: number | null;
+  createdAt: string;
+};
+
+export type ReignitionNotificationCreateInput = {
+  bikeId: string;
+  plateNumber: string;
+  occurredAt: string;
+  nextCustomerName?: string | null;
+  nextAddress?: string | null;
+  nextLatitude?: number | null;
+  nextLongitude?: number | null;
+};
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
@@ -1292,6 +1316,10 @@ export type ServiceOpsApiClient = {
   offerCall: (payload: DeliveryCallPayload) => Promise<ServiceOpsDispatchOrder>;
   acceptCall: (orderId: string, bikeId: string) => Promise<ServiceOpsDispatchOrder>;
   listOfferedCalls: () => Promise<ServiceOpsDispatchOrder[]>;
+
+  // ── Re-ignition notifications ──
+  recordReignitionNotification: (input: ReignitionNotificationCreateInput) => Promise<ServiceOpsReignitionNotification>;
+  listReignitionNotifications: () => Promise<ServiceOpsReignitionNotification[]>;
 };
 
 type ServiceOpsApiOptions = {
@@ -1975,6 +2003,15 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       }),
     listOfferedCalls: () =>
       request<ServiceOpsDispatchOrder[]>("/dispatch-orders/calls/offered", { method: "GET" }),
+
+    // ── Re-ignition notifications ──
+    recordReignitionNotification: (input) =>
+      request<ServiceOpsReignitionNotification>("/reignition-notifications", {
+        body: JSON.stringify(input),
+        method: "POST"
+      }),
+    listReignitionNotifications: () =>
+      request<ServiceOpsReignitionNotification[]>("/reignition-notifications", { method: "GET" }),
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/controller/AuditLogCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/controller/AuditLogCommandController.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.audit.controller;
+
+import com.thundercrew.opsapi.audit.dto.AuditLogCreateRequest;
+import com.thundercrew.opsapi.audit.dto.AuditLogReadResponse;
+import com.thundercrew.opsapi.audit.service.AuditLogCommandService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/audit-logs")
+public class AuditLogCommandController {
+
+    private final AuditLogCommandService auditLogCommandService;
+
+    public AuditLogCommandController(AuditLogCommandService auditLogCommandService) {
+        this.auditLogCommandService = auditLogCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<AuditLogReadResponse> record(
+            @Valid @RequestBody AuditLogCreateRequest req) {
+        AuditLogReadResponse response = auditLogCommandService.record(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/controller/AuditLogReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/controller/AuditLogReadController.java
@@ -1,0 +1,29 @@
+package com.thundercrew.opsapi.audit.controller;
+
+import com.thundercrew.opsapi.audit.dto.AuditLogReadResponse;
+import com.thundercrew.opsapi.audit.service.AuditLogReadService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/audit-logs")
+public class AuditLogReadController {
+
+    private final AuditLogReadService auditLogReadService;
+
+    public AuditLogReadController(AuditLogReadService auditLogReadService) {
+        this.auditLogReadService = auditLogReadService;
+    }
+
+    @GetMapping
+    List<AuditLogReadResponse> list(@RequestParam(required = false) UUID entityId) {
+        if (entityId != null) {
+            return auditLogReadService.listByEntity(entityId);
+        }
+        return auditLogReadService.listRecent();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/domain/AuditLog.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/domain/AuditLog.java
@@ -1,0 +1,78 @@
+package com.thundercrew.opsapi.audit.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "audit_logs")
+public class AuditLog extends DisplaySequencedEntity {
+
+    @Column(name = "entity_type", nullable = false, columnDefinition = "text")
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private UUID entityId;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String field;
+
+    @Column(name = "old_value", columnDefinition = "text")
+    private String oldValue;
+
+    @Column(name = "new_value", columnDefinition = "text")
+    private String newValue;
+
+    @Column(columnDefinition = "text")
+    private String actor;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    public static AuditLog create(String entityType, UUID entityId, String field,
+                                   String oldValue, String newValue, String actor, Instant occurredAt) {
+        AuditLog auditLog = new AuditLog();
+        auditLog.entityType = entityType;
+        auditLog.entityId = entityId;
+        auditLog.field = field;
+        auditLog.oldValue = oldValue;
+        auditLog.newValue = newValue;
+        auditLog.actor = actor;
+        auditLog.occurredAt = occurredAt;
+        return auditLog;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public UUID getEntityId() {
+        return entityId;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getOldValue() {
+        return oldValue;
+    }
+
+    public String getNewValue() {
+        return newValue;
+    }
+
+    public String getActor() {
+        return actor;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    protected AuditLog() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/dto/AuditLogCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/dto/AuditLogCreateRequest.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.audit.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record AuditLogCreateRequest(
+        @NotBlank String entityType,
+        @NotNull UUID entityId,
+        @NotBlank String field,
+        String oldValue,
+        String newValue
+) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/dto/AuditLogReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/dto/AuditLogReadResponse.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.audit.dto;
+
+import com.thundercrew.opsapi.audit.domain.AuditLog;
+import java.time.Instant;
+import java.util.UUID;
+
+public record AuditLogReadResponse(
+        UUID id,
+        Long idx,
+        String entityType,
+        UUID entityId,
+        String field,
+        String oldValue,
+        String newValue,
+        String actor,
+        Instant occurredAt,
+        Instant createdAt
+) {
+    public static AuditLogReadResponse from(AuditLog auditLog) {
+        return new AuditLogReadResponse(
+                auditLog.getId(),
+                auditLog.getIdx(),
+                auditLog.getEntityType(),
+                auditLog.getEntityId(),
+                auditLog.getField(),
+                auditLog.getOldValue(),
+                auditLog.getNewValue(),
+                auditLog.getActor(),
+                auditLog.getOccurredAt(),
+                auditLog.getCreatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/repository/AuditLogRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/repository/AuditLogRepository.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.audit.repository;
+
+import com.thundercrew.opsapi.audit.domain.AuditLog;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, UUID> {
+
+    List<AuditLog> findTop100ByDeletedAtIsNullOrderByOccurredAtDesc();
+
+    List<AuditLog> findByEntityIdAndDeletedAtIsNullOrderByOccurredAtDesc(UUID entityId);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/service/AuditLogCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/service/AuditLogCommandService.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.audit.service;
+
+import com.thundercrew.opsapi.audit.domain.AuditLog;
+import com.thundercrew.opsapi.audit.dto.AuditLogCreateRequest;
+import com.thundercrew.opsapi.audit.dto.AuditLogReadResponse;
+import com.thundercrew.opsapi.audit.repository.AuditLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AuditLogCommandService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public AuditLogCommandService(AuditLogRepository auditLogRepository) {
+        this.auditLogRepository = auditLogRepository;
+    }
+
+    public AuditLogReadResponse record(AuditLogCreateRequest req) {
+        AuditLog auditLog = AuditLog.create(
+                req.entityType(),
+                req.entityId(),
+                req.field(),
+                req.oldValue(),
+                req.newValue(),
+                null,
+                java.time.Instant.now()
+        );
+        AuditLog saved = auditLogRepository.save(auditLog);
+        return AuditLogReadResponse.from(saved);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/service/AuditLogReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/audit/service/AuditLogReadService.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.audit.service;
+
+import com.thundercrew.opsapi.audit.dto.AuditLogReadResponse;
+import com.thundercrew.opsapi.audit.repository.AuditLogRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AuditLogReadService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public AuditLogReadService(AuditLogRepository auditLogRepository) {
+        this.auditLogRepository = auditLogRepository;
+    }
+
+    public List<AuditLogReadResponse> listRecent() {
+        return auditLogRepository.findTop100ByDeletedAtIsNullOrderByOccurredAtDesc().stream()
+                .map(AuditLogReadResponse::from)
+                .toList();
+    }
+
+    public List<AuditLogReadResponse> listByEntity(UUID entityId) {
+        return auditLogRepository.findByEntityIdAndDeletedAtIsNullOrderByOccurredAtDesc(entityId).stream()
+                .map(AuditLogReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationCommandController.java
@@ -1,0 +1,30 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationCreateRequest;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.ReignitionNotificationCommandService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reignition-notifications")
+public class ReignitionNotificationCommandController {
+
+    private final ReignitionNotificationCommandService reignitionNotificationCommandService;
+
+    public ReignitionNotificationCommandController(ReignitionNotificationCommandService reignitionNotificationCommandService) {
+        this.reignitionNotificationCommandService = reignitionNotificationCommandService;
+    }
+
+    @PostMapping
+    ResponseEntity<ReignitionNotificationReadResponse> record(
+            @Valid @RequestBody ReignitionNotificationCreateRequest req) {
+        ReignitionNotificationReadResponse response = reignitionNotificationCommandService.record(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/ReignitionNotificationReadController.java
@@ -1,0 +1,24 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.ReignitionNotificationReadService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reignition-notifications")
+public class ReignitionNotificationReadController {
+
+    private final ReignitionNotificationReadService reignitionNotificationReadService;
+
+    public ReignitionNotificationReadController(ReignitionNotificationReadService reignitionNotificationReadService) {
+        this.reignitionNotificationReadService = reignitionNotificationReadService;
+    }
+
+    @GetMapping
+    List<ReignitionNotificationReadResponse> listRecent() {
+        return reignitionNotificationReadService.listRecent();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/ReignitionNotification.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/ReignitionNotification.java
@@ -1,0 +1,79 @@
+package com.thundercrew.opsapi.notification.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reignition_notifications")
+public class ReignitionNotification extends DisplaySequencedEntity {
+
+    @Column(name = "bike_id", nullable = false)
+    private UUID bikeId;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String plateNumber;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "next_customer_name", columnDefinition = "text")
+    private String nextCustomerName;
+
+    @Column(name = "next_address", columnDefinition = "text")
+    private String nextAddress;
+
+    @Column(name = "next_latitude")
+    private Double nextLatitude;
+
+    @Column(name = "next_longitude")
+    private Double nextLongitude;
+
+    public static ReignitionNotification create(UUID bikeId, String plateNumber, Instant occurredAt,
+                                                String nextCustomerName, String nextAddress,
+                                                Double nextLatitude, Double nextLongitude) {
+        ReignitionNotification notification = new ReignitionNotification();
+        notification.bikeId = bikeId;
+        notification.plateNumber = plateNumber;
+        notification.occurredAt = occurredAt;
+        notification.nextCustomerName = nextCustomerName;
+        notification.nextAddress = nextAddress;
+        notification.nextLatitude = nextLatitude;
+        notification.nextLongitude = nextLongitude;
+        return notification;
+    }
+
+    public UUID getBikeId() {
+        return bikeId;
+    }
+
+    public String getPlateNumber() {
+        return plateNumber;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public String getNextCustomerName() {
+        return nextCustomerName;
+    }
+
+    public String getNextAddress() {
+        return nextAddress;
+    }
+
+    public Double getNextLatitude() {
+        return nextLatitude;
+    }
+
+    public Double getNextLongitude() {
+        return nextLongitude;
+    }
+
+    protected ReignitionNotification() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationCreateRequest.java
@@ -1,0 +1,16 @@
+package com.thundercrew.opsapi.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReignitionNotificationCreateRequest(
+        @NotNull UUID bikeId,
+        @NotBlank String plateNumber,
+        @NotNull Instant occurredAt,
+        String nextCustomerName,
+        String nextAddress,
+        Double nextLatitude,
+        Double nextLongitude
+) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/ReignitionNotificationReadResponse.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.notification.dto;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReignitionNotificationReadResponse(
+        UUID id,
+        Long idx,
+        UUID bikeId,
+        String plateNumber,
+        Instant occurredAt,
+        String nextCustomerName,
+        String nextAddress,
+        Double nextLatitude,
+        Double nextLongitude,
+        Instant createdAt
+) {
+    public static ReignitionNotificationReadResponse from(ReignitionNotification notification) {
+        return new ReignitionNotificationReadResponse(
+                notification.getId(),
+                notification.getIdx(),
+                notification.getBikeId(),
+                notification.getPlateNumber(),
+                notification.getOccurredAt(),
+                notification.getNextCustomerName(),
+                notification.getNextAddress(),
+                notification.getNextLatitude(),
+                notification.getNextLongitude(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/ReignitionNotificationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/ReignitionNotificationRepository.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.notification.repository;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReignitionNotificationRepository extends JpaRepository<ReignitionNotification, UUID> {
+
+    List<ReignitionNotification> findTop50ByDeletedAtIsNullOrderByOccurredAtDesc();
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationCommandService.java
@@ -1,0 +1,33 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.notification.domain.ReignitionNotification;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationCreateRequest;
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.ReignitionNotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReignitionNotificationCommandService {
+
+    private final ReignitionNotificationRepository reignitionNotificationRepository;
+
+    public ReignitionNotificationCommandService(ReignitionNotificationRepository reignitionNotificationRepository) {
+        this.reignitionNotificationRepository = reignitionNotificationRepository;
+    }
+
+    public ReignitionNotificationReadResponse record(ReignitionNotificationCreateRequest req) {
+        ReignitionNotification notification = ReignitionNotification.create(
+                req.bikeId(),
+                req.plateNumber(),
+                req.occurredAt(),
+                req.nextCustomerName(),
+                req.nextAddress(),
+                req.nextLatitude(),
+                req.nextLongitude()
+        );
+        ReignitionNotification saved = reignitionNotificationRepository.save(notification);
+        return ReignitionNotificationReadResponse.from(saved);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/ReignitionNotificationReadService.java
@@ -1,0 +1,24 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.notification.dto.ReignitionNotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.ReignitionNotificationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ReignitionNotificationReadService {
+
+    private final ReignitionNotificationRepository reignitionNotificationRepository;
+
+    public ReignitionNotificationReadService(ReignitionNotificationRepository reignitionNotificationRepository) {
+        this.reignitionNotificationRepository = reignitionNotificationRepository;
+    }
+
+    public List<ReignitionNotificationReadResponse> listRecent() {
+        return reignitionNotificationRepository.findTop50ByDeletedAtIsNullOrderByOccurredAtDesc().stream()
+                .map(ReignitionNotificationReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V41__create_reignition_notifications.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V41__create_reignition_notifications.sql
@@ -1,0 +1,18 @@
+create table reignition_notifications (
+    id uuid primary key,
+    idx bigserial not null unique,
+    bike_id uuid not null,
+    plate_number text not null,
+    occurred_at timestamptz not null,
+    next_customer_name text,
+    next_address text,
+    next_latitude double precision,
+    next_longitude double precision,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+create index idx_reignition_notifications_occurred_at on reignition_notifications (occurred_at desc);

--- a/development/service-ops-api/src/main/resources/db/migration/V42__create_audit_logs.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V42__create_audit_logs.sql
@@ -1,0 +1,19 @@
+create table audit_logs (
+    id uuid primary key,
+    idx bigserial not null unique,
+    entity_type text not null,
+    entity_id uuid not null,
+    field text not null,
+    old_value text,
+    new_value text,
+    actor text,
+    occurred_at timestamptz not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid,
+    updated_by uuid,
+    deleted_by uuid
+);
+create index idx_audit_logs_entity on audit_logs (entity_type, entity_id);
+create index idx_audit_logs_occurred_at on audit_logs (occurred_at desc);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -114,7 +114,8 @@ class ArchitectureBoundaryTests {
                         || isTestVehicleCommand(method)
                         || isTestRiderCommand(method)
                         || isTestMatchingCommand(method)
-                        || isReignitionNotificationCommand(method)) {
+                        || isReignitionNotificationCommand(method)
+                        || isAuditLogCommand(method)) {
                     return;
                 }
 
@@ -157,7 +158,8 @@ class ArchitectureBoundaryTests {
                         && !isTestVehicleCommand(method)
                         && !isTestRiderCommand(method)
                         && !isTestMatchingCommand(method)
-                        && !isReignitionNotificationCommand(method)) {
+                        && !isReignitionNotificationCommand(method)
+                        && !isAuditLogCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -318,6 +320,11 @@ class ArchitectureBoundaryTests {
     private static boolean isReignitionNotificationCommand(JavaMethod method) {
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.notification.controller.ReignitionNotificationCommandController");
+    }
+
+    private static boolean isAuditLogCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.audit.controller.AuditLogCommandController");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -113,7 +113,8 @@ class ArchitectureBoundaryTests {
                         || isDeviceApiSyncCommand(method)
                         || isTestVehicleCommand(method)
                         || isTestRiderCommand(method)
-                        || isTestMatchingCommand(method)) {
+                        || isTestMatchingCommand(method)
+                        || isReignitionNotificationCommand(method)) {
                     return;
                 }
 
@@ -155,7 +156,8 @@ class ArchitectureBoundaryTests {
                         && !isDeviceApiSyncCommand(method)
                         && !isTestVehicleCommand(method)
                         && !isTestRiderCommand(method)
-                        && !isTestMatchingCommand(method)) {
+                        && !isTestMatchingCommand(method)
+                        && !isReignitionNotificationCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -311,6 +313,11 @@ class ArchitectureBoundaryTests {
                 "com.thundercrew.opsapi.testmatching.matching.controller.TestMatchingCommandController")
                 && (method.getName().equals("create")
                 || method.getName().equals("delete"));
+    }
+
+    private static boolean isReignitionNotificationCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.notification.controller.ReignitionNotificationCommandController");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AuditLogApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/AuditLogApiContractTests.java
@@ -1,0 +1,167 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuditLogApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID ENTITY_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID OTHER_ENTITY_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from audit_logs");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① POST /api/v1/audit-logs → 201, fields persisted
+    @Test
+    void postReturns201WithAllFields() throws Exception {
+        mockMvc.perform(post("/api/v1/audit-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "entityType": "bike",
+                                  "entityId": "%s",
+                                  "field": "operationStatus",
+                                  "oldValue": "IDLE",
+                                  "newValue": "IN_USE"
+                                }
+                                """.formatted(ENTITY_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.entityType").value("bike"))
+                .andExpect(jsonPath("$.entityId").value(ENTITY_ID.toString()))
+                .andExpect(jsonPath("$.field").value("operationStatus"))
+                .andExpect(jsonPath("$.oldValue").value("IDLE"))
+                .andExpect(jsonPath("$.newValue").value("IN_USE"))
+                .andExpect(jsonPath("$.occurredAt").isString())
+                .andExpect(jsonPath("$.createdAt").isString());
+    }
+
+    // ② POST then GET returns it in list
+    @Test
+    void getListReturnsPostedEntry() throws Exception {
+        mockMvc.perform(post("/api/v1/audit-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "entityType": "bike",
+                                  "entityId": "%s",
+                                  "field": "insuranceStatus",
+                                  "oldValue": "ACTIVE",
+                                  "newValue": "EXPIRED"
+                                }
+                                """.formatted(ENTITY_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/audit-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].entityType").value("bike"))
+                .andExpect(jsonPath("$[0].entityId").value(ENTITY_ID.toString()))
+                .andExpect(jsonPath("$[0].field").value("insuranceStatus"))
+                .andExpect(jsonPath("$[0].oldValue").value("ACTIVE"))
+                .andExpect(jsonPath("$[0].newValue").value("EXPIRED"));
+    }
+
+    // ③ GET with entityId param filters correctly
+    @Test
+    void getByEntityIdFiltersCorrectly() throws Exception {
+        mockMvc.perform(post("/api/v1/audit-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"entityType":"bike","entityId":"%s","field":"operationStatus","oldValue":"IDLE","newValue":"IN_USE"}
+                                """.formatted(ENTITY_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/audit-logs")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"entityType":"bike","entityId":"%s","field":"operationStatus","oldValue":"IN_USE","newValue":"IDLE"}
+                                """.formatted(OTHER_ENTITY_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/audit-logs")
+                        .param("entityId", ENTITY_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].entityId").value(ENTITY_ID.toString()));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        Assertions.assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReignitionNotificationApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ReignitionNotificationApiContractTests.java
@@ -1,0 +1,197 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ReignitionNotificationApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from reignition_notifications");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① POST /api/v1/reignition-notifications → 201, fields persisted including next-destination
+    @Test
+    void postReturns201WithAllNextDestinationFields() throws Exception {
+        String occurredAt = "2026-06-16T10:00:00Z";
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0001",
+                                  "occurredAt": "%s",
+                                  "nextCustomerName": "홍길동",
+                                  "nextAddress": "서울 강남구 역삼동 123",
+                                  "nextLatitude": 37.4987,
+                                  "nextLongitude": 127.0276
+                                }
+                                """.formatted(BIKE_ID, occurredAt)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.idx").isNumber())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.plateNumber").value("서울CC-0001"))
+                .andExpect(jsonPath("$.occurredAt").value(occurredAt))
+                .andExpect(jsonPath("$.nextCustomerName").value("홍길동"))
+                .andExpect(jsonPath("$.nextAddress").value("서울 강남구 역삼동 123"))
+                .andExpect(jsonPath("$.nextLatitude").value(37.4987))
+                .andExpect(jsonPath("$.nextLongitude").value(127.0276))
+                .andExpect(jsonPath("$.createdAt").isString());
+    }
+
+    // ② POST then GET list returns the event (ordered by occurredAt desc), next-destination fields visible
+    @Test
+    void getListReturnsRecentEventWithNextDestinationFields() throws Exception {
+        String occurredAt = "2026-06-16T09:00:00Z";
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0001",
+                                  "occurredAt": "%s",
+                                  "nextCustomerName": "김철수",
+                                  "nextAddress": "서울 마포구 합정동 456",
+                                  "nextLatitude": 37.5503,
+                                  "nextLongitude": 126.9142
+                                }
+                                """.formatted(BIKE_ID, occurredAt)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$[0].plateNumber").value("서울CC-0001"))
+                .andExpect(jsonPath("$[0].occurredAt").value(occurredAt))
+                .andExpect(jsonPath("$[0].nextCustomerName").value("김철수"))
+                .andExpect(jsonPath("$[0].nextAddress").value("서울 마포구 합정동 456"))
+                .andExpect(jsonPath("$[0].nextLatitude").value(37.5503))
+                .andExpect(jsonPath("$[0].nextLongitude").value(126.9142));
+    }
+
+    // ③ POST without next-destination fields (nullable) → 201
+    @Test
+    void postWithNullNextDestinationFieldsReturns201() throws Exception {
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bikeId": "%s",
+                                  "plateNumber": "서울CC-0002",
+                                  "occurredAt": "2026-06-16T08:00:00Z"
+                                }
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nextCustomerName").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextAddress").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextLatitude").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.nextLongitude").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    // ④ Two events posted: GET list is ordered occurredAt desc
+    @Test
+    void getListOrdersByOccurredAtDesc() throws Exception {
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s","plateNumber":"서울CC-0001","occurredAt":"2026-06-16T07:00:00Z"}
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s","plateNumber":"서울CC-0002","occurredAt":"2026-06-16T08:00:00Z"}
+                                """.formatted(BIKE_ID)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/reignition-notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].plateNumber").value("서울CC-0002"))
+                .andExpect(jsonPath("$[1].plateNumber").value("서울CC-0001"));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andReturn();
+
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        Assertions.assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}


### PR DESCRIPTION
@
## 릴리스 내용 (Task C ③④)
- [#443](https://github.com/EVNSolution/thundercrew-domain/pull/443) ③ 순차/왕복 차량 상세 배차 큐에 다음 목적지 거리+예상 도착시간 (프론트 전용)
- [#444](https://github.com/EVNSolution/thundercrew-domain/pull/444) ④ 재시동 알림 서버 영속화 + 다음 목적지 + 벨 시드 (V41 신규 테이블)

## 배포 영향
- **V41** `reignition_notifications` 신규 테이블 (additive). API 재기동 시 Flyway 적용.
- 머지 시 aws-ec2-deploy 자동 실행.

## QA (배포 후)
- ③ 순차 배차 있는 차량 상세 → 배차 큐 현재 배차 아래 "다음 목적지까지 N km · 예상 M분" 확인
- ④ 순차 차량 재시동(시뮬) 시 벨 알림 + 새로고침 후에도 알림 유지(서버 시드) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@