### PR TITLE
릴리스: 매칭 서비스 유형 표시 + 지도 배송 탭 제거

### DIFF
--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/management/matching/actions";
 import type {
   ServiceOpsRiderBikeContract,
+  ServiceOpsBikeServiceType,
   ServiceOpsContractCategory,
   ServiceOpsContractReturnType,
 } from "@/lib/services/service-ops-api";
@@ -32,6 +33,15 @@ function categoryLabel(category?: ServiceOpsContractCategory | null): React.Reac
 function returnTypeLabel(returnType?: ServiceOpsContractReturnType | null): React.ReactNode {
   if (returnType === "TAKEOVER") return "인수형";
   if (returnType === "RETURN") return "반납형";
+  return <span className="muted">—</span>;
+}
+
+function serviceTypeLabel(serviceType?: ServiceOpsBikeServiceType | null): React.ReactNode {
+  if (serviceType === "CALL") return "콜 배차";
+  if (serviceType === "SINGLE") return "단일 배차";
+  if (serviceType === "SEQUENTIAL") return "순차 배차";
+  if (serviceType === "ROUND") return "왕복 배차";
+  if (serviceType === "OTHER") return "기타";
   return <span className="muted">—</span>;
 }
 
@@ -88,6 +98,7 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
           <thead>
             <tr>
               <th>차량번호</th>
+              <th>서비스 유형</th>
               <th>라이더 이름</th>
               <th>연락처</th>
               <th>계약형태</th>
@@ -100,16 +111,17 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={8} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={9} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : contracts.length === 0 ? (
               <tr>
-                <td colSpan={8} className="table-empty-cell">계약 없음</td>
+                <td colSpan={9} className="table-empty-cell">계약 없음</td>
               </tr>
             ) : (
               contracts.map((c) => (
                 <tr key={c.id}>
                   <td>{c.plateNumber ?? <span className="muted">—</span>}</td>
+                  <td>{serviceTypeLabel(c.serviceType)}</td>
                   <td>{c.riderName ?? <span className="muted">—</span>}</td>
                   <td>{c.riderPhoneNumber ?? <span className="muted">—</span>}</td>
                   <td>{categoryLabel(c.category)}</td>

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 import { VehiclesPanel } from "@/components/management/VehiclesPanel";
 import { StationsPanel } from "@/components/management/StationsPanel";
-import { DeliveryStatusPanel } from "@/components/overview/DeliveryStatusPanel";
 import type { InsuranceOption } from "@/components/management/RidersPanel";
 import type {
   FrontendVehicle,
@@ -15,7 +14,7 @@ import type { StationDataResult } from "@/lib/services/station-data";
 import type { VehicleDataResult } from "@/lib/services/vehicle-data";
 import type { RiderActiveContractSummary } from "@/lib/services/rider-matching-snapshot-data";
 
-type BottomTab = "vehicles" | "stations" | "delivery" | "tips";
+type BottomTab = "vehicles" | "stations" | "tips";
 
 export interface BottomMapPanelProps {
   /** 패널 열림 상태 — 부모가 제어 (controlled). */
@@ -64,14 +63,14 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
   return (
     <div className={`bottom-map-panel${open ? " bottom-map-panel--open" : ""}`}>
       <div className="bottom-map-panel-tabbar">
-        {(["vehicles", "stations", "delivery", "tips"] as BottomTab[]).map((tab) => (
+        {(["vehicles", "stations", "tips"] as BottomTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
             className={`bottom-map-panel-tab${activeTab === tab && open ? " is-active" : ""}`}
             onClick={() => handleTabClick(tab)}
           >
-            {tab === "vehicles" ? "차량" : tab === "stations" ? "충전소" : tab === "delivery" ? "배송" : "팁"}
+            {tab === "vehicles" ? "차량" : tab === "stations" ? "충전소" : "팁"}
           </button>
         ))}
         {open && (
@@ -111,9 +110,6 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
               )}
               <StationsPanel data={props.stationData} />
             </>
-          )}
-          {activeTab === "delivery" && (
-            <DeliveryStatusPanel vehicles={props.visibleVehicles} />
           )}
           {activeTab === "tips" && (
             props.tipContent ?? (

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -364,6 +364,8 @@ export type ServiceOpsRiderBikeContract = {
   /** Denormalized from ContractTemplate — populated in list responses. */
   category?: ServiceOpsContractCategory | null;
   returnType?: ServiceOpsContractReturnType | null;
+  /** Denormalized from Bike — populated in list responses. */
+  serviceType?: ServiceOpsBikeServiceType | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/dto/RiderBikeContractReadResponse.java
@@ -1,5 +1,6 @@
 package com.thundercrew.opsapi.contract.dto;
 
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import com.thundercrew.opsapi.contract.domain.ContractCategory;
 import com.thundercrew.opsapi.contract.domain.ContractReturnType;
 import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
@@ -24,6 +25,7 @@ public record RiderBikeContractReadResponse(
         String riderPhoneNumber,
         ContractCategory category,
         ContractReturnType returnType,
+        BikeServiceType serviceType,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -58,6 +60,7 @@ public record RiderBikeContractReadResponse(
                 null,
                 null,
                 null,
+                null,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );
@@ -70,7 +73,8 @@ public record RiderBikeContractReadResponse(
             String riderName,
             String riderPhoneNumber,
             ContractCategory category,
-            ContractReturnType returnType
+            ContractReturnType returnType,
+            BikeServiceType serviceType
     ) {
         return new RiderBikeContractReadResponse(
                 contract.getId(),
@@ -90,6 +94,7 @@ public record RiderBikeContractReadResponse(
                 riderPhoneNumber,
                 category,
                 returnType,
+                serviceType,
                 contract.getCreatedAt(),
                 contract.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractReadService.java
@@ -83,7 +83,8 @@ public class ContractReadService {
                     rider != null ? rider.getName() : null,
                     rider != null ? rider.getPhoneNumber() : null,
                     template != null ? template.getCategory() : null,
-                    template != null ? template.getReturnType() : null
+                    template != null ? template.getReturnType() : null,
+                    bike != null ? bike.getServiceType() : null
             );
         }));
     }


### PR DESCRIPTION
@
## 릴리스 내용
[#449](https://github.com/EVNSolution/thundercrew-domain/pull/449) — 매칭 테이블에 "서비스 유형" 컬럼 추가(엑셀과 일치), 지도 하단 "배송" 탭 제거.

## 배포 영향
- 마이그레이션 없음(프론트 + 백엔드 read DTO만). 머지 시 aws-ec2-deploy 자동 실행.

## QA (배포 후)
- 자원 관리 → 매칭 표에 "서비스 유형" 컬럼 표시 확인.
- 지도 하단 패널 탭이 차량/충전소/팁(배송 없음) 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@