### PR TITLE
release: 라이더 자가 회원가입 (dev→main)

### DIFF
--- a/development/front-admin-web/app/rider/login/page.tsx
+++ b/development/front-admin-web/app/rider/login/page.tsx
@@ -42,6 +42,10 @@ export default function RiderLoginPage() {
           {pending ? "로그인 중…" : "로그인"}
         </button>
       </form>
+      <p style={{ marginTop: 16, fontSize: 14, textAlign: "center" }}>
+        계정이 없으신가요?{" "}
+        <a href="/rider/register" style={{ color: "#2563eb" }}>회원가입</a>
+      </p>
     </main>
   );
 }

--- a/development/front-admin-web/app/rider/register/page.tsx
+++ b/development/front-admin-web/app/rider/register/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { registerRiderAction } from "./register-action";
+
+export default function RiderRegisterPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function onSubmit(formData: FormData) {
+    setError(null);
+    const password = String(formData.get("password") ?? "");
+    const confirm = String(formData.get("confirm") ?? "");
+    const name = String(formData.get("name") ?? "").trim();
+    const phoneNumber = String(formData.get("phoneNumber") ?? "").trim();
+
+    if (!name || !phoneNumber || !password || !confirm) {
+      setError("모든 항목을 입력하세요.");
+      return;
+    }
+    if (password !== confirm) {
+      setError("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await registerRiderAction(formData);
+      if (result?.error) {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: "0 auto", padding: "48px 16px" }}>
+      <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 24 }}>썬더크루 라이더 회원가입</h1>
+      <form action={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>이름</span>
+          <input
+            name="name"
+            type="text"
+            autoComplete="name"
+            placeholder="홍길동"
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>전화번호</span>
+          <input
+            name="phoneNumber"
+            type="tel"
+            inputMode="tel"
+            autoComplete="tel"
+            placeholder="010-0000-0000"
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>비밀번호</span>
+          <input name="password" type="password" autoComplete="new-password" required />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>비밀번호 확인</span>
+          <input name="confirm" type="password" autoComplete="new-password" required />
+        </label>
+        {error ? <p style={{ color: "#dc2626", fontSize: 14, margin: 0 }}>{error}</p> : null}
+        <button type="submit" disabled={pending} style={{ marginTop: 8, padding: "10px 0" }}>
+          {pending ? "가입 중…" : "회원가입"}
+        </button>
+      </form>
+      <p style={{ marginTop: 16, fontSize: 14, textAlign: "center" }}>
+        이미 계정이 있으신가요?{" "}
+        <a href="/rider/login" style={{ color: "#2563eb" }}>로그인</a>
+      </p>
+    </main>
+  );
+}

--- a/development/front-admin-web/app/rider/register/register-action.ts
+++ b/development/front-admin-web/app/rider/register/register-action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { RiderApiError, riderApiConfigured, riderRegister } from "@/lib/services/rider-api";
+import { setRiderSession } from "@/lib/services/rider-session";
+
+export async function registerRiderAction(formData: FormData): Promise<{ error: string } | void> {
+  const name = String(formData.get("name") ?? "").trim();
+  const phoneNumber = String(formData.get("phoneNumber") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+  if (!name || !phoneNumber || !password) return { error: "이름·전화번호·비밀번호를 모두 입력하세요." };
+  if (password.length < 8) return { error: "비밀번호는 8자 이상이어야 합니다." };
+  if (!riderApiConfigured()) return { error: "서버가 구성되지 않았습니다." };
+  try {
+    const auth = await riderRegister(name, phoneNumber, password);
+    await setRiderSession(auth);
+  } catch (e) {
+    if (e instanceof RiderApiError) {
+      if (e.status === 409) return { error: "이미 가입된 계정입니다. 로그인하세요." };
+      if (e.status === 401 || e.status === 404) return { error: "이름·전화번호가 일치하는 라이더가 없습니다. 관리자에게 문의하세요." };
+      if (e.status === 400) return { error: "비밀번호는 8자 이상이어야 합니다." };
+    }
+    return { error: "가입에 실패했습니다. 잠시 후 다시 시도하세요." };
+  }
+  redirect("/rider");
+}

--- a/development/front-admin-web/lib/services/rider-api.ts
+++ b/development/front-admin-web/lib/services/rider-api.ts
@@ -83,6 +83,17 @@ export function riderLogin(phoneNumber: string, password: string): Promise<Rider
   });
 }
 
