### PR TITLE
릴리스: 팁 제출→발행 플로우 (V45)

### DIFF
--- a/development/front-admin-web/app/tips/actions.ts
+++ b/development/front-admin-web/app/tips/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { ServiceOpsApiError, type ServiceOpsTip, type TipUpsertPayload } from "@/lib/services/service-ops-api";
+import { ServiceOpsApiError, type ServiceOpsTip, type TipSubmitPayload, type TipUpsertPayload } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 
 /**
@@ -72,6 +72,33 @@ export async function deleteTipAction(id: string): Promise<{ ok: true } | { ok: 
     await client.deleteTip(id);
     revalidatePath("/");
     return { ok: true };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function publishTipAction(id: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    await client.publishTip(id);
+    revalidatePath("/");
+    revalidatePath("/management");
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: extractError(err) };
+  }
+}
+
+export async function submitTipAction(
+  data: TipSubmitPayload
+): Promise<{ ok: true; tip: ServiceOpsTip } | { ok: false; error: string }> {
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) return { ok: false, error: "로그인이 필요합니다." };
+  try {
+    const tip = await client.submitTip(data);
+    revalidatePath("/");
+    return { ok: true, tip };
   } catch (err) {
     return { ok: false, error: extractError(err) };
   }

--- a/development/front-admin-web/components/layout/NotificationBell.tsx
+++ b/development/front-admin-web/components/layout/NotificationBell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { publishTipAction } from "@/app/tips/actions";
 import { useNotifications, type UnifiedNotification } from "@/components/layout/NotificationContext";
 
 function formatRelativeTime(occurredAt: number, now: number): string {
@@ -53,6 +54,8 @@ export function NotificationBell() {
   const [open, setOpen] = useState(false);
   // Snapshot of Date.now() captured in an effect/handler — never during render (react-hooks/purity)
   const [now, setNow] = useState(0);
+  const [publishingId, setPublishingId] = useState<string | null>(null);
+  const [, startPublishTransition] = useTransition();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   // Update "now" every 30s while panel is open.
@@ -97,6 +100,17 @@ export function NotificationBell() {
       markAllRead();
       setNow(Date.now());
     }
+  }
+
+  function handlePublishTip(notifId: string, tipId: string) {
+    if (!tipId) return;
+    setPublishingId(notifId);
+    startPublishTransition(async () => {
+      await publishTipAction(tipId);
+      acknowledge(notifId);
+      setPublishingId(null);
+      setOpen(false);
+    });
   }
 
   // Un-acknowledged generic items first, then rest — within each type already sorted by occurredAt desc
@@ -170,7 +184,16 @@ export function NotificationBell() {
                           <span className="notif-item-time">
                             {now > 0 ? formatRelativeTime(n.occurredAt, now) : ""}
                           </span>
-                          {n.type !== "REIGNITION" && !n.acknowledged && (
+                          {n.type === "TIP_SUBMISSION" && !n.acknowledged && n.refEntityId ? (
+                            <button
+                              type="button"
+                              className="notif-ack-btn"
+                              disabled={publishingId === n.id}
+                              onClick={() => handlePublishTip(n.id, n.refEntityId!)}
+                            >
+                              발행
+                            </button>
+                          ) : n.type !== "REIGNITION" && !n.acknowledged ? (
                             <button
                               type="button"
                               className="notif-ack-btn"
@@ -178,7 +201,7 @@ export function NotificationBell() {
                             >
                               확인
                             </button>
-                          )}
+                          ) : null}
                         </div>
                       </div>
                     ))}

--- a/development/front-admin-web/components/layout/NotificationContext.tsx
+++ b/development/front-admin-web/components/layout/NotificationContext.tsx
@@ -31,12 +31,14 @@ export type IgnitionNotification = {
  */
 export type UnifiedNotification = {
   id: string;
-  type: "MAINTENANCE_ALARM" | "REIGNITION" | string;
+  type: "MAINTENANCE_ALARM" | "REIGNITION" | "TIP_SUBMISSION" | string;
   title: string;
   body: string | null;
   occurredAt: number; // ms since epoch
   acknowledged: boolean;
   refBikeId?: string | null;
+  /** 팁 제출 알림의 팁 ID 등 참조 엔티티 ID. */
+  refEntityId?: string | null;
 };
 
 type NotificationContextValue = {
@@ -86,6 +88,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         occurredAt: new Date(r.occurredAt).getTime(),
         acknowledged: r.acknowledgedAt != null,
         refBikeId: r.refBikeId,
+        refEntityId: r.refEntityId,
       }));
       // newest-first already from server; keep that order
       setGenericNotifications(mapped);

