### PR TITLE
feat(rider): P1 코어 UI — 내 업무·차량 위치 지도·주행거리

### DIFF
--- a/development/front-admin-web/app/rider/page.tsx
+++ b/development/front-admin-web/app/rider/page.tsx
@@ -1,9 +1,18 @@
 import { redirect } from "next/navigation";
 
-import { riderApiConfigured, riderGetMe, type RiderMe } from "@/lib/services/rider-api";
+import {
+  riderApiConfigured,
+  riderGetMe,
+  riderGetDispatchOrders,
+  riderGetVehicle,
+  type RiderMe,
+  type RiderDispatchOrder,
+  type RiderVehicle,
+} from "@/lib/services/rider-api";
 import { getRiderAccessToken } from "@/lib/services/rider-session";
 
 import { logoutRiderAction } from "./actions";
+import RiderMap from "@/components/rider/RiderMap";
 
 export const dynamic = "force-dynamic";
 
@@ -24,33 +33,222 @@ export default async function RiderHomePage() {
     redirect("/rider/login");
   }
 
+  let vehicle: RiderVehicle | null = null;
+  let orders: RiderDispatchOrder[] = [];
+
+  if (me.activeBikeId) {
+    [vehicle, orders] = await Promise.all([
+      riderGetVehicle(accessToken),
+      riderGetDispatchOrders(accessToken),
+    ]);
+  }
+
+  const connectionColor =
+    vehicle?.connectionStatus === "ONLINE"
+      ? "#16a34a"
+      : vehicle?.connectionStatus === "OFFLINE"
+        ? "#dc2626"
+        : "#6b7280";
+
   return (
-    <main style={{ maxWidth: 480, margin: "0 auto", padding: 24 }}>
-      <h1 style={{ fontSize: 20, fontWeight: 700 }}>안녕하세요, {me.name} 님</h1>
-      <dl style={{ marginTop: 16, lineHeight: 1.8 }}>
-        <div>
-          <dt style={{ display: "inline", color: "#6b7280" }}>전화번호 </dt>
-          <dd style={{ display: "inline", margin: 0 }}>{me.phoneNumber}</dd>
+    <main style={{ maxWidth: 480, margin: "0 auto", padding: "24px 16px" }}>
+      {/* 프로필 헤더 */}
+      <div style={{ marginBottom: 20 }}>
+        <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0 }}>
+          안녕하세요, {me.name} 님
+        </h1>
+        <div style={{ marginTop: 6, color: "#6b7280", fontSize: 14 }}>
+          {me.phoneNumber}
+          {me.teamName ? <span> · {me.teamName}</span> : null}
+          {me.areaName ? <span> · {me.areaName}</span> : null}
         </div>