+export function riderRegister(
+  name: string,
+  phoneNumber: string,
+  password: string
+): Promise<RiderAuthResponse> {
+  return call<RiderAuthResponse>("/rider-auth/register", {
+    method: "POST",
+    body: JSON.stringify({ name, phoneNumber, password })
+  });
+}
+
 export function riderRefresh(refreshToken: string): Promise<RiderAuthResponse> {
   return call<RiderAuthResponse>("/rider-auth/refresh", {
     method: "POST",

--- a/development/front-admin-web/middleware.ts
+++ b/development/front-admin-web/middleware.ts
@@ -181,7 +181,7 @@ async function riderGate(request: NextRequest, pathname: string): Promise<NextRe
   const accessToken = request.cookies.get(RIDER_ACCESS_TOKEN_COOKIE)?.value;
   const refreshToken = request.cookies.get(RIDER_REFRESH_TOKEN_COOKIE)?.value;
 
-  if (pathname === "/rider/login") {
+  if (pathname === "/rider/login" || pathname === "/rider/register") {
     if (accessToken || refreshToken) {
       return NextResponse.redirect(new URL("/rider", request.url));
     }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
@@ -72,7 +72,8 @@ public class SecurityConfig {
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/refresh",
                                 "/api/v1/rider-auth/login",
-                                "/api/v1/rider-auth/refresh").permitAll()
+                                "/api/v1/rider-auth/refresh",
+                                "/api/v1/rider-auth/register").permitAll()
                         .requestMatchers("/api/v1/rider/**", "/api/v1/rider-auth/logout").hasRole("RIDER")
                         .anyRequest().hasRole("ADMIN"))
                 .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthController.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.riderauth.controller;
 import com.thundercrew.opsapi.riderauth.dto.RiderLoginRequest;
 import com.thundercrew.opsapi.riderauth.dto.RiderLoginResponse;
 import com.thundercrew.opsapi.riderauth.dto.RiderRefreshRequest;
+import com.thundercrew.opsapi.riderauth.dto.RiderRegisterRequest;
 import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,11 @@ public class RiderAuthController {
 
     public RiderAuthController(RiderAuthService riderAuthService) {
         this.riderAuthService = riderAuthService;
+    }
+
+    @PostMapping("/register")
+    RiderLoginResponse register(@Valid @RequestBody RiderRegisterRequest request) {
+        return riderAuthService.register(request);
     }
 
     @PostMapping("/login")

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.riderauth.controller;
 
 import com.thundercrew.opsapi.common.api.ApiErrorResponse;
 import com.thundercrew.opsapi.common.api.ErrorCode;
+import com.thundercrew.opsapi.riderauth.service.RiderAlreadyRegisteredException;
 import com.thundercrew.opsapi.riderauth.service.RiderAuthenticationException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
@@ -32,5 +33,19 @@ public class RiderAuthExceptionHandler {
                 Instant.now(clock)
         );
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(RiderAlreadyRegisteredException.class)
+    ResponseEntity<ApiErrorResponse> handleAlreadyRegistered(
+            RiderAlreadyRegisteredException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.DUPLICATE_ACTIVE_RESOURCE,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderRegisterRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/dto/RiderRegisterRequest.java
@@ -1,0 +1,11 @@
+package com.thundercrew.opsapi.riderauth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderRegisterRequest(
+        @NotBlank String name,
+        @NotBlank String phoneNumber,
+        @NotBlank @Size(min = 8, max = 100) String password
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAlreadyRegisteredException.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.thundercrew.opsapi.riderauth.service;
+
+public class RiderAlreadyRegisteredException extends RuntimeException {
+    public RiderAlreadyRegisteredException() {
+        super("Rider account already registered.");
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
@@ -8,6 +8,7 @@ import com.thundercrew.opsapi.riderauth.dto.RiderIdentityResponse;
 import com.thundercrew.opsapi.riderauth.dto.RiderLoginRequest;
 import com.thundercrew.opsapi.riderauth.dto.RiderLoginResponse;
 import com.thundercrew.opsapi.riderauth.dto.RiderRefreshRequest;
+import com.thundercrew.opsapi.riderauth.dto.RiderRegisterRequest;
 import com.thundercrew.opsapi.riderauth.repository.RiderCredentialRepository;
 import java.util.UUID;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -65,6 +66,19 @@ public class RiderAuthService {
         UUID riderId = parseRiderId(jwt.getClaimAsString("riderId"));
         Rider rider = riderRepository.findByIdAndDeletedAtIsNull(riderId)
                 .orElseThrow(RiderAuthenticationException::new);
+        return issueTokens(rider);
+    }
+
+    @Transactional
+    public RiderLoginResponse register(RiderRegisterRequest request) {
+        Rider rider = riderRepository.findByPhoneNumberAndDeletedAtIsNull(request.phoneNumber())
+                .filter(r -> r.getName() != null && r.getName().trim().equals(request.name().trim()))
+                .orElseThrow(RiderAuthenticationException::new);
+        if (riderCredentialRepository.findByRiderId(rider.getId()).isPresent()) {
+            throw new RiderAlreadyRegisteredException();
+        }
+        riderCredentialRepository.save(
+                RiderCredential.create(rider.getId(), passwordEncoder.encode(request.password())));
         return issueTokens(rider);
     }
 

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
@@ -183,6 +183,65 @@ class RiderAuthApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isNotFound());
     }
 
+    // ── register scenarios ──────────────────────────────────────────────────
+
+    @Test
+    void riderSelfRegistersAndCanAccessOwnProfile() throws Exception {
+        // credential is NOT issued; @BeforeEach deleted all credentials
+        MvcResult registerResult = mockMvc.perform(post("/api/v1/rider-auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"라이더1\",\"phoneNumber\":\"%s\",\"password\":\"secure-pw-1\"}".formatted(RIDER_PHONE)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()))
+                .andReturn();
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, registerResult);
+
+        mockMvc.perform(get("/api/v1/rider/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(RIDER_ID.toString()));
+    }
+
+    @Test
+    void registerWithNameMismatchIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"다른이름\",\"phoneNumber\":\"%s\",\"password\":\"secure-pw-1\"}".formatted(RIDER_PHONE)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void registerWithUnknownPhoneIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"라이더1\",\"phoneNumber\":\"010-9999-9999\",\"password\":\"secure-pw-1\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void registerWhenAlreadyRegisteredIsConflict() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+
+        mockMvc.perform(post("/api/v1/rider-auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"라이더1\",\"phoneNumber\":\"%s\",\"password\":\"secure-pw-1\"}".formatted(RIDER_PHONE)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_ACTIVE_RESOURCE"));
+    }
+
+    @Test
+    void registerWithWeakPasswordIsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/rider-auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"라이더1\",\"phoneNumber\":\"%s\",\"password\":\"1234567\"}".formatted(RIDER_PHONE)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
     private void issueRiderCredential(UUID riderId, String password) throws Exception {
         mockMvc.perform(patch("/api/v1/riders/{id}/credential", riderId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)

--- a/docs/superpowers/plans/2026-06-17-rider-self-register.md
+++ b/docs/superpowers/plans/2026-06-17-rider-self-register.md
@@ -1,0 +1,204 @@
+# 라이더 자가 회원가입 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** 라이더가 이름+전화+비번으로 자가 가입(사전등록 Rider 매칭, 미가입 확인) 후 즉시 로그인.
+
+**Architecture:** P0 riderauth 슬라이스에 register 추가. 프론트는 /rider/register + 미들웨어 공개 경로 + login 링크. login 흐름과 대칭.
+
+스펙: `docs/superpowers/specs/2026-06-17-rider-self-register-design.md`.
+
+---
+
+## Task 1 — 백엔드 register
+
+**Files (development/service-ops-api/src/main/java/com/thundercrew/opsapi):**
+- Create: `riderauth/dto/RiderRegisterRequest.java`
+- Create: `riderauth/service/RiderAlreadyRegisteredException.java`
+- Modify: `riderauth/service/RiderAuthService.java` (register 메서드)
+- Modify: `riderauth/controller/RiderAuthController.java` (POST /register)
+- Modify: `riderauth/controller/RiderAuthExceptionHandler.java` (409 핸들러)
+- Modify: `auth/config/SecurityConfig.java` (permit /register)
+- Modify: 기존 `src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java` (register 시나리오 추가) 또는 새 테스트
+
+### Step 1: `RiderRegisterRequest`
+```java
+package com.thundercrew.opsapi.riderauth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderRegisterRequest(
+        @NotBlank String name,
+        @NotBlank String phoneNumber,
+        @NotBlank @Size(min = 8, max = 100) String password
+) {
+}
+```
+
+### Step 2: `RiderAlreadyRegisteredException`
+```java
+package com.thundercrew.opsapi.riderauth.service;
+
+public class RiderAlreadyRegisteredException extends RuntimeException {
+    public RiderAlreadyRegisteredException() {
+        super("Rider account already registered.");
+    }
+}
+```
+
+### Step 3: `RiderAuthService.register`
+기존 필드(riderRepository, riderCredentialRepository, passwordEncoder, riderTokenService) 재사용. 기존 `issueTokens(Rider)` private 메서드 재사용. 추가:
+```java
+@Transactional
+public RiderLoginResponse register(RiderRegisterRequest request) {
+    Rider rider = riderRepository.findByPhoneNumberAndDeletedAtIsNull(request.phoneNumber())
+            .filter(r -> r.getName() != null && r.getName().trim().equals(request.name().trim()))
+            .orElseThrow(RiderAuthenticationException::new);
+    if (riderCredentialRepository.findByRiderId(rider.getId()).isPresent()) {
+        throw new RiderAlreadyRegisteredException();
+    }
+    riderCredentialRepository.save(
+            RiderCredential.create(rider.getId(), passwordEncoder.encode(request.password())));
+    return issueTokens(rider);
+}
+```
+import 추가: RiderRegisterRequest.
+
+### Step 4: `RiderAuthController` — POST /register
+```java
+@PostMapping("/register")
+RiderLoginResponse register(@Valid @RequestBody RiderRegisterRequest request) {
+    return riderAuthService.register(request);
+}
+```
+import: RiderRegisterRequest.
+
+### Step 5: `RiderAuthExceptionHandler` — 409 핸들러 추가
+기존 클래스에 메서드 추가. ErrorCode는 `common/api/ErrorCode`를 READ해서 conflict/duplicate 성격의 값이 있으면 사용, 없으면 가장 근접한 값 사용(HTTP 상태는 반드시 409 CONFLICT):
+```java
+@ExceptionHandler(RiderAlreadyRegisteredException.class)
+ResponseEntity<ApiErrorResponse> handleAlreadyRegistered(
+        RiderAlreadyRegisteredException exception, HttpServletRequest request) {
+    ApiErrorResponse body = ApiErrorResponse.of(
+            ErrorCode.<CONFLICT_OR_CLOSEST>, exception.getMessage(),
+            request.getRequestURI(), Instant.now(clock));
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+}
+```
+> ErrorCode 실제 값 확인 필수. import RiderAlreadyRegisteredException.
+
+### Step 6: `SecurityConfig` — permit register
+`requestMatchers(...).permitAll()` 목록(현재 `/api/v1/rider-auth/login`, `/api/v1/rider-auth/refresh` 포함)에 `"/api/v1/rider-auth/register"` 추가.
+
+### Step 7: 계약 테스트 (기존 RiderAuthApiContractTests에 추가 메서드)
+시드 패턴은 기존 파일 그대로. 추가 시나리오:
+- 사전등록 라이더(이름="라이더1", 전화=RIDER_PHONE), credential 미발급 상태에서 → `POST /api/v1/rider-auth/register {name,phoneNumber,password}` → 200 + accessToken 추출 → `/rider/me` 200, id 일치.
+- 이름 불일치(전화 맞음) → 401 AUTHENTICATION_FAILED.
+- 미등록 전화 → 401.
+- 이미 credential 발급된 라이더(기존 issueRiderCredential 후) register → 409.
+- 비번 7자 → 400.
+> 주의: 기존 테스트의 @BeforeEach가 admin+rider 시드하고 일부 테스트가 credential을 발급함. register "정상" 테스트는 credential 미발급 상태에서 시작해야 하니, 테스트 시작 시 rider_credentials가 비어있는지 확인(@BeforeEach가 `delete from rider_credentials` 하므로 OK).
+
+### Step 8: 빌드 + 테스트
+`cd development/service-ops-api`
+`./gradlew compileJava compileTestJava -q` 통과
+`./gradlew test --tests "*RiderAuthApiContractTests" --tests "*ArchitectureBoundaryTests" -q` (Docker 없으면 계약테스트 initializationError=환경문제로 보고; ArchUnit 신규 위반 0 — RiderAuthController는 이미 allow-list).
+
+### Step 9: 커밋
+`git add -A && git commit -m "feat(rider): self-register endpoint (name+phone match)"`
+
+---
+
+## Task 2 — 프론트 회원가입
+
+**Files (development/front-admin-web):**
+- Modify: `lib/services/rider-api.ts` (riderRegister)
+- Create: `app/rider/register/register-action.ts`
+- Create: `app/rider/register/page.tsx`
+- Modify: `app/rider/login/page.tsx` (회원가입 링크)
+- Modify: `middleware.ts` (riderGate 공개 경로에 /rider/register)
+
+### Step 1: `rider-api.ts`
+```ts
+export function riderRegister(
+  name: string, phoneNumber: string, password: string
+): Promise<RiderAuthResponse> {
+  return call<RiderAuthResponse>("/rider-auth/register", {
+    method: "POST",
+    body: JSON.stringify({ name, phoneNumber, password })
+  });
+}
+```
+
+### Step 2: `register-action.ts` ("use server")
+login-action.ts 패턴. confirm 불일치/빈값 클라이언트 검증은 page에서, 여기선 서버 검증 + 상태별 메시지:
+```ts
+"use server";
+import { redirect } from "next/navigation";
+import { RiderApiError, riderApiConfigured, riderRegister } from "@/lib/services/rider-api";
+import { setRiderSession } from "@/lib/services/rider-session";
+
+export async function registerRiderAction(formData: FormData): Promise<{ error: string } | void> {
+  const name = String(formData.get("name") ?? "").trim();
+  const phoneNumber = String(formData.get("phoneNumber") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+  if (!name || !phoneNumber || !password) return { error: "이름·전화번호·비밀번호를 모두 입력하세요." };
+  if (password.length < 8) return { error: "비밀번호는 8자 이상이어야 합니다." };
+  if (!riderApiConfigured()) return { error: "서버가 구성되지 않았습니다." };
+  try {
+    const auth = await riderRegister(name, phoneNumber, password);
+    await setRiderSession(auth);
+  } catch (e) {
+    if (e instanceof RiderApiError) {
+      if (e.status === 409) return { error: "이미 가입된 계정입니다. 로그인하세요." };
+      if (e.status === 401 || e.status === 404) return { error: "이름·전화번호가 일치하는 라이더가 없습니다. 관리자에게 문의하세요." };
+      if (e.status === 400) return { error: "비밀번호는 8자 이상이어야 합니다." };
+    }
+    return { error: "가입에 실패했습니다. 잠시 후 다시 시도하세요." };
+  }
+  redirect("/rider");
+}
+```
+
+### Step 3: `register/page.tsx` ("use client")
+login/page.tsx 패턴(useState/useTransition, form action). 필드: 이름, 전화번호(tel), 비밀번호, 비밀번호 확인. 제출 전 클라이언트 검증: 빈값/비번≠확인 → setError. 통과 시 startTransition(registerRiderAction(formData)). 하단에 "로그인" 링크(`/rider/login`). 스타일은 login 페이지와 동일 톤(maxWidth 360 등).
+
+### Step 4: `login/page.tsx` — 회원가입 링크
+폼 하단에 `<a href="/rider/register">회원가입</a>` 추가(간단 스타일). 기존 로직 변경 없음.
+
+### Step 5: `middleware.ts` — register 공개
+`riderGate` 안의 공개 경로 처리. 현재:
+```ts
+if (pathname === "/rider/login") {
+  if (accessToken || refreshToken) {
+    return NextResponse.redirect(new URL("/rider", request.url));
+  }
+  return NextResponse.next();
+}
+```
+를 다음으로 확장:
+```ts
+if (pathname === "/rider/login" || pathname === "/rider/register") {
+  if (accessToken || refreshToken) {
+    return NextResponse.redirect(new URL("/rider", request.url));
+  }
+  return NextResponse.next();
+}
+```
+(나머지 riderGate 로직 불변.)
+
+### Step 6: 검증
+`cd development/front-admin-web && npm run typecheck && npm run lint && npm run build`
+통과 + `/rider/register` 라우트 생성. 경쟁 dev 서버 금지.
+
+### Step 7: 커밋
+`git add -A && git commit -m "feat(rider): self-register page + login link"`
+
+---
+
+## Self-Review
+- 스펙 커버: register 엔드포인트+검증(T1), 페이지+미들웨어 공개+링크(T2). 일치.
+- 타입 일관성: 백엔드 RiderRegisterRequest(name,phoneNumber,password) ↔ 프론트 riderRegister 인자. 응답 RiderLoginResponse ↔ RiderAuthResponse(기존).
+- 상태코드 매핑: 401/404(불일치), 409(중복), 400(약한비번) ↔ 프론트 메시지. 일치.
+- Placeholder: ErrorCode 409 값은 "실제 enum 확인" 표기 — 구현 시 결정.

--- a/docs/superpowers/specs/2026-06-17-rider-self-register-design.md
+++ b/docs/superpowers/specs/2026-06-17-rider-self-register-design.md
@@ -1,0 +1,60 @@
+# 라이더 자가 회원가입 — 설계
+
+## 목표
+라이더가 **이름 + 전화번호 + 비밀번호**로 직접 가입한다. 서버는 입력한 이름·전화번호가 **사전 등록된 Rider 레코드와 일치**하고 **아직 미가입**일 때만 자격증명을 생성하고 즉시 로그인시킨다. 별도 SMS/OTP 인증은 없음. 관리자 비번 발급 흐름(P0의 `PATCH /riders/{id}/credential`)은 재설정 용도로 유지(UI는 후속).
+
+이게 라이더 온보딩의 1차 경로가 되며, P1 QA(라이더 로그인)도 이걸로 풀린다.
+
+## 보안 메모(정직)
+이름+전화는 알려질 수 있는 정보 → 검증 강도 낮음(아는 사람이 선점 가능). **닫힌 조직 + 선착순 1회 가입** 전제로 MVP 수용. 후속에 SMS 인증을 끼울 수 있게 흐름을 단순 유지.
+
+## 흐름
+1. 관리자가 라이더(이름·전화) 사전 등록(기존 라이더 관리).
+2. 라이더가 `/rider/register`에서 이름·전화·비번 입력.
+3. 서버:
+   - 전화번호로 Rider 조회(`findByPhoneNumberAndDeletedAtIsNull`). 없으면 거부.
+   - `rider.name`이 입력 이름과 일치(trim 후 equals)하는지 확인. 불일치 거부.
+   - 해당 riderId에 이미 credential 있으면 거부(중복 가입).
+   - 통과 시 credential 생성 + 즉시 로그인 토큰 발급.
+4. 성공 → 세션 쿠키 설정 + `/rider`. 실패 → 사유별 메시지.
+
+## 백엔드
+### `POST /api/v1/rider-auth/register` (공개)
+- 요청 DTO `RiderRegisterRequest`: `@NotBlank name`, `@NotBlank phoneNumber`, `@NotBlank @Size(min=8,max=100) password`.
+- `RiderAuthService.register(RiderRegisterRequest)`:
+  - `riderRepository.findByPhoneNumberAndDeletedAtIsNull(phone)` → 없거나 `!rider.getName().trim().equals(name.trim())` → `throw new RiderAuthenticationException()` (401, "일치하는 라이더 없음" — not-found와 이름불일치를 합쳐 라이더 존재 여부 미노출).
+  - `riderCredentialRepository.findByRiderId(riderId).isPresent()` → `throw new RiderAlreadyRegisteredException()` (409).
+  - 아니면 `riderCredentialRepository.save(RiderCredential.create(riderId, passwordEncoder.encode(password)))` + `issueTokens(rider)` 반환(`RiderLoginResponse`).
+- `RiderAuthController`에 `@PostMapping("/register")` 추가 → `RiderLoginResponse`. (arch allow-list: `isRiderAuthCommand`가 owner-class 매칭이라 자동 커버.)
+- 신규 예외 `RiderAlreadyRegisteredException`(riderauth.service) + `RiderAuthExceptionHandler`에 핸들러 추가 → 409 + ApiErrorResponse(ErrorCode 적절값; 없으면 CONFLICT 계열/기존 코드 재사용).
+- `SecurityConfig`: permitAll 목록에 `"/api/v1/rider-auth/register"` 추가.
+- 비번 약함(@Size 위반) → 기존 검증 핸들러가 400 반환.
+
+### 계약 테스트 (`RiderRegisterApiContractTests` 또는 기존 RiderAuth 테스트에 추가)
+- 사전등록 라이더(이름·전화) 시드, credential 없음 → register 200 + accessToken + `/rider/me` 200.
+- 이름 불일치 → 401.
+- 미등록 전화 → 401.
+- 이미 credential 있는 라이더 → register 409.
+- 비번 7자 → 400.
+
+## 프론트엔드
+- `lib/services/rider-api.ts`: `riderRegister(name, phoneNumber, password): Promise<RiderAuthResponse>` → POST `/rider-auth/register`. (RiderApiError status로 프론트가 메시지 분기.)
+- `app/rider/register/register-action.ts` ("use server"): 입력 검증(빈값/비번확인 불일치) → `riderRegister` → `setRiderSession` → `redirect("/rider")`. 실패 시 `{error}`:
+  - 401 → "이름·전화번호가 일치하는 라이더가 없습니다. 관리자에게 문의하세요."
+  - 409 → "이미 가입된 계정입니다. 로그인하세요."
+  - 400 → "비밀번호는 8자 이상이어야 합니다."
+  - 기타 → 일반 오류.
+- `app/rider/register/page.tsx` ("use client"): 이름·전화·비밀번호·비밀번호확인 입력 + 제출(useTransition, login 페이지 패턴). 비번≠확인 시 클라이언트 검증.
+- `app/rider/login/page.tsx`: 하단에 "회원가입" 링크(`/rider/register`).
+- `middleware.ts`: 라이더 게이트의 공개 경로에 `/rider/register` 추가(현재 `/rider/login`만 공개). 로그인 상태로 register 접근 시 `/rider`로.
+
+## 검증
+- 백엔드: compileJava/compileTestJava + 계약 테스트(5종). ArchUnit 신규 위반 0(RiderAuthController는 이미 allow-list).
+- 프론트: typecheck/lint/build, `/rider/register` 라우트 생성.
+- prod(배포 후): `/rider/register`에서 실제 라이더 이름·전화로 가입 → `/rider` 진입. → **이걸로 P1 QA도 수행 가능**.
+
+## 범위 밖(후속)
+- 라이더 본인 비번 변경 UI
+- 관리자 비번 재설정 UI(현재 API만)
+- SMS/OTP 인증
+- 분실 시 재설정 셀프 플로우


### PR DESCRIPTION
## 릴리스 내용
라이더 자가 회원가입 (#464) — 이름+전화 매칭, SMS 없음.

- `POST /api/v1/rider-auth/register` + `/rider/register` 페이지 + 로그인 링크 + 미들웨어 공개
- 마이그레이션 없음

## QA (배포 후)
1. `rider.thcr.cleversystem.ai/rider/register` → 실제 라이더 **이름·전화**(형식 정확히)·비번(8자+) → 가입 즉시 `/rider` 진입
2. 같은 정보로 재가입 시도 → "이미 가입된 계정" / 틀린 이름 → "일치하는 라이더 없음"
3. 가입 후 `/rider` 홈에서 P1(주행거리·지도·업무) 확인 + 지도 로드(NCP 허용목록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)