### PR TITLE
release: P0 라이더 웹앱 인증 기반 (dev→main)

### DIFF
--- a/development/front-admin-web/app/rider/actions.ts
+++ b/development/front-admin-web/app/rider/actions.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { riderApiConfigured, riderLogout } from "@/lib/services/rider-api";
+import { clearRiderSession, getRiderAccessToken } from "@/lib/services/rider-session";
+
+export async function logoutRiderAction(): Promise<void> {
+  const accessToken = await getRiderAccessToken();
+  try {
+    if (riderApiConfigured() && accessToken) {
+      await riderLogout(accessToken);
+    }
+  } catch {
+    // 무상태 — 서버 로그아웃 실패해도 쿠키 정리가 최종 기준.
+  }
+  await clearRiderSession();
+  redirect("/rider/login");
+}

--- a/development/front-admin-web/app/rider/login/login-action.ts
+++ b/development/front-admin-web/app/rider/login/login-action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { riderApiConfigured, riderLogin } from "@/lib/services/rider-api";
+import { setRiderSession } from "@/lib/services/rider-session";
+
+export async function loginRiderAction(formData: FormData): Promise<{ error: string } | void> {
+  const phoneNumber = String(formData.get("phoneNumber") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+
+  if (!phoneNumber || !password) {
+    return { error: "전화번호와 비밀번호를 입력하세요." };
+  }
+  if (!riderApiConfigured()) {
+    return { error: "서버가 구성되지 않았습니다. 관리자에게 문의하세요." };
+  }
+
+  try {
+    const auth = await riderLogin(phoneNumber, password);
+    await setRiderSession(auth);
+  } catch {
+    return { error: "전화번호 또는 비밀번호가 올바르지 않습니다." };
+  }
+
+  redirect("/rider");
+}

--- a/development/front-admin-web/app/rider/login/page.tsx
+++ b/development/front-admin-web/app/rider/login/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { loginRiderAction } from "./login-action";
+
+export default function RiderLoginPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function onSubmit(formData: FormData) {
+    setError(null);
+    startTransition(async () => {
+      const result = await loginRiderAction(formData);
+      if (result?.error) {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: "0 auto", padding: "48px 16px" }}>
+      <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 24 }}>썬더크루 라이더 로그인</h1>
+      <form action={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>전화번호</span>
+          <input
+            name="phoneNumber"
+            type="tel"
+            inputMode="tel"
+            autoComplete="username"
+            placeholder="010-0000-0000"
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>비밀번호</span>
+          <input name="password" type="password" autoComplete="current-password" required />
+        </label>
+        {error ? <p style={{ color: "#dc2626", fontSize: 14, margin: 0 }}>{error}</p> : null}
+        <button type="submit" disabled={pending} style={{ marginTop: 8, padding: "10px 0" }}>
+          {pending ? "로그인 중…" : "로그인"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/development/front-admin-web/app/rider/page.tsx
+++ b/development/front-admin-web/app/rider/page.tsx
@@ -1,0 +1,57 @@
+import { redirect } from "next/navigation";
+
+import { riderApiConfigured, riderGetMe, type RiderMe } from "@/lib/services/rider-api";
+import { getRiderAccessToken } from "@/lib/services/rider-session";
+
+import { logoutRiderAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function RiderHomePage() {
+  if (!riderApiConfigured()) {
+    return <main style={{ padding: 24 }}>서버가 구성되지 않았습니다.</main>;
+  }
+
+  const accessToken = await getRiderAccessToken();
+  if (!accessToken) {
+    redirect("/rider/login");
+  }
+
+  let me: RiderMe;
+  try {
+    me = await riderGetMe(accessToken);
+  } catch {
+    redirect("/rider/login");
+  }
+
+  return (
+    <main style={{ maxWidth: 480, margin: "0 auto", padding: 24 }}>
+      <h1 style={{ fontSize: 20, fontWeight: 700 }}>안녕하세요, {me.name} 님</h1>
+      <dl style={{ marginTop: 16, lineHeight: 1.8 }}>
+        <div>
+          <dt style={{ display: "inline", color: "#6b7280" }}>전화번호 </dt>
+          <dd style={{ display: "inline", margin: 0 }}>{me.phoneNumber}</dd>
+        </div>
+        {me.teamName ? (
+          <div>
+            <dt style={{ display: "inline", color: "#6b7280" }}>팀 </dt>
+            <dd style={{ display: "inline", margin: 0 }}>{me.teamName}</dd>
+          </div>
+        ) : null}
+        {me.areaName ? (
+          <div>
+            <dt style={{ display: "inline", color: "#6b7280" }}>지역 </dt>
+            <dd style={{ display: "inline", margin: 0 }}>{me.areaName}</dd>
+          </div>
+        ) : null}
+        <div>
+          <dt style={{ display: "inline", color: "#6b7280" }}>배정 차량 </dt>
+          <dd style={{ display: "inline", margin: 0 }}>{me.activeBikeId ?? "없음"}</dd>
+        </div>
+      </dl>
+      <form action={logoutRiderAction} style={{ marginTop: 24 }}>
+        <button type="submit">로그아웃</button>
+      </form>
+    </main>
+  );
+}

--- a/development/front-admin-web/lib/services/rider-api.ts
+++ b/development/front-admin-web/lib/services/rider-api.ts
@@ -1,0 +1,99 @@
+// 라이더 웹앱(P0) 전용 자기완결형 API 클라이언트. admin service-ops-api 와 분리해
+// 결합도를 낮춘다. 서버 사이드(server action/component)에서만 호출.
+
+const RIDER_API_PREFIX = "/api/v1";
+
+function baseUrl(): string | null {
+  const raw = (process.env.SERVICE_OPS_API_BASE_URL ?? "").trim();
+  if (!raw || raw.includes("<") || raw.includes(">")) return null;
+  try {
+    return new URL(raw).toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+export function riderApiConfigured(): boolean {
+  return baseUrl() !== null;
+}
+
+export class RiderApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "RiderApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export type RiderAuthResponse = {
+  tokenType: string;
+  accessToken: string;
+  expiresAt: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+  rider: { id: string; name: string; phoneNumber: string };
+};
+
+export type RiderMe = {
+  id: string;
+  name: string;
+  phoneNumber: string;
+  teamName: string | null;
+  areaName: string | null;
+  activeBikeId: string | null;
+};
+
+async function call<T>(path: string, init: RequestInit, accessToken?: string): Promise<T> {
+  const base = baseUrl();
+  if (!base) {
+    throw new RiderApiError("SERVICE_OPS_API_BASE_URL is not configured.", 0, "RIDER_API_NOT_CONFIGURED");
+  }
+  const headers = new Headers(init.headers);
+  if (init.body && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  if (accessToken) {
+    headers.set("authorization", `Bearer ${accessToken}`);
+  }
+  const response = await fetch(`${base}${RIDER_API_PREFIX}${path}`, { ...init, headers, cache: "no-store" });
+  if (!response.ok) {
+    let code: string | undefined;
+    try {
+      const body = (await response.json()) as { code?: string };
+      code = body.code;
+    } catch {
+      // 본문 파싱 실패는 무시
+    }
+    throw new RiderApiError(`Rider API ${path} failed (${response.status}).`, response.status, code);
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+export function riderLogin(phoneNumber: string, password: string): Promise<RiderAuthResponse> {
+  return call<RiderAuthResponse>("/rider-auth/login", {
+    method: "POST",
+    body: JSON.stringify({ phoneNumber, password })
+  });
+}
+
+export function riderRefresh(refreshToken: string): Promise<RiderAuthResponse> {
+  return call<RiderAuthResponse>("/rider-auth/refresh", {
+    method: "POST",
+    body: JSON.stringify({ refreshToken })
+  });
+}
+
+export function riderLogout(accessToken: string): Promise<void> {
+  return call<void>("/rider-auth/logout", { method: "POST" }, accessToken);
+}
+
+export function riderGetMe(accessToken: string): Promise<RiderMe> {
+  return call<RiderMe>("/rider/me", { method: "GET" }, accessToken);
+}

--- a/development/front-admin-web/lib/services/rider-session.ts
+++ b/development/front-admin-web/lib/services/rider-session.ts
@@ -1,0 +1,33 @@
+import { cookies } from "next/headers";
+
+import { type RiderAuthResponse } from "./rider-api";
+
+export const RIDER_ACCESS_TOKEN_COOKIE = "thundercrew_rider_access_token";
+export const RIDER_REFRESH_TOKEN_COOKIE = "thundercrew_rider_refresh_token";
+
+function secure(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function parseExpires(value: string): Date {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date(Date.now() + 30 * 60 * 1000) : parsed;
+}
+
+export async function setRiderSession(auth: RiderAuthResponse): Promise<void> {
+  const store = await cookies();
+  const common = { httpOnly: true as const, path: "/" as const, sameSite: "lax" as const, secure: secure() };
+  store.set(RIDER_ACCESS_TOKEN_COOKIE, auth.accessToken, { ...common, expires: parseExpires(auth.expiresAt) });
+  store.set(RIDER_REFRESH_TOKEN_COOKIE, auth.refreshToken, { ...common, expires: parseExpires(auth.refreshExpiresAt) });
+}
+
+export async function clearRiderSession(): Promise<void> {
+  const store = await cookies();
+  store.delete(RIDER_ACCESS_TOKEN_COOKIE);
+  store.delete(RIDER_REFRESH_TOKEN_COOKIE);
+}
+
+export async function getRiderAccessToken(): Promise<string | null> {
+  const store = await cookies();
+  return store.get(RIDER_ACCESS_TOKEN_COOKIE)?.value ?? null;
+}

--- a/development/front-admin-web/middleware.ts
+++ b/development/front-admin-web/middleware.ts
@@ -8,6 +8,10 @@ import { NextResponse, type NextRequest } from "next/server";
 const SERVICE_OPS_ACCESS_TOKEN_COOKIE = "thundercrew_ops_access_token";
 const SERVICE_OPS_REFRESH_TOKEN_COOKIE = "thundercrew_ops_refresh_token";
 
+// 라이더 웹앱(/rider/*)은 별도 쿠키 + role=RIDER JWT 로 게이트한다.
+const RIDER_ACCESS_TOKEN_COOKIE = "thundercrew_rider_access_token";
+const RIDER_REFRESH_TOKEN_COOKIE = "thundercrew_rider_refresh_token";
+
 // 인증 API base URL. 빌드 타임에 박힌다 — 서버 사이드 전용 변수이지만 Edge
 // 런타임에서도 `process.env.X` 로 접근 가능 (next.config 에서 노출 처리 안
 // 해도 됨, 동일 프로세스 내 환경 변수).
@@ -40,6 +44,12 @@ type RefreshResponse = {
  */
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // 라이더 앱 경로는 운영자 게이트와 완전히 분리해서 처리한다.
+  if (pathname === "/rider" || pathname.startsWith("/rider/")) {
+    return riderGate(request, pathname);
+  }
+
   const accessToken = request.cookies.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value;
   const refreshToken = request.cookies.get(SERVICE_OPS_REFRESH_TOKEN_COOKIE)?.value;
 
@@ -143,6 +153,87 @@ function clearAuthCookiesAndRedirectToLogin(request: NextRequest): NextResponse 
 function parseCookieExpires(value: string): Date {
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? new Date(Date.now() + 30 * 60 * 1000) : parsed;
+}
+
+/**
+ * 라이더 앱(/rider/*) 입장 게이트 + 만료 access token 자동 재발급. 운영자 게이트와
+ * 동일한 구조지만 라이더 쿠키 + role=RIDER refresh 엔드포인트(/api/v1/rider-auth/refresh)를
+ * 쓴다. 미인증 시 /rider/login 으로 보낸다.
+ */
+async function riderGate(request: NextRequest, pathname: string): Promise<NextResponse> {
+  const accessToken = request.cookies.get(RIDER_ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = request.cookies.get(RIDER_REFRESH_TOKEN_COOKIE)?.value;
+
+  if (pathname === "/rider/login") {
+    if (accessToken || refreshToken) {
+      return NextResponse.redirect(new URL("/rider", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (!accessToken && !refreshToken) {
+    return clearRiderCookiesAndRedirect(request);
+  }
+  if (accessToken) {
+    return NextResponse.next();
+  }
+  if (!refreshToken || !SERVICE_OPS_API_BASE_URL) {
+    return clearRiderCookiesAndRedirect(request);
+  }
+
+  const refreshed = await refreshRiderAccessToken(refreshToken);
+  if (!refreshed) {
+    return clearRiderCookiesAndRedirect(request);
+  }
+
+  request.cookies.set(RIDER_ACCESS_TOKEN_COOKIE, refreshed.accessToken);
+  request.cookies.set(RIDER_REFRESH_TOKEN_COOKIE, refreshed.refreshToken);
+
+  const response = NextResponse.next({ request: { headers: request.headers } });
+  const secure = process.env.NODE_ENV === "production";
+  response.cookies.set({
+    name: RIDER_ACCESS_TOKEN_COOKIE,
+    value: refreshed.accessToken,
+    expires: parseCookieExpires(refreshed.expiresAt),
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secure
+  });
+  response.cookies.set({
+    name: RIDER_REFRESH_TOKEN_COOKIE,
+    value: refreshed.refreshToken,
+    expires: parseCookieExpires(refreshed.refreshExpiresAt),
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secure
+  });
+  return response;
+}
+
+async function refreshRiderAccessToken(refreshToken: string): Promise<RefreshResponse | null> {
+  try {
+    const result = await fetch(`${SERVICE_OPS_API_BASE_URL.replace(/\/+$/, "")}/api/v1/rider-auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      cache: "no-store"
+    });
+    if (!result.ok) return null;
+    const json = (await result.json()) as RefreshResponse;
+    if (!json.accessToken || !json.refreshToken) return null;
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+function clearRiderCookiesAndRedirect(request: NextRequest): NextResponse {
+  const response = NextResponse.redirect(new URL("/rider/login", request.url));
+  response.cookies.delete(RIDER_ACCESS_TOKEN_COOKIE);
+  response.cookies.delete(RIDER_REFRESH_TOKEN_COOKIE);
+  return response;
 }
 
 /**

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
@@ -2,14 +2,16 @@ package com.thundercrew.opsapi.auth.config;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.util.List;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
-import com.thundercrew.opsapi.common.api.ApiErrorResponse;
 import com.thundercrew.opsapi.auth.service.AdminSessionJwtValidator;
+import com.thundercrew.opsapi.auth.service.RoleAwareJwtValidator;
+import com.thundercrew.opsapi.common.api.ApiErrorResponse;
 import com.thundercrew.opsapi.common.api.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +21,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,15 +31,14 @@ import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtClaimValidator;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
-import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.util.StringUtils;
 
 @Configuration
 public class SecurityConfig {
@@ -55,7 +58,8 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(
             HttpSecurity http,
-            AuthenticationEntryPoint authenticationEntryPoint
+            AuthenticationEntryPoint authenticationEntryPoint,
+            JwtAuthenticationConverter jwtAuthenticationConverter
     ) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -63,13 +67,35 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health", "/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
-                        .anyRequest().authenticated())
+                        .requestMatchers(
+                                "/actuator/health",
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/refresh",
+                                "/api/v1/rider-auth/login",
+                                "/api/v1/rider-auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/rider/**", "/api/v1/rider-auth/logout").hasRole("RIDER")
+                        .anyRequest().hasRole("ADMIN"))
                 .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .authenticationEntryPoint(authenticationEntryPoint)
-                        .jwt(jwt -> { }))
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)))
                 .build();
+    }
+
+    @Bean
+    JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            String role = jwt.getClaimAsString("role");
+            if ("ADMIN".equals(role)) {
+                return List.<GrantedAuthority>of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            }
+            if ("RIDER".equals(role) && "access".equals(jwt.getClaimAsString("tokenType"))) {
+                return List.<GrantedAuthority>of(new SimpleGrantedAuthority("ROLE_RIDER"));
+            }
+            return List.<GrantedAuthority>of();
+        });
+        return converter;
     }
 
     @Bean
@@ -88,10 +114,7 @@ public class SecurityConfig {
                 .build();
         OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
                 JwtValidators.createDefaultWithIssuer(issuer),
-                new JwtClaimValidator<String>("adminUserId", StringUtils::hasText),
-                new JwtClaimValidator<String>("loginId", StringUtils::hasText),
-                new JwtClaimValidator<String>("role", "ADMIN"::equals),
-                adminSessionJwtValidator
+                new RoleAwareJwtValidator(adminSessionJwtValidator)
         );
         decoder.setJwtValidator(validator);
         return decoder;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/RoleAwareJwtValidator.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/service/RoleAwareJwtValidator.java
@@ -1,0 +1,46 @@
+package com.thundercrew.opsapi.auth.service;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.StringUtils;
+
+/**
+ * 공유 JwtDecoder 가 admin/rider 토큰을 모두 받도록, role 클레임으로 검증을 분기한다.
+ * ADMIN: adminUserId/loginId 존재 + 활성 admin 세션(AdminSessionJwtValidator).
+ * RIDER: riderId 존재(무상태). 그 외 role 은 거부.
+ */
+public class RoleAwareJwtValidator implements OAuth2TokenValidator<Jwt> {
+
+    private static final OAuth2Error INVALID_TOKEN = new OAuth2Error(
+            "invalid_token",
+            "Token role or required claims are missing or invalid.",
+            null
+    );
+
+    private final OAuth2TokenValidator<Jwt> adminSessionValidator;
+
+    public RoleAwareJwtValidator(OAuth2TokenValidator<Jwt> adminSessionValidator) {
+        this.adminSessionValidator = adminSessionValidator;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt token) {
+        String role = token.getClaimAsString("role");
+        if ("ADMIN".equals(role)) {
+            if (!StringUtils.hasText(token.getClaimAsString("adminUserId"))
+                    || !StringUtils.hasText(token.getClaimAsString("loginId"))) {
+                return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+            }
+            return adminSessionValidator.validate(token);
+        }
+        if ("RIDER".equals(role)) {
+            if (!StringUtils.hasText(token.getClaimAsString("riderId"))) {
+                return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+            }
+            return OAuth2TokenValidatorResult.success();
+        }
+        return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
@@ -84,4 +84,13 @@ public interface RiderBikeContractRepository extends Repository<RiderBikeContrac
             limit 1
             """, nativeQuery = true)
     Optional<RiderBikeContract> findActiveByBikeId(@Param("bikeId") UUID bikeId);
+
+    @Query(value = """
+            select * from rider_bike_contracts
+            where rider_id = :riderId
+              and terminated_at is null
+              and deleted_at is null
+            limit 1
+            """, nativeQuery = true)
+    Optional<RiderBikeContract> findActiveByRiderId(@Param("riderId") UUID riderId);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
@@ -1,0 +1,27 @@
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.rider.dto.RiderMeResponse;
+import com.thundercrew.opsapi.rider.service.RiderSelfReadService;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider")
+public class RiderSelfReadController {
+
+    private final RiderSelfReadService riderSelfReadService;
+
+    public RiderSelfReadController(RiderSelfReadService riderSelfReadService) {
+        this.riderSelfReadService = riderSelfReadService;
+    }
+
+    @GetMapping("/me")
+    RiderMeResponse me(@AuthenticationPrincipal Jwt jwt) {
+        UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+        return riderSelfReadService.getMe(riderId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderMeResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderMeResponse.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import java.util.UUID;
+
+public record RiderMeResponse(
+        UUID id,
+        String name,
+        String phoneNumber,
+        String teamName,
+        String areaName,
+        UUID activeBikeId
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderSelfReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderSelfReadService.java
@@ -1,0 +1,43 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.domain.RiderBikeContract;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.dto.RiderMeResponse;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderSelfReadService {
+
+    private final RiderRepository riderRepository;
+    private final RiderBikeContractRepository riderBikeContractRepository;
+
+    public RiderSelfReadService(
+            RiderRepository riderRepository,
+            RiderBikeContractRepository riderBikeContractRepository
+    ) {
+        this.riderRepository = riderRepository;
+        this.riderBikeContractRepository = riderBikeContractRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public RiderMeResponse getMe(UUID riderId) {
+        Rider rider = riderRepository.findByIdAndDeletedAtIsNull(riderId)
+                .orElseThrow(() -> new ResourceNotFoundException("Rider", riderId));
+        UUID activeBikeId = riderBikeContractRepository.findActiveByRiderId(riderId)
+                .map(RiderBikeContract::getBikeId)
+                .orElse(null);
+        return new RiderMeResponse(
+                rider.getId(),
+                rider.getName(),
+                rider.getPhoneNumber(),
+                rider.getTeamName(),
+                rider.getAreaName(),
+                activeBikeId
+        );
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthController.java
@@ -1,0 +1,42 @@
+package com.thundercrew.opsapi.riderauth.controller;
+
+import com.thundercrew.opsapi.riderauth.dto.RiderLoginRequest;
+import com.thundercrew.opsapi.riderauth.dto.RiderLoginResponse;
+import com.thundercrew.opsapi.riderauth.dto.RiderRefreshRequest;
+import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider-auth")
+public class RiderAuthController {
+
+    private final RiderAuthService riderAuthService;
+
+    public RiderAuthController(RiderAuthService riderAuthService) {
+        this.riderAuthService = riderAuthService;
+    }
+
+    @PostMapping("/login")
+    RiderLoginResponse login(@Valid @RequestBody RiderLoginRequest request) {
+        return riderAuthService.login(request);
+    }
+
+    @PostMapping("/refresh")
+    RiderLoginResponse refresh(@Valid @RequestBody RiderRefreshRequest request) {
+        return riderAuthService.refresh(request);
+    }
+
+    /**
+     * 무상태 라이더 JWT 라 서버측에서 폐기할 세션이 없다. 클라이언트가 쿠키를
+     * 지우면 로그아웃. 후속에 라이더 세션 테이블을 도입하면 여기서 revoke.
+     */
+    @PostMapping("/logout")
+    ResponseEntity<Void> logout() {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.thundercrew.opsapi.riderauth.controller;
+
+import com.thundercrew.opsapi.common.api.ApiErrorResponse;
+import com.thundercrew.opsapi.common.api.ErrorCode;
+import com.thundercrew.opsapi.riderauth.service.RiderAuthenticationException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = {RiderAuthController.class, RiderCredentialAdminController.class})
+public class RiderAuthExceptionHandler {
+
+    private final Clock clock;
+
+    public RiderAuthExceptionHandler(Clock clock) {
+        this.clock = clock;
+    }
+
+    @ExceptionHandler(RiderAuthenticationException.class)
+    ResponseEntity<ApiErrorResponse> handleRiderAuthentication(
+            RiderAuthenticationException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.AUTHENTICATION_FAILED,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderCredentialAdminController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderCredentialAdminController.java
@@ -1,0 +1,36 @@
+package com.thundercrew.opsapi.riderauth.controller;
+
+import com.thundercrew.opsapi.riderauth.dto.RiderCredentialUpdateRequest;
+import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자가 라이더의 앱 비밀번호를 발급/재설정. ADMIN 전용
+ * (/api/v1/riders/** 는 SecurityConfig 에서 hasRole("ADMIN")).
+ */
+@RestController
+@RequestMapping("/api/v1/riders")
+public class RiderCredentialAdminController {
+
+    private final RiderAuthService riderAuthService;
+
+    public RiderCredentialAdminController(RiderAuthService riderAuthService) {
+        this.riderAuthService = riderAuthService;
+    }
+
+    @PatchMapping("/{id}/credential")
+    ResponseEntity<Void> setCredential(
+            @PathVariable UUID id,
+            @Valid @RequestBody RiderCredentialUpdateRequest request
+    ) {
+        riderAuthService.setPassword(id, request.newPassword());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/domain/RiderCredential.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/domain/RiderCredential.java
@@ -1,0 +1,40 @@
+package com.thundercrew.opsapi.riderauth.domain;
+
+import com.thundercrew.opsapi.common.domain.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "rider_credentials")
+public class RiderCredential extends AuditableEntity {
+
+    @Column(nullable = false)
+    private UUID riderId;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    public static RiderCredential create(UUID riderId, String passwordHash) {
+        RiderCredential credential = new RiderCredential();
+        credential.riderId = riderId;
+        credential.passwordHash = passwordHash;
+        return credential;
+    }
+
+    public void updatePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public UUID getRiderId() {
+        return riderId;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    protected RiderCredential() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderCredentialUpdateRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderCredentialUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderCredentialUpdateRequest(
+        @NotBlank @Size(min = 8, max = 100) String newPassword
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderIdentityResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderIdentityResponse.java
@@ -1,0 +1,14 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import com.thundercrew.opsapi.rider.domain.Rider;
+import java.util.UUID;
+
+public record RiderIdentityResponse(
+        UUID id,
+        String name,
+        String phoneNumber
+) {
+    public static RiderIdentityResponse from(Rider rider) {
+        return new RiderIdentityResponse(rider.getId(), rider.getName(), rider.getPhoneNumber());
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderLoginRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderLoginRequest.java
@@ -1,0 +1,9 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RiderLoginRequest(
+        @NotBlank String phoneNumber,
+        @NotBlank String password
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderLoginResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderLoginResponse.java
@@ -1,0 +1,22 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import java.time.Instant;
+
+public record RiderLoginResponse(
+        String tokenType,
+        String accessToken,
+        Instant expiresAt,
+        String refreshToken,
+        Instant refreshExpiresAt,
+        RiderIdentityResponse rider
+) {
+    public static RiderLoginResponse bearer(
+            String accessToken,
+            Instant expiresAt,
+            String refreshToken,
+            Instant refreshExpiresAt,
+            RiderIdentityResponse rider
+    ) {
+        return new RiderLoginResponse("Bearer", accessToken, expiresAt, refreshToken, refreshExpiresAt, rider);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderRefreshRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RiderRefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/repository/RiderCredentialRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/repository/RiderCredentialRepository.java
@@ -1,0 +1,13 @@
+package com.thundercrew.opsapi.riderauth.repository;
+
+import com.thundercrew.opsapi.riderauth.domain.RiderCredential;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface RiderCredentialRepository extends Repository<RiderCredential, UUID> {
+
+    Optional<RiderCredential> findByRiderId(UUID riderId);
+
+    RiderCredential save(RiderCredential credential);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
@@ -1,0 +1,105 @@
+package com.thundercrew.opsapi.riderauth.service;
+
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.rider.domain.Rider;
+import com.thundercrew.opsapi.rider.repository.RiderRepository;
+import com.thundercrew.opsapi.riderauth.domain.RiderCredential;
+import com.thundercrew.opsapi.riderauth.dto.RiderIdentityResponse;
+import com.thundercrew.opsapi.riderauth.dto.RiderLoginRequest;
+import com.thundercrew.opsapi.riderauth.dto.RiderLoginResponse;
+import com.thundercrew.opsapi.riderauth.dto.RiderRefreshRequest;
+import com.thundercrew.opsapi.riderauth.repository.RiderCredentialRepository;
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderAuthService {
+
+    private final RiderRepository riderRepository;
+    private final RiderCredentialRepository riderCredentialRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final RiderTokenService riderTokenService;
+    private final JwtDecoder jwtDecoder;
+
+    public RiderAuthService(
+            RiderRepository riderRepository,
+            RiderCredentialRepository riderCredentialRepository,
+            PasswordEncoder passwordEncoder,
+            RiderTokenService riderTokenService,
+            JwtDecoder jwtDecoder
+    ) {
+        this.riderRepository = riderRepository;
+        this.riderCredentialRepository = riderCredentialRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.riderTokenService = riderTokenService;
+        this.jwtDecoder = jwtDecoder;
+    }
+
+    @Transactional(readOnly = true)
+    public RiderLoginResponse login(RiderLoginRequest request) {
+        Rider rider = riderRepository.findByPhoneNumberAndDeletedAtIsNull(request.phoneNumber())
+                .orElseThrow(RiderAuthenticationException::new);
+        riderCredentialRepository.findByRiderId(rider.getId())
+                .filter(credential -> passwordEncoder.matches(request.password(), credential.getPasswordHash()))
+                .orElseThrow(RiderAuthenticationException::new);
+        return issueTokens(rider);
+    }
+
+    @Transactional(readOnly = true)
+    public RiderLoginResponse refresh(RiderRefreshRequest request) {
+        Jwt jwt;
+        try {
+            jwt = jwtDecoder.decode(request.refreshToken());
+        } catch (JwtException exception) {
+            throw new RiderAuthenticationException();
+        }
+        if (!RiderTokenService.ROLE_RIDER.equals(jwt.getClaimAsString("role"))
+                || !RiderTokenService.TOKEN_TYPE_REFRESH.equals(jwt.getClaimAsString("tokenType"))) {
+            throw new RiderAuthenticationException();
+        }
+        UUID riderId = parseRiderId(jwt.getClaimAsString("riderId"));
+        Rider rider = riderRepository.findByIdAndDeletedAtIsNull(riderId)
+                .orElseThrow(RiderAuthenticationException::new);
+        return issueTokens(rider);
+    }
+
+    @Transactional
+    public void setPassword(UUID riderId, String rawPassword) {
+        if (riderRepository.findByIdAndDeletedAtIsNull(riderId).isEmpty()) {
+            throw new ResourceNotFoundException("Rider", riderId);
+        }
+        String passwordHash = passwordEncoder.encode(rawPassword);
+        RiderCredential credential = riderCredentialRepository.findByRiderId(riderId).orElse(null);
+        if (credential == null) {
+            credential = RiderCredential.create(riderId, passwordHash);
+        } else {
+            credential.updatePasswordHash(passwordHash);
+        }
+        riderCredentialRepository.save(credential);
+    }
+
+    private RiderLoginResponse issueTokens(Rider rider) {
+        RiderTokenService.IssuedToken accessToken = riderTokenService.issueAccessToken(rider.getId());
+        RiderTokenService.IssuedToken refreshToken = riderTokenService.issueRefreshToken(rider.getId());
+        return RiderLoginResponse.bearer(
+                accessToken.value(),
+                accessToken.expiresAt(),
+                refreshToken.value(),
+                refreshToken.expiresAt(),
+                RiderIdentityResponse.from(rider)
+        );
+    }
+
+    private UUID parseRiderId(String value) {
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new RiderAuthenticationException();
+        }
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthenticationException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthenticationException.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.riderauth.service;
+
+public class RiderAuthenticationException extends RuntimeException {
+
+    public RiderAuthenticationException() {
+        super("Rider authentication failed.");
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderTokenService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderTokenService.java
@@ -1,0 +1,77 @@
+package com.thundercrew.opsapi.riderauth.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+/**
+ * 라이더용 무상태(stateless) JWT 발급. admin 토큰과 동일한 시크릿/issuer/HS256 으로
+ * 서명하되 role=RIDER, subject=riderId, riderId 클레임을 싣는다. access/refresh 를
+ * tokenType 클레임으로 구분한다 — refresh 토큰은 SecurityConfig 의 권한 변환기에서
+ * ROLE_RIDER 를 받지 못해 리소스 접근에 쓸 수 없다.
+ */
+@Service
+public class RiderTokenService {
+
+    public static final String ROLE_RIDER = "RIDER";
+    public static final String TOKEN_TYPE_ACCESS = "access";
+    public static final String TOKEN_TYPE_REFRESH = "refresh";
+
+    private final JwtEncoder jwtEncoder;
+    private final Clock clock;
+    private final String issuer;
+    private final Duration accessTokenTtl;
+    private final Duration refreshTokenTtl;
+
+    public RiderTokenService(
+            JwtEncoder jwtEncoder,
+            Clock clock,
+            @Value("${thundercrew.auth.jwt.issuer:thundercrew-domain}") String issuer,
+            @Value("${thundercrew.auth.rider.access-token-ttl:PT30M}") Duration accessTokenTtl,
+            @Value("${thundercrew.auth.rider.refresh-token-ttl:P14D}") Duration refreshTokenTtl
+    ) {
+        this.jwtEncoder = jwtEncoder;
+        this.clock = clock;
+        this.issuer = issuer;
+        this.accessTokenTtl = accessTokenTtl;
+        this.refreshTokenTtl = refreshTokenTtl;
+    }
+
+    public IssuedToken issueAccessToken(UUID riderId) {
+        return issue(riderId, TOKEN_TYPE_ACCESS, accessTokenTtl);
+    }
+
+    public IssuedToken issueRefreshToken(UUID riderId) {
+        return issue(riderId, TOKEN_TYPE_REFRESH, refreshTokenTtl);
+    }
+
+    private IssuedToken issue(UUID riderId, String tokenType, Duration ttl) {
+        Instant issuedAt = Instant.now(clock);
+        Instant expiresAt = issuedAt.plus(ttl);
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(issuer)
+                .subject(riderId.toString())
+                .id(UUID.randomUUID().toString())
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("riderId", riderId.toString())
+                .claim("role", ROLE_RIDER)
+                .claim("tokenType", tokenType)
+                .build();
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+        String token = jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+        return new IssuedToken(token, expiresAt);
+    }
+
+    public record IssuedToken(String value, Instant expiresAt) {
+    }
+}

--- a/development/service-ops-api/src/main/resources/db/migration/V46__create_rider_credentials.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V46__create_rider_credentials.sql
@@ -1,0 +1,9 @@
+create table rider_credentials (
+    id uuid primary key,
+    rider_id uuid not null unique,
+    password_hash text not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    created_by uuid,
+    updated_by uuid
+);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -116,7 +116,9 @@ class ArchitectureBoundaryTests {
                         || isTestMatchingCommand(method)
                         || isReignitionNotificationCommand(method)
                         || isNotificationCommand(method)
-                        || isAuditLogCommand(method)) {
+                        || isAuditLogCommand(method)
+                        || isRiderAuthCommand(method)
+                        || isRiderCredentialCommand(method)) {
                     return;
                 }
 
@@ -161,7 +163,9 @@ class ArchitectureBoundaryTests {
                         && !isTestMatchingCommand(method)
                         && !isReignitionNotificationCommand(method)
                         && !isNotificationCommand(method)
-                        && !isAuditLogCommand(method)) {
+                        && !isAuditLogCommand(method)
+                        && !isRiderAuthCommand(method)
+                        && !isRiderCredentialCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -330,6 +334,16 @@ class ArchitectureBoundaryTests {
     private static boolean isAuditLogCommand(JavaMethod method) {
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.audit.controller.AuditLogCommandController");
+    }
+
+    private static boolean isRiderAuthCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.riderauth.controller.RiderAuthController");
+    }
+
+    private static boolean isRiderCredentialCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.riderauth.controller.RiderCredentialAdminController");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
@@ -1,0 +1,214 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderAuthApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final String RIDER_PHONE = "010-1234-5678";
+    private static final String RIDER_PASSWORD = "rider-secret-1";
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern REFRESH_TOKEN_PATTERN = Pattern.compile("\"refreshToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String adminToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from rider_credentials");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더1', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_ID, RIDER_PHONE);
+        adminToken = loginAdminAndExtractAccessToken();
+    }
+
+    @Test
+    void adminIssuesCredentialThenRiderLogsInAndReadsOwnProfile() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+
+        MvcResult loginResult = riderLogin(RIDER_PHONE, RIDER_PASSWORD)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()))
+                .andReturn();
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, loginResult);
+
+        mockMvc.perform(get("/api/v1/rider/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()))
+                .andExpect(jsonPath("$.phoneNumber").value(RIDER_PHONE))
+                .andExpect(jsonPath("$.activeBikeId").doesNotExist());
+    }
+
+    @Test
+    void riderLoginWithWrongPasswordIsUnauthorized() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+
+        riderLogin(RIDER_PHONE, "wrong-password")
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void riderLoginWithUnknownPhoneIsUnauthorized() throws Exception {
+        riderLogin("010-0000-0000", RIDER_PASSWORD)
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void riderSelfEndpointRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/rider/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void adminTokenCannotAccessRiderSelfEndpoint() throws Exception {
+        mockMvc.perform(get("/api/v1/rider/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void riderTokenCannotAccessAdminEndpoint() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn());
+
+        mockMvc.perform(get("/api/v1/riders")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void riderRefreshRotatesAccessTokenAndNewTokenWorks() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        MvcResult loginResult = riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn();
+        String refreshToken = extract(REFRESH_TOKEN_PATTERN, loginResult);
+
+        MvcResult refreshResult = mockMvc.perform(post("/api/v1/rider-auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"%s\"}".formatted(refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()))
+                .andReturn();
+        String rotatedAccessToken = extract(ACCESS_TOKEN_PATTERN, refreshResult);
+
+        mockMvc.perform(get("/api/v1/rider/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + rotatedAccessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()));
+    }
+
+    @Test
+    void refreshRejectsAccessTokenUsedAsRefreshToken() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        String accessToken = extract(ACCESS_TOKEN_PATTERN, riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn());
+
+        mockMvc.perform(post("/api/v1/rider-auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"%s\"}".formatted(accessToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void riderCredentialIssuanceRequiresAdminAuthentication() throws Exception {
+        mockMvc.perform(patch("/api/v1/riders/{id}/credential", RIDER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newPassword\":\"%s\"}".formatted(RIDER_PASSWORD)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void issuingCredentialForUnknownRiderReturnsNotFound() throws Exception {
+        UUID unknownRiderId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        mockMvc.perform(patch("/api/v1/riders/{id}/credential", unknownRiderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newPassword\":\"%s\"}".formatted(RIDER_PASSWORD)))
+                .andExpect(status().isNotFound());
+    }
+
+    private void issueRiderCredential(UUID riderId, String password) throws Exception {
+        mockMvc.perform(patch("/api/v1/riders/{id}/credential", riderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newPassword\":\"%s\"}".formatted(password)))
+                .andExpect(status().isNoContent());
+    }
+
+    private ResultActions riderLogin(String phone, String password) throws Exception {
+        return mockMvc.perform(post("/api/v1/rider-auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"phoneNumber\":\"%s\",\"password\":\"%s\"}".formatted(phone, password)));
+    }
+
+    private String loginAdminAndExtractAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"loginId\":\"ops-admin\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extract(ACCESS_TOKEN_PATTERN, result);
+    }
+
+    private String extract(Pattern pattern, MvcResult result) throws Exception {
+        Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/specs/2026-06-17-rider-web-app-design.md
+++ b/docs/superpowers/specs/2026-06-17-rider-web-app-design.md
@@ -1,0 +1,26 @@
+# 라이더 웹앱(PWA) — 설계
+
+대형 앱 프로젝트 #1+#2. 플랫폼 = 웹앱(PWA). 위치 = 기존 front-admin-web 의 `/rider/*` 라우트. 인증 = 전화번호+비밀번호(JWT role=RIDER, 최초 비밀번호 관리자 발급).
+
+## 단계
+- **P0 기반(이번)**: 라이더 인증(전화+비밀번호, JWT role=RIDER) + 라이더-스코프 read API(내 프로필/계약/차량·내 업무·내 위치·내 알림) + 프론트 인증 스캐폴드(/rider/login, /rider, 미들웨어, 라이더 세션/클라이언트).
+- **P1 코어 UI**: 내 업무(배차 목록) + 매칭 차량 위치(지도) + 주행거리.
+- **P2**: 팁 제출(핀+로그), 알림 수신(정비/재시동), 배송 완료(사진).
+- **P3**: PWA(manifest/서비스워커/설치형).
+
+## P0 백엔드
+- V46: `rider_credentials`(rider_id uuid unique, password_hash text, + base audit).
+- `riderauth` 슬라이스: RiderCredential 엔티티/repo; RiderAuthService(인증: phone→Rider→verify→JWT; 관리자 set/reset 비밀번호); RiderAuthController `POST /api/v1/rider-auth/login|refresh|logout`. JWT role=RIDER, subject=riderId(JwtTokenService 확장 or 별도 발급).
+- 관리자: `PATCH /api/v1/riders/{id}/credential`(비밀번호 발급/재설정) — admin command + arch allow-list.
+- Security: /api/v1/rider/** 와 /api/v1/rider-auth/** 는 RIDER 토큰 허용; 기존 admin 경로는 그대로. (SecurityFilterChain/JWT 필터 확장.)
+- 라이더-스코프 read(인증된 riderId 기준): `GET /api/v1/rider/me`(프로필+활성계약+bikeId+plate), `/rider/me/dispatch-orders`, `/rider/me/vehicle`(위치·주행거리), `/rider/me/notifications`(refRiderId=me). RiderBikeContractRepository.findActiveByRiderId 신규.
+- 팁 제출: 기존 `/tips/submissions` 를 라이더용으로 래핑(`POST /rider/me/tips`)해 riderId를 인증에서 도출.
+
+## P0 프론트(스캐폴드)
+- 미들웨어: /rider/** 는 라이더 세션(별도 쿠키 thundercrew_rider_*)로 게이트 + /rider/login 리다이렉트. admin 경로 무영향.
+- 라이더 세션 모듈 + 라이더 api 클라이언트(/api/v1/rider/**).
+- `/rider/login`(전화+비밀번호), `/rider`(랜딩 최소).
+
+## 범위/원칙
+- 관리자가 라이더 비밀번호 발급(자가 가입 없음, MVP).
+- 팁/알림 라이더 전달은 P0 API + P2 UI로 완성.


### PR DESCRIPTION
## 릴리스 내용
**P0 라이더 웹앱 인증 토대** (#458) + 라이더 웹앱 설계 스펙.

라이더 모바일 웹앱(PWA, `/rider/*`)의 첫 단계 — 전화번호+비밀번호 로그인 → role=RIDER JWT → 라이더 스코프 API(`/rider/me`).

### 백엔드 (service-ops-api)
- **V46** `rider_credentials` 테이블 + `RiderCredential`
- `riderauth` 패키지: 토큰 발급(role=RIDER, access/refresh) · 로그인/refresh · 비번 발급(ADMIN 전용 `PATCH /riders/{id}/credential`)
- `RoleAwareJwtValidator` + SecurityConfig: `/rider/**`=`hasRole("RIDER")`, 그 외=`hasRole("ADMIN")` → admin↔rider 교차 접근 차단
- `GET /api/v1/rider/me` + 계약 테스트

### 프론트 (front-admin-web)
- `/rider/login`, `/rider` + middleware 라이더 게이트(role=RIDER refresh 자동 재발급)

## 검증
- backend compile + ArchUnit(riderauth 위반 0), frontend typecheck/lint/build 통과
- ⚠️ 라이더 인증 계약 테스트는 Testcontainers라 미실행 — **배포 후 prod QA 필수**

## 배포 후 QA
1. 관리자가 라이더 비번 발급(`PATCH /api/v1/riders/{id}/credential`)
2. 휴대폰에서 `/rider/login` (전화번호+비번)
3. `/rider`에서 본인 정보·배정 차량 표시 확인
4. admin 토큰으로 `/rider/me` 접근 시 403, 라이더 토큰으로 admin API 403 확인

## 마이그레이션
V46 신규 테이블 생성(파괴적 변경 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)