### PR TITLE
릴리스: 정비 % 알람 + 관리자 알림 센터 (V44)

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -12,6 +12,7 @@ import {
   type ServiceOpsStationStatus,
   type ServiceOpsRiderEducationType,
   type AuditLogCreateInput,
+  type ServiceOpsNotification,
   serviceOpsApiConfigured,
   ServiceOpsApiError
 } from "@/lib/services/service-ops-api";
@@ -558,12 +559,14 @@ export async function createMaintenanceItemAction(formData: FormData): Promise<v
     // 백엔드 check 제약과 동일 정책 — 최소 한 종류의 cycle 표현은 있어야 한다.
     redirect("/management/maintenance?status=maintenance-item-cycle-required");
   }
+  const alertThresholdPercent = optionalInteger(formData.get("alertThresholdPercent"));
   try {
     await client.createMaintenanceItem({
       name,
       categories,
       cycleKm,
-      cycleMonths
+      cycleMonths,
+      alertThresholdPercent
     });
   } catch {
     redirect("/management/maintenance?status=maintenance-item-create-error");
@@ -591,7 +594,8 @@ export async function updateMaintenanceItemAction(
       name,
       categories,
       cycleKm: optionalInteger(formData.get("cycleKm")),
-      cycleMonths: optionalInteger(formData.get("cycleMonths"))
+      cycleMonths: optionalInteger(formData.get("cycleMonths")),
+      alertThresholdPercent: optionalInteger(formData.get("alertThresholdPercent"))
     });
   } catch {
     redirect("/management/maintenance?status=maintenance-item-update-error");
@@ -1007,5 +1011,32 @@ export async function setNextCustomerAction(
     return { ok: true, lat: geocoded.latitude, lng: geocoded.longitude };
   } catch {
     return { ok: false, error: "저장 중 오류가 발생했습니다. 다시 시도해주세요." };
+  }
+}
+
+// ── Generic notification actions ──
+
+/**
+ * 서버 알림 목록을 반환한다. 미인증 또는 오류 시 빈 배열 반환.
+ */
+export async function listNotificationsAction(): Promise<ServiceOpsNotification[]> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return [];
+  return client.listNotifications().catch(() => []);
+}
+
+/**
+ * 서버 알림을 확인(acknowledge) 처리한다.
+ */
+export async function acknowledgeNotificationAction(
+  id: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: false });
+  if (!client) return { ok: false, error: "session-required" };
+  try {
+    await client.acknowledgeNotification(id);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
   }
 }

--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1464,6 +1464,166 @@ textarea { padding-top: 10px; min-height: 96px; }
   flex-shrink: 0;
 }
 