--- a/development/front-admin-web/components/overview/TipsPanel.tsx
+++ b/development/front-admin-web/components/overview/TipsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState, useTransition } from "react";
 
-import { deleteTipAction, listTipsAction } from "@/app/tips/actions";
+import { deleteTipAction, listTipsAction, publishTipAction } from "@/app/tips/actions";
 import type { ServiceOpsTip } from "@/lib/services/service-ops-api";
 
 import { CreateTipDialog } from "./CreateTipDialog";
@@ -31,6 +31,7 @@ export function TipsPanel({ selectedTipId, onTipSelect }: TipsPanelProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ServiceOpsTip | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const reload = useCallback(() => {
@@ -59,6 +60,19 @@ export function TipsPanel({ selectedTipId, onTipSelect }: TipsPanelProps) {
     });
   };
 
+  const handlePublish = (tip: ServiceOpsTip) => {
+    setPublishError(null);
+    startTransition(async () => {
+      const result = await publishTipAction(tip.id);
+      if (!result.ok) {
+        setPublishError(result.error);
+        return;
+      }
+      const data = await listTipsAction();
+      setTips(data);
+    });
+  };
+
   const formatDate = (iso: string) =>
     new Date(iso).toLocaleDateString("ko-KR", {
       year: "2-digit",
@@ -80,6 +94,11 @@ export function TipsPanel({ selectedTipId, onTipSelect }: TipsPanelProps) {
           {deleteError}
         </p>
       ) : null}
+      {publishError ? (
+        <p role="alert" className="panel-error-banner tips-panel-error">
+          {publishError}
+        </p>
+      ) : null}
 
       <div className="table-card">
         <table className="table tips-table">
@@ -87,6 +106,7 @@ export function TipsPanel({ selectedTipId, onTipSelect }: TipsPanelProps) {
             <tr>
               <th>주소</th>
               <th>내용</th>
+              <th>상태</th>
               <th>등록일</th>
               <th aria-label="액션" />
             </tr>
@@ -94,41 +114,56 @@ export function TipsPanel({ selectedTipId, onTipSelect }: TipsPanelProps) {
           <tbody>
             {tips.length === 0 ? (
               <tr>
-                <td colSpan={4} className="table-empty-cell">
+                <td colSpan={5} className="table-empty-cell">
                   {isPending ? "로딩 중…" : "등록된 팁이 없습니다"}
                 </td>
               </tr>
             ) : (
-              tips.map((tip) => (
-                <tr
-                  key={tip.id}
-                  className={`table-row-clickable${tip.id === selectedTipId ? " is-selected" : ""}`}
-                  onClick={() => onTipSelect(tip.id === selectedTipId ? null : tip.id)}
-                >
-                  <td>{tip.address}</td>
-                  <td className="tips-table-content-cell">{tip.content}</td>
-                  <td>{formatDate(tip.createdAt)}</td>
-                  <td className="tips-table-actions" onClick={(e) => e.stopPropagation()}>
-                    <button
-                      type="button"
-                      className="button-neutral tips-table-edit"
-                      onClick={() => setEditTarget(tip)}
-                    >
-                      편집
-                    </button>
-                    <button
-                      type="button"
-                      className="delete-icon-button"
-                      onClick={() => handleDelete(tip)}
-                      disabled={isPending}
-                      title={`"${tip.address}" 팁 삭제`}
-                      aria-label={`"${tip.address}" 팁 삭제`}
-                    >
-                      <TrashIcon />
-                    </button>
-                  </td>
-                </tr>
-              ))
+              tips.map((tip) => {
+                const isPending_ = tip.status === "PENDING";
+                return (
+                  <tr
+                    key={tip.id}
+                    className={`table-row-clickable${tip.id === selectedTipId ? " is-selected" : ""}`}
+                    onClick={() => onTipSelect(tip.id === selectedTipId ? null : tip.id)}
+                  >
+                    <td>{tip.address}</td>
+                    <td className="tips-table-content-cell">{tip.content}</td>
+                    <td>{isPending_ ? "대기" : "발행"}</td>
+                    <td>{formatDate(tip.createdAt)}</td>
+                    <td className="tips-table-actions" onClick={(e) => e.stopPropagation()}>
+                      {isPending_ ? (
+                        <button
+                          type="button"
+                          className="button-primary tips-table-publish"
+                          onClick={() => handlePublish(tip)}
+                          disabled={isPending}
+                          title={`"${tip.address}" 팁 발행`}
+                        >
+                          발행
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="button-neutral tips-table-edit"
+                        onClick={() => setEditTarget(tip)}
+                      >
+                        편집
+                      </button>
+                      <button
+                        type="button"
+                        className="delete-icon-button"
+                        onClick={() => handleDelete(tip)}
+                        disabled={isPending}
+                        title={`"${tip.address}" 팁 삭제`}
+                        aria-label={`"${tip.address}" 팁 삭제`}
+                      >
+                        <TrashIcon />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -814,6 +814,8 @@ export interface FrontendTipPin {
   content: string;
   latitude: number;
   longitude: number;
+  /** 팁 상태 — 백엔드 V+ 부터 포함. 없으면 PUBLISHED 로 간주 (back-compat). */
+  status?: "PENDING" | "PUBLISHED";
 }
 
 export type FrontendDashboardMapState = {
@@ -835,6 +837,10 @@ export type ServiceOpsTip = {
   content: string;
   latitude: number;
   longitude: number;
+  /** 팁 상태 — 백엔드 V+ 부터 포함. 구 버전 호환을 위해 optional. */
+  status?: "PENDING" | "PUBLISHED";
+  /** 라이더 앱 제출 팁의 제출자 라이더 ID. 관리자 생성 팁은 null. */
+  submittedByRiderId?: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -845,6 +851,15 @@ export type TipUpsertPayload = {
   content: string;
   latitude: number;
   longitude: number;
+};
+
+/** 라이더 앱 팁 제출 payload — POST /tips/submissions body. */
+export type TipSubmitPayload = {
+  address: string;
+  content: string;
+  latitude: number;
+  longitude: number;
+  riderId?: string | null;
 };
 
 export type ServiceOpsBikeCurrentState = {
@@ -1224,6 +1239,10 @@ export type ServiceOpsApiClient = {
   createTip: (request: TipUpsertPayload) => Promise<ServiceOpsTip>;
   updateTip: (id: string, request: TipUpsertPayload) => Promise<ServiceOpsTip>;
   deleteTip: (id: string) => Promise<void>;
+  /** PENDING → PUBLISHED 전환. */
+  publishTip: (id: string) => Promise<ServiceOpsTip>;
+  /** 라이더 앱/BFF 경로의 팁 제출 (PENDING 팁 + TIP_SUBMISSION 알림 생성). */
+  submitTip: (request: TipSubmitPayload) => Promise<ServiceOpsTip>;
   listVehicles: (params?: { page?: number; size?: number; sort?: string }) => Promise<ServiceOpsPage<FrontendVehicle>>;
   getVehicle: (id: string) => Promise<FrontendVehicle>;
   createVehicle: (request: VehicleCreateInput) => Promise<FrontendVehicle>;
@@ -1559,6 +1578,13 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     deleteTip: async (id) => {
       await request<void>(`/tips/${encodeURIComponent(id)}`, { method: "DELETE" });
     },
+    publishTip: (id) =>
+      request<ServiceOpsTip>(`/tips/${encodeURIComponent(id)}/publish`, { method: "POST" }),
+    submitTip: (submitRequest) =>
+      request<ServiceOpsTip>("/tips/submissions", {
+        body: JSON.stringify(submitRequest),
+        method: "POST"
+      }),
     listVehicles: async ({ page = 0, size = 20, sort } = {}) => {
       const response = await request<ServiceOpsPage<ServiceOpsBike>>("/bikes", { method: "GET" }, { page, size, sort });
       return {
@@ -2142,20 +2168,25 @@ export function toFrontendDashboardMapState(mapState: ServiceOpsDashboardMapStat
       slug: pin.stationId
     })),
     // 백엔드 tip 마이그레이션(Task 3-4) 전까지 응답에 `tips` 가 없을 수 있어
-    // 방어적으로 읽는다. 도착하면 lat/lng 만 숫자로 정규화.
+    // 방어적으로 읽는다. PENDING 팁은 지도에 표시하지 않는다 (관리자 발행 전).
+    // status 가 없으면 PUBLISHED 로 간주 (구 버전 back-compat).
     tips: (((mapState as { tipPins?: unknown }).tipPins ?? []) as Array<{
       id: string;
       address: string;
       content: string;
       latitude: number | string;
       longitude: number | string;
-    }>).map((tip) => ({
-      id: tip.id,
-      address: tip.address,
-      content: tip.content,
-      latitude: toNumber(tip.latitude),
-      longitude: toNumber(tip.longitude)
-    }))
+      status?: string;
+    }>)
+      .filter((tip) => (tip.status ?? "PUBLISHED") !== "PENDING")
+      .map((tip) => ({
+        id: tip.id,
+        address: tip.address,
+        content: tip.content,
+        latitude: toNumber(tip.latitude),
+        longitude: toNumber(tip.longitude),
+        status: (tip.status as FrontendTipPin["status"]) ?? "PUBLISHED"
+      }))
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/controller/TipCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/controller/TipCommandController.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.tip.controller;
 
 import com.thundercrew.opsapi.tip.dto.TipCreateRequest;
 import com.thundercrew.opsapi.tip.dto.TipReadResponse;
+import com.thundercrew.opsapi.tip.dto.TipSubmissionCreateRequest;
 import com.thundercrew.opsapi.tip.dto.TipUpdateRequest;
 import com.thundercrew.opsapi.tip.service.TipCommandService;
 import jakarta.validation.Valid;
@@ -42,5 +43,17 @@ public class TipCommandController {
     ResponseEntity<Void> delete(@PathVariable UUID id) {
         tipCommandService.deleteTip(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/submissions")
+    ResponseEntity<TipReadResponse> submit(@Valid @RequestBody TipSubmissionCreateRequest request) {
+        TipReadResponse response = tipCommandService.submit(request);
+        return ResponseEntity.created(URI.create("/api/v1/tips/" + response.id()))
+                .body(response);
+    }
+
+    @PostMapping("/{id}/publish")
+    TipReadResponse publish(@PathVariable UUID id) {
+        return tipCommandService.publish(id);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/domain/Tip.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/domain/Tip.java
@@ -3,7 +3,10 @@ package com.thundercrew.opsapi.tip.domain;
 import com.thundercrew.opsapi.common.domain.DisplaySequencedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.util.UUID;
 
 @Entity
 @Table(name = "tips")
@@ -21,12 +24,32 @@ public class Tip extends DisplaySequencedEntity {
     @Column(nullable = false)
     private double longitude;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TipStatus status;
+
+    @Column(name = "submitted_by_rider_id")
+    private UUID submittedByRiderId;
+
     public static Tip create(String address, String content, double latitude, double longitude) {
         Tip tip = new Tip();
         tip.address = address;
         tip.content = content;
         tip.latitude = latitude;
         tip.longitude = longitude;
+        tip.status = TipStatus.PUBLISHED;
+        tip.submittedByRiderId = null;
+        return tip;
+    }
+
+    public static Tip createSubmission(String address, String content, double latitude, double longitude, UUID riderId) {
+        Tip tip = new Tip();
+        tip.address = address;
+        tip.content = content;
+        tip.latitude = latitude;
+        tip.longitude = longitude;
+        tip.status = TipStatus.PENDING;
+        tip.submittedByRiderId = riderId;
         return tip;
     }
 
@@ -35,6 +58,12 @@ public class Tip extends DisplaySequencedEntity {
         this.content = content;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public void publish() {
+        if (this.status == TipStatus.PENDING) {
+            this.status = TipStatus.PUBLISHED;
+        }
     }
 
     public String getAddress() {
@@ -51,6 +80,14 @@ public class Tip extends DisplaySequencedEntity {
 
     public double getLongitude() {
         return longitude;
+    }
+
+    public TipStatus getStatus() {
+        return status;
+    }
+
+    public UUID getSubmittedByRiderId() {
+        return submittedByRiderId;
     }
 
     protected Tip() {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/domain/TipStatus.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/domain/TipStatus.java
@@ -1,0 +1,6 @@
+package com.thundercrew.opsapi.tip.domain;
+
+public enum TipStatus {
+    PENDING,
+    PUBLISHED
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/dto/TipReadResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/dto/TipReadResponse.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.tip.dto;
 
 import com.thundercrew.opsapi.tip.domain.Tip;
+import com.thundercrew.opsapi.tip.domain.TipStatus;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -11,6 +12,8 @@ public record TipReadResponse(
         String content,
         double latitude,
         double longitude,
+        TipStatus status,
+        UUID submittedByRiderId,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -22,6 +25,8 @@ public record TipReadResponse(
                 tip.getContent(),
                 tip.getLatitude(),
                 tip.getLongitude(),
+                tip.getStatus(),
+                tip.getSubmittedByRiderId(),
                 tip.getCreatedAt(),
                 tip.getUpdatedAt()
         );

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/dto/TipSubmissionCreateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/dto/TipSubmissionCreateRequest.java
@@ -1,0 +1,17 @@
+package com.thundercrew.opsapi.tip.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TipSubmissionCreateRequest(
+        @NotBlank @Size(max = 2000) String address,
+        @NotBlank String content,
+        @DecimalMin("-90.0") @DecimalMax("90.0") double latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") double longitude,
+        UUID riderId
+) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/repository/TipRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/repository/TipRepository.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.tip.repository;
 
 import com.thundercrew.opsapi.tip.domain.Tip;
+import com.thundercrew.opsapi.tip.domain.TipStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface TipRepository extends Repository<Tip, UUID> {
     Tip save(Tip tip);
 
     List<Tip> findAllByDeletedAtIsNull();
+
+    List<Tip> findByStatusAndDeletedAtIsNull(TipStatus status);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/service/TipCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/service/TipCommandService.java
@@ -1,12 +1,15 @@
 package com.thundercrew.opsapi.tip.service;
 
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.notification.service.NotificationCommandService;
 import com.thundercrew.opsapi.tip.domain.Tip;
 import com.thundercrew.opsapi.tip.dto.TipCreateRequest;
 import com.thundercrew.opsapi.tip.dto.TipReadResponse;
+import com.thundercrew.opsapi.tip.dto.TipSubmissionCreateRequest;
 import com.thundercrew.opsapi.tip.dto.TipUpdateRequest;
 import com.thundercrew.opsapi.tip.repository.TipRepository;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TipCommandService {
 
     private final TipRepository tipRepository;
+    private final NotificationCommandService notificationCommandService;
     private final Clock clock;
 
-    public TipCommandService(TipRepository tipRepository, Clock clock) {
+    public TipCommandService(TipRepository tipRepository, NotificationCommandService notificationCommandService, Clock clock) {
         this.tipRepository = tipRepository;
+        this.notificationCommandService = notificationCommandService;
         this.clock = clock;
     }
 
@@ -39,5 +44,31 @@ public class TipCommandService {
         Tip tip = tipRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Tip", id));
         tip.markDeleted(null, clock.instant());
+    }
+
+    public TipReadResponse submit(TipSubmissionCreateRequest request) {
+        Tip tip = Tip.createSubmission(
+                request.address(),
+                request.content(),
+                request.latitude(),
+                request.longitude(),
+                request.riderId());
+        Tip saved = tipRepository.save(tip);
+        notificationCommandService.record(
+                "TIP_SUBMISSION",
+                "팁 제출: " + request.address(),
+                request.content(),
+                null,
+                saved.getId(),
+                request.riderId(),
+                Instant.now(clock));
+        return TipReadResponse.from(saved);
+    }
+
+    public TipReadResponse publish(UUID id) {
+        Tip tip = tipRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Tip", id));
+        tip.publish();
+        return TipReadResponse.from(tip);
     }
 }

--- a/development/service-ops-api/src/main/resources/db/migration/V45__tip_status_and_submitter.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V45__tip_status_and_submitter.sql
@@ -1,0 +1,2 @@
+alter table tips add column status varchar(20) not null default 'PUBLISHED';
+alter table tips add column submitted_by_rider_id uuid;

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -268,10 +268,8 @@ class ArchitectureBoundaryTests {
     }
 
     private static boolean isTipCommand(JavaMethod method) {
-        return method.getOwner().getName().equals("com.thundercrew.opsapi.tip.controller.TipCommandController")
-                && (method.getName().equals("create")
-                || method.getName().equals("update")
-                || method.getName().equals("delete"));
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.tip.controller.TipCommandController");
     }
 
     private static boolean isDispatchCommand(JavaMethod method) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TipApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TipApiContractTests.java
@@ -53,6 +53,7 @@ class TipApiContractTests extends PostgresContainerSupport {
 
     @BeforeEach
     void resetRows() throws Exception {
+        jdbcTemplate.update("delete from notifications");
         jdbcTemplate.update("delete from tips");
         jdbcTemplate.update("delete from admin_users");
         jdbcTemplate.update("""
@@ -189,6 +190,62 @@ class TipApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$.items").isArray())
                 .andExpect(jsonPath("$.items.length()").value(3))
                 .andExpect(jsonPath("$.page.totalItems").value(3));
+    }
+
+    @Test
+    void submitCreatesPendingTipAndRecordsNotification() throws Exception {
+        UUID riderId = UUID.randomUUID();
+
+        MvcResult result = mockMvc.perform(post("/api/v1/tips/submissions")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("""
+                                {
+                                  "address": "서울 강남구 제출 주소",
+                                  "content": "제출된 팁 내용",
+                                  "latitude": 37.4987,
+                                  "longitude": 127.0276,
+                                  "riderId": "%s"
+                                }
+                                """, riderId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.submittedByRiderId").value(riderId.toString()))
+                .andReturn();
+
+        String tipId = extractId(result.getResponse().getContentAsString());
+
+        int notificationCount = jdbcTemplate.queryForObject(
+                "select count(*) from notifications where type = 'TIP_SUBMISSION' and ref_entity_id = ?",
+                Integer.class, UUID.fromString(tipId));
+        assert notificationCount == 1 : "Expected 1 TIP_SUBMISSION notification but got " + notificationCount;
+    }
+
+    @Test
+    void publishChangesStatusToPublished() throws Exception {
+        MvcResult submitted = mockMvc.perform(post("/api/v1/tips/submissions")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "address": "서울 송파구 퍼블리시 주소",
+                                  "content": "퍼블리시할 팁 내용",
+                                  "latitude": 37.514,
+                                  "longitude": 127.106
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andReturn();
+
+        String tipId = extractId(submitted.getResponse().getContentAsString());
+
+        mockMvc.perform(post("/api/v1/tips/{id}/publish", tipId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(tipId))
+                .andExpect(jsonPath("$.status").value("PUBLISHED"));
     }
 
     @Test

--- a/docs/superpowers/specs/2026-06-17-tip-submission-publish-design.md
+++ b/docs/superpowers/specs/2026-06-17-tip-submission-publish-design.md
@@ -1,0 +1,22 @@
+# 팁 제출→발행 플로우 (관리자/서버 측) — 설계
+
+대형 앱 프로젝트 #3. 라이더 앱 제출 트리거는 별도 트랙; 여기선 서버+관리자.
+
+## 모델 (기존 Tip에 상태 추가, V45)
+- Tip에 `status`(PENDING|PUBLISHED, 기본 PUBLISHED — 기존 행/관리자 직접 추가는 PUBLISHED) + `submitted_by_rider_id`(uuid nullable) 추가.
+- 라이더 제출: `POST /api/v1/tips/submissions` {address, content, latitude, longitude, riderId?} → status=PENDING Tip 생성 + 공통 notifications에 type=TIP_SUBMISSION 알림(title/ body=주소·내용, refEntityId=tipId, refRiderId).
+- 발행: `POST /api/v1/tips/{id}/publish` → PENDING→PUBLISHED. (관리자)
+- Tip read(지도 마커 + TipsPanel 목록)는 **PUBLISHED만** 노출. 펜딩은 알림/별도.
+
+## 관리자 UI
+- 알림 센터 TIP_SUBMISSION 항목(📍)에 **[발행]** 액션 → publish 호출 + 알림 acknowledge → 지도에 표시.
+- TipsPanel: status 컬럼(대기/발행). (펜딩은 발행 전까지 지도 미표시)
+
+## 전체 앱 표시
+PUBLISHED 팁 = 기존 Tip read로 노출 → 앱이 나중에 소비. 웹 지도엔 즉시.
+
+## QA
+앱 없이 제출 엔드포인트를 API로 호출 → PENDING + 알림 → 발행 → 지도 표시 체인 검증.
+
+## 범위 밖
+라이더 앱 제출 UI, 앱 측 팁 표시.


### PR DESCRIPTION
@
## 릴리스 내용
[#453](https://github.com/EVNSolution/thundercrew-domain/pull/453) — 팁 제출(PENDING)→관리자 발행(PUBLISHED) 플로우. 지도엔 발행된 팁만, TipsPanel 상태/발행 버튼, 알림 센터 발행 액션.

## 배포 영향
- **V45**: tips.status + submitted_by_rider_id 컬럼(additive, 기존 팁 PUBLISHED). API 재기동 시 Flyway.

## QA (배포 후)
- TipsPanel 상태 컬럼(발행) 확인.
- (제출 엔드포인트로 PENDING 생성 시) 알림 센터 발행 버튼 → 지도 표시 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@