### PR TITLE
합성 핀에 현재 배차(currentDispatch) 주입 — 지도 표시 + 순차 시뮬 출발 수정

### DIFF
--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -1,6 +1,7 @@
 import {
   type FrontendDashboardMapState,
   type ServiceOpsApiError,
+  type ServiceOpsDispatchOrder,
   serviceOpsApiConfigured
 } from "@/lib/services/service-ops-api";
 import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
@@ -51,10 +52,41 @@ async function withSimulatedPins(
     const existingBikeIds = new Set(state.bikePins.map((p) => p.bikeId));
     const rawSimulated = generatePinsForUntrackedVehicles(vehiclePage.items, existingBikeIds);
 
-    // CLEANING 차량의 다음 고객 좌표를 주입한다. 텔레메트리가 없는 차량도
-    // bike_next_customer 에 데이터가 있을 수 있으므로 개별 조회 후 병합.
+    // 합성 핀(텔레메트리 없는 차량)은 currentDispatch* 가 null 로 생성된다.
+    // 백엔드 대시보드 핀과 달리 배차가 안 실리므로, 활성(ASSIGNED) 배차를 한 번
+    // 조회해 bikeId → 최저 sequence 주문 맵을 만들어 주입한다. 이게 없으면 지도에
+    // 배차 목적지가 안 뜨고, 청소형 시뮬도 다음 목적지를 못 받아 출발하지 않는다.
+    const dispatchByBike = new Map<string, ServiceOpsDispatchOrder>();
+    const dispatchCountByBike = new Map<string, number>();
+    try {
+      const active = await client.listActiveDispatchOrders();
+      for (const order of active) {
+        if (order.status !== "ASSIGNED" || !order.bikeId) continue;
+        dispatchCountByBike.set(order.bikeId, (dispatchCountByBike.get(order.bikeId) ?? 0) + 1);
+        const cur = dispatchByBike.get(order.bikeId);
+        if (!cur || order.sequence < cur.sequence) dispatchByBike.set(order.bikeId, order);
+      }
+    } catch {
+      // 배차 조회 실패 시 currentDispatch 주입 없이 진행
+    }
+
+    // CLEANING 차량의 다음 고객 좌표(bike_next_customer)도 개별 조회 후 병합.
     const simulated = await Promise.all(
-      rawSimulated.map(async (pin) => {
+      rawSimulated.map(async (rawPin) => {
+        // 1) 현재 배차(ASSIGNED 최저 sequence) 좌표 주입 — 차종 무관(지도 표시 + 시뮬).
+        const order = dispatchByBike.get(rawPin.bikeId);
+        const pin = order
+          ? {
+              ...rawPin,
+              currentDispatchCustomerName: order.customerName,
+              currentDispatchAddress: order.address,
+              currentDispatchLatitude: order.latitude,
+              currentDispatchLongitude: order.longitude,
+              currentDispatchKind: order.kind ?? "DELIVERY",
+              dispatchQueueCount: dispatchCountByBike.get(rawPin.bikeId) ?? 0
+            }
+          : rawPin;
+        // 2) 청소형은 다음 고객 좌표도 병합.
         if (!isCleaningServiceType(pin.serviceType)) return pin;
         try {
           const nc = await client.getBikeNextCustomer(pin.bikeId);


### PR DESCRIPTION
@
## 문제 (라이브 재현으로 확정)
prod는 실 텔레메트리가 없어 차량 핀이 `generatePinsForUntrackedVehicles`로 **합성**되는데, 합성 핀의 `currentDispatch*`가 **하드코딩 null**이었습니다. 지도 배차 마커도, 청소형 시뮬의 IDLE→MOVING(재시동) 트리거도 `currentDispatchLatitude/Longitude`를 읽는데 항상 비어 있어 — **untracked 차량의 배차가 지도에 안 뜨고**, 순차 시뮬이 배차가 있어도 출발하지 않았습니다(재시동 알림 미발생).

## 수정 (프론트 전용)
`withSimulatedPins`가 활성(ASSIGNED) 배차를 1회 조회 → bikeId→최저 sequence 주문 맵 → 합성 핀에 `currentDispatch*`(+dispatchQueueCount) 주입. 기존 next-customer 주입 패턴과 동일. → 합성 차량도 배차가 지도에 뜨고, 청소형은 출발 → 재시동 알림 발화.

## 검증
typecheck/lint/build 통과. 마이그레이션 없음.

## QA (배포 후)
순차+IMEI"-1" 차량에 배차 1건 → 새 로드 → IDLE→MOVING 출발 + 재시동 알림(벨/센터) 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@