+/* ── Notification Center Panel (right-side slide) ───────────────── */
+.notif-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 360px;
+  max-width: 100vw;
+  height: 100vh;
+  background: var(--rm-card-bg, #fff);
+  border-left: 1px solid var(--rm-border, #e5e7eb);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.13);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  animation: notif-panel-slide-in 0.2s ease;
+}
+
+@keyframes notif-panel-slide-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.notif-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rm-border, #e5e7eb);
+  flex-shrink: 0;
+}
+
+.notif-panel-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--rm-text, #374151);
+}
+
+.notif-panel-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  color: var(--rm-text-muted, #9ca3af);
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.notif-panel-close:hover {
+  background: var(--rm-hover, rgba(0, 0, 0, 0.06));
+  color: var(--rm-text, #374151);
+}
+
+.notif-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+/* Groups */
+.notif-group {
+  margin-bottom: 4px;
+}
+
+.notif-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--rm-text-muted, #9ca3af);
+  border-bottom: 1px solid var(--rm-border, #e5e7eb);
+}
+
+.notif-group-icon {
+  font-size: 13px;
+}
+
+.notif-group-label {
+  flex: 1;
+}
+
+.notif-group-count {
+  background: var(--rm-border, #e5e7eb);
+  border-radius: 10px;
+  padding: 0 6px;
+  font-size: 10px;
+  color: var(--rm-text-muted, #9ca3af);
+}
+
+/* Per-type item overrides */
+.notif-item--maintenance {
+  border-left: 3px solid #f59e0b;
+}
+
+.notif-item--reignition {
+  border-left: 3px solid #6366f1;
+}
+
+.notif-item--other {
+  border-left: 3px solid #10b981;
+}
+
+/* Unread emphasis */
+.notif-item--unread {
+  background: var(--rm-hover, rgba(0, 0, 0, 0.03));
+}
+
+.notif-item--unread .notif-item-text {
+  font-weight: 700;
+}
+
+/* Item content layout override for panel */
+.notif-panel .notif-item {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  padding: 10px 16px;
+}
+
+.notif-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.notif-item-body {
+  font-size: 11px;
+  color: var(--rm-text-muted, #9ca3af);
+}
+
+.notif-item-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+/* Acknowledge button */
+.notif-ack-btn {
+  background: none;
+  border: 1px solid var(--rm-border, #e5e7eb);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--rm-text-muted, #9ca3af);
+  white-space: nowrap;
+}
+
+.notif-ack-btn:hover {
+  background: var(--rm-hover, rgba(0, 0, 0, 0.06));
+  color: var(--rm-text, #374151);
+  border-color: var(--rm-text-muted, #9ca3af);
+}
+
 /* ── Map Ignition Bubble ────────────────────────────────────────── */
 .map-ignition-bubble {
   position: absolute;

--- a/development/front-admin-web/components/layout/NotificationBell.tsx
+++ b/development/front-admin-web/components/layout/NotificationBell.tsx
@@ -1,21 +1,74 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useNotifications } from "@/components/layout/NotificationContext";
+import { useNotifications, type UnifiedNotification } from "@/components/layout/NotificationContext";
 
-function formatRelativeTime(startedAt: number): string {
-  const diffMs = Date.now() - startedAt;
+function formatRelativeTime(occurredAt: number, now: number): string {
+  const diffMs = now - occurredAt;
   const diffMin = Math.floor(diffMs / 60_000);
   if (diffMin < 1) return "방금";
   if (diffMin < 60) return `${diffMin}분 전`;
   return `${Math.floor(diffMin / 60)}시간 전`;
 }
 
+function typeIcon(type: string): string {
+  if (type === "MAINTENANCE_ALARM") return "⚙️";
+  if (type === "REIGNITION") return "🔑";
+  return "📍";
+}
+
+function typeLabel(type: string): string {
+  if (type === "MAINTENANCE_ALARM") return "정비 알람";
+  if (type === "REIGNITION") return "시동 알림";
+  return "알림";
+}
+
+function typeItemClass(type: string): string {
+  if (type === "MAINTENANCE_ALARM") return "notif-item notif-item--maintenance";
+  if (type === "REIGNITION") return "notif-item notif-item--reignition";
+  return "notif-item notif-item--other";
+}
+
+function groupByType(items: UnifiedNotification[]): Map<string, UnifiedNotification[]> {
+  const map = new Map<string, UnifiedNotification[]>();
+  for (const item of items) {
+    const arr = map.get(item.type) ?? [];
+    arr.push(item);
+    map.set(item.type, arr);
+  }
+  return map;
+}
+
+// Type display order
+const TYPE_ORDER = ["MAINTENANCE_ALARM", "REIGNITION"];
+
+function sortedTypes(types: string[]): string[] {
+  const ordered = TYPE_ORDER.filter((t) => types.includes(t));
+  const rest = types.filter((t) => !TYPE_ORDER.includes(t)).sort();
+  return [...ordered, ...rest];
+}
+
 export function NotificationBell() {
-  const { notifications, unreadCount, markAllRead } = useNotifications();
+  const { unifiedNotifications, unreadCount, markAllRead, acknowledge } = useNotifications();
   const [open, setOpen] = useState(false);
+  // Snapshot of Date.now() captured in an effect/handler — never during render (react-hooks/purity)
+  const [now, setNow] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  // Update "now" every 30s while panel is open.
+  // The first tick fires at 0 ms (asynchronous, not synchronous in effect body).
+  useEffect(() => {
+    if (!open) return;
+    const tick = () => setNow(Date.now());
+    const t0 = setTimeout(tick, 0);
+    const interval = setInterval(tick, 30_000);
+    return () => {
+      clearTimeout(t0);
+      clearInterval(interval);
+    };
+  }, [open]);
+
+  // Close on outside click
   useEffect(() => {
     if (!open) return;
     function handleClick(e: MouseEvent) {
@@ -27,11 +80,32 @@ export function NotificationBell() {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
   function handleToggle() {
     const next = !open;
     setOpen(next);
-    if (next) markAllRead();
+    if (next) {
+      markAllRead();
+      setNow(Date.now());
+    }
   }
+
+  // Un-acknowledged generic items first, then rest — within each type already sorted by occurredAt desc
+  const unacknowledged = unifiedNotifications.filter((n) => !n.acknowledged);
+  const acknowledged = unifiedNotifications.filter((n) => n.acknowledged);
+  const sorted = [...unacknowledged, ...acknowledged];
+
+  const grouped = groupByType(sorted);
+  const types = sortedTypes([...grouped.keys()]);
 
   return (
     <div className="notif-bell-wrapper" ref={wrapperRef}>
@@ -40,6 +114,7 @@ export function NotificationBell() {
         className="notif-bell-btn"
         onClick={handleToggle}
         aria-label={`알림${unreadCount > 0 ? ` (읽지 않은 알림 ${unreadCount}건)` : ""}`}
+        aria-expanded={open}
       >
         🔔
         {unreadCount > 0 && (
@@ -48,23 +123,70 @@ export function NotificationBell() {
           </span>
         )}
       </button>
+
+      {/* Right-side slide panel */}
       {open && (
-        <div className="notif-dropdown" role="list" aria-label="이동 알림 이력">
-          {notifications.length === 0 ? (
-            <div className="notif-empty">알림 없음</div>
-          ) : (
-            [...notifications].reverse().map((n) => (
-              <div key={n.id} className="notif-item" role="listitem">
-                <span className="notif-item-text">
-                  {(() => {
-                    const kindLabel = n.kind === "PICKUP" ? "수거" : n.kind === "DELIVERY" ? "배송" : "";
-                    return <>🔑 {n.plateNumber}{kindLabel ? ` ${kindLabel}` : ""} 출발{n.customerName ? ` → ${n.customerName}` : ""}{n.address ? ` (${n.address})` : ""}</>;
-                  })()}
-                </span>
-                <span className="notif-item-time">{formatRelativeTime(n.startedAt)}</span>
-              </div>
-            ))
-          )}
+        <div
+          className="notif-panel"
+          role="dialog"
+          aria-label="알림 센터"
+        >
+          <div className="notif-panel-header">
+            <span className="notif-panel-title">알림 센터</span>
+            <button
+              type="button"
+              className="notif-panel-close"
+              aria-label="닫기"
+              onClick={() => setOpen(false)}
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="notif-panel-body">
+            {unifiedNotifications.length === 0 ? (
+              <div className="notif-empty">알림 없음</div>
+            ) : (
+              types.map((type) => {
+                const items = grouped.get(type) ?? [];
+                return (
+                  <section key={type} className="notif-group">
+                    <div className="notif-group-header">
+                      <span className="notif-group-icon">{typeIcon(type)}</span>
+                      <span className="notif-group-label">{typeLabel(type)}</span>
+                      <span className="notif-group-count">{items.length}</span>
+                    </div>
+                    {items.map((n) => (
+                      <div
+                        key={n.id}
+                        className={`${typeItemClass(n.type)}${!n.acknowledged ? " notif-item--unread" : ""}`}
+                        role="listitem"
+                      >
+                        <div className="notif-item-content">
+                          <span className="notif-item-text">{n.title}</span>
+                          {n.body && <span className="notif-item-body">{n.body}</span>}
+                        </div>
+                        <div className="notif-item-meta">
+                          <span className="notif-item-time">
+                            {now > 0 ? formatRelativeTime(n.occurredAt, now) : ""}
+                          </span>
+                          {n.type !== "REIGNITION" && !n.acknowledged && (
+                            <button
+                              type="button"
+                              className="notif-ack-btn"
+                              onClick={() => acknowledge(n.id)}
+                            >
+                              확인
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </section>
+                );
+              })
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import { listReignitionNotificationsAction } from "@/app/dispatch/actions";
+import { acknowledgeNotificationAction, listNotificationsAction } from "@/app/actions";
 
 export type IgnitionNotification = {
   id: string;
@@ -25,11 +26,26 @@ export type IgnitionNotification = {
   kind?: "PICKUP" | "DELIVERY";
 };
 
+/**
+ * 통합 알림 모델 — re-ignition 과 서버 generic notification 을 단일 목록으로 합친다.
+ */
+export type UnifiedNotification = {
+  id: string;
+  type: "MAINTENANCE_ALARM" | "REIGNITION" | string;
+  title: string;
+  body: string | null;
+  occurredAt: number; // ms since epoch
+  acknowledged: boolean;
+  refBikeId?: string | null;
+};
+
 type NotificationContextValue = {
   notifications: IgnitionNotification[];
+  unifiedNotifications: UnifiedNotification[];
   unreadCount: number;
   addNotification: (n: Omit<IgnitionNotification, "id">) => void;
   markAllRead: () => void;
+  acknowledge: (id: string) => void;
 };
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
@@ -37,9 +53,9 @@ const NotificationContext = createContext<NotificationContextValue | null>(null)
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<IgnitionNotification[]>([]);
   const [readCount, setReadCount] = useState(0);
+  const [genericNotifications, setGenericNotifications] = useState<UnifiedNotification[]>([]);
 
-  // 앱 로드 시 서버에서 최근 re-ignition 알림을 가져와 벨을 초기화한다.
-  // 서버 레코드 id 는 클라이언트 생성 id 와 충돌하지 않으므로 dedup 불필요.
+  // 앱 로드 시 re-ignition 알림을 가져와 벨을 초기화한다.
   useEffect(() => {
     listReignitionNotificationsAction().then((records) => {
       if (records.length === 0) return;
@@ -50,14 +66,29 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         customerName: r.nextCustomerName ?? undefined,
         address: r.nextAddress ?? undefined,
       }));
-      // newest-first — server returns newest first, so reverse for oldest-first
-      // then cap to 20 via the same logic as addNotification.
       setNotifications((prev) => {
-        if (prev.length > 0) return prev; // already has live notifications, skip seed
-        const combined = [...seeded].reverse(); // convert newest-first → oldest-first
+        if (prev.length > 0) return prev;
+        const combined = [...seeded].reverse();
         return combined.length > 20 ? combined.slice(-20) : combined;
       });
       setReadCount(0);
+    }).catch(() => undefined);
+  }, []);
+
+  // 앱 로드 시 서버 generic notifications 를 가져온다.
+  useEffect(() => {
+    listNotificationsAction().then((records) => {
+      const mapped: UnifiedNotification[] = records.map((r) => ({
+        id: r.id,
+        type: r.type,
+        title: r.title,
+        body: r.body,
+        occurredAt: new Date(r.occurredAt).getTime(),
+        acknowledged: r.acknowledgedAt != null,
+        refBikeId: r.refBikeId,
+      }));
+      // newest-first already from server; keep that order
+      setGenericNotifications(mapped);
     }).catch(() => undefined);
   }, []);
 
@@ -76,11 +107,39 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const unreadCount = Math.max(0, notifications.length - readCount);
+  const acknowledge = useCallback((id: string) => {
+    // Optimistic local update
+    setGenericNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, acknowledged: true } : n))
+    );
+    // Fire-and-forget server call
+    acknowledgeNotificationAction(id).catch(() => undefined);
+  }, []);
+
+  // Build unified list from reignition + generic notifications, sorted by occurredAt desc
+  const reignitionAsUnified: UnifiedNotification[] = notifications.map((n) => ({
+    id: n.id,
+    type: "REIGNITION" as const,
+    title: `${n.plateNumber}${n.kind === "PICKUP" ? " 수거" : n.kind === "DELIVERY" ? " 배송" : ""} 출발${n.customerName ? ` → ${n.customerName}` : ""}`,
+    body: n.address ?? null,
+    occurredAt: n.startedAt,
+    acknowledged: true, // reignition items have no server-side ack; treat as always-seen
+    refBikeId: null,
+  }));
+
+  const unifiedNotifications: UnifiedNotification[] = [
+    ...reignitionAsUnified,
+    ...genericNotifications,
+  ].sort((a, b) => b.occurredAt - a.occurredAt);
+
+  // unreadCount = reignition unread + unacknowledged generic
+  const reignitionUnread = Math.max(0, notifications.length - readCount);
+  const genericUnread = genericNotifications.filter((n) => !n.acknowledged).length;
+  const unreadCount = reignitionUnread + genericUnread;
 
   return (
     <NotificationContext.Provider
-      value={{ notifications, unreadCount, addNotification, markAllRead }}
+      value={{ notifications, unifiedNotifications, unreadCount, addNotification, markAllRead, acknowledge }}
     >
       {children}
     </NotificationContext.Provider>

--- a/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
+++ b/development/front-admin-web/components/management/MaintenanceItemDetailDialog.tsx
@@ -95,6 +95,10 @@ export function MaintenanceItemDetailDialog({
             label="교환주기 (개월)"
             value={row!.cycleMonths !== null ? `${row!.cycleMonths}개월` : "—"}
           />
+          <DetailField
+            label="알람 임계"
+            value={row!.alertThresholdPercent != null ? `${row!.alertThresholdPercent}%` : "—"}
+          />
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={handleClose}>닫기</button>
             <button type="button" className="button-primary" onClick={() => setMode("edit")}>수정</button>
@@ -165,6 +169,18 @@ export function MaintenanceItemDetailDialog({
               />
             </label>
           </div>
+
+          <label>
+            알람 임계 %
+            <input
+              name="alertThresholdPercent"
+              type="number"
+              min={0}
+              max={100}
+              defaultValue={row?.alertThresholdPercent ?? ""}
+              placeholder="비우면 알람 없음"
+            />
+          </label>
 
           <div className="overview-create-dialog-actions">
             <button

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -233,6 +233,7 @@ export type ServiceOpsMaintenanceItem = {
   name: string;
   cycleKm: number | null;
   cycleMonths: number | null;
+  alertThresholdPercent?: number | null;
   memo: string | null;
   categories: ServiceOpsMaintenanceCategory[];
 };
@@ -261,6 +262,7 @@ export type MaintenanceItemCreateInput = {
   categories: ServiceOpsMaintenanceCategory[];
   cycleKm?: number | null;
   cycleMonths?: number | null;
+  alertThresholdPercent?: number | null;
   memo?: string | null;
 };
 
@@ -269,6 +271,7 @@ export type MaintenanceItemUpdateInput = {
   categories?: ServiceOpsMaintenanceCategory[];
   cycleKm?: number | null;
   cycleMonths?: number | null;
+  alertThresholdPercent?: number | null;
   memo?: string | null;
 };
 
@@ -1164,6 +1167,22 @@ export type ReignitionNotificationCreateInput = {
   nextLongitude?: number | null;
 };
 
+// ── Generic notifications ──
+
+export type ServiceOpsNotification = {
+  id: string;
+  idx?: number | null;
+  type: string;
+  title: string;
+  body: string | null;
+  refBikeId: string | null;
+  refEntityId: string | null;
+  refRiderId: string | null;
+  occurredAt: string;
+  acknowledgedAt: string | null;
+  createdAt: string;
+};
+
 // ── Audit log ──
 
 export type ServiceOpsAuditLog = {
@@ -1349,6 +1368,10 @@ export type ServiceOpsApiClient = {
   // ── Re-ignition notifications ──
   recordReignitionNotification: (input: ReignitionNotificationCreateInput) => Promise<ServiceOpsReignitionNotification>;
   listReignitionNotifications: () => Promise<ServiceOpsReignitionNotification[]>;
+
+  // ── Generic notifications ──
+  listNotifications: (opts?: { unacknowledgedOnly?: boolean; type?: string }) => Promise<ServiceOpsNotification[]>;
+  acknowledgeNotification: (id: string) => Promise<void>;
 
   // ── Audit logs ──
   recordAuditLog: (input: AuditLogCreateInput) => Promise<ServiceOpsAuditLog>;
@@ -2067,6 +2090,17 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         { method: "GET" },
         entityId !== undefined ? { entityId } : undefined
       ),
+
+    // ── Generic notifications ──
+    listNotifications: ({ unacknowledgedOnly, type } = {}) => {
+      const query: Record<string, string | number | undefined> = {};
+      if (unacknowledgedOnly !== undefined) query.unacknowledgedOnly = String(unacknowledgedOnly);
+      if (type !== undefined) query.type = type;
+      return request<ServiceOpsNotification[]>("/notifications", { method: "GET" }, query);
+    },
+    acknowledgeNotification: async (id) => {
+      await request<void>(`/notifications/${encodeURIComponent(id)}/acknowledge`, { method: "POST" });
+    },
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/ServiceOpsApiApplication.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/ServiceOpsApiApplication.java
@@ -2,8 +2,10 @@ package com.thundercrew.opsapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServiceOpsApiApplication {
 
 	public static void main(String[] args) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
@@ -75,4 +75,13 @@ public interface RiderBikeContractRepository extends Repository<RiderBikeContrac
             @Param("riderId") UUID riderId);
 
     List<RiderBikeContract> findAllByTerminatedAtIsNullAndDeletedAtIsNull();
+
+    @Query(value = """
+            select * from rider_bike_contracts
+            where bike_id = :bikeId
+              and terminated_at is null
+              and deleted_at is null
+            limit 1
+            """, nativeQuery = true)
+    Optional<RiderBikeContract> findActiveByBikeId(@Param("bikeId") UUID bikeId);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/domain/MaintenanceItem.java
@@ -43,12 +43,16 @@ public class MaintenanceItem extends DisplaySequencedEntity {
     @Column
     private String memo;
 
+    @Column(name = "alert_threshold_percent")
+    private Integer alertThresholdPercent;
+
     public static MaintenanceItem create(
             String name,
             Set<MaintenanceCategory> categories,
             Integer cycleKm,
             Integer cycleMonths,
-            String memo
+            String memo,
+            Integer alertThresholdPercent
     ) {
         MaintenanceItem item = new MaintenanceItem();
         item.name = name;
@@ -56,6 +60,7 @@ public class MaintenanceItem extends DisplaySequencedEntity {
         item.cycleKm = cycleKm;
         item.cycleMonths = cycleMonths;
         item.memo = memo;
+        item.alertThresholdPercent = alertThresholdPercent;
         return item;
     }
 
@@ -64,7 +69,8 @@ public class MaintenanceItem extends DisplaySequencedEntity {
             Set<MaintenanceCategory> categories,
             Integer cycleKm,
             Integer cycleMonths,
-            String memo
+            String memo,
+            Integer alertThresholdPercent
     ) {
         if (name != null) {
             this.name = name;
@@ -77,6 +83,7 @@ public class MaintenanceItem extends DisplaySequencedEntity {
         if (memo != null) {
             this.memo = memo;
         }
+        this.alertThresholdPercent = alertThresholdPercent;
     }
 
     public String getName() {
@@ -97,6 +104,10 @@ public class MaintenanceItem extends DisplaySequencedEntity {
 
     public String getMemo() {
         return memo;
+    }
+
+    public Integer getAlertThresholdPercent() {
+        return alertThresholdPercent;
     }
 
     protected MaintenanceItem() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemCreateRequest.java
@@ -2,6 +2,8 @@ package com.thundercrew.opsapi.maintenance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -14,6 +16,7 @@ public record MaintenanceItemCreateRequest(
         @NotEmpty Set<MaintenanceCategory> categories,
         @PositiveOrZero Integer cycleKm,
         @PositiveOrZero Integer cycleMonths,
-        String memo
+        String memo,
+        @Min(0) @Max(100) Integer alertThresholdPercent
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemReadResponse.java
@@ -14,6 +14,7 @@ public record MaintenanceItemReadResponse(
         Integer cycleKm,
         Integer cycleMonths,
         String memo,
+        Integer alertThresholdPercent,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -26,6 +27,7 @@ public record MaintenanceItemReadResponse(
                 item.getCycleKm(),
                 item.getCycleMonths(),
                 item.getMemo(),
+                item.getAlertThresholdPercent(),
                 item.getCreatedAt(),
                 item.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/dto/MaintenanceItemUpdateRequest.java
@@ -2,6 +2,8 @@ package com.thundercrew.opsapi.maintenance.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.thundercrew.opsapi.maintenance.domain.MaintenanceCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
@@ -16,6 +18,7 @@ public record MaintenanceItemUpdateRequest(
         Set<MaintenanceCategory> categories,
         @PositiveOrZero Integer cycleKm,
         @PositiveOrZero Integer cycleMonths,
-        String memo
+        String memo,
+        @Min(0) @Max(100) Integer alertThresholdPercent
 ) {
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceAlarmEvaluator.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceAlarmEvaluator.java
@@ -1,0 +1,214 @@
+package com.thundercrew.opsapi.maintenance.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeOperationStatus;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.maintenance.domain.MaintenanceCategory;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.repository.MaintenanceItemRepository;
+import com.thundercrew.opsapi.maintenance.repository.VehicleMaintenanceRecordRepository;
+import com.thundercrew.opsapi.notification.repository.NotificationRepository;
+import com.thundercrew.opsapi.notification.service.NotificationCommandService;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MaintenanceAlarmEvaluator {
+
+    private static final Logger log = LoggerFactory.getLogger(MaintenanceAlarmEvaluator.class);
+    private static final String TYPE_MAINTENANCE_ALARM = "MAINTENANCE_ALARM";
+    private static final double DAYS_PER_MONTH = 30.4;
+
+    private final BikeRepository bikeRepository;
+    private final MaintenanceItemRepository maintenanceItemRepository;
+    private final VehicleMaintenanceRecordRepository vehicleMaintenanceRecordRepository;
+    private final BikeCurrentStateRepository bikeCurrentStateRepository;
+    private final RiderBikeContractRepository riderBikeContractRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationCommandService notificationCommandService;
+    private final Clock clock;
+
+    public MaintenanceAlarmEvaluator(
+            BikeRepository bikeRepository,
+            MaintenanceItemRepository maintenanceItemRepository,
+            VehicleMaintenanceRecordRepository vehicleMaintenanceRecordRepository,
+            BikeCurrentStateRepository bikeCurrentStateRepository,
+            RiderBikeContractRepository riderBikeContractRepository,
+            NotificationRepository notificationRepository,
+            NotificationCommandService notificationCommandService,
+            Clock clock
+    ) {
+        this.bikeRepository = bikeRepository;
+        this.maintenanceItemRepository = maintenanceItemRepository;
+        this.vehicleMaintenanceRecordRepository = vehicleMaintenanceRecordRepository;
+        this.bikeCurrentStateRepository = bikeCurrentStateRepository;
+        this.riderBikeContractRepository = riderBikeContractRepository;
+        this.notificationRepository = notificationRepository;
+        this.notificationCommandService = notificationCommandService;
+        this.clock = clock;
+    }
+
+    @Scheduled(fixedDelayString = "${thundercrew.maintenance.alarm-interval-ms:600000}")
+    public void evaluate() {
+        Instant now = Instant.now(clock);
+        List<Bike> activeBikes = bikeRepository.findAllByDeletedAtIsNull().stream()
+                .filter(b -> b.getOperationStatus() == BikeOperationStatus.IN_SERVICE)
+                .toList();
+
+        for (Bike bike : activeBikes) {
+            try {
+                evaluateBike(bike, now);
+            } catch (Exception ex) {
+                log.error("MaintenanceAlarmEvaluator: failed for bike {} — skipping", bike.getId(), ex);
+            }
+        }
+    }
+
+    private void evaluateBike(Bike bike, Instant now) {
+        UUID bikeId = bike.getId();
+
+        // Resolve category for this bike
+        MaintenanceCategory category = toCategory(bike);
+
+        // Applicable items (with alertThresholdPercent set)
+        List<MaintenanceItemReadResponse> applicableItems = maintenanceItemRepository
+                .findByCategory(category)
+                .stream()
+                .map(MaintenanceItemReadResponse::from)
+                .filter(item -> item.alertThresholdPercent() != null)
+                .toList();
+
+        if (applicableItems.isEmpty()) {
+            return;
+        }
+
+        // Latest record per item (records already servicedAt DESC)
+        List<VehicleMaintenanceRecordReadResponse> records =
+                vehicleMaintenanceRecordRepository
+                        .findByBikeIdAndDeletedAtIsNullOrderByServicedAtDesc(bikeId)
+                        .stream()
+                        .map(VehicleMaintenanceRecordReadResponse::from)
+                        .toList();
+
+        Map<UUID, VehicleMaintenanceRecordReadResponse> latestByItemId = records.stream()
+                .collect(Collectors.toMap(
+                        VehicleMaintenanceRecordReadResponse::itemId,
+                        r -> r,
+                        (existing, replacement) -> existing  // keep first (most recent)
+                ));
+
+        // Current odometer (may be null)
+        Integer currentOdometer = bikeCurrentStateRepository.findByBikeId(bikeId)
+                .map(state -> state.getOdometerKm())
+                .orElse(null);
+
+        for (MaintenanceItemReadResponse item : applicableItems) {
+            VehicleMaintenanceRecordReadResponse latestRecord = latestByItemId.get(item.id());
+            if (latestRecord == null) {
+                continue;
+            }
+
+            Double consumed = computeConsumedRatio(item, latestRecord, currentOdometer, now);
+            if (consumed == null) {
+                continue;
+            }
+
+            if (consumed * 100 >= item.alertThresholdPercent()) {
+                // Dedup: skip if alarm already raised this cycle (occurredAt after servicedAt of latest record)
+                boolean alreadyRaised = notificationRepository
+                        .existsByRefBikeIdAndRefEntityIdAndTypeAndOccurredAtAfterAndDeletedAtIsNull(
+                                bikeId,
+                                item.id(),
+                                TYPE_MAINTENANCE_ALARM,
+                                latestRecord.servicedAt()
+                        );
+
+                if (alreadyRaised) {
+                    continue;
+                }
+
+                UUID riderId = riderBikeContractRepository.findActiveByBikeId(bikeId)
+                        .map(contract -> contract.getRiderId())
+                        .orElse(null);
+
+                long roundedPercent = Math.round(consumed * 100);
+                String title = String.format("정비 임박: %s %s", bike.getPlateNumber(), item.name());
+                String body = String.format("%s %d%% 소진 (임계 %d%%)",
+                        item.name(), roundedPercent, item.alertThresholdPercent());
+
+                notificationCommandService.record(
+                        TYPE_MAINTENANCE_ALARM,
+                        title,
+                        body,
+                        bikeId,
+                        item.id(),
+                        riderId,
+                        now
+                );
+
+                log.info("MaintenanceAlarmEvaluator: raised alarm for bike={} item={} consumed={}%",
+                        bikeId, item.id(), roundedPercent);
+            }
+        }
+    }
+
+    /**
+     * Computes the consumed ratio (0.0 = new, 1.0 = fully consumed, >1.0 = overdue).
+     * Returns null if neither months nor km ratio can be computed.
+     */
+    private Double computeConsumedRatio(
+            MaintenanceItemReadResponse item,
+            VehicleMaintenanceRecordReadResponse latestRecord,
+            Integer currentOdometer,
+            Instant now
+    ) {
+        Double monthsRatio = null;
+        if (item.cycleMonths() != null) {
+            long daysBetween = ChronoUnit.DAYS.between(latestRecord.servicedAt(), now);
+            double fractionalMonths = daysBetween / DAYS_PER_MONTH;
+            monthsRatio = fractionalMonths / item.cycleMonths();
+        }
+
+        Double kmRatio = null;
+        if (item.cycleKm() != null
+                && currentOdometer != null
+                && latestRecord.servicedAtOdometerKm() != null) {
+            double kmDelta = currentOdometer - latestRecord.servicedAtOdometerKm();
+            kmRatio = kmDelta / item.cycleKm();
+        }
+
+        if (monthsRatio == null && kmRatio == null) {
+            return null;
+        }
+        if (monthsRatio == null) {
+            return kmRatio;
+        }
+        if (kmRatio == null) {
+            return monthsRatio;
+        }
+        return Math.max(monthsRatio, kmRatio);
+    }
+
+    private MaintenanceCategory toCategory(Bike bike) {
+        boolean four = bike.getWheelType() == com.thundercrew.opsapi.bike.domain.BikeWheelType.FOUR_WHEEL;
+        boolean ice = bike.getEngineType() == com.thundercrew.opsapi.bike.domain.BikeEngineType.ICE;
+        if (four) {
+            return ice ? MaintenanceCategory.FOUR_WHEEL_ICE : MaintenanceCategory.FOUR_WHEEL_ELECTRIC;
+        }
+        return ice ? MaintenanceCategory.TWO_WHEEL_ICE : MaintenanceCategory.TWO_WHEEL_ELECTRIC;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/maintenance/service/MaintenanceCommandService.java
@@ -48,7 +48,8 @@ public class MaintenanceCommandService {
                 request.categories(),
                 request.cycleKm(),
                 request.cycleMonths(),
-                request.memo()
+                request.memo(),
+                request.alertThresholdPercent()
         );
         MaintenanceItem saved = itemRepository.save(item);
         entityManager.flush();
@@ -65,7 +66,8 @@ public class MaintenanceCommandService {
                 request.categories(),
                 request.cycleKm(),
                 request.cycleMonths(),
-                request.memo()
+                request.memo(),
+                request.alertThresholdPercent()
         );
         entityManager.flush();
         return MaintenanceItemReadResponse.from(item);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/NotificationCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/NotificationCommandController.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.NotificationCommandService;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationCommandController {
+
+    private final NotificationCommandService notificationCommandService;
+
+    public NotificationCommandController(NotificationCommandService notificationCommandService) {
+        this.notificationCommandService = notificationCommandService;
+    }
+
+    @PostMapping("/{id}/acknowledge")
+    ResponseEntity<NotificationReadResponse> acknowledge(@PathVariable UUID id) {
+        NotificationReadResponse response = notificationCommandService.acknowledge(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/NotificationReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/controller/NotificationReadController.java
@@ -1,0 +1,31 @@
+package com.thundercrew.opsapi.notification.controller;
+
+import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.NotificationReadService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationReadController {
+
+    private final NotificationReadService notificationReadService;
+
+    public NotificationReadController(NotificationReadService notificationReadService) {
+        this.notificationReadService = notificationReadService;
+    }
+
+    @GetMapping
+    List<NotificationReadResponse> listRecent(
+            @RequestParam(required = false) Boolean unacknowledgedOnly,
+            @RequestParam(required = false) String type
+    ) {
+        return notificationReadService.listRecent(
+                Boolean.TRUE.equals(unacknowledgedOnly),
+                type
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/Notification.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/domain/Notification.java
@@ -1,0 +1,97 @@
+package com.thundercrew.opsapi.notification.domain;
+
+import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notifications")
+public class Notification extends DisplaySequencedEntity {
+
+    @Column(name = "type", nullable = false, length = 40)
+    private String type;
+
+    @Column(name = "title", nullable = false, columnDefinition = "text")
+    private String title;
+
+    @Column(name = "body", columnDefinition = "text")
+    private String body;
+
+    @Column(name = "ref_bike_id")
+    private UUID refBikeId;
+
+    @Column(name = "ref_entity_id")
+    private UUID refEntityId;
+
+    @Column(name = "ref_rider_id")
+    private UUID refRiderId;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "acknowledged_at")
+    private Instant acknowledgedAt;
+
+    public static Notification create(
+            String type,
+            String title,
+            String body,
+            UUID refBikeId,
+            UUID refEntityId,
+            UUID refRiderId,
+            Instant occurredAt
+    ) {
+        Notification notification = new Notification();
+        notification.type = type;
+        notification.title = title;
+        notification.body = body;
+        notification.refBikeId = refBikeId;
+        notification.refEntityId = refEntityId;
+        notification.refRiderId = refRiderId;
+        notification.occurredAt = occurredAt;
+        notification.acknowledgedAt = null;
+        return notification;
+    }
+
+    public void acknowledge(Instant when) {
+        this.acknowledgedAt = when;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public UUID getRefBikeId() {
+        return refBikeId;
+    }
+
+    public UUID getRefEntityId() {
+        return refEntityId;
+    }
+
+    public UUID getRefRiderId() {
+        return refRiderId;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public Instant getAcknowledgedAt() {
+        return acknowledgedAt;
+    }
+
+    protected Notification() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/NotificationReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/dto/NotificationReadResponse.java
@@ -1,0 +1,35 @@
+package com.thundercrew.opsapi.notification.dto;
+
+import com.thundercrew.opsapi.notification.domain.Notification;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationReadResponse(
+        UUID id,
+        Long idx,
+        String type,
+        String title,
+        String body,
+        UUID refBikeId,
+        UUID refEntityId,
+        UUID refRiderId,
+        Instant occurredAt,
+        Instant acknowledgedAt,
+        Instant createdAt
+) {
+    public static NotificationReadResponse from(Notification notification) {
+        return new NotificationReadResponse(
+                notification.getId(),
+                notification.getIdx(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getRefBikeId(),
+                notification.getRefEntityId(),
+                notification.getRefRiderId(),
+                notification.getOccurredAt(),
+                notification.getAcknowledgedAt(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/NotificationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/NotificationRepository.java
@@ -1,0 +1,23 @@
+package com.thundercrew.opsapi.notification.repository;
+
+import com.thundercrew.opsapi.notification.domain.Notification;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+    List<Notification> findTop100ByDeletedAtIsNullOrderByOccurredAtDesc();
+
+    List<Notification> findTop100ByAcknowledgedAtIsNullAndDeletedAtIsNullOrderByOccurredAtDesc();
+
+    List<Notification> findTop100ByTypeAndDeletedAtIsNullOrderByOccurredAtDesc(String type);
+
+    boolean existsByRefBikeIdAndRefEntityIdAndTypeAndOccurredAtAfterAndDeletedAtIsNull(
+            UUID bikeId,
+            UUID entityId,
+            String type,
+            Instant after
+    );
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationCommandService.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.notification.domain.Notification;
+import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.NotificationRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class NotificationCommandService {
+
+    private final NotificationRepository notificationRepository;
+    private final Clock clock;
+
+    public NotificationCommandService(NotificationRepository notificationRepository, Clock clock) {
+        this.notificationRepository = notificationRepository;
+        this.clock = clock;
+    }
+
+    public NotificationReadResponse acknowledge(UUID id) {
+        Notification notification = notificationRepository.findById(id)
+                .filter(n -> n.getDeletedAt() == null)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification", id));
+        notification.acknowledge(Instant.now(clock));
+        return NotificationReadResponse.from(notification);
+    }
+
+    public NotificationReadResponse record(
+            String type,
+            String title,
+            String body,
+            UUID refBikeId,
+            UUID refEntityId,
+            UUID refRiderId,
+            Instant occurredAt
+    ) {
+        Notification notification = Notification.create(type, title, body, refBikeId, refEntityId, refRiderId, occurredAt);
+        Notification saved = notificationRepository.save(notification);
+        return NotificationReadResponse.from(saved);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationReadService.java
@@ -1,0 +1,40 @@
+package com.thundercrew.opsapi.notification.service;
+
+import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
+import com.thundercrew.opsapi.notification.repository.NotificationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NotificationReadService {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationReadService(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    public List<NotificationReadResponse> listRecent(boolean unacknowledgedOnly, String typeOrNull) {
+        if (typeOrNull != null) {
+            return notificationRepository
+                    .findTop100ByTypeAndDeletedAtIsNullOrderByOccurredAtDesc(typeOrNull)
+                    .stream()
+                    .map(NotificationReadResponse::from)
+                    .toList();
+        }
+        if (unacknowledgedOnly) {
+            return notificationRepository
+                    .findTop100ByAcknowledgedAtIsNullAndDeletedAtIsNullOrderByOccurredAtDesc()
+                    .stream()
+                    .map(NotificationReadResponse::from)
+                    .toList();
+        }
+        return notificationRepository
+                .findTop100ByDeletedAtIsNullOrderByOccurredAtDesc()
+                .stream()
+                .map(NotificationReadResponse::from)
+                .toList();
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V44__maintenance_alert_and_notifications.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V44__maintenance_alert_and_notifications.sql
@@ -1,0 +1,21 @@
+alter table maintenance_items add column alert_threshold_percent integer;
+
+create table notifications (
+    id uuid primary key,
+    idx bigserial not null unique,
+    type varchar(40) not null,
+    title text not null,
+    body text,
+    ref_bike_id uuid,
+    ref_entity_id uuid,
+    ref_rider_id uuid,
+    occurred_at timestamptz not null,
+    acknowledged_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz,
+    created_by uuid, updated_by uuid, deleted_by uuid
+);
+create index idx_notifications_occurred_at on notifications (occurred_at desc);
+create index idx_notifications_ack on notifications (acknowledged_at);
+create index idx_notifications_bike_entity on notifications (ref_bike_id, ref_entity_id);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -115,6 +115,7 @@ class ArchitectureBoundaryTests {
                         || isTestRiderCommand(method)
                         || isTestMatchingCommand(method)
                         || isReignitionNotificationCommand(method)
+                        || isNotificationCommand(method)
                         || isAuditLogCommand(method)) {
                     return;
                 }
@@ -159,6 +160,7 @@ class ArchitectureBoundaryTests {
                         && !isTestRiderCommand(method)
                         && !isTestMatchingCommand(method)
                         && !isReignitionNotificationCommand(method)
+                        && !isNotificationCommand(method)
                         && !isAuditLogCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
@@ -320,6 +322,11 @@ class ArchitectureBoundaryTests {
     private static boolean isReignitionNotificationCommand(JavaMethod method) {
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.notification.controller.ReignitionNotificationCommandController");
+    }
+
+    private static boolean isNotificationCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.notification.controller.NotificationCommandController");
     }
 
     private static boolean isAuditLogCommand(JavaMethod method) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/NotificationApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/NotificationApiContractTests.java
@@ -1,0 +1,168 @@
+package com.thundercrew.opsapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NotificationApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final Pattern ACCESS_TOKEN_PATTERN =
+            Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from notifications");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+    }
+
+    // ① GET /api/v1/notifications returns empty list initially
+    @Test
+    void getListReturnsEmptyInitially() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ② Seed a notification and GET list returns it
+    @Test
+    void getListReturnsSeedNotification() throws Exception {
+        UUID notifId = UUID.randomUUID();
+        UUID bikeId = UUID.randomUUID();
+        UUID entityId = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, body, ref_bike_id, ref_entity_id, occurred_at)
+                values (?, 'MAINTENANCE_ALARM', '정비 임박: 서울A-0001 엔진오일', '엔진오일 85% 소진 (임계 80%)', ?, ?, now())
+                """, notifId, bikeId, entityId);
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(notifId.toString()))
+                .andExpect(jsonPath("$[0].type").value("MAINTENANCE_ALARM"))
+                .andExpect(jsonPath("$[0].title").value("정비 임박: 서울A-0001 엔진오일"))
+                .andExpect(jsonPath("$[0].acknowledgedAt").isEmpty());
+    }
+
+    // ③ POST acknowledge → 200 with acknowledgedAt set
+    @Test
+    void acknowledgeNotificationSetsAcknowledgedAt() throws Exception {
+        UUID notifId = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, occurred_at)
+                values (?, 'MAINTENANCE_ALARM', '정비 임박: 테스트', now())
+                """, notifId);
+
+        mockMvc.perform(post("/api/v1/notifications/{id}/acknowledge", notifId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(notifId.toString()))
+                .andExpect(jsonPath("$.acknowledgedAt").isString());
+    }
+
+    // ④ unacknowledgedOnly filter
+    @Test
+    void unacknowledgedOnlyFilterWorks() throws Exception {
+        UUID notifA = UUID.randomUUID();
+        UUID notifB = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, occurred_at)
+                values (?, 'MAINTENANCE_ALARM', 'A 알람', now() - interval '2 minutes')
+                """, notifA);
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, occurred_at, acknowledged_at)
+                values (?, 'MAINTENANCE_ALARM', 'B 알람', now() - interval '1 minute', now())
+                """, notifB);
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .param("unacknowledgedOnly", "true")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(notifA.toString()));
+    }
+
+    // ⑤ type filter
+    @Test
+    void typeFilterWorks() throws Exception {
+        UUID notifA = UUID.randomUUID();
+        UUID notifB = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, occurred_at)
+                values (?, 'MAINTENANCE_ALARM', 'A 정비', now() - interval '2 minutes')
+                """, notifA);
+        jdbcTemplate.update("""
+                insert into notifications (id, type, title, occurred_at)
+                values (?, 'OTHER_TYPE', 'B 기타', now() - interval '1 minute')
+                """, notifB);
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .param("type", "MAINTENANCE_ALARM")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(notifA.toString()));
+    }
+
+    // --- helpers ---
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        Assertions.assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/specs/2026-06-17-maintenance-alarm-notification-center-design.md
+++ b/docs/superpowers/specs/2026-06-17-maintenance-alarm-notification-center-design.md
@@ -1,0 +1,28 @@
+# 정비 % 알람 + 관리자 알림 센터 — 설계
+
+대형 앱 프로젝트의 첫 서브프로젝트(백엔드/관리자웹). 앱은 별도 트랙.
+
+## A. 정비 % 알람
+- **알람 임계 %**: `MaintenanceItem.alert_threshold_percent`(int, nullable; null=알람 off, 기본 입력값 90). 정비 관리 항목 편집 다이얼로그에 입력.
+- **소진율 계산**(기존 derive 동일 의미): 항목별로
+  - 개월: (now − 최근 record.servicedAt) / cycleMonths
+  - km: (현재 odometer − record.servicedAtOdometerKm) / cycleKm  (둘 다 있을 때만)
+  - consumed = 사용 가능한 비율 중 **최댓값**. consumed ≥ threshold/100 → 알람.
+  - **기준선 = 최근 정비 record**(표준 정비 의미). 최근 record 없으면(미정비) 이번 범위에선 알람 생성 안 함(기준선 없음).
+- **평가 트리거**: 백엔드 `@Scheduled`(10분 주기, `@EnableScheduling`). 대상 = **operationStatus=IN_SERVICE 차량만**("운행 진입 시 체킹"). 차량별 적용 항목(카테고리=wheel×engine)에 대해 평가.
+- **중복 방지**: 같은 (bikeId, itemId)에 대해, **최근 record.servicedAt 이후 생성된 미해제 MAINTENANCE_ALARM 알림**이 이미 있으면 재생성 안 함(현재 주기당 1회). 교환 완료(새 record)로 주기 리셋되면 다시 발생.
+- **전달**: 웹 알림 센터 + 알림 레코드에 매칭 라이더 id 기록(앱이 나중에 읽음).
+- ⚠️ prod 텔레메트리 odometer는 합성/null → **km 알람은 실데이터로 잘 안 뜸, 개월(시간) 알람은 정상**.
+
+## B. 공통 알림 + 관리자 알림 센터
+- **신규 `notifications` 테이블**: id, idx, `type`(varchar; MAINTENANCE_ALARM 등), `title`, `body`, `ref_bike_id`(uuid null), `ref_entity_id`(uuid null), `ref_rider_id`(uuid null), `occurred_at`, `acknowledged_at`(null), + base audit. 인덱스 (occurred_at desc), (acknowledged_at).
+- **API**: `GET /api/v1/notifications?unacknowledgedOnly=&type=`(최근 top 100 desc), `POST /api/v1/notifications/{id}/acknowledge`. command 컨트롤러 arch allow-list 등록.
+- **관리자 UX**: 기존 벨(🔔) 확장 — 미확인 배지 + 클릭 시 우측 슬라이드 패널. 항목별 유형 아이콘(⚙️정비/📍팁/🔑재시동)·차량·내용·시각 + **확인(acknowledge)** + 유형별 액션(정비→차량 상세, 팁→발행[나중]). 미확인 상단.
+- 기존 reignition 알림 시드는 유지(점진 통합). 이번엔 generic notifications(정비 알람)를 추가 로드해 병합·그룹.
+
+## 구현 범위
+**백엔드(V44)**: maintenance_items.alert_threshold_percent + DTO; notifications 테이블/엔티티/repo/read+command 서비스/컨트롤러 + arch allow-list; @EnableScheduling + MaintenanceAlarmEvaluator(@Scheduled); 매칭 라이더 조회; 테스트.
+**프론트**: ServiceOpsMaintenanceItem + alertThresholdPercent; MaintenanceItemDetailDialog % 입력; 알림 센터(NotificationContext/Bell + 우측 패널 + acknowledge + 유형 그룹/아이콘 + CSS) + generic notifications 클라이언트/액션.
+
+## 범위 밖
+라이더 앱 전달(앱 트랙), 팁 제출 플로우(#3), reignition 완전 통합.


### PR DESCRIPTION
@
## 릴리스 내용
[#451](https://github.com/EVNSolution/thundercrew-domain/pull/451) — 정비 항목별 % 임계 알람(IN_SERVICE 차량 스케줄 평가) + 공통 알림 테이블 + 관리자 우측 알림 센터(유형 그룹·확인).

## 배포 영향
- **V44**: maintenance_items.alert_threshold_percent 컬럼 + notifications 테이블(additive). API 재기동 시 Flyway + @Scheduled 평가기(10분) 가동.
- caveat: prod 텔레메트리 odometer 합성/null → km 알람은 실데이터 제약, 개월 기준은 정상.

## QA (배포 후)
- 정비 관리 항목 편집에 "알람 임계 %" 입력 확인.
- 알림 벨 클릭 → 우측 알림 센터(유형 그룹·확인 버튼) 확인.
- (개월 임계 도달 정비 항목이 IN_SERVICE 차량에 있으면) 알람 발생 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@