### PR TITLE
차량 IMEI 자원관리와 통일 + 서비스 타입별 배차 제한

### DIFF
--- a/development/front-admin-web/app/page.tsx
+++ b/development/front-admin-web/app/page.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/lib/services/service-ops-api";
 import { loadStationList } from "@/lib/services/station-data";
 import { loadVehicleList } from "@/lib/services/vehicle-data";
-import { loadVehicleDeviceMap } from "@/lib/services/vehicle-device-data";
 import { loadMaintenanceDataset } from "@/lib/services/vehicle-maintenance-data";
 import { summarizeMaintenanceByBike } from "@/components/management/vehicle-maintenance-derive";
 
@@ -53,9 +52,6 @@ export default async function RootPage({
   }
   // Always fetch the cross-tab datasets so the panels can fill the lookup
   // columns and KPI tiles without a second round-trip on tab switch.
-  // `deviceMap` 은 차량 테이블의 IMEI 컬럼을 N+1 호출 없이 한 번에 채우는
-  // batch lookup. installations + devices 두 list 를 조인해 bikeId → deviceUid
-  // 사전 한 장으로 내려준다.
   const [
     { tab: tabParam },
     mapState,
@@ -63,7 +59,6 @@ export default async function RootPage({
     vehicleData,
     matching,
     opsExtra,
-    deviceMap,
     maintenanceData,
     stationData
   ] = await Promise.all([
@@ -73,7 +68,6 @@ export default async function RootPage({
     loadVehicleList(),
     loadRiderMatchingSnapshot(),
     loadContractsAndInsurances(),
-    loadVehicleDeviceMap(),
     loadMaintenanceDataset(),
     loadStationList()
   ]);
@@ -193,7 +187,6 @@ export default async function RootPage({
           stations={stationData.stations}
           bikeActiveRiderById={matching.bikeActiveRiderById}
           riderInfoById={riderInfoById}
-          deviceUidByBikeId={deviceMap.deviceUidByBikeId}
           maintenanceSummaryByBike={maintenanceSummaryByBike}
           educationTypeByRiderId={matching.educationTypeByRiderId}
           riderActiveBikeId={riderActiveBikeId}

--- a/development/front-admin-web/components/management/VehiclesPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesPanel.tsx
@@ -26,7 +26,7 @@ import type {
  *
  * 데이터 매핑:
  * - 차량번호 / 구분(engineType) / 운영 상태 ← FrontendVehicle (이 패널 데이터)
- * - IMEI ← deviceUidByBikeId (페이지 진입 시 batch-load)
+ * - IMEI ← vehicle.imei (자원 관리·차량 상세와 동일 소스)
  * - 이름 / 연락처 ← bikeActiveRiderById → riderInfoById 두 단계 lookup
  * - 교육 / 구독·렌탈 / 형태 / 기간 / 보험 ← bikeActiveRiderById 로 riderId 를
  *   먼저 찾고, 라이더 탭과 동일한 4 종 map (educationTypeByRiderId,
@@ -46,7 +46,6 @@ export function VehiclesPanel({
   data,
   bikeActiveRiderById,
   riderInfoById,
-  deviceUidByBikeId,
   educationTypeByRiderId,
   riderActiveContractById,
   riderActiveInsuranceByRiderId,
@@ -55,8 +54,6 @@ export function VehiclesPanel({
   data: VehicleDataResult;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
-  /** 차량 → 부착된 단말기 IMEI 사전. 루트 페이지가 batch loader 로 받아서 내려준다. */
-  deviceUidByBikeId?: Map<string, string>;
   /** riderId → ONLINE/OFFLINE 교육 type. */
   educationTypeByRiderId?: Map<string, "ONLINE" | "OFFLINE">;
   /** riderId → 활성 매칭의 계약 요약(category / returnType / durationLabel). */
@@ -113,7 +110,7 @@ export function VehiclesPanel({
               const activeRiderId = bikeActiveRiderById?.get(vehicleKey) ?? null;
               const riderInfo = activeRiderId ? riderInfoById?.get(activeRiderId) ?? null : null;
               const op = vehicle.operationStatus ?? statusToOperation(vehicle.status);
-              const imei = deviceUidByBikeId?.get(vehicleKey) ?? null;
+              const imei = vehicle.imei ?? null;
               // 라이더-측 lookup. 매칭이 없으면 모두 null → "—" 폴백.
               const educationType = activeRiderId ? educationTypeByRiderId?.get(activeRiderId) ?? null : null;
               const contract = activeRiderId ? riderActiveContractById?.get(activeRiderId) ?? null : null;

--- a/development/front-admin-web/components/overview/BottomMapPanel.tsx
+++ b/development/front-admin-web/components/overview/BottomMapPanel.tsx
@@ -28,7 +28,6 @@ export interface BottomMapPanelProps {
   visibleVehicles: ReadonlyArray<FrontendVehicle>;
   bikeActiveRiderById: Map<string, string>;
   riderInfoById: Map<string, { name: string; phone: string }>;
-  deviceUidByBikeId: Map<string, string>;
   educationTypeByRiderId: Map<string, ServiceOpsRiderEducationType>;
   riderActiveContractById: Map<string, RiderActiveContractSummary>;
   riderActiveInsuranceByRiderId: Map<string, ServiceOpsRiderInsurance>;
@@ -95,7 +94,6 @@ export function BottomMapPanel(props: BottomMapPanelProps) {
                 data={{ ...props.vehicleData, vehicles: [...props.visibleVehicles] }}
                 bikeActiveRiderById={props.bikeActiveRiderById}
                 riderInfoById={props.riderInfoById}
-                deviceUidByBikeId={props.deviceUidByBikeId}
                 educationTypeByRiderId={props.educationTypeByRiderId}
                 riderActiveContractById={props.riderActiveContractById}
                 riderActiveInsuranceByRiderId={props.riderActiveInsuranceByRiderId}

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -59,7 +59,6 @@ export interface FullscreenMapHostProps {
   stations: ReadonlyArray<BatteryStation>;
   bikeActiveRiderById?: Map<string, string>;
   riderInfoById?: Map<string, { name: string; phone: string }>;
-  deviceUidByBikeId?: Map<string, string>;
   maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
   educationTypeByRiderId?: Map<string, ServiceOpsRiderEducationType>;
   riderActiveBikeId?: Map<string, string>;
@@ -88,7 +87,6 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     vehicles,
     bikeActiveRiderById,
     riderInfoById,
-    deviceUidByBikeId,
     educationTypeByRiderId,
     riderActiveContractById,
     riderAllInsurancesByRiderId,
@@ -248,7 +246,6 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
           visibleVehicles={visibleVehicles}
           bikeActiveRiderById={bikeActiveRiderById ?? new Map()}
           riderInfoById={riderInfoById ?? new Map()}
-          deviceUidByBikeId={deviceUidByBikeId ?? new Map()}
           educationTypeByRiderId={educationTypeByRiderId ?? new Map()}
           riderActiveContractById={riderActiveContractById ?? new Map()}
           riderActiveInsuranceByRiderId={riderActiveInsuranceByRiderId ?? new Map()}

--- a/development/front-admin-web/components/overview/filter-compute.ts
+++ b/development/front-admin-web/components/overview/filter-compute.ts
@@ -87,17 +87,16 @@ export function applyVehicleFilters(input: {
   vehicles: ReadonlyArray<FrontendVehicle>;
   filters: VehicleFilterState;
   bikePinById: Map<string, FrontendDashboardBikePin>;
-  deviceUidByBikeId?: Map<string, string>;
   maintenanceSummaryByBike?: Map<string, VehicleMaintenanceSummary>;
 }): FrontendVehicle[] {
-  const { vehicles, filters, bikePinById, deviceUidByBikeId, maintenanceSummaryByBike } = input;
+  const { vehicles, filters, bikePinById, maintenanceSummaryByBike } = input;
   const q = filters.query.trim().toLowerCase();
   return vehicles.filter((vehicle) => {
     const vehicleKey = vehicle.id ?? vehicle.slug;
     if (q) {
       const plateMatch = vehicle.plateNumber.toLowerCase().includes(q);
       const modelMatch = (vehicle.model ?? "").toLowerCase().includes(q);
-      const imei = deviceUidByBikeId?.get(vehicleKey) ?? "";
+      const imei = vehicle.imei ?? "";
       const imeiMatch = imei.toLowerCase().includes(q);
       if (!plateMatch && !modelMatch && !imeiMatch) return false;
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DeliveryCallService.java
@@ -43,8 +43,7 @@ public class DeliveryCallService {
     public DispatchOrderReadResponse systemDispatch(String customerName, String customerPhone,
                                                     String address, double latitude, double longitude) {
         List<Bike> deliveryBikes = bikeRepository.findAllByDeletedAtIsNull().stream()
-                .filter(b -> b.getServiceType() == BikeServiceType.CALL
-                        || b.getServiceType() == BikeServiceType.SINGLE)
+                .filter(b -> b.getServiceType() == BikeServiceType.CALL)
                 .toList();
         if (deliveryBikes.isEmpty()) {
             throw new InvalidStateTransitionException("가용 배송 차량이 없습니다.");
@@ -72,8 +71,11 @@ public class DeliveryCallService {
     public DispatchOrderReadResponse acceptCall(UUID orderId, UUID bikeId) {
         DispatchOrder order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
                 .orElseThrow(() -> new ResourceNotFoundException("DispatchOrder", orderId));
-        bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+        if (bike.getServiceType() != BikeServiceType.CALL) {
+            throw new InvalidStateTransitionException("콜 배차 차량이 아닙니다.");
+        }
         long nextSequence = orderRepository
                 .findTopByBikeIdAndDeletedAtIsNullOrderBySequenceDesc(bikeId)
                 .map(o -> o.getSequence() + 1)

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderBulkService.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.dispatch.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.bulk.BulkApplyResponse;
 import com.thundercrew.opsapi.common.excel.ExcelExporter;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,8 +69,18 @@ public class DispatchOrderBulkService {
     /** Persist the frontend-geocoded rows. Each row is appended for its bike. */
     @Transactional
     public BulkApplyResponse apply(DispatchBulkApplyRequest request) {
+        List<UUID> bikeIds = request.rows().stream().map(DispatchBulkApplyRow::bikeId).distinct().toList();
+        Map<UUID, Bike> bikeById = new HashMap<>();
+        bikeRepository.findAllByIdIn(bikeIds).forEach(b -> bikeById.put(b.getId(), b));
+
         long applied = 0;
+        long skipped = 0;
         for (DispatchBulkApplyRow row : request.rows()) {
+            Bike bike = bikeById.get(row.bikeId());
+            if (bike == null || bike.getServiceType() != BikeServiceType.SINGLE) {
+                skipped++;
+                continue;
+            }
             commandService.appendForBike(
                     row.bikeId(),
                     row.customerName(),
@@ -81,7 +93,7 @@ public class DispatchOrderBulkService {
                     row.originLongitude());
             applied++;
         }
-        return new BulkApplyResponse(applied, 0);
+        return new BulkApplyResponse(applied, skipped);
     }
 
     /** Export currently ASSIGNED orders as rows [차량번호, 고객명, 연락처, 배송지주소]. */
@@ -118,19 +130,29 @@ public class DispatchOrderBulkService {
     /** 차량별 순번 오름차순 정렬 후 큐에 append (순번=정렬 키, 저장 sequence 는 append 연속값). */
     @Transactional
     public BulkApplyResponse applySequential(DispatchBulkApplyRequest request) {
+        List<UUID> bikeIds = request.rows().stream().map(DispatchBulkApplyRow::bikeId).distinct().toList();
+        Map<UUID, Bike> bikeById = new HashMap<>();
+        bikeRepository.findAllByIdIn(bikeIds).forEach(b -> bikeById.put(b.getId(), b));
+
         long applied = 0;
+        long skipped = 0;
         List<DispatchBulkApplyRow> ordered = request.rows().stream()
                 .sorted(Comparator
                         .comparing(DispatchBulkApplyRow::bikeId)
                         .thenComparing(r -> r.sequence() == null ? Long.MAX_VALUE : r.sequence()))
                 .toList();
         for (DispatchBulkApplyRow row : ordered) {
+            Bike bike = bikeById.get(row.bikeId());
+            if (bike == null || bike.getServiceType() != BikeServiceType.SEQUENTIAL) {
+                skipped++;
+                continue;
+            }
             commandService.appendForBike(row.bikeId(), row.customerName(), row.customerPhone(),
                     row.address(), row.latitude(), row.longitude(),
                     row.originAddress(), row.originLatitude(), row.originLongitude());
             applied++;
         }
-        return new BulkApplyResponse(applied, 0);
+        return new BulkApplyResponse(applied, skipped);
     }
 
     private DispatchBulkPreviewRow evaluateSequentialRow(List<String> cols, int rowNum) {
@@ -147,6 +169,11 @@ public class DispatchOrderBulkService {
         Optional<Bike> bike = bikeRepository.findByPlateNumberAndDeletedAtIsNull(plate);
         if (bike.isEmpty()) {
             return DispatchBulkPreviewRow.errorSeq(rowNum, plate, null, customerName, customerPhone, address, null, "차량 없음: " + plate);
+        }
+        if (bike.get().getServiceType() != BikeServiceType.SEQUENTIAL) {
+            return DispatchBulkPreviewRow.errorSeq(rowNum, plate, bike.get().getId(),
+                    customerName, customerPhone, address, null,
+                    "순차 배차 차량이 아닙니다 (서비스 유형: " + bike.get().getServiceType() + ")");
         }
         UUID bikeId = bike.get().getId();
         if (customerName.isBlank()) {
@@ -183,6 +210,11 @@ public class DispatchOrderBulkService {
         if (bike.isEmpty()) {
             return DispatchBulkPreviewRow.error(rowNum, plate, null,
                     customerName, customerPhone, address, "차량 없음: " + plate);
+        }
+        if (bike.get().getServiceType() != BikeServiceType.SINGLE) {
+            return DispatchBulkPreviewRow.error(rowNum, plate, bike.get().getId(),
+                    customerName, customerPhone, address,
+                    "단일 배차 차량이 아닙니다 (서비스 유형: " + bike.get().getServiceType() + ")");
         }
         if (customerName.isBlank()) {
             return DispatchBulkPreviewRow.error(rowNum, plate, bike.get().getId(),

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchRoundService.java
@@ -1,5 +1,8 @@
 package com.thundercrew.opsapi.dispatch.service;
 
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.dispatch.domain.DispatchBatch;
@@ -12,7 +15,9 @@ import com.thundercrew.opsapi.dispatch.dto.DispatchBulkApplyRow;
 import com.thundercrew.opsapi.dispatch.dto.DispatchRoundResponse;
 import com.thundercrew.opsapi.dispatch.repository.DispatchBatchRepository;
 import com.thundercrew.opsapi.dispatch.repository.DispatchOrderRepository;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -33,13 +38,16 @@ public class DispatchRoundService {
     private final DispatchBatchRepository batchRepository;
     private final DispatchOrderRepository orderRepository;
     private final DispatchOrderCommandService commandService;
+    private final BikeRepository bikeRepository;
 
     public DispatchRoundService(DispatchBatchRepository batchRepository,
                                 DispatchOrderRepository orderRepository,
-                                DispatchOrderCommandService commandService) {
+                                DispatchOrderCommandService commandService,
+                                BikeRepository bikeRepository) {
         this.batchRepository = batchRepository;
         this.orderRepository = orderRepository;
         this.commandService = commandService;
+        this.bikeRepository = bikeRepository;
     }
 
     /** 새 라운드 생성. 동시 활성 라운드는 1개만 허용. 각 행을 PICKUP 주문으로 적재. */
@@ -49,6 +57,16 @@ public class DispatchRoundService {
         }
         if (!batchRepository.findByStatusInAndDeletedAtIsNull(ACTIVE).isEmpty()) {
             throw new InvalidStateTransitionException("이미 진행 중인 유모차 라운드가 있습니다.");
+        }
+        List<UUID> bikeIds = request.rows().stream().map(DispatchBulkApplyRow::bikeId).distinct().toList();
+        Map<UUID, Bike> bikeById = new HashMap<>();
+        bikeRepository.findAllByIdIn(bikeIds).forEach(b -> bikeById.put(b.getId(), b));
+        for (DispatchBulkApplyRow row : request.rows()) {
+            Bike bike = bikeById.get(row.bikeId());
+            if (bike == null || bike.getServiceType() != BikeServiceType.ROUND) {
+                String plateOrId = bike != null ? bike.getPlateNumber() : row.bikeId().toString();
+                throw new InvalidStateTransitionException("왕복 배차 차량이 아닙니다: " + plateOrId);
+            }
         }
         DispatchBatch batch = batchRepository.save(DispatchBatch.create());
         for (DispatchBulkApplyRow row : request.rows()) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DeliveryCallApiContractTests.java
@@ -239,16 +239,39 @@ class DeliveryCallApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isConflict());
     }
 
+    // ⑦ acceptCall with non-CALL bike → 409
+    @Test
+    void acceptCallWithNonCallBikeIsRejected() throws Exception {
+        seedCleaningBike(BIKE_C_ID, "순차-C2", "VIN-SEQ-C-007");
+
+        MvcResult offerResult = mockMvc.perform(post("/api/v1/dispatch-orders/calls/offer")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callBody("거절고객", "010-6666-6666", "서울 은평구 응암동 1")))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String offeredId = extractId(offerResult.getResponse().getContentAsString());
+
+        mockMvc.perform(post("/api/v1/dispatch-orders/calls/{id}/accept", offeredId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"bikeId":"%s"}
+                                """.formatted(BIKE_C_ID)))
+                .andExpect(status().isConflict());
+    }
+
     // --- helpers ---------------------------------------------------------
 
     /**
-     * Seed a SINGLE bike (service_type = 'SINGLE') using inline SQL.
-     * SINGLE is the delivery-family type (formerly DELIVERY) eligible for systemDispatch.
+     * Seed a CALL bike (service_type = 'CALL') using inline SQL.
+     * CALL is the only type eligible for systemDispatch and acceptCall.
      */
     private void seedDeliveryBike(UUID id, String plateNumber, String vin) {
         jdbcTemplate.update("""
                 insert into bikes (id, plate_number, vin, model_name, engine_type, service_type, operation_status, ignition_blocked)
-                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'SINGLE', 'IN_SERVICE', false)
+                values (?, ?, ?, 'Thunder M1', 'ELECTRIC', 'CALL', 'IN_SERVICE', false)
                 """, id, plateNumber, vin);
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchOrderApiContractTests.java
@@ -41,8 +41,10 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
 
     private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID SEQ_BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbd");
     private static final UUID DEVICE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
     private static final String BIKE_PLATE = "서울CC-0001";
+    private static final String SEQ_BIKE_PLATE = "서울CC-0009";
 
     /** Matches dispatch-template.xlsx: 0-based row 2 is the first data row (header at row 1). */
     private static final int DATA_START_ROW = 2;
@@ -81,7 +83,8 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
                 values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
                 """, ADMIN_ID, passwordEncoder.encode("correct-password"));
 
-        seedBike(BIKE_ID, BIKE_PLATE, "VIN-DISPATCH-001", "IN_SERVICE");
+        seedBike(BIKE_ID, BIKE_PLATE, "VIN-DISPATCH-001", "IN_SERVICE", "SINGLE");
+        seedBike(SEQ_BIKE_ID, SEQ_BIKE_PLATE, "VIN-DISPATCH-SEQ-001", "IN_SERVICE", "SEQUENTIAL");
 
         accessToken = loginAndExtractToken();
     }
@@ -298,10 +301,10 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
     @Test
     void bulkPreviewSequentialReturnsSequenceOnNewRowsAndErrorOnInvalidSequence() throws Exception {
         byte[] xlsx = buildSequentialWorkbook(
-                new String[]{BIKE_PLATE, "순차고객A", "010-1111-2222", "순차 주소 A", "2"},
-                new String[]{BIKE_PLATE, "순차고객B", "010-3333-4444", "순차 주소 B", "1"},
-                new String[]{BIKE_PLATE, "순번없음", "010-5555-6666", "주소 C", ""},
-                new String[]{BIKE_PLATE, "순번오류", "010-7777-8888", "주소 D", "abc"});
+                new String[]{SEQ_BIKE_PLATE, "순차고객A", "010-1111-2222", "순차 주소 A", "2"},
+                new String[]{SEQ_BIKE_PLATE, "순차고객B", "010-3333-4444", "순차 주소 B", "1"},
+                new String[]{SEQ_BIKE_PLATE, "순번없음", "010-5555-6666", "주소 C", ""},
+                new String[]{SEQ_BIKE_PLATE, "순번오류", "010-7777-8888", "주소 D", "abc"});
 
         MockMultipartFile file = new MockMultipartFile(
                 "file", "upload-seq.xlsx",
@@ -342,7 +345,7 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
                      "address":"주소 B","latitude":37.50,"longitude":127.00,"sequence":2}
                   ]
                 }
-                """.formatted(BIKE_ID);
+                """.formatted(SEQ_BIKE_ID);
 
         mockMvc.perform(post("/api/v1/dispatch-orders/bulk-apply-sequential")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
@@ -354,7 +357,7 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
 
         // 큐 조회: appendForBike 는 순번 오름차순으로 호출되었으므로 저장 sequence 1→A, 2→B, 3→C
         mockMvc.perform(get("/api/v1/dispatch-orders")
-                        .param("bikeId", BIKE_ID.toString())
+                        .param("bikeId", SEQ_BIKE_ID.toString())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(3))
@@ -413,6 +416,48 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
                 .andExpect(jsonPath("$[0].originAddress").value("출발지 주소"))
                 .andExpect(jsonPath("$[0].originLatitude").value(37.48))
                 .andExpect(jsonPath("$[0].originLongitude").value(126.98));
+    }
+
+    // ⑩ bulk-preview service type: SEQ 차량으로 단일 preview → ERROR (서비스 유형 불일치)
+    @Test
+    void bulkPreviewReturnsErrorForNonSingleBike() throws Exception {
+        byte[] xlsx = buildUploadWorkbook(
+                new String[]{SEQ_BIKE_PLATE, "순차고객", "010-7777-7777", "주소"});
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "upload-type.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", xlsx);
+
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/bulk-preview")
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows.length()").value(1))
+                .andExpect(jsonPath("$.rows[0].status").value("ERROR"))
+                .andExpect(jsonPath("$.rows[0].message").value(org.hamcrest.Matchers.containsString("단일 배차 차량이 아닙니다")))
+                .andExpect(jsonPath("$.summary.error").value(1))
+                .andExpect(jsonPath("$.summary.new").value(0));
+    }
+
+    // ⑪ bulk-preview-sequential service type: SINGLE 차량으로 순차 preview → ERROR (서비스 유형 불일치)
+    @Test
+    void bulkPreviewSequentialReturnsErrorForNonSequentialBike() throws Exception {
+        byte[] xlsx = buildSequentialWorkbook(
+                new String[]{BIKE_PLATE, "단일고객", "010-8888-8888", "주소", "1"});
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "upload-seq-type.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", xlsx);
+
+        mockMvc.perform(multipart("/api/v1/dispatch-orders/bulk-preview-sequential")
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows.length()").value(1))
+                .andExpect(jsonPath("$.rows[0].status").value("ERROR"))
+                .andExpect(jsonPath("$.rows[0].message").value(org.hamcrest.Matchers.containsString("순차 배차 차량이 아닙니다")))
+                .andExpect(jsonPath("$.summary.error").value(1))
+                .andExpect(jsonPath("$.summary.new").value(0));
     }
 
     // --- helpers ---------------------------------------------------------
@@ -493,11 +538,11 @@ class DispatchOrderApiContractTests extends PostgresContainerSupport {
         }
     }
 
-    private void seedBike(UUID id, String plateNumber, String vin, String operationStatus) {
+    private void seedBike(UUID id, String plateNumber, String vin, String operationStatus, String serviceType) {
         jdbcTemplate.update("""
-                insert into bikes (id, plate_number, vin, model_name, operation_status)
-                values (?, ?, ?, 'Thunder M1', ?)
-                """, id, plateNumber, vin, operationStatus);
+                insert into bikes (id, plate_number, vin, model_name, service_type, operation_status)
+                values (?, ?, ?, 'Thunder M1', ?, ?)
+                """, id, plateNumber, vin, serviceType, operationStatus);
     }
 
     private void insertCurrentState(UUID bikeId, UUID deviceId, Instant receivedAt,

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/DispatchRoundApiContractTests.java
@@ -33,9 +33,10 @@ import org.springframework.test.web.servlet.MvcResult;
 @ActiveProfiles("test")
 class DispatchRoundApiContractTests extends PostgresContainerSupport {
 
-    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab");
-    private static final UUID BIKE_ID  = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbc");
-    private static final UUID DEVICE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccd");
+    private static final UUID ADMIN_ID   = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab");
+    private static final UUID BIKE_ID    = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbc");
+    private static final UUID SINGLE_BIKE_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbe");
+    private static final UUID DEVICE_ID  = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccd");
     private static final String BIKE_PLATE = "서울CC-0002";
 
     private static final Pattern ACCESS_TOKEN_PATTERN =
@@ -75,6 +76,7 @@ class DispatchRoundApiContractTests extends PostgresContainerSupport {
                 """, ADMIN_ID, passwordEncoder.encode("correct-password"));
 
         seedBike(BIKE_ID, BIKE_PLATE, "VIN-ROUND-001", "IN_SERVICE");
+        seedBikeWithServiceType(SINGLE_BIKE_ID, "서울CC-0010", "VIN-SINGLE-ROUND-001", "IN_SERVICE", "SINGLE");
 
         accessToken = loginAndExtractToken();
     }
@@ -224,6 +226,21 @@ class DispatchRoundApiContractTests extends PostgresContainerSupport {
                         .value(org.hamcrest.Matchers.contains("PICKUP")));
     }
 
+    // ⑦ createRound with non-ROUND bike → 409 (invalid service type)
+    @Test
+    void createRoundWithNonRoundBikeIsRejected() throws Exception {
+        String body = """
+                {"rows":[{"bikeId":"%s","customerName":"비라운드","customerPhone":"010-9999-1111",
+                 "address":"서울 강남구 역삼동 1","latitude":37.4987,"longitude":127.0276}]}
+                """.formatted(SINGLE_BIKE_ID);
+
+        mockMvc.perform(post("/api/v1/dispatch-batches/round")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+
     // --- helpers ---------------------------------------------------------
 
     private String buildRoundBody(int n) {
@@ -293,9 +310,17 @@ class DispatchRoundApiContractTests extends PostgresContainerSupport {
 
     private void seedBike(UUID id, String plateNumber, String vin, String operationStatus) {
         jdbcTemplate.update("""
-                insert into bikes (id, plate_number, vin, model_name, operation_status)
-                values (?, ?, ?, 'Thunder M1', ?)
+                insert into bikes (id, plate_number, vin, model_name, service_type, operation_status)
+                values (?, ?, ?, 'Thunder M1', 'ROUND', ?)
                 """, id, plateNumber, vin, operationStatus);
+    }
+
+    private void seedBikeWithServiceType(UUID id, String plateNumber, String vin,
+                                         String operationStatus, String serviceType) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, service_type, operation_status)
+                values (?, ?, ?, 'Thunder M1', ?, ?)
+                """, id, plateNumber, vin, serviceType, operationStatus);
     }
 
     private void insertCurrentState(UUID bikeId, UUID deviceId, Instant receivedAt,


### PR DESCRIPTION
@
## A. IMEI 통일
차량 tab 하단 테이블이 IMEI를 device deviceUid로 표시해 자원 관리(=Bike.imei)와 불일치했습니다. VehiclesPanel + filter-compute가 `vehicle.imei`를 쓰도록 통일하고, 안 쓰게 된 `deviceUidByBikeId` prop 체인(page→FullscreenMapHost→BottomMapPanel→VehiclesPanel) 제거. 차량 상세의 "단말기 연동(deviceUid)" 편집 필드는 그대로(의도).

## B. 서비스 타입별 배차 제한
배차 흐름이 차량 서비스 타입과 일치해야만 배차되도록: **콜→CALL, 단일→SINGLE, 순차→SEQUENTIAL, 왕복→ROUND** (OTHER 불가).
- 단일/순차 벌크: 미리보기 불일치 행 ERROR + 적용 시 스킵.
- 왕복: createRound에서 ROUND 아닌 차량 있으면 거부.
- 콜: systemDispatch를 CALL 전용으로(기존 CALL|SINGLE), acceptCall이 CALL 아니면 거부.
- 각 거부 경로 contract 테스트 추가.

## 검증
프론트 typecheck/lint/build + 백엔드 compileJava/compileTestJava + ArchUnit(신규 위반 없음) 통과. 마이그레이션 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@