### PR TITLE
릴리스: 배송 완료(사진 증빙) + 단일 배차 무순서 목록 (V43)

### DIFF
--- a/development/front-admin-web/app/api/dispatch/completion-photo/[id]/route.ts
+++ b/development/front-admin-web/app/api/dispatch/completion-photo/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+
+import { serviceOpsApiBaseUrl } from "@/lib/services/service-ops-api";
+import { getServiceOpsAccessToken } from "@/lib/services/service-ops-session";
+
+/**
+ * Proxy route: GET /api/dispatch/completion-photo/[id]
+ *
+ * Fetches the completion photo for a dispatch order from the backend and
+ * streams it back to the browser. Auth is forwarded via Bearer token from
+ * the server-side session (same mechanism as other authenticated routes).
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+
+  const baseUrl = serviceOpsApiBaseUrl();
+  if (!baseUrl) {
+    return new NextResponse("서비스 설정 오류", { status: 500 });
+  }
+
+  const accessToken = await getServiceOpsAccessToken();
+  if (!accessToken) {
+    return new NextResponse("인증이 필요합니다.", { status: 401 });
+  }
+
+  const backendUrl = `${baseUrl}/api/v1/dispatch-orders/${encodeURIComponent(id)}/completion-photo`;
+
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${accessToken}`);
+
+  let backendResponse: Response;
+  try {
+    backendResponse = await fetch(backendUrl, {
+      method: "GET",
+      cache: "no-store",
+      headers
+    });
+  } catch {
+    return new NextResponse("백엔드 연결 오류", { status: 502 });
+  }
+
+  if (backendResponse.status === 404) {
+    return new NextResponse("사진을 찾을 수 없습니다.", { status: 404 });
+  }
+
+  if (!backendResponse.ok) {
+    return new NextResponse("사진 조회에 실패했습니다.", { status: backendResponse.status });
+  }
+
+  const contentType = backendResponse.headers.get("content-type") ?? "application/octet-stream";
+  const body = await backendResponse.arrayBuffer();
+
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "private, max-age=300"
+    }
+  });
+}

--- a/development/front-admin-web/app/dispatch/actions.ts
+++ b/development/front-admin-web/app/dispatch/actions.ts
@@ -197,19 +197,31 @@ export async function listActiveDispatchOrdersAction(): Promise<ServiceOpsDispat
 }
 
 export async function completeDispatchOrderAction(
-  id: string
+  id: string,
+  formData: FormData
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
   if (!client) return { ok: false, error: "로그인이 필요합니다." };
 
+  const photo = formData.get("photo");
+  if (!(photo instanceof File)) return { ok: false, error: "사진이 필요합니다." };
+
   try {
-    await client.completeDispatchOrder(id);
+    await client.completeDispatchOrder(id, photo);
     revalidatePath("/management");
     revalidatePath("/");
     return { ok: true };
   } catch (err) {
     return { ok: false, error: extractError(err) };
   }
+}
+
+export async function listCompletedDispatchOrdersAction(
+  bikeId: string
+): Promise<ServiceOpsDispatchOrder[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listCompletedDispatchOrders(bikeId).catch(() => []);
 }
 
 export async function cancelDispatchOrderAction(

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1782,3 +1782,19 @@ textarea { padding-top: 10px; min-height: 96px; }
 .baemin-call-accept-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .baemin-call-vehicle-select { height: 32px; padding: 0 8px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-soft); color: var(--color-text-primary); font-size: 13px; font-family: var(--font-sans); min-width: 120px; }
 .baemin-call-hint { font-size: 12px; color: var(--color-text-muted); }
+
+/* ── 배송 목록 (단일/배송 패밀리 — isSequential=false) ─────────────────── */
+.dispatch-delivery-list { list-style: none; margin: 6px 0 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+
+/* ── 완료 내역 섹션 ─────────────────────────────────────────────────────── */
+.dispatch-completed-section { margin-top: 12px; border-top: 1px solid var(--color-divider); padding-top: 8px; }
+.dispatch-completed-toggle { background: none; border: none; cursor: pointer; font-size: 12px; font-weight: 600; color: var(--color-text-muted); padding: 0; display: flex; align-items: center; gap: 4px; font-family: var(--font-sans); }
+.dispatch-completed-toggle:hover { color: var(--color-text-primary); }
+.dispatch-completed-body { margin-top: 8px; }
+.dispatch-completed-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.dispatch-completed-item { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; padding: 8px 10px; border-radius: 8px; background: var(--color-bg-soft); border: 1px solid var(--color-border); }
+.dispatch-completed-info { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.dispatch-completed-name { font-size: 13px; font-weight: 600; color: var(--color-text-primary); }
+.dispatch-completed-address { font-size: 12px; color: var(--color-text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dispatch-completed-time { font-size: 11px; color: var(--color-text-disabled); font-variant-numeric: tabular-nums; }
+.dispatch-completed-thumbnail { width: 52px; height: 52px; object-fit: cover; border-radius: 6px; border: 1px solid var(--color-border); flex-shrink: 0; }

--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -18,6 +18,7 @@ import {
 import {
   cancelDispatchOrderAction,
   completeDispatchOrderAction,
+  listCompletedDispatchOrdersAction,
   listDispatchOrdersAction
 } from "@/app/dispatch/actions";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
@@ -916,13 +917,20 @@ function formatRemaining(ms: number): string {
 // ============================================================================
 
 /**
- * 차량 상세 패널의 "배차 큐" 섹션. 열릴 때 `listDispatchOrdersAction(bikeId)` 로
- * 큐를 받아 ASSIGNED 잔여 건을 sequence 오름차순으로 정렬한다.
- *   - 현재 배차 = 가장 낮은 sequence 의 ASSIGNED (고객명/연락처/주소)
+ * 차량 상세 패널의 "배차 큐" 섹션.
+ *
+ * isSequential === true (순차/왕복):
+ *   - 현재 배차 = 가장 낮은 sequence ASSIGNED + renderNextDestinationEta
  *   - 대기 목록 = 나머지 ASSIGNED
- * 각 건에 완료(completeDispatchOrderAction)·취소(cancelDispatchOrderAction) 버튼.
- * 두 액션 모두 `{ ok } | { ok:false, error }` 를 반환 — 성공 시 큐 재페치, 실패 시
- * error 노출. MaintenanceRowView 의 startTransition + 재페치 패턴을 미러링.
+ *
+ * isSequential === false (단일/배송 패밀리):
+ *   - 모든 ASSIGNED 를 단순 목록으로 (배송 목록 N건)
+ *   - 현재/대기 split 없음, ETA 없음
+ *
+ * 완료 버튼은 항상 사진 첨부 필요 — 숨겨진 file input 을 클릭해 파일을 선택하면
+ * 자동으로 서버 액션을 호출한다.
+ *
+ * 하단에 접을 수 있는 "완료 내역" 섹션을 제공한다.
  */
 function DispatchQueueSection({
   bikeId,
@@ -932,7 +940,7 @@ function DispatchQueueSection({
   bikeId: string;
   /** 차량 현재 위치 (시뮬 position). 다음 목적지 거리·ETA 계산에 사용. null 이면 미표시. */
   currentPosition?: { lat: number; lng: number } | null;
-  /** 순차/왕복(cleaning family) 일 때만 다음 목적지 거리·ETA 를 보여준다. */
+  /** 순차/왕복(cleaning family) 일 때만 현재/대기 split + ETA 를 보여준다. */
   isSequential?: boolean;
 }) {
   const [orders, setOrders] = useState<ServiceOpsDispatchOrder[] | null>(null);
@@ -960,17 +968,37 @@ function DispatchQueueSection({
       .sort((a, b) => a.sequence - b.sequence);
   }, [orders]);
 
-  const runAction = (
-    action: (id: string) => Promise<{ ok: true } | { ok: false; error: string }>,
-    id: string
-  ) => {
+  const runComplete = (id: string, photo: File) => {
     if (pending) return;
     setError(null);
+    const fd = new FormData();
+    fd.append("photo", photo);
     startTransition(async () => {
-      const result = await action(id);
+      const result = await completeDispatchOrderAction(id, fd);
       if (result.ok) {
         setReloadTick((tick) => tick + 1);
       } else {
+        if (result.error === "로그인이 필요합니다.") {
+          window.location.href = "/login?status=session-required";
+          return;
+        }
+        window.alert(result.error);
+      }
+    });
+  };
+
+  const runCancel = (id: string) => {
+    if (pending) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await cancelDispatchOrderAction(id);
+      if (result.ok) {
+        setReloadTick((tick) => tick + 1);
+      } else {
+        if (result.error === "로그인이 필요합니다.") {
+          window.location.href = "/login?status=session-required";
+          return;
+        }
         setError(result.error);
       }
     });
@@ -985,45 +1013,150 @@ function DispatchQueueSection({
     );
   }
 
-  if (!assigned || assigned.length === 0) {
-    return (
-      <section className="dispatch-queue-section">
-        <h4>배차 큐</h4>
-        <p className="muted">배차 없음</p>
-      </section>
-    );
-  }
-
-  const [current, ...waiting] = assigned;
+  const activeList = assigned ?? [];
 
   return (
     <section className="dispatch-queue-section">
-      <h4>배차 큐 <span className="muted" style={{ fontSize: "0.8em" }}>({assigned.length}건)</span></h4>
       {error && <p className="dispatch-queue-error">{error}</p>}
 
-      {/* ── 현재 배차 (가장 낮은 sequence) ── */}
-      <div className="dispatch-queue-current">
-        <span className="dispatch-queue-tag">현재 배차</span>
-        <DispatchOrderRow order={current} pending={pending} onComplete={runAction} onCancel={runAction} />
-        {isSequential && currentPosition
-          ? renderNextDestinationEta(currentPosition, { lat: current.latitude, lng: current.longitude })
-          : null}
-      </div>
+      {isSequential ? (
+        /* ── 순차/왕복: 현재 배차 + 대기 목록 split ── */
+        <>
+          <h4>배차 큐 <span className="muted" style={{ fontSize: "0.8em" }}>({activeList.length}건)</span></h4>
+          {activeList.length === 0 ? (
+            <p className="muted">배차 없음</p>
+          ) : (
+            <>
+              {(() => {
+                const [current, ...waiting] = activeList;
+                return (
+                  <>
+                    <div className="dispatch-queue-current">
+                      <span className="dispatch-queue-tag">현재 배차</span>
+                      <DispatchOrderRow order={current} pending={pending} onComplete={runComplete} onCancel={runCancel} />
+                      {currentPosition
+                        ? renderNextDestinationEta(currentPosition, { lat: current.latitude, lng: current.longitude })
+                        : null}
+                    </div>
+                    {waiting.length > 0 && (
+                      <div className="dispatch-queue-waiting">
+                        <span className="dispatch-queue-tag muted">대기 목록</span>
+                        <ul className="dispatch-queue-list">
+                          {waiting.map((order) => (
+                            <li key={order.id} className="dispatch-queue-item">
+                              <DispatchOrderRow order={order} pending={pending} onComplete={runComplete} onCancel={runCancel} />
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
+            </>
+          )}
+        </>
+      ) : (
+        /* ── 단일/배송 패밀리: 단순 목록 ── */
+        <>
+          <h4>배송 목록 <span className="muted" style={{ fontSize: "0.8em" }}>({activeList.length}건)</span></h4>
+          {activeList.length === 0 ? (
+            <p className="muted">배차 없음</p>
+          ) : (
+            <ul className="dispatch-queue-list dispatch-delivery-list">
+              {activeList.map((order) => (
+                <li key={order.id} className="dispatch-queue-item">
+                  <DispatchOrderRow order={order} pending={pending} onComplete={runComplete} onCancel={runCancel} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
 
-      {/* ── 대기 목록 ── */}
-      {waiting.length > 0 && (
-        <div className="dispatch-queue-waiting">
-          <span className="dispatch-queue-tag muted">대기 목록</span>
-          <ul className="dispatch-queue-list">
-            {waiting.map((order) => (
-              <li key={order.id} className="dispatch-queue-item">
-                <DispatchOrderRow order={order} pending={pending} onComplete={runAction} onCancel={runAction} />
-              </li>
-            ))}
-          </ul>
+      {/* ── 완료 내역 ── */}
+      <CompletedOrdersSection bikeId={bikeId} reloadTick={reloadTick} />
+    </section>
+  );
+}
+
+/**
+ * 완료 내역 섹션 — 접기/펼치기 가능. 펼치면 bikeId 의 COMPLETED 주문을
+ * `listCompletedDispatchOrdersAction` 으로 가져와 목록을 보여준다.
+ * hasCompletionPhoto 가 true 이면 /api/dispatch/completion-photo/{id} 썸네일.
+ * reloadTick 이 바뀌면 (완료 처리 후) 자동으로 재페치한다.
+ */
+function CompletedOrdersSection({
+  bikeId,
+  reloadTick
+}: {
+  bikeId: string;
+  reloadTick: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [completed, setCompleted] = useState<ServiceOpsDispatchOrder[] | null>(null);
+
+  useEffect(() => {
+    if (!expanded) return;
+    let cancelled = false;
+    listCompletedDispatchOrdersAction(bikeId).then((next) => {
+      if (cancelled) return;
+      setCompleted(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [bikeId, expanded, reloadTick]);
+
+  return (
+    <div className="dispatch-completed-section">
+      <button
+        type="button"
+        className="dispatch-completed-toggle"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        완료 내역 {expanded ? "▲" : "▼"}
+      </button>
+      {expanded && (
+        <div className="dispatch-completed-body">
+          {completed === null ? (
+            <p className="muted" style={{ fontSize: "12px" }}>불러오는 중…</p>
+          ) : completed.length === 0 ? (
+            <p className="muted" style={{ fontSize: "12px" }}>완료된 배차 없음</p>
+          ) : (
+            <ul className="dispatch-completed-list">
+              {completed.map((o) => (
+                <li key={o.id} className="dispatch-completed-item">
+                  <div className="dispatch-completed-info">
+                    <span className="dispatch-completed-name">{o.customerName}</span>
+                    <span className="dispatch-completed-address">{o.address}</span>
+                    {o.completedAt && (
+                      <span className="dispatch-completed-time">
+                        {new Date(o.completedAt).toLocaleString("ko-KR", {
+                          month: "2-digit",
+                          day: "2-digit",
+                          hour: "2-digit",
+                          minute: "2-digit"
+                        })}
+                      </span>
+                    )}
+                  </div>
+                  {o.hasCompletionPhoto && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={`/api/dispatch/completion-photo/${o.id}`}
+                      alt="완료 사진"
+                      className="dispatch-completed-thumbnail"
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
-    </section>
+    </div>
   );
 }
 
@@ -1049,6 +1182,10 @@ function renderNextDestinationEta(
   );
 }
 
+/**
+ * 배차 주문 단건 행. 완료 버튼은 hidden file input 을 열어 사진을 선택하면
+ * 자동으로 `onComplete(id, file)` 를 호출한다.
+ */
 function DispatchOrderRow({
   order,
   pending,
@@ -1057,17 +1194,37 @@ function DispatchOrderRow({
 }: {
   order: ServiceOpsDispatchOrder;
   pending: boolean;
-  onComplete: (
-    action: (id: string) => Promise<{ ok: true } | { ok: false; error: string }>,
-    id: string
-  ) => void;
-  onCancel: (
-    action: (id: string) => Promise<{ ok: true } | { ok: false; error: string }>,
-    id: string
-  ) => void;
+  /** 완료 — 선택된 사진 파일과 함께 호출. */
+  onComplete: (id: string, photo: File) => void;
+  /** 취소 */
+  onCancel: (id: string) => void;
 }) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleCompleteClick = () => {
+    if (pending) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.currentTarget.files?.[0];
+    if (!file) return;
+    // Reset so same file can be re-selected if needed
+    e.currentTarget.value = "";
+    onComplete(order.id, file);
+  };
+
   return (
     <div className="dispatch-order-row">
+      {/* Hidden file picker for 완료 photo */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        style={{ display: "none" }}
+        onChange={handleFileChange}
+      />
       <dl className="delivery-meta">
         <div className="delivery-meta-row">
           <dt>고객 이름</dt>
@@ -1102,8 +1259,8 @@ function DispatchOrderRow({
           type="button"
           className="action-btn primary"
           disabled={pending}
-          onClick={() => onComplete(completeDispatchOrderAction, order.id)}
-          title="배차 완료 처리"
+          onClick={handleCompleteClick}
+          title="완료 처리 (사진 필요)"
         >
           완료
         </button>
@@ -1111,7 +1268,7 @@ function DispatchOrderRow({
           type="button"
           className="action-btn"
           disabled={pending}
-          onClick={() => onCancel(cancelDispatchOrderAction, order.id)}
+          onClick={() => onCancel(order.id)}
           title="배차 취소"
         >
           취소

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1084,6 +1084,10 @@ export type ServiceOpsDispatchOrder = {
   status: ServiceOpsDispatchOrderStatus;
   kind: ServiceOpsDispatchOrderKind;
   completedAt: string | null;
+  /** 완료 처리한 관리자 이름. 구 버전 백엔드 호환 위해 optional. */
+  completedBy?: string | null;
+  /** 완료 사진이 첨부되어 있으면 true. 구 버전 백엔드 호환 위해 optional. */
+  hasCompletionPhoto?: boolean;
   createdAt: string;
 };
 
@@ -1320,8 +1324,9 @@ export type ServiceOpsApiClient = {
   // ── Dispatch orders (배차) ──
   listDispatchOrders: (bikeId: string) => Promise<ServiceOpsDispatchOrder[]>;
   listActiveDispatchOrders: () => Promise<ServiceOpsDispatchOrder[]>;
-  completeDispatchOrder: (id: string) => Promise<ServiceOpsDispatchOrder>;
+  completeDispatchOrder: (id: string, photo: File) => Promise<ServiceOpsDispatchOrder>;
   cancelDispatchOrder: (id: string) => Promise<void>;
+  listCompletedDispatchOrders: (bikeId: string) => Promise<ServiceOpsDispatchOrder[]>;
   previewDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
   applyDispatchOrders: (rows: DispatchBulkApplyRow[]) => Promise<BulkApplyResponse>;
   previewSequentialDispatchOrders: (file: File | FormData) => Promise<DispatchBulkPreviewResponse>;
@@ -1941,14 +1946,23 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
       request<ServiceOpsDispatchOrder[]>("/dispatch-orders", { method: "GET" }, { bikeId }),
     listActiveDispatchOrders: () =>
       request<ServiceOpsDispatchOrder[]>("/dispatch-orders/active", { method: "GET" }),
-    completeDispatchOrder: (id) =>
-      request<ServiceOpsDispatchOrder>(
+    completeDispatchOrder: (id, photo) => {
+      const form = new FormData();
+      form.append("photo", photo);
+      return request<ServiceOpsDispatchOrder>(
         `/dispatch-orders/${encodeURIComponent(id)}/complete`,
-        { method: "POST" }
-      ),
+        { method: "POST", body: form }
+      );
+    },
     cancelDispatchOrder: async (id) => {
       await request<void>(`/dispatch-orders/${encodeURIComponent(id)}`, { method: "DELETE" });
     },
+    listCompletedDispatchOrders: (bikeId) =>
+      request<ServiceOpsDispatchOrder[]>(
+        "/dispatch-orders/completed",
+        { method: "GET" },
+        { bikeId }
+      ),
     previewDispatchOrders: (file) => {
       const form = file instanceof FormData ? file : new FormData();
       if (!(file instanceof FormData)) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderCommandController.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,9 +52,20 @@ public class DispatchOrderCommandController {
                 .body(response);
     }
 
-    @PostMapping("/{id}/complete")
-    DispatchOrderReadResponse complete(@PathVariable UUID id) {
-        return dispatchOrderCommandService.complete(id);
+    @PostMapping(value = "/{id}/complete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    DispatchOrderReadResponse complete(@PathVariable UUID id,
+                                       @RequestPart("photo") MultipartFile photo,
+                                       @AuthenticationPrincipal Jwt jwt) throws IOException {
+        return dispatchOrderCommandService.complete(id, photo.getBytes(), photo.getContentType(), currentAdminId(jwt));
+    }
+
+    private UUID currentAdminId(Jwt jwt) {
+        if (jwt == null) return null;
+        try {
+            return UUID.fromString(jwt.getSubject());
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @DeleteMapping("/{id}")

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/controller/DispatchOrderReadController.java
@@ -5,7 +5,10 @@ import com.thundercrew.opsapi.dispatch.service.DeliveryCallService;
 import com.thundercrew.opsapi.dispatch.service.DispatchOrderReadService;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,5 +40,26 @@ public class DispatchOrderReadController {
     @GetMapping("/calls/offered")
     List<DispatchOrderReadResponse> offeredCalls() {
         return deliveryCallService.listOffered();
+    }
+
+    @GetMapping("/completed")
+    List<DispatchOrderReadResponse> completedByBike(@RequestParam UUID bikeId) {
+        return dispatchOrderReadService.listCompletedByBike(bikeId);
+    }
+
+    @GetMapping("/{id}/completion-photo")
+    ResponseEntity<byte[]> completionPhoto(@PathVariable UUID id) {
+        var order = dispatchOrderReadService.findOrderForPhoto(id);
+        byte[] photo = order.getCompletionPhoto();
+        if (photo == null || photo.length == 0) {
+            return ResponseEntity.notFound().build();
+        }
+        String contentType = order.getCompletionPhotoContentType();
+        if (contentType == null || contentType.isBlank()) {
+            contentType = "image/jpeg";
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .body(photo);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/domain/DispatchOrder.java
@@ -49,6 +49,15 @@ public class DispatchOrder extends DisplaySequencedEntity {
     @Column
     private Instant completedAt;
 
+    @Column(name = "completion_photo")
+    private byte[] completionPhoto;
+
+    @Column(name = "completion_photo_content_type")
+    private String completionPhotoContentType;
+
+    @Column(name = "completed_by")
+    private UUID completedBy;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private DispatchOrderKind kind;
@@ -81,12 +90,18 @@ public class DispatchOrder extends DisplaySequencedEntity {
         return order;
     }
 
-    public void complete(Instant when) {
+    public void complete(Instant when, byte[] photo, String contentType, UUID completedBy) {
         if (this.status != DispatchOrderStatus.ASSIGNED) {
             throw new InvalidStateTransitionException("배정된 배차만 완료할 수 있습니다. 현재: " + this.status);
         }
+        if (photo == null || photo.length == 0) {
+            throw new InvalidStateTransitionException("배송 완료에는 사진이 필요합니다.");
+        }
         this.status = DispatchOrderStatus.COMPLETED;
         this.completedAt = when;
+        this.completionPhoto = photo;
+        this.completionPhotoContentType = contentType;
+        this.completedBy = completedBy;
     }
 
     /** 배민 라이더 수락 콜: 차량 미배정(OFFERED) 생성. 수락 시 assign 으로 차량/순번 부여. */
@@ -170,6 +185,18 @@ public class DispatchOrder extends DisplaySequencedEntity {
 
     public Double getOriginLongitude() {
         return originLongitude;
+    }
+
+    public byte[] getCompletionPhoto() {
+        return completionPhoto;
+    }
+
+    public String getCompletionPhotoContentType() {
+        return completionPhotoContentType;
+    }
+
+    public UUID getCompletedBy() {
+        return completedBy;
     }
 
     public void setOrigin(String originAddress, Double originLatitude, Double originLongitude) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchOrderReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/dto/DispatchOrderReadResponse.java
@@ -22,7 +22,9 @@ public record DispatchOrderReadResponse(
         DispatchOrderStatus status,
         DispatchOrderKind kind,
         Instant completedAt,
-        Instant createdAt
+        Instant createdAt,
+        UUID completedBy,
+        boolean hasCompletionPhoto
 ) {
     public static DispatchOrderReadResponse from(DispatchOrder order) {
         return new DispatchOrderReadResponse(
@@ -41,7 +43,9 @@ public record DispatchOrderReadResponse(
                 order.getStatus(),
                 order.getKind(),
                 order.getCompletedAt(),
-                order.getCreatedAt()
+                order.getCreatedAt(),
+                order.getCompletedBy(),
+                order.getCompletionPhoto() != null && order.getCompletionPhoto().length > 0
         );
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/repository/DispatchOrderRepository.java
@@ -28,5 +28,7 @@ public interface DispatchOrderRepository extends Repository<DispatchOrder, UUID>
 
     List<DispatchOrder> findByStatusAndDeletedAtIsNullOrderByCreatedAtAsc(DispatchOrderStatus status);
 
+    List<DispatchOrder> findByBikeIdAndStatusAndDeletedAtIsNullOrderByCompletedAtDesc(UUID bikeId, DispatchOrderStatus status);
+
     DispatchOrder save(DispatchOrder order);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderCommandService.java
@@ -1,5 +1,7 @@
 package com.thundercrew.opsapi.dispatch.service;
 
+import com.thundercrew.opsapi.audit.dto.AuditLogCreateRequest;
+import com.thundercrew.opsapi.audit.service.AuditLogCommandService;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
 import com.thundercrew.opsapi.dispatch.domain.DispatchBatchStatus;
@@ -21,13 +23,16 @@ public class DispatchOrderCommandService {
 
     private final DispatchOrderRepository dispatchOrderRepository;
     private final DispatchBatchRepository dispatchBatchRepository;
+    private final AuditLogCommandService auditLogCommandService;
     private final Clock clock;
 
     public DispatchOrderCommandService(DispatchOrderRepository dispatchOrderRepository,
                                        DispatchBatchRepository dispatchBatchRepository,
+                                       AuditLogCommandService auditLogCommandService,
                                        Clock clock) {
         this.dispatchOrderRepository = dispatchOrderRepository;
         this.dispatchBatchRepository = dispatchBatchRepository;
+        this.auditLogCommandService = auditLogCommandService;
         this.clock = clock;
     }
 
@@ -44,11 +49,11 @@ public class DispatchOrderCommandService {
                 request.originLongitude());
     }
 
-    public DispatchOrderReadResponse complete(UUID id) {
+    public DispatchOrderReadResponse complete(UUID id, byte[] photo, String contentType, UUID completedBy) {
         DispatchOrder order = dispatchOrderRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", id));
         // 관리 엔티티는 @Transactional 종료 시 dirty-checking 으로 flush 되므로 mutate 경로에 명시적 save() 없음.
-        order.complete(clock.instant());
+        order.complete(clock.instant(), photo, contentType, completedBy);
         // 유모차 라운드: 마지막 배송 완료 시 배치를 DONE 으로 자동 전환.
         if (order.getBatchId() != null && order.getKind() == DispatchOrderKind.DELIVERY
                 && dispatchOrderRepository.findByBatchIdAndKindAndStatusAndDeletedAtIsNull(
@@ -57,6 +62,7 @@ public class DispatchOrderCommandService {
                     .filter(b -> b.getStatus() == DispatchBatchStatus.DELIVERING)
                     .ifPresent(b -> b.markDone(null, clock.instant()));
         }
+        auditLogCommandService.record(new AuditLogCreateRequest("DISPATCH_ORDER", id, "status", "ASSIGNED", "COMPLETED"));
         return DispatchOrderReadResponse.from(order);
     }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
@@ -1,5 +1,7 @@
 package com.thundercrew.opsapi.dispatch.service;
 
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
 import com.thundercrew.opsapi.dispatch.domain.DispatchOrderStatus;
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
 import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
@@ -38,5 +40,18 @@ public class DispatchOrderReadService {
                 .stream()
                 .findFirst()
                 .map(DispatchOrderReadResponse::from);
+    }
+
+    public List<DispatchOrderReadResponse> listCompletedByBike(UUID bikeId) {
+        return dispatchOrderRepository
+                .findByBikeIdAndStatusAndDeletedAtIsNullOrderByCompletedAtDesc(bikeId, DispatchOrderStatus.COMPLETED)
+                .stream()
+                .map(DispatchOrderReadResponse::from)
+                .toList();
+    }
+
+    public DispatchOrder findOrderForPhoto(UUID id) {
+        return dispatchOrderRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", id));
     }
 }

--- a/development/service-ops-api/src/main/resources/application.properties
+++ b/development/service-ops-api/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.application.name=service-ops-api
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
 
 spring.datasource.url=${SERVICE_OPS_DB_URL:jdbc:postgresql://localhost:5432/service_ops_api}
 spring.datasource.username=${SERVICE_OPS_DB_USERNAME:service_ops}

--- a/development/service-ops-api/src/main/resources/db/migration/V43__add_dispatch_completion_photo.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V43__add_dispatch_completion_photo.sql
@@ -1,0 +1,3 @@
+alter table dispatch_orders add column completion_photo bytea;
+alter table dispatch_orders add column completion_photo_content_type varchar(100);
+alter table dispatch_orders add column completed_by uuid;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
@@ -70,6 +70,7 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
 
     @BeforeEach
     void resetRows() throws Exception {
+        jdbcTemplate.update("delete from audit_logs");
         jdbcTemplate.update("delete from dispatch_orders");
         jdbcTemplate.update("delete from bike_current_states");
         jdbcTemplate.update("delete from bikes");
@@ -130,12 +131,7 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
         String firstId = createOrder("고객A", "010-1111-1111", "주소 A");
         createOrder("고객B", "010-2222-2222", "주소 B");
 
-        mockMvc.perform(post("/api/v1/dispatch-orders/{id}/complete", firstId)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(firstId))
-                .andExpect(jsonPath("$.status").value("COMPLETED"))
-                .andExpect(jsonPath("$.completedAt").isString());
+        completeOrder(firstId);
 
         mockMvc.perform(get("/api/v1/dispatch-orders")
                         .param("bikeId", BIKE_ID.toString())
@@ -145,6 +141,75 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$[0].id").value(firstId))
                 .andExpect(jsonPath("$[0].status").value("COMPLETED"))
                 .andExpect(jsonPath("$[1].status").value("ASSIGNED"));
+    }
+
+    // ③-photo: 사진 포함 완료 → COMPLETED, hasCompletionPhoto=true, GET 사진 엔드포인트 바이트/콘텐츠타입 반환
+    @Test
+    void completeWithPhotoStoresPhotoAndRetrievesItViaPhotoEndpoint() throws Exception {
+        String orderId = createOrder("사진고객", "010-9999-0000", "사진 주소");
+        byte[] photoBytes = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10};
+
+        MockMultipartFile photo = new MockMultipartFile("photo", "test.jpg", "image/jpeg", photoBytes);
+
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/{id}/complete", orderId)
+                        .file(photo)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(orderId))
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.completedAt").isString())
+                .andExpect(jsonPath("$.hasCompletionPhoto").value(true));
+
+        mockMvc.perform(get("/api/v1/dispatch-orders/{id}/completion-photo", orderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    byte[] body = result.getResponse().getContentAsByteArray();
+                    assertThat(body).isEqualTo(photoBytes);
+                    assertThat(result.getResponse().getContentType()).startsWith("image/jpeg");
+                });
+    }
+
+    // ③-nophoto: 사진 없이 완료 시도 → 거부 (400/409)
+    @Test
+    void completeWithoutPhotoIsRejected() throws Exception {
+        String orderId = createOrder("사진없음고객", "010-0000-1111", "주소");
+
+        MockMultipartFile emptyPhoto = new MockMultipartFile("photo", "empty.jpg", "image/jpeg", new byte[0]);
+
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/{id}/complete", orderId)
+                        .file(emptyPhoto)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(result -> assertThat(result.getResponse().getStatus()).isIn(400, 409));
+    }
+
+    // ③-completed-list: GET /completed?bikeId → hasCompletionPhoto=true 인 COMPLETED 건 반환
+    @Test
+    void completedByBikeListsCompletedOrdersWithHasCompletionPhotoTrue() throws Exception {
+        String orderId = createOrder("완료목록고객", "010-1234-0000", "완료 주소");
+        completeOrder(orderId);
+
+        mockMvc.perform(get("/api/v1/dispatch-orders/completed")
+                        .param("bikeId", BIKE_ID.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(orderId))
+                .andExpect(jsonPath("$[0].status").value("COMPLETED"))
+                .andExpect(jsonPath("$[0].hasCompletionPhoto").value(true));
+    }
+
+    // ③-audit: complete → audit_logs 에 DISPATCH_ORDER/status 행 생성
+    @Test
+    void completeRecordsAuditLog() throws Exception {
+        String orderId = createOrder("감사고객", "010-5678-0000", "감사 주소");
+        completeOrder(orderId);
+
+        int count = jdbcTemplate.queryForObject(
+                "select count(*) from audit_logs where entity_type='DISPATCH_ORDER' and entity_id=?::uuid and field='status' and old_value='ASSIGNED' and new_value='COMPLETED'",
+                Integer.class,
+                orderId);
+        assertThat(count).isEqualTo(1);
     }
 
     // ④ DELETE → 204, 소프트 삭제로 목록에서 제외
@@ -351,6 +416,15 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
     }
 
     // --- helpers ---------------------------------------------------------
+
+    private void completeOrder(String orderId) throws Exception {
+        byte[] photoBytes = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
+        MockMultipartFile photo = new MockMultipartFile("photo", "photo.jpg", "image/jpeg", photoBytes);
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/{id}/complete", orderId)
+                        .file(photo)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk());
+    }
 
     private String createBody(String name, String phone, String address, double lat, double lng) {
         return """

--- a/docs/superpowers/specs/2026-06-17-delivery-completion-photo-design.md
+++ b/docs/superpowers/specs/2026-06-17-delivery-completion-photo-design.md
@@ -1,0 +1,42 @@
+# 배송 완료(사진 증빙) + 단일 배차 무순서 목록 — 설계
+
+## 목표
+차량 상세의 배차 큐에서 운영자가 배송 건을 완료할 때 **사진 1장을 필수로 첨부**하고, 완료 이벤트를 **공통 audit_logs에 로그로 남긴다**. 단일 배차 큐는 "현재/대기 순서" 대신 **무순서 배송 목록**으로 표시한다(기사가 순서를 알아서 정한다는 의미). 순차/왕복은 기존 순서 + 거리·ETA 유지. 기사 앱은 이번 범위 제외(운영자가 admin 웹에서 완료 대행).
+
+## 결정
+- 사진 저장: **DB bytea** (신규 객체스토리지 인프라 없이 진행). 업로드 최대 ~5MB.
+- 사진: 건당 **1장, 완료 필수**(없으면 완료 불가).
+- 적용 범위: **모든 배차(단일+순차+왕복) 완료**에 사진 필수.
+- 로그: ⑤의 **공통 audit_logs 재사용**(배송 완료 이벤트), 사진 bytea는 주문에 별도 저장.
+
+## 데이터 모델 (V43)
+`dispatch_orders` 컬럼 추가:
+- `completion_photo` bytea (nullable)
+- `completion_photo_content_type` varchar(100) (nullable)
+- `completed_by` uuid (nullable)
+(`completed_at` 기존)
+
+## 백엔드
+- `DispatchOrder.complete(Instant when, byte[] photo, String contentType, UUID completedBy)` — photo null/empty면 거부(도메인 불변식). status ASSIGNED→COMPLETED.
+- `POST /api/v1/dispatch-orders/{id}/complete` → 멀티파트(`@RequestPart("photo") MultipartFile photo`) 필수. 5MB 초과/빈 파일 거부(400).
+- 완료 서비스에서 **AuditLogCommandService.record**(entityType=`DISPATCH_ORDER`, entityId=orderId, field=`status`, oldValue=`ASSIGNED`, newValue=`COMPLETED`, actor=completedBy) 호출(백엔드 원자적 기록).
+- `GET /api/v1/dispatch-orders/{id}/completion-photo` → 이미지 바이트 + content-type(read 컨트롤러).
+- `GET /api/v1/dispatch-orders/completed?bikeId=` → 그 차량의 완료 주문 목록(사진 bytea 제외, 메타 + hasCompletionPhoto만). 리포지토리 `findByBikeIdAndStatusAndDeletedAtIsNullOrderByCompletedAtDesc`.
+- `DispatchOrderReadResponse`에 `completedBy`, `hasCompletionPhoto` 추가(바이트 미포함).
+- 배치(라운드) 완료도 주문 단위 complete를 거치므로 동일 규칙.
+
+## 프론트엔드
+- 차량 상세 `DispatchQueueSection`:
+  - **배송 패밀리(단일/CALL/OTHER)**: 무순서 목록(현재/대기·ETA 없음). 각 건: 고객·연락처·주소(·출발지) + [완료(사진)] + [취소].
+  - **청소 패밀리(순차/왕복)**: 기존 현재/대기 + 거리·ETA 유지.
+- [완료(사진)] 버튼: 숨은 file input(capture) → 사진 1장 선택 시 멀티파트 완료 호출(필수). 성공 시 목록에서 제거.
+- **완료 내역** 접이식 섹션: 그 차량의 최근 완료 배송 + 사진 보기(썸네일). 사진은 same-origin Next.js 프록시 라우트(`/api/dispatch/completion-photo/[id]`)가 백엔드에서 인증 fetch해 스트리밍 → `<img src>`로 표시.
+- `completeDispatchOrderAction`이 사진(File)을 받도록 변경 — 모든 완료 호출부가 사진 업로드 흐름이 됨.
+
+## 검증
+- 백엔드: compileJava/compileTestJava + 멀티파트 완료→사진 저장→GET 반환, 사진 없으면 거부, audit 기록 contract 테스트.
+- 프론트: typecheck/lint/build.
+- prod: 배차 건 완료(사진 첨부)→목록 제거 + 완료 내역에서 사진 확인 + audit 적재.
+
+## 범위 밖
+기사 모바일 앱, 객체스토리지 전환, 사진 여러 장.


### PR DESCRIPTION
@
## 릴리스 내용
[#447](https://github.com/EVNSolution/thundercrew-domain/pull/447) — 배송 완료 시 사진 1장 필수 첨부 + 완료 로그(audit_logs), 단일 배차 무순서 목록, 완료 내역(사진) 보기.

## 배포 영향
- **V43** `dispatch_orders`에 completion_photo(bytea) 등 컬럼 추가(additive). API 재기동 시 Flyway 적용.
- 사진은 DB bytea 저장(객체스토리지 미사용). 멀티파트 5MB 한도.
- 머지 시 aws-ec2-deploy 자동 실행.

## QA (배포 후)
단일 배차 차량 상세 → 무순서 배송 목록 → 완료 버튼에서 사진 선택 → 완료/목록제거 → "완료 내역"에서 사진 확인. 순차/왕복은 기존 순서+ETA 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@