### PR TITLE
release: 라이더 서브도메인 분리 (dev→main)

### DIFF
--- a/development/front-admin-web/middleware.ts
+++ b/development/front-admin-web/middleware.ts
@@ -24,6 +24,12 @@ type RefreshResponse = {
   refreshExpiresAt: string;
 };
 
+function isRiderHost(request: NextRequest): boolean {
+  const host = (request.headers.get("host") ?? request.nextUrl.hostname).toLowerCase();
+  const label = host.split(":")[0].split(".")[0];
+  return label === "rider";
+}
+
 /**
  * 운영자 콘솔 입장 게이트 + 만료 access token 자동 재발급.
  *
@@ -44,10 +50,21 @@ type RefreshResponse = {
  */
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const riderHost = isRiderHost(request);
+  const isRiderPath = pathname === "/rider" || pathname.startsWith("/rider/");
 
-  // 라이더 앱 경로는 운영자 게이트와 완전히 분리해서 처리한다.
-  if (pathname === "/rider" || pathname.startsWith("/rider/")) {
-    return riderGate(request, pathname);
+  // 라이더 서브도메인(rider.*): 이 호스트는 라이더 앱 전용.
+  if (riderHost) {
+    if (isRiderPath) {
+      return riderGate(request, pathname);
+    }
+    // 비-/rider 경로(루트·관리자 경로 등)는 라이더 앱으로 흡수.
+    return NextResponse.redirect(new URL("/rider", request.url));
+  }
+
+  // 관리자 호스트: 라이더 경로는 이 호스트에 존재하지 않음 → 루트로.
+  if (isRiderPath) {
+    return NextResponse.redirect(new URL("/", request.url));
   }
 
   const accessToken = request.cookies.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value;

--- a/docs/deploy/rider-subdomain-setup.md
+++ b/docs/deploy/rider-subdomain-setup.md
@@ -1,0 +1,41 @@
+# rider.thcr.cleversystem.ai 서브도메인 셋업 (EC2)
+
+라이더 웹앱을 별도 호스트로 노출. 코드(미들웨어)는 host로 분기하므로 같은
+Next 업스트림(127.0.0.1:3000)에 프록시하면 된다. admin server block을 복제.
+
+## 1) DNS
+`rider.thcr.cleversystem.ai` A 레코드 → `3.35.123.221`
+
+## 2) nginx server block (admin 블록 복제, server_name만 변경)
+/etc/nginx/sites-available/ 의 기존 admin 블록을 복사해 새 파일 생성:
+
+    server {
+        server_name rider.thcr.cleversystem.ai;
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;            # 미들웨어 호스트 판정에 필수
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+
+(기존 admin 블록의 proxy_set_header 세트를 그대로 따르되 server_name만 교체.
+proxy_set_header Host $host 가 빠지면 미들웨어가 라이더 호스트를 인식 못 함.)
+
+활성화: `sudo ln -s ../sites-available/<file> /etc/nginx/sites-enabled/ && sudo nginx -t`
+
+## 3) TLS
+`sudo certbot --nginx -d rider.thcr.cleversystem.ai`
+(certbot이 443 server block + 인증서 + 자동 갱신을 구성)
+
+## 4) reload
+`sudo systemctl reload nginx`
+
+## 5) 검증
+- https://rider.thcr.cleversystem.ai/         → 307 → /rider/login → 200(로그인 폼)
+- https://rider.thcr.cleversystem.ai/management → 307 → /rider
+- https://thcr.cleversystem.ai/rider/login    → 307 → / → (미인증) /login
+- https://thcr.cleversystem.ai/login          → 정상(admin)

--- a/docs/superpowers/plans/2026-06-17-rider-subdomain-separation.md
+++ b/docs/superpowers/plans/2026-06-17-rider-subdomain-separation.md
@@ -1,0 +1,159 @@
+# 라이더 서브도메인 분리 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** 단일 `front-admin-web` 앱이 호스트네임으로 admin/rider를 분기하도록 미들웨어를 호스트 인지로 바꾸고, 라이더 서브도메인용 nginx/DNS/TLS 적용 절차를 문서화한다.
+
+**Architecture:** 코드 변경은 `middleware.ts` 1파일(호스트 판정 + 분기). 인증 게이트(`riderGate`/admin gate)·쿠키·헬퍼는 그대로 재사용. nginx/DNS/certbot은 EC2/외부 적용이라 레포엔 적용 절차 문서만 추가.
+
+**Tech Stack:** Next.js(미들웨어, Edge), nginx, certbot.
+
+---
+
+### Task 1: 호스트 인지 미들웨어
+
+**Files:**
+- Modify: `development/front-admin-web/middleware.ts`
+
+설계 규칙(스펙 `docs/superpowers/specs/2026-06-17-rider-subdomain-separation-design.md`):
+- `isRiderHost`: 요청 호스트 첫 라벨이 `rider`이면 true. `localhost` 등은 false → 로컬 경로 기반 동작 유지.
+- 라이더 호스트: `/rider*`→`riderGate`; `/`→`/rider`로 redirect; 그 외→`/rider`로 redirect.
+- 관리자 호스트: `/rider*`→`/`로 redirect; 그 외→기존 admin 게이트.
+
+- [ ] **Step 1: `isRiderHost` 헬퍼 추가** (`middleware.ts`, 헬퍼 영역)
+
+```ts
+function isRiderHost(request: NextRequest): boolean {
+  const host = (request.headers.get("host") ?? request.nextUrl.hostname).toLowerCase();
+  const label = host.split(":")[0].split(".")[0];
+  return label === "rider";
+}
+```
+
+- [ ] **Step 2: `middleware()` 진입부를 호스트 분기로 교체**
+
+기존:
+```ts
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 라이더 앱 경로는 운영자 게이트와 완전히 분리해서 처리한다.
+  if (pathname === "/rider" || pathname.startsWith("/rider/")) {
+    return riderGate(request, pathname);
+  }
+
+  const accessToken = request.cookies.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value;
+```
+교체 후:
+```ts
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const riderHost = isRiderHost(request);
+  const isRiderPath = pathname === "/rider" || pathname.startsWith("/rider/");
+
+  // 라이더 서브도메인(rider.*): 이 호스트는 라이더 앱 전용.
+  if (riderHost) {
+    if (isRiderPath) {
+      return riderGate(request, pathname);
+    }
+    // 비-/rider 경로(루트·관리자 경로 등)는 라이더 앱으로 흡수.
+    return NextResponse.redirect(new URL("/rider", request.url));
+  }
+
+  // 관리자 호스트: 라이더 경로는 이 호스트에 존재하지 않음 → 루트로.
+  if (isRiderPath) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  const accessToken = request.cookies.get(SERVICE_OPS_ACCESS_TOKEN_COOKIE)?.value;
+```
+(이후 admin 게이트 로직은 기존 그대로 유지. `riderGate`/`refreshRiderAccessToken`/`clearRiderCookiesAndRedirect`/admin 헬퍼 모두 변경 없음.)
+
+- [ ] **Step 3: 빌드 검증**
+
+Run (`development/front-admin-web`): `npm run typecheck && npm run lint && npm run build`
+Expected: 통과. `/rider`·`/rider/login` 라우트 여전히 생성. 미들웨어(Proxy) 빌드 OK.
+
+- [ ] **Step 4: 동작 검증 (로컬, 선택)** — `next start` 후 Host 헤더로 분기 확인
+
+```
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" -H "Host: rider.thcr.cleversystem.ai" http://localhost:3000/        # → 307 .../rider
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" -H "Host: rider.thcr.cleversystem.ai" http://localhost:3000/rider   # → 307 .../rider/login (미인증)
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" -H "Host: thcr.cleversystem.ai"       http://localhost:3000/rider/login  # → 307 .../  (admin 호스트)
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" -H "Host: thcr.cleversystem.ai"       http://localhost:3000/login   # → 200/정상 admin
+```
+(사용자가 자체 dev 서버를 돌리므로, 경쟁 서버를 띄우지 말 것. 빌드 통과로 1차 확인하고 prod에서 최종 검증.)
+
+- [ ] **Step 5: 커밋**
+
+```
+git add development/front-admin-web/middleware.ts
+git commit -m "feat(rider): host-aware middleware for rider subdomain"
+```
+
+---
+
+### Task 2: nginx / DNS / TLS 적용 절차 문서
+
+**Files:**
+- Create: `docs/deploy/rider-subdomain-setup.md`
+
+- [ ] **Step 1: 문서 작성** — 아래 내용 그대로
+
+```markdown
+# rider.thcr.cleversystem.ai 서브도메인 셋업 (EC2)
+
+라이더 웹앱을 별도 호스트로 노출. 코드(미들웨어)는 host로 분기하므로 같은
+Next 업스트림(127.0.0.1:3000)에 프록시하면 된다. admin server block을 복제.
+
+## 1) DNS
+`rider.thcr.cleversystem.ai` A 레코드 → `3.35.123.221`
+
+## 2) nginx server block (admin 블록 복제, server_name만 변경)
+/etc/nginx/sites-available/ 의 기존 admin 블록을 복사해 새 파일 생성:
+
+    server {
+        server_name rider.thcr.cleversystem.ai;
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;            # 미들웨어 호스트 판정에 필수
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+
+(기존 admin 블록의 proxy_set_header 세트를 그대로 따르되 server_name만 교체.
+proxy_set_header Host $host 가 빠지면 미들웨어가 라이더 호스트를 인식 못 함.)
+
+활성화: `sudo ln -s ../sites-available/<file> /etc/nginx/sites-enabled/ && sudo nginx -t`
+
+## 3) TLS
+`sudo certbot --nginx -d rider.thcr.cleversystem.ai`
+(certbot이 443 server block + 인증서 + 자동 갱신을 구성)
+
+## 4) reload
+`sudo systemctl reload nginx`
+
+## 5) 검증
+- https://rider.thcr.cleversystem.ai/         → 307 → /rider/login → 200(로그인 폼)
+- https://rider.thcr.cleversystem.ai/management → 307 → /rider
+- https://thcr.cleversystem.ai/rider/login    → 307 → / → (미인증) /login
+- https://thcr.cleversystem.ai/login          → 정상(admin)
+```
+
+- [ ] **Step 2: 커밋**
+
+```
+git add docs/deploy/rider-subdomain-setup.md
+git commit -m "docs: rider subdomain nginx/DNS/TLS setup steps"
+```
+
+---
+
+## Self-Review
+- 스펙 커버: 호스트 분기(Task1), 인프라 절차(Task2). 쿠키 격리는 host-only로 자동(코드 변경 없음) — 스펙과 일치.
+- 타입 일관성: `isRiderHost(request: NextRequest)`, `riderGate(request, pathname)` 기존 시그니처 재사용.
+- Placeholder 없음. 실제 호스트(`rider.thcr.cleversystem.ai`)·IP(`3.35.123.221`) 명시.

--- a/docs/superpowers/specs/2026-06-17-rider-subdomain-separation-design.md
+++ b/docs/superpowers/specs/2026-06-17-rider-subdomain-separation-design.md
@@ -1,0 +1,62 @@
+# 라이더 앱 서브도메인 분리 — 설계
+
+## 목표
+라이더 웹앱을 관리자 콘솔과 **별도 호스트(`rider.thcr.cleversystem.ai`)** 로 분리한다. 코드베이스는 단일 `front-admin-web` 그대로 두고(공유 타입·서버액션·배포 1개 유지), **호스트네임으로 동작을 분기**한다. 목적: 쿠키 격리, 모바일 PWA 정체성, 라이더가 관리자 도메인의 존재를 모르게.
+
+현재 상태(이미 prod): 단일 Next 앱이 `thcr.cleversystem.ai`(EC2 systemd `thundercrew-front-admin-web` + nginx)에서 admin + `/rider/*`를 함께 서빙. 인증은 이미 분리됨(admin 쿠키 `thundercrew_ops_*`/role=ADMIN vs 라이더 쿠키 `thundercrew_rider_*`/role=RIDER, 로그인 페이지 별도).
+
+## 아키텍처
+하나의 Next 프로세스(127.0.0.1:3000)가 두 호스트를 서빙하고 nginx가 호스트별로 같은 업스트림에 프록시한다.
+- `thcr.cleversystem.ai` → 관리자 (기존 그대로)
+- `rider.thcr.cleversystem.ai` → 라이더 앱
+
+라이더 경로는 `/rider/*`를 **유지**한다(예: `rider.thcr.cleversystem.ai/rider/login`). 프리픽스를 숨겨 `/login`으로 만드는 건 다수 내부 링크 수정이 필요해 이번 범위에서 제외(YAGNI).
+
+## ① 코드 변경 — 호스트 인지 미들웨어 (`development/front-admin-web/middleware.ts`)
+
+호스트 판정 헬퍼: 요청 호스트의 첫 라벨이 `rider`이면 라이더 호스트로 본다.
+```ts
+function isRiderHost(request: NextRequest): boolean {
+  const host = (request.headers.get("host") ?? request.nextUrl.hostname).toLowerCase();
+  const label = host.split(":")[0].split(".")[0];
+  return label === "rider";
+}
+```
+(환경변수 불필요. `rider.*` 어떤 호스트에도 동작. 로컬 `localhost`는 라이더 호스트가 아니므로 기존 경로 기반 동작 유지 → 로컬 개발 영향 없음.)
+
+`middleware()` 분기 규칙:
+- **라이더 호스트일 때**:
+  - `pathname`이 `/rider`/`/rider/*` → 기존 `riderGate(request, pathname)` 그대로 적용.
+  - `pathname === "/"` → `/rider/login`으로 redirect (라이더 진입점).
+  - 그 외 비-`/rider` 경로(예: `/login`, `/management`, admin 경로) → `/rider`로 redirect. (라이더 호스트에 관리자 경로 노출 안 함.)
+- **관리자 호스트일 때**(현행 + 가드 추가):
+  - `pathname`이 `/rider`/`/rider/*` → admin 호스트엔 라이더 경로가 없으므로 `/`로 **redirect**(이후 기존 admin 게이트가 미인증 시 `/login`으로 보냄). 미들웨어 404의 soft-200 모호함을 피하려 redirect로 통일.
+  - 그 외 → 기존 admin 게이트 로직 그대로.
+
+라우팅 정적 자산 매처(`config.matcher`)는 현행 유지(정적/`_next` 제외).
+
+**쿠키 격리**: 라이더 쿠키는 Domain 속성 없이(host-only) 설정 중이므로, 라이더 서브도메인에서 발급되면 자동으로 admin 도메인과 분리된다. 코드 변경 불필요. `secure`는 prod(NODE_ENV=production)에서 이미 true.
+
+## ② 인프라 (EC2/DNS — 레포 밖, 코드 아님)
+레포에 nginx 설정이 없고 EC2 박스에 있으므로, 아래는 **사용자가 EC2/DNS에 적용**한다. 적용에 필요한 설정 블록·명령은 구현 산출물로 함께 제공한다(문서/스니펫). 배포 워크플로(`aws-ec2-deploy.yml`)는 같은 앱이라 변경 없음.
+
+1. **DNS**: `rider.thcr.cleversystem.ai` A 레코드 → `3.35.123.221`.
+2. **nginx**: 기존 admin server block을 복제한 라이더 호스트 server block 추가 — `server_name rider.thcr.cleversystem.ai;`, 동일하게 `proxy_pass http://127.0.0.1:3000;`(같은 업스트림). admin과 동일 프록시 헤더(Host/X-Forwarded-*).
+3. **TLS**: `sudo certbot --nginx -d rider.thcr.cleversystem.ai`로 인증서 발급/자동 갱신.
+
+> 주의: nginx가 `Host` 헤더를 업스트림에 그대로 전달해야(`proxy_set_header Host $host;`) 미들웨어의 호스트 판정이 동작한다. admin 블록이 이미 그렇게 설정돼 있을 것이므로 동일 패턴 복제.
+
+## 검증
+- **코드(로컬/CI 빌드)**: `typecheck`/`lint`/`build`. 로컬에서 host 헤더로 분기 동작 단위 확인 가능(`curl -H "Host: rider.thcr.cleversystem.ai" localhost:3000/` 등은 EC2 적용 후).
+- **prod(인프라 적용 후, 사용자)**:
+  - `https://rider.thcr.cleversystem.ai/` → `/rider/login`(200, 로그인 폼)
+  - `https://rider.thcr.cleversystem.ai/management` → `/rider`로 redirect (관리자 경로 차단)
+  - `https://thcr.cleversystem.ai/rider/login` → `/`로 redirect → (미인증 시) `/login` (admin 호스트에선 라이더 경로 차단)
+  - `https://thcr.cleversystem.ai/login` → 기존 관리자 로그인 정상
+  - 라이더 로그인 후 발급된 쿠키가 admin 도메인 요청에 실리지 않음(host-only).
+
+## 범위 밖
+- PWA manifest/Service Worker (P3)
+- 프리픽스 숨김(`rider.../login`) — 후속 폴리시
+- `thundercrew-domain.vercel.app` 잔재 폐기 — 별도
+- nginx 설정의 레포 편입(infra-as-code) — 현행 on-box 유지


### PR DESCRIPTION
## 릴리스 내용
라이더 앱 서브도메인 분리 (#460) — 호스트 인지 미들웨어 + 셋업 문서.

## ⚠️ 배포 순서 (중요)
이 변경 배포 후 admin 호스트(`thcr.cleversystem.ai`)에서 `/rider/*` → `/`로 리다이렉트(라이더 경로는 서브도메인 전용이 됨). 따라서 **먼저 rider 서브도메인 인프라를 적용한 뒤 이 PR을 머지**해야 라이더 접근 공백이 없음:

1. **인프라 먼저** (`docs/deploy/rider-subdomain-setup.md`): DNS `rider.thcr.cleversystem.ai`→`3.35.123.221`, nginx 라이더 server block(admin 복제, `proxy_set_header Host $host` 필수), `certbot --nginx -d rider.thcr.cleversystem.ai`, reload. (구 코드에서도 path 기반으로 동작하니 먼저 깔아도 무해.)
2. **그다음 이 PR 머지** → 배포 워크플로가 호스트 인지 미들웨어 반영.
3. **검증**: rider.thcr.../ →/rider/login(200), thcr.../rider/login →/ →login, thcr.../login 정상.

## 마이그레이션
없음(코드/문서만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)