-        {me.teamName ? (
-          <div>
-            <dt style={{ display: "inline", color: "#6b7280" }}>팀 </dt>
-            <dd style={{ display: "inline", margin: 0 }}>{me.teamName}</dd>
+      </div>
+
+      {me.activeBikeId ? (
+        <>
+          {/* 주행거리 카드 */}
+          <div
+            style={{
+              background: "#f9fafb",
+              border: "1px solid #e5e7eb",
+              borderRadius: 12,
+              padding: "16px 20px",
+              marginBottom: 16,
+            }}
+          >
+            <div style={{ fontSize: 13, color: "#6b7280", marginBottom: 4 }}>
+              주행거리
+            </div>
+            <div style={{ fontSize: 28, fontWeight: 700, color: "#111827" }}>
+              {vehicle?.odometerKm != null ? `${vehicle.odometerKm} km` : "—"}
+            </div>
+            <div
+              style={{
+                marginTop: 8,
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "wrap",
+              }}
+            >
+              {vehicle?.plateNumber ? (
+                <span
+                  style={{
+                    fontSize: 13,
+                    color: "#374151",
+                    fontWeight: 600,
+                  }}
+                >
+                  {vehicle.plateNumber}
+                </span>
+              ) : null}
+              {vehicle?.connectionStatus ? (
+                <span
+                  style={{
+                    display: "inline-block",
+                    padding: "2px 8px",
+                    borderRadius: 9999,
+                    background: connectionColor,
+                    color: "#fff",
+                    fontSize: 11,
+                    fontWeight: 600,
+                  }}
+                >
+                  {vehicle.connectionStatus}
+                </span>
+              ) : null}
+            </div>
           </div>
-        ) : null}
-        {me.areaName ? (
-          <div>
-            <dt style={{ display: "inline", color: "#6b7280" }}>지역 </dt>
-            <dd style={{ display: "inline", margin: 0 }}>{me.areaName}</dd>
+
+          {/* 차량 위치 지도 */}
+          <div style={{ marginBottom: 16 }}>
+            <RiderMap vehicle={vehicle} orders={orders} />
           </div>
-        ) : null}
-        <div>
-          <dt style={{ display: "inline", color: "#6b7280" }}>배정 차량 </dt>
-          <dd style={{ display: "inline", margin: 0 }}>{me.activeBikeId ?? "없음"}</dd>
+
+          {/* 내 업무 목록 */}
+          <div>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+              내 업무
+            </h2>
+            {orders.length === 0 ? (
+              <div
+                style={{
+                  textAlign: "center",
+                  padding: "32px 0",
+                  color: "#9ca3af",
+                  fontSize: 14,
+                }}
+              >
+                현재 배정된 업무가 없습니다
+              </div>
+            ) : (
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {orders.map((order) => (
+                  <li
+                    key={order.id}
+                    style={{
+                      background: "#fff",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: 12,
+                      padding: "14px 16px",
+                      marginBottom: 10,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        marginBottom: 8,
+                      }}
+                    >
+                      <span
+                        style={{
+                          display: "inline-block",
+                          padding: "2px 8px",
+                          borderRadius: 9999,
+                          background:
+                            order.kind === "PICKUP" ? "#dbeafe" : "#dcfce7",
+                          color:
+                            order.kind === "PICKUP" ? "#1d4ed8" : "#15803d",
+                          fontSize: 11,
+                          fontWeight: 700,
+                        }}
+                      >
+                        {order.kind === "PICKUP" ? "픽업" : "배달"}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: 14,
+                          fontWeight: 600,
+                          color: "#111827",
+                        }}
+                      >
+                        {order.customerName}
+                      </span>
+                    </div>
+                    <div style={{ fontSize: 13, color: "#374151", marginBottom: 4 }}>
+                      {order.address}
+                    </div>
+                    {order.originAddress ? (
+                      <div
+                        style={{
+                          fontSize: 12,
+                          color: "#6b7280",
+                          marginBottom: 4,
+                        }}
+                      >
+                        출발지: {order.originAddress}
+                      </div>
+                    ) : null}
+                    <a
+                      href={`tel:${order.customerPhone}`}
+                      style={{
+                        display: "inline-block",
+                        marginTop: 4,
+                        fontSize: 13,
+                        color: "#2563eb",
+                        textDecoration: "none",
+                      }}
+                    >
+                      {order.customerPhone}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      ) : (
+        <div
+          style={{
+            textAlign: "center",
+            padding: "48px 0",
+            color: "#9ca3af",
+            fontSize: 15,
+          }}
+        >
+          배정된 차량이 없습니다
         </div>
-      </dl>
-      <form action={logoutRiderAction} style={{ marginTop: 24 }}>
-        <button type="submit">로그아웃</button>
+      )}
+
+      <form action={logoutRiderAction} style={{ marginTop: 32 }}>
+        <button
+          type="submit"
+          style={{
+            width: "100%",
+            padding: "12px 0",
+            borderRadius: 8,
+            border: "1px solid #e5e7eb",
+            background: "#f9fafb",
+            color: "#374151",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          로그아웃
+        </button>
       </form>
     </main>
   );

--- a/development/front-admin-web/components/rider/RiderMap.tsx
+++ b/development/front-admin-web/components/rider/RiderMap.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { loadNcpMapsSdk } from "@/lib/maps/load-ncp-sdk";
+import type { RiderDispatchOrder, RiderVehicle } from "@/lib/services/rider-api";
+
+type Props = { vehicle: RiderVehicle | null; orders: RiderDispatchOrder[] };
+
+const SEOUL = { lat: 37.5665, lng: 126.978 };
+
+export default function RiderMap({ vehicle, orders }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadNcpMapsSdk()
+      .then(() => {
+        if (cancelled || !ref.current) return;
+        const naver = window.naver;
+        if (!naver?.maps) return;
+
+        const hasVehicle =
+          vehicle?.currentLatitude != null && vehicle?.currentLongitude != null;
+        const center = hasVehicle
+          ? { lat: vehicle!.currentLatitude!, lng: vehicle!.currentLongitude! }
+          : orders.length > 0
+            ? { lat: orders[0].latitude, lng: orders[0].longitude }
+            : SEOUL;
+
+        const map = new naver.maps.Map(ref.current, {
+          center: new naver.maps.LatLng(center.lat, center.lng),
+          zoom: 13,
+        });
+
+        const bounds = new naver.maps.LatLngBounds(
+          new naver.maps.LatLng(center.lat, center.lng),
+          new naver.maps.LatLng(center.lat, center.lng),
+        );
+        let anyPoint = false;
+
+        orders.forEach((o, i) => {
+          const pos = new naver.maps.LatLng(o.latitude, o.longitude);
+          new naver.maps.Marker({
+            position: pos,
+            map,
+            icon: {
+              content: destPinSvg(i + 1),
+              anchor: new naver.maps.Point(12, 28),
+              size: new naver.maps.Size(24, 30),
+            },
+          });
+          bounds.extend(pos);
+          anyPoint = true;
+        });
+
+        if (hasVehicle) {
+          const pos = new naver.maps.LatLng(
+            vehicle!.currentLatitude!,
+            vehicle!.currentLongitude!,
+          );
+          new naver.maps.Marker({
+            position: pos,
+            map,
+            icon: {
+              content: bikePinSvg(),
+              anchor: new naver.maps.Point(14, 14),
+              size: new naver.maps.Size(28, 28),
+            },
+          });
+          bounds.extend(pos);
+          anyPoint = true;
+        }
+
+        const totalPoints = orders.length + (hasVehicle ? 1 : 0);
+        if (anyPoint && totalPoints > 1 && map.fitBounds) {
+          map.fitBounds(bounds, 40);
+        }
+      })
+      .catch(() => {
+        // SDK load failure — map stays as empty grey box
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [vehicle, orders]);
+
+  const empty = (!vehicle || vehicle.currentLatitude == null) && orders.length === 0;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: 260,
+        borderRadius: 12,
+        overflow: "hidden",
+        background: "#e5e7eb",
+      }}
+    >
+      <div ref={ref} style={{ width: "100%", height: "100%" }} />
+      {empty ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "grid",
+            placeItems: "center",
+            color: "#6b7280",
+            fontSize: 14,
+          }}
+        >
+          표시할 위치가 없습니다
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function destPinSvg(n: number): string {
+  return `<div style="display:grid;place-items:center;width:24px;height:30px;color:#fff;font:700 11px sans-serif">
+    <svg width="24" height="30" viewBox="0 0 24 30" style="position:absolute"><path d="M12 0C5.4 0 0 5.4 0 12c0 8 12 18 12 18s12-10 12-18C24 5.4 18.6 0 12 0z" fill="#2563eb"/></svg>
+    <span style="position:relative;top:-3px">${n}</span></div>`;
+}
+
+function bikePinSvg(): string {
+  return `<div style="width:28px;height:28px;border-radius:50%;background:#16a34a;border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.4);display:grid;place-items:center;color:#fff;font:700 12px sans-serif">🛵</div>`;
+}

--- a/development/front-admin-web/lib/services/rider-api.ts
+++ b/development/front-admin-web/lib/services/rider-api.ts
@@ -97,3 +97,44 @@ export function riderLogout(accessToken: string): Promise<void> {
 export function riderGetMe(accessToken: string): Promise<RiderMe> {
   return call<RiderMe>("/rider/me", { method: "GET" }, accessToken);
 }
+
+export type RiderDispatchOrder = {
+  id: string;
+  bikeId: string;
+  customerName: string;
+  customerPhone: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  originAddress: string | null;
+  originLatitude: number | null;
+  originLongitude: number | null;
+  sequence: number;
+  status: string;
+  kind: string; // "PICKUP" | "DELIVERY"
+};
+
+export type RiderVehicle = {
+  bikeId: string;
+  plateNumber: string;
+  imei: string | null;
+  serviceType: string;
+  currentLatitude: number | null;
+  currentLongitude: number | null;
+  odometerKm: number | null;
+  connectionStatus: string | null;
+  lastReceivedAt: string | null;
+};
+
+export function riderGetDispatchOrders(accessToken: string): Promise<RiderDispatchOrder[]> {
+  return call<RiderDispatchOrder[]>("/rider/me/dispatch-orders", { method: "GET" }, accessToken);
+}
+
+export async function riderGetVehicle(accessToken: string): Promise<RiderVehicle | null> {
+  try {
+    return await call<RiderVehicle>("/rider/me/vehicle", { method: "GET" }, accessToken);
+  } catch (e) {
+    if (e instanceof RiderApiError && e.status === 404) return null;
+    throw e;
+  }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/dispatch/service/DispatchOrderReadService.java
@@ -42,6 +42,14 @@ public class DispatchOrderReadService {
                 .map(DispatchOrderReadResponse::from);
     }
 
+    public List<DispatchOrderReadResponse> listAssignedByBike(UUID bikeId) {
+        return dispatchOrderRepository
+                .findByBikeIdAndStatusAndDeletedAtIsNullOrderBySequenceAsc(bikeId, DispatchOrderStatus.ASSIGNED)
+                .stream()
+                .map(DispatchOrderReadResponse::from)
+                .toList();
+    }
+
     public List<DispatchOrderReadResponse> listCompletedByBike(UUID bikeId) {
         return dispatchOrderRepository
                 .findByBikeIdAndStatusAndDeletedAtIsNullOrderByCompletedAtDesc(bikeId, DispatchOrderStatus.COMPLETED)

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
@@ -1,7 +1,12 @@
 package com.thundercrew.opsapi.rider.controller;
 
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.service.DispatchOrderReadService;
 import com.thundercrew.opsapi.rider.dto.RiderMeResponse;
+import com.thundercrew.opsapi.rider.dto.RiderVehicleResponse;
 import com.thundercrew.opsapi.rider.service.RiderSelfReadService;
+import com.thundercrew.opsapi.rider.service.RiderVehicleReadService;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -14,14 +19,38 @@ import org.springframework.web.bind.annotation.RestController;
 public class RiderSelfReadController {
 
     private final RiderSelfReadService riderSelfReadService;
+    private final DispatchOrderReadService dispatchOrderReadService;
+    private final RiderVehicleReadService riderVehicleReadService;
 
-    public RiderSelfReadController(RiderSelfReadService riderSelfReadService) {
+    public RiderSelfReadController(
+            RiderSelfReadService riderSelfReadService,
+            DispatchOrderReadService dispatchOrderReadService,
+            RiderVehicleReadService riderVehicleReadService
+    ) {
         this.riderSelfReadService = riderSelfReadService;
+        this.dispatchOrderReadService = dispatchOrderReadService;
+        this.riderVehicleReadService = riderVehicleReadService;
     }
 
     @GetMapping("/me")
     RiderMeResponse me(@AuthenticationPrincipal Jwt jwt) {
         UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
         return riderSelfReadService.getMe(riderId);
+    }
+
+    @GetMapping("/me/dispatch-orders")
+    List<DispatchOrderReadResponse> myDispatchOrders(@AuthenticationPrincipal Jwt jwt) {
+        UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+        if (bikeId == null) {
+            return List.of();
+        }
+        return dispatchOrderReadService.listAssignedByBike(bikeId);
+    }
+
+    @GetMapping("/me/vehicle")
+    RiderVehicleResponse myVehicle(@AuthenticationPrincipal Jwt jwt) {
+        UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+        return riderVehicleReadService.getMyVehicle(riderId);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderVehicleResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderVehicleResponse.java
@@ -1,0 +1,18 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderVehicleResponse(
+        UUID bikeId,
+        String plateNumber,
+        String imei,
+        BikeServiceType serviceType,
+        Double currentLatitude,
+        Double currentLongitude,
+        Integer odometerKm,
+        String connectionStatus,
+        Instant lastReceivedAt
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
@@ -1,0 +1,66 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.rider.dto.RiderVehicleResponse;
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryConnection;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderVehicleReadService {
+
+    private final RiderBikeContractRepository contractRepository;
+    private final BikeRepository bikeRepository;
+    private final BikeCurrentStateRepository currentStateRepository;
+    private final Clock clock;
+
+    public RiderVehicleReadService(
+            RiderBikeContractRepository contractRepository,
+            BikeRepository bikeRepository,
+            BikeCurrentStateRepository currentStateRepository,
+            Clock clock
+    ) {
+        this.contractRepository = contractRepository;
+        this.bikeRepository = bikeRepository;
+        this.currentStateRepository = currentStateRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public RiderVehicleResponse getMyVehicle(UUID riderId) {
+        UUID bikeId = contractRepository.findActiveByRiderId(riderId)
+                .map(c -> c.getBikeId())
+                .orElseThrow(() -> new ResourceNotFoundException("RiderVehicle", riderId));
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+
+        BikeCurrentState state = currentStateRepository.findByBikeId(bikeId).orElse(null);
+        Double lat = null, lng = null;
+        Integer odo = null;
+        String connection = null;
+        Instant lastReceivedAt = null;
+        if (state != null) {
+            lat = state.getLatitude() == null ? null : state.getLatitude().doubleValue();
+            lng = state.getLongitude() == null ? null : state.getLongitude().doubleValue();
+            odo = state.getOdometerKm();
+            lastReceivedAt = state.getLastReceivedAt();
+            connection = TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock));
+        }
+        return new RiderVehicleResponse(
+                bike.getId(), bike.getPlateNumber(), bike.getImei(), bike.getServiceType(),
+                lat, lng, odo, connection, lastReceivedAt);
+    }
+
+    @Transactional(readOnly = true)
+    public UUID activeBikeIdOrNull(UUID riderId) {
+        return contractRepository.findActiveByRiderId(riderId).map(c -> c.getBikeId()).orElse(null);
+    }
+}

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderSelfReadApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderSelfReadApiContractTests.java
@@ -1,0 +1,244 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderSelfReadApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID RIDER_NO_VEHICLE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID BIKE_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID CONTRACT_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String RIDER_PHONE = "010-9999-1111";
+    private static final String RIDER_NO_VEHICLE_PHONE = "010-9999-2222";
+    private static final String RIDER_PASSWORD = "rider-test-secret";
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String adminToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from bike_current_states");
+        jdbcTemplate.update("delete from dispatch_orders");
+        jdbcTemplate.update("delete from rider_credentials");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin-sr', 'ops-sr@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        // Rider with vehicle
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더A', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_ID, RIDER_PHONE);
+
+        // Rider without vehicle
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더B', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_NO_VEHICLE_ID, RIDER_NO_VEHICLE_PHONE);
+
+        // Bike
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, operation_status, engine_type, wheel_type,
+                    service_type, ignition_blocked, created_at, updated_at)
+                values (?, '12가3456', 'IN_SERVICE', 'ELECTRIC', 'TWO_WHEEL', 'SINGLE', false, now(), now())
+                """, BIKE_ID);
+
+        // Active contract linking RIDER_ID → BIKE_ID
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, created_at, updated_at)
+                values (?, ?, ?, ?, ?, now(), now())
+                """,
+                UUID.randomUUID(), RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID,
+                Instant.parse("2026-01-01T00:00:00Z"));
+
+        adminToken = loginAdminAndExtractAccessToken();
+    }
+
+    // ────────────────────────────────────── /me/dispatch-orders ──────────────────────────
+
+    @Test
+    void dispatchOrders_withAssignedOrders_returns200AndOrdersInSequence() throws Exception {
+        seedAssignedOrder(BIKE_ID, 1, "고객A", "010-1111-0001", "서울 강남구 테헤란로 1", 37.5000, 127.0000);
+        seedAssignedOrder(BIKE_ID, 2, "고객B", "010-1111-0002", "서울 강남구 테헤란로 2", 37.5001, 127.0001);
+
+        String token = loginRiderAndGetToken(RIDER_PHONE, RIDER_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/rider/me/dispatch-orders")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].sequence").value(1))
+                .andExpect(jsonPath("$[1].sequence").value(2));
+    }
+
+    @Test
+    void dispatchOrders_riderWithNoVehicle_returns200AndEmptyList() throws Exception {
+        String token = loginRiderAndGetToken(RIDER_NO_VEHICLE_PHONE, RIDER_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/rider/me/dispatch-orders")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ────────────────────────────────────── /me/vehicle ──────────────────────────────────
+
+    @Test
+    void vehicle_withTelemetry_returns200AndAllFields() throws Exception {
+        seedBikeCurrentState(BIKE_ID, 37.5665, 126.9780, 1234,
+                Instant.now().minusSeconds(60)); // 1 minute ago = ONLINE
+
+        String token = loginRiderAndGetToken(RIDER_PHONE, RIDER_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/rider/me/vehicle")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plateNumber").value("12가3456"))
+                .andExpect(jsonPath("$.currentLatitude").isNumber())
+                .andExpect(jsonPath("$.odometerKm").value(1234))
+                .andExpect(jsonPath("$.connectionStatus").exists());
+    }
+
+    @Test
+    void vehicle_withoutTelemetry_returns200AndNullLocationFields() throws Exception {
+        String token = loginRiderAndGetToken(RIDER_PHONE, RIDER_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/rider/me/vehicle")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plateNumber").value("12가3456"))
+                .andExpect(jsonPath("$.currentLatitude").doesNotExist())
+                .andExpect(jsonPath("$.odometerKm").doesNotExist())
+                .andExpect(jsonPath("$.connectionStatus").doesNotExist());
+    }
+
+    @Test
+    void vehicle_riderWithNoVehicle_returns404() throws Exception {
+        String token = loginRiderAndGetToken(RIDER_NO_VEHICLE_PHONE, RIDER_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/rider/me/vehicle")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void vehicle_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/rider/me/vehicle"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ────────────────────────────────────── helpers ──────────────────────────────────────
+
+    private void seedAssignedOrder(UUID bikeId, long sequence, String customerName,
+            String customerPhone, String address, double lat, double lng) {
+        jdbcTemplate.update("""
+                insert into dispatch_orders
+                    (id, bike_id, customer_name, customer_phone, address,
+                     latitude, longitude, sequence, status, kind, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?, 'ASSIGNED', 'DELIVERY', now(), now())
+                """,
+                UUID.randomUUID(), bikeId, customerName, customerPhone, address, lat, lng, sequence);
+    }
+
+    private void seedBikeCurrentState(UUID bikeId, double lat, double lng,
+            int odometerKm, Instant lastReceivedAt) {
+        jdbcTemplate.update("""
+                insert into bike_current_states
+                    (bike_id, last_received_at, latitude, longitude, odometer_km,
+                     ignition_status, telemetry_source, updated_at)
+                values (?, ?, ?, ?, ?, 'ON', 'POLLING', now())
+                """,
+                bikeId, lastReceivedAt, lat, lng, odometerKm);
+    }
+
+    private String loginRiderAndGetToken(String phone, String password) throws Exception {
+        issueRiderCredential(RIDER_ID.equals(getIdByPhone(phone)) ? RIDER_ID : RIDER_NO_VEHICLE_ID, password);
+        MvcResult result = riderLogin(phone, password)
+                .andExpect(status().isOk())
+                .andReturn();
+        return extract(ACCESS_TOKEN_PATTERN, result);
+    }
+
+    private UUID getIdByPhone(String phone) {
+        return RIDER_PHONE.equals(phone) ? RIDER_ID : RIDER_NO_VEHICLE_ID;
+    }
+
+    private void issueRiderCredential(UUID riderId, String password) throws Exception {
+        mockMvc.perform(patch("/api/v1/riders/{id}/credential", riderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newPassword\":\"%s\"}".formatted(password)))
+                .andExpect(status().isNoContent());
+    }
+
+    private ResultActions riderLogin(String phone, String password) throws Exception {
+        return mockMvc.perform(post("/api/v1/rider-auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"phoneNumber\":\"%s\",\"password\":\"%s\"}".formatted(phone, password)));
+    }
+
+    private String loginAdminAndExtractAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"loginId\":\"ops-admin-sr\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extract(ACCESS_TOKEN_PATTERN, result);
+    }
+
+    private String extract(Pattern pattern, MvcResult result) throws Exception {
+        Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-17-rider-p1-core-ui.md
+++ b/docs/superpowers/plans/2026-06-17-rider-p1-core-ui.md
@@ -1,0 +1,335 @@
+# 라이더 P1 코어 UI 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox.
+
+**Goal:** 라이더 홈에 내 업무(배차)·차량 위치 지도·주행거리 표시. 백엔드 read 2개 + 프론트 홈 확장.
+
+**Architecture:** 백엔드는 `RiderSelfReadController`에 GET 2개 추가(dispatch/bike/telemetry read 집계). 프론트는 rider-api 확장 + `/rider` 서버컴포넌트 확장 + 경량 NCP 지도 client 컴포넌트.
+
+**Tech Stack:** Spring Boot, Next.js, NCP Maps.
+
+스펙: `docs/superpowers/specs/2026-06-17-rider-p1-core-ui-design.md`. 백엔드 식별자는 Explore로 확인됨(아래 명시).
+
+---
+
+## Task 1 — 백엔드 라이더 read 2개 + 계약 테스트
+
+**Files:**
+- Modify: `dispatch/service/DispatchOrderReadService.java` (메서드 추가)
+- Create: `rider/dto/RiderVehicleResponse.java`
+- Create: `rider/service/RiderVehicleReadService.java`
+- Modify: `rider/controller/RiderSelfReadController.java` (GET 2개 추가)
+- Create test: `src/test/java/com/thundercrew/opsapi/RiderSelfReadApiContractTests.java`
+
+### Step 1: `DispatchOrderReadService`에 ASSIGNED-by-bike 목록 메서드 추가
+기존 `currentByBike`/`listByBike` 옆에 추가. repo 메서드 `findByBikeIdAndStatusAndDeletedAtIsNullOrderBySequenceAsc(bikeId, DispatchOrderStatus.ASSIGNED)` 사용, 기존 매핑 방식(같은 클래스의 toResponse 매퍼) 재사용:
+```java
+@Transactional(readOnly = true)
+public java.util.List<DispatchOrderReadResponse> listAssignedByBike(java.util.UUID bikeId) {
+    return dispatchOrderRepository
+            .findByBikeIdAndStatusAndDeletedAtIsNullOrderBySequenceAsc(bikeId, DispatchOrderStatus.ASSIGNED)
+            .stream()
+            .map(this::toResponse)   // 기존 private 매퍼 이름에 맞춰 사용 (currentByBike가 쓰는 것과 동일)
+            .toList();
+}
+```
+> 구현 시 이 클래스의 기존 매퍼 메서드명을 확인해 그대로 쓸 것(예: `toResponse`/`map`). repo 필드명도 기존 그대로.
+
+### Step 2: `RiderVehicleResponse` DTO 생성
+```java
+package com.thundercrew.opsapi.rider.dto;
+
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderVehicleResponse(
+        UUID bikeId,
+        String plateNumber,
+        String imei,
+        BikeServiceType serviceType,
+        Double currentLatitude,
+        Double currentLongitude,
+        Integer odometerKm,
+        String connectionStatus,
+        Instant lastReceivedAt
+) {
+}
+```
+
+### Step 3: `RiderVehicleReadService` 생성
+`BikeReadService`(또는 `BikeRepository.findByIdAndDeletedAtIsNull`) + `BikeCurrentStateRepository.findByBikeId` + `TelemetryConnection.status` 사용. 활성 차량 없으면 404. 텔레메트리 없으면 위치/odometer/connection null.
+```java
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.repository.BikeRepository;
+import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
+import com.thundercrew.opsapi.rider.dto.RiderVehicleResponse;
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryConnection;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderVehicleReadService {
+
+    private final RiderBikeContractRepository contractRepository;
+    private final BikeRepository bikeRepository;
+    private final BikeCurrentStateRepository currentStateRepository;
+    private final Clock clock;
+
+    public RiderVehicleReadService(
+            RiderBikeContractRepository contractRepository,
+            BikeRepository bikeRepository,
+            BikeCurrentStateRepository currentStateRepository,
+            Clock clock
+    ) {
+        this.contractRepository = contractRepository;
+        this.bikeRepository = bikeRepository;
+        this.currentStateRepository = currentStateRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public RiderVehicleResponse getMyVehicle(UUID riderId) {
+        UUID bikeId = contractRepository.findActiveByRiderId(riderId)
+                .map(c -> c.getBikeId())
+                .orElseThrow(() -> new ResourceNotFoundException("RiderVehicle", riderId));
+        Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bike", bikeId));
+
+        BikeCurrentState state = currentStateRepository.findByBikeId(bikeId).orElse(null);
+        Double lat = null, lng = null;
+        Integer odo = null;
+        String connection = null;
+        Instant lastReceivedAt = null;
+        if (state != null) {
+            lat = state.getLatitude() == null ? null : state.getLatitude().doubleValue();
+            lng = state.getLongitude() == null ? null : state.getLongitude().doubleValue();
+            odo = state.getOdometerKm();
+            lastReceivedAt = state.getLastReceivedAt();
+            connection = TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock));
+        }
+        return new RiderVehicleResponse(
+                bike.getId(), bike.getPlateNumber(), bike.getImei(), bike.getServiceType(),
+                lat, lng, odo, connection, lastReceivedAt);
+    }
+
+    // riderId가 곧 활성 차량으로 매핑되는지 외부에서 쓰려면 노출; dispatch endpoint는 컨트롤러에서 contractRepository로 bikeId 도출.
+    @Transactional(readOnly = true)
+    public UUID activeBikeIdOrNull(UUID riderId) {
+        return contractRepository.findActiveByRiderId(riderId).map(c -> c.getBikeId()).orElse(null);
+    }
+}
+```
+> `BikeCurrentState` getter명(`getLatitude`/`getLongitude`/`getOdometerKm`/`getLastReceivedAt`)과 `TelemetryConnection.status(Instant,Instant)` 시그니처는 Explore 확인됨. 다르면 실제에 맞춰 조정.
+
+### Step 4: `RiderSelfReadController`에 GET 2개 추가
+```java
+@GetMapping("/me/dispatch-orders")
+java.util.List<DispatchOrderReadResponse> myDispatchOrders(@AuthenticationPrincipal Jwt jwt) {
+    UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+    UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+    if (bikeId == null) {
+        return java.util.List.of();
+    }
+    return dispatchOrderReadService.listAssignedByBike(bikeId);
+}
+
+@GetMapping("/me/vehicle")
+RiderVehicleResponse myVehicle(@AuthenticationPrincipal Jwt jwt) {
+    UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+    return riderVehicleReadService.getMyVehicle(riderId);
+}
+```
+생성자에 `DispatchOrderReadService`, `RiderVehicleReadService` 주입 추가. import 추가(DispatchOrderReadResponse, DispatchOrderReadService, RiderVehicleResponse, List, etc.).
+
+### Step 5: 계약 테스트 `RiderSelfReadApiContractTests`
+`RiderAuthApiContractTests` 패턴 복제(PostgresContainerSupport, admin 시드, 라이더 시드 + credential 발급 + 라이더 로그인). 시나리오:
+- 활성 계약 + bike + ASSIGNED 주문 2건 시드 → `GET /me/dispatch-orders` 200, 길이 2, sequence순.
+- 활성 차량 없는 라이더 → `GET /me/dispatch-orders` 200 `[]`.
+- bike + `bike_current_states` 시드(lat/lng/odometer) → `GET /me/vehicle` 200, plateNumber·latitude·odometerKm 일치, connectionStatus 존재.
+- 텔레메트리 없는 bike → `GET /me/vehicle` 200, latitude/odometerKm/connectionStatus null.
+- 활성 차량 없는 라이더 → `GET /me/vehicle` 404.
+- 미인증 `GET /me/vehicle` → 401.
+시드는 jdbcTemplate raw insert(테이블: riders, rider_bike_contracts, bikes, dispatch_orders, bike_current_states, rider_credentials, admin_users). 컬럼은 각 엔티티/마이그레이션 확인해 맞출 것.
+
+### Step 6: 빌드 + 테스트
+`cd development/service-ops-api`
+`./gradlew compileJava compileTestJava -q` → 통과
+`./gradlew test --tests "*RiderSelfReadApiContractTests" --tests "*ArchitectureBoundaryTests" -q` → 라이더 테스트 통과, ArchUnit 새 위반 0 (기존 issue_70 pre-red는 무관).
+(로컬 Docker 없으면 계약 테스트는 컴파일만 확인 — CI/배포에서 실행.)
+
+### Step 7: 커밋
+`git add -A && git commit -m "feat(rider): /me/dispatch-orders + /me/vehicle read API"`
+
+---
+
+## Task 2 — 프론트 라이더 홈(업무·지도·주행거리)
+
+**Files:**
+- Modify: `lib/services/rider-api.ts` (타입 + 함수 2개)
+- Create: `components/rider/RiderMap.tsx` (client)
+- Modify: `app/rider/page.tsx` (3섹션)
+- Modify: `app/globals.css` (라이더 카드/지도 스타일, 기존 패턴 따라)
+
+### Step 1: `rider-api.ts` 확장
+```ts
+export type RiderDispatchOrder = {
+  id: string;
+  bikeId: string;
+  customerName: string;
+  customerPhone: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  originAddress: string | null;
+  originLatitude: number | null;
+  originLongitude: number | null;
+  sequence: number;
+  status: string;
+  kind: string; // "PICKUP" | "DELIVERY"
+};
+
+export type RiderVehicle = {
+  bikeId: string;
+  plateNumber: string;
+  imei: string | null;
+  serviceType: string;
+  currentLatitude: number | null;
+  currentLongitude: number | null;
+  odometerKm: number | null;
+  connectionStatus: string | null;
+  lastReceivedAt: string | null;
+};
+
+export function riderGetDispatchOrders(accessToken: string): Promise<RiderDispatchOrder[]> {
+  return call<RiderDispatchOrder[]>("/rider/me/dispatch-orders", { method: "GET" }, accessToken);
+}
+
+export async function riderGetVehicle(accessToken: string): Promise<RiderVehicle | null> {
+  try {
+    return await call<RiderVehicle>("/rider/me/vehicle", { method: "GET" }, accessToken);
+  } catch (e) {
+    if (e instanceof RiderApiError && e.status === 404) return null;
+    throw e;
+  }
+}
+```
+
+### Step 2: `RiderMap.tsx` (경량 NCP 지도)
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import { loadNcpMapsSdk } from "@/lib/maps/load-ncp-sdk";
+import type { RiderDispatchOrder, RiderVehicle } from "@/lib/services/rider-api";
+
+type Props = { vehicle: RiderVehicle | null; orders: RiderDispatchOrder[] };
+
+const SEOUL = { lat: 37.5665, lng: 126.978 };
+
+export default function RiderMap({ vehicle, orders }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let map: any;
+    let cancelled = false;
+    loadNcpMapsSdk()
+      .then(() => {
+        if (cancelled || !ref.current) return;
+        const naver = (window as any).naver;
+        if (!naver?.maps) return;
+        const hasVehicle = vehicle?.currentLatitude != null && vehicle?.currentLongitude != null;
+        const center = hasVehicle
+          ? { lat: vehicle!.currentLatitude!, lng: vehicle!.currentLongitude! }
+          : orders.length > 0
+            ? { lat: orders[0].latitude, lng: orders[0].longitude }
+            : SEOUL;
+        map = new naver.maps.Map(ref.current, {
+          center: new naver.maps.LatLng(center.lat, center.lng),
+          zoom: 13
+        });
+        const bounds = new naver.maps.LatLngBounds();
+        let any = false;
+        orders.forEach((o, i) => {
+          const pos = new naver.maps.LatLng(o.latitude, o.longitude);
+          new naver.maps.Marker({
+            position: pos, map,
+            icon: { content: destPinSvg(i + 1), anchor: new naver.maps.Point(12, 28), size: new naver.maps.Size(24, 30) }
+          });
+          bounds.extend(pos); any = true;
+        });
+        if (hasVehicle) {
+          const pos = new naver.maps.LatLng(vehicle!.currentLatitude!, vehicle!.currentLongitude!);
+          new naver.maps.Marker({
+            position: pos, map,
+            icon: { content: bikePinSvg(), anchor: new naver.maps.Point(14, 14), size: new naver.maps.Size(28, 28) }
+          });
+          bounds.extend(pos); any = true;
+        }
+        if (any && (orders.length + (hasVehicle ? 1 : 0)) > 1) map.fitBounds(bounds);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [vehicle, orders]);
+
+  const empty = (!vehicle || vehicle.currentLatitude == null) && orders.length === 0;
+  return (
+    <div style={{ position: "relative", width: "100%", height: 260, borderRadius: 12, overflow: "hidden", background: "#e5e7eb" }}>
+      <div ref={ref} style={{ width: "100%", height: "100%" }} />
+      {empty ? (
+        <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", color: "#6b7280", fontSize: 14 }}>
+          표시할 위치가 없습니다
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function destPinSvg(n: number): string {
+  return `<div style="display:grid;place-items:center;width:24px;height:30px;color:#fff;font:700 11px sans-serif">
+    <svg width="24" height="30" viewBox="0 0 24 30" style="position:absolute"><path d="M12 0C5.4 0 0 5.4 0 12c0 8 12 18 12 18s12-10 12-18C24 5.4 18.6 0 12 0z" fill="#2563eb"/></svg>
+    <span style="position:relative;top:-3px">${n}</span></div>`;
+}
+function bikePinSvg(): string {
+  return `<div style="width:28px;height:28px;border-radius:50%;background:#16a34a;border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.4);display:grid;place-items:center;color:#fff;font:700 12px sans-serif">🛵</div>`;
+}
+```
+> `loadNcpMapsSdk`, `@/types/naver-maps` 존재 확인됨. `any` 캐스팅 최소화하되 타입이 번거로우면 naver 전역은 `(window as any).naver` 허용(MapShell도 유사). lint 통과 필수 — 미사용 import/var 없게.
+
+### Step 3: `app/rider/page.tsx` 확장
+서버 컴포넌트. `getMe` 후 activeBikeId 있으면 `riderGetDispatchOrders` + `riderGetVehicle` 병렬. 섹션: 프로필 헤더 → 주행거리 카드(odometerKm ?? "—" + 번호판 + connectionStatus 칩) → `<RiderMap vehicle orders />` → 내 업무 목록(카드: kind 배지, 고객명, 전화 `tel:` 링크, 주소, originAddress 있으면 출발지) → 로그아웃 form. 빈 상태 문구 포함. activeBikeId null이면 "배정된 차량이 없습니다"만.
+```tsx
+const accessToken = await getRiderAccessToken();
+// ... me fetch ...
+let vehicle = null; let orders = [];
+if (me.activeBikeId) {
+  [vehicle, orders] = await Promise.all([riderGetVehicle(accessToken), riderGetDispatchOrders(accessToken)]);
+}
+```
+(타입 import: RiderVehicle, RiderDispatchOrder. RiderMap는 client라 page에서 직접 import해 props 전달 가능.)
+
+### Step 4: `globals.css` 라이더 스타일 (선택, 기존 패턴 따라 최소)
+카드/리스트/칩 클래스 몇 개. 인라인 스타일로 충분하면 생략 가능.
+
+### Step 5: 검증
+`cd development/front-admin-web && npm run typecheck && npm run lint && npm run build`
+통과 + `/rider` 라우트 생성. 경쟁 dev 서버 띄우지 말 것.
+
+### Step 6: 커밋
+`git add -A && git commit -m "feat(rider): home with tasks, vehicle map, odometer"`
+
+---
+
+## Self-Review
+- 스펙 커버: dispatch-orders/vehicle 엔드포인트(T1), 홈 3섹션+지도(T2). 텔레메트리 graceful null(T1 vehicle, T2 빈 상태) — 일치.
+- 타입 일관성: 백엔드 `RiderVehicleResponse` ↔ 프론트 `RiderVehicle` 필드 1:1. dispatch DTO ↔ `RiderDispatchOrder`.
+- 인프라: NCP origin 허용목록(rider 호스트)은 코드 밖 — 스펙에 명시, 배포 후 사용자 적용.
+- Placeholder 없음(식별자 일부는 "실제 확인" 주석으로 표시 — 구현 시 검증).

--- a/docs/superpowers/specs/2026-06-17-rider-p1-core-ui-design.md
+++ b/docs/superpowers/specs/2026-06-17-rider-p1-core-ui-design.md
@@ -1,0 +1,72 @@
+# 라이더 P1 코어 UI — 설계
+
+## 목표
+라이더 홈(`rider.thcr.cleversystem.ai/rider`)에 코어 3섹션을 띄운다: **내 업무(배차 목록)** + **매칭 차량 위치 지도** + **주행거리**. 읽기 전용. 완료(사진)·팁·알림 수신은 P2.
+
+데이터 결정(브레인스토밍):
+- 지도 = **배차 목적지 핀(실데이터)** + **차량 GPS 위치(텔레메트리 있으면, 없으면 목적지만)**.
+- 주행거리 = **텔레메트리 odometer**(있으면 km, 없으면 "—"). 텔레메트리 들어오면 자동 반영.
+
+## 백엔드 — 라이더 스코프 read 2개 추가
+`RiderSelfReadController`(`/api/v1/rider`)에 GET 2개 추가. riderId는 JWT claim → `RiderBikeContractRepository.findActiveByRiderId(riderId)` → `getBikeId()`로 도출(이미 `getMe`에서 쓰는 패턴). 활성 차량 없으면: dispatch-orders는 `200 []`, vehicle은 `404`.
+
+### 1) `GET /api/v1/rider/me/dispatch-orders`
+- 내 차량의 **ASSIGNED 배차 목록**(sequence 오름차순). 활성 차량 없으면 빈 배열.
+- 구현: `DispatchOrderReadService`에 `listAssignedByBike(UUID bikeId)` 추가 — repo의 기존 `findByBikeIdAndStatusAndDeletedAtIsNullOrderBySequenceAsc(bikeId, ASSIGNED)` 사용, `DispatchOrderReadResponse`로 매핑(기존 매퍼 재사용).
+- 응답: `List<DispatchOrderReadResponse>`(기존 DTO 그대로 — id, customerName, customerPhone, address, latitude, longitude, originAddress, originLat/Lng, sequence, status, kind, …).
+
+### 2) `GET /api/v1/rider/me/vehicle`
+- 내 차량 요약 + 현재 위치/주행거리. 신규 DTO `RiderVehicleResponse`:
+  ```
+  UUID bikeId, String plateNumber, String imei, BikeServiceType serviceType,
+  Double currentLatitude, Double currentLongitude,   // 텔레메트리, null 가능
+  Integer odometerKm,                                // null 가능
+  String connectionStatus,                           // "ONLINE"/"OFFLINE"/null(텔레메트리 없음)
+  Instant lastReceivedAt                             // null 가능
+  ```
+- 구현: 신규 `RiderVehicleReadService`(또는 `RiderSelfReadService` 확장)에서 `BikeReadService.getBike(bikeId)`(번호판·imei·serviceType) + `BikeCurrentStateRepository.findByBikeId(bikeId)`(위치·odometer·lastReceivedAt; **throwing 서비스 말고 repository 직접** 써서 텔레메트리 없으면 null 처리). connectionStatus는 `TelemetryConnection.status(lastReceivedAt, now)`(120분) — 텔레메트리 없으면 null.
+- 활성 차량 없으면 `ResourceNotFoundException`(404).
+
+### 계약 테스트
+- 로그인→`/me/dispatch-orders`: 활성 차량 + ASSIGNED 주문 N개 시드 → N개 sequence순 반환. 차량 없는 라이더 → `[]`.
+- `/me/vehicle`: 차량 + 텔레메트리 시드 → 위치/odometer 반환; 텔레메트리 없는 차량 → 위치/odometer null + connectionStatus null; 차량 없는 라이더 → 404.
+- 미인증 → 401(기존 게이트). arch allow-list 불필요(GET read).
+
+> 아키텍처 노트: 라이더 read 서비스가 dispatch/bike/telemetry read를 가로질러 집계 — dashboard 서비스와 동일 패턴(common이 아니므로 arch 규칙 위반 아님).
+
+## 프론트엔드 — 라이더 홈 확장
+### API 클라이언트(`lib/services/rider-api.ts`) 추가
+- 타입 `RiderDispatchOrder`(백엔드 DispatchOrderReadResponse 대응), `RiderVehicle`(RiderVehicleResponse 대응).
+- `riderGetDispatchOrders(token): Promise<RiderDispatchOrder[]>` → GET `/rider/me/dispatch-orders`
+- `riderGetVehicle(token): Promise<RiderVehicle | null>` → GET `/rider/me/vehicle` (404 → null)
+
+### `/rider` 홈(`app/rider/page.tsx`) — 서버 컴포넌트
+- `getMe` 후 `activeBikeId` 있으면 `dispatch-orders` + `vehicle` 병렬 fetch. 없으면 "배정된 차량이 없습니다" 빈 상태.
+- 레이아웃(모바일 단일 컬럼): 프로필 헤더 → **주행거리 카드** → **차량 위치 지도** → **내 업무 목록** → 로그아웃. (순서: 요약→지도→상세)
+- **내 업무**: 카드 리스트. 카드당 종류 배지(배송/픽업), 고객명·연락처(tel: 링크)·주소(·출발지). 순서는 백엔드 sequence(순차/왕복은 의미 있음, 배송은 참고용). 빈 목록 시 "현재 배정된 업무가 없습니다".
+- **주행거리**: `vehicle.odometerKm != null ? "{}km" : "—"` + 번호판 + 연결상태 칩(ONLINE/OFFLINE/정보없음).
+
+### 라이더 지도 컴포넌트(신규 `components/rider/RiderMap.tsx`, client)
+- `loadNcpMapsSdk()`(공용 로더, GL 불필요) → `new naver.maps.Map`.
+- 마커: 배차 목적지(주문 lat/lng)들 + (vehicle.currentLat/Lng 있으면) 차량 마커 1개. 타입 `@/types/naver-maps`.
+- center/zoom: 차량 위치 있으면 그 기준, 없으면 목적지들 bounds fit, 둘 다 없으면 기본 서울 좌표 + "표시할 위치 없음" 오버레이.
+- 마커 아이콘: 간단한 inline SVG(목적지=핀, 차량=스쿠터). MapShell의 복잡한 헬퍼는 복사 안 하고 경량 자체 구현(YAGNI).
+- props: `{ vehicle: RiderVehicle | null, orders: RiderDispatchOrder[] }`. 서버 컴포넌트(page)에서 데이터 받아 client 컴포넌트로 전달.
+
+### CSS
+`app/globals.css`(또는 라이더 전용 블록)에 모바일 카드/지도 컨테이너 스타일. 인라인 스타일 최소.
+
+## 인프라 (사용자, 코드 아님)
+- **NCP 지도 origin 허용목록**: NCP Maps 애플리케이션의 Web 서비스 URL에 `https://rider.thcr.cleversystem.ai` 추가. 안 하면 라이더 호스트에서 지도 SDK가 referer 거부로 로드 실패. (admin은 `thcr.cleversystem.ai`만 등록돼 있을 것이므로 rider 호스트 추가 필요.)
+- 배포 워크플로 `.env.local`의 `NEXT_PUBLIC_NCP_MAP_CLIENT_ID`는 같은 빌드라 라이더 페이지에도 인라인됨 — 추가 env 불필요.
+
+## 검증
+- 백엔드: compileJava/compileTestJava + 계약 테스트(위 3종). ArchUnit 위반 0(read라 allow-list 무관, 단 새 위반 없는지 확인).
+- 프론트: typecheck/lint/build, `/rider` 라우트 생성.
+- prod(배포 + NCP 허용목록 후, 사용자): 라이더 로그인 → 홈에 업무/지도/주행거리 표시, 지도 SDK 로드 확인.
+
+## 범위 밖
+- 배송 완료(사진)·팁 제출·알림 수신 (P2)
+- PWA (P3)
+- 라이더 계정관리(비번 변경/발급 UI) — 별도(사용자가 P1 다음으로 지정)
+- 길찾기 네이티브 연동(외부 지도 앱) — 주소/좌표 표시까지만(원하면 후속)


### PR DESCRIPTION
## 개요
라이더 홈(`rider.thcr.cleversystem.ai/rider`)에 코어 3섹션: 내 업무(배차 목록) + 매칭 차량 위치 지도 + 주행거리. 읽기 전용(완료/팁/알림은 P2).

## 백엔드 (read 2개)
- `GET /api/v1/rider/me/dispatch-orders` — 내 차량 ASSIGNED 배차 목록(sequence순, 차량 없으면 [])
- `GET /api/v1/rider/me/vehicle` — 번호판·IMEI·serviceType + 텔레메트리 위치/odometer/연결상태(없으면 null, 차량 없으면 404)
- `RiderVehicleReadService`(contract→bike→telemetry 집계), `DispatchOrderReadService.listAssignedByBike`, 계약 테스트

## 프론트
- `rider-api.ts`: `RiderDispatchOrder`/`RiderVehicle` 타입 + fetch 2개
- `components/rider/RiderMap.tsx`: 경량 NCP 지도(목적지 핀 + 차량 마커, 텔레메트리 없으면 목적지만/빈 상태)
- `app/rider/page.tsx`: 프로필 → 주행거리 카드 → 지도 → 내 업무 카드 리스트(전화 tel: 링크) → 로그아웃. 빈 상태 처리.

## 검증
- 백엔드 compileJava/compileTestJava 통과, ArchUnit 신규 위반 0(GET read), 계약테스트는 CI(Docker)
- 프론트 typecheck/lint/build 통과, `/rider` 라우트 유지

## ⚠️ 배포 후 인프라 (사용자)
**NCP 지도 origin 허용목록에 `https://rider.thcr.cleversystem.ai` 추가** 필요 — 안 하면 라이더 호스트에서 지도 SDK가 referer 거부로 로드 실패(페이지 나머지는 정상). NCP Maps 애플리케이션 Web 서비스 URL 설정.

스펙: `docs/superpowers/specs/2026-06-17-rider-p1-core-ui-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)