### PR TITLE
fix(excel): 자원관리 템플릿 '보호된 셀'로 행 추가 불가 수정

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -16,8 +15,9 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
  *
  * <p>Loads the named template from the classpath ({@code /templates/excel/}),
  * clears all rows at or after {@code dataStartRow}, fills in the provided
- * rows with unlocked cell styles, protects the sheet (locks header rows),
- * and returns the result as a byte array.
+ * data rows, and returns the result as a byte array. The sheet is left
+ * unprotected so users can add rows and re-upload (the parser reads by
+ * column position and ignores headers).
  */
 public class ExcelExporter {
 
@@ -42,19 +42,16 @@ public class ExcelExporter {
             Sheet sheet = wb.getSheetAt(0);
             clearDataRows(sheet, dataStartRow);
 
-            CellStyle unlocked = wb.createCellStyle();
-            unlocked.setLocked(false);
-
             for (int i = 0; i < rows.size(); i++) {
                 Row row = sheet.createRow(dataStartRow + i);
                 List<String> cols = rows.get(i);
                 for (int j = 0; j < cols.size(); j++) {
                     Cell cell = row.createCell(j);
                     cell.setCellValue(cols.get(j) != null ? cols.get(j) : "");
-                    cell.setCellStyle(unlocked);
                 }
             }
-            sheet.protectSheet("");
+            // 시트 보호(protectSheet)는 하지 않는다 — 다운로드 후 빈 행에 차량/라이더를 추가
+            // 입력하는 라운드트립 용도라, 보호하면 빈 셀이 잠겨 "보호된 셀" 오류가 난다.
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             wb.write(out);
             return out.toByteArray();


### PR DESCRIPTION
## 문제
자원관리(차량·라이더·매칭)에서 엑셀을 받아 **새 행을 추가 입력하면 "보호된 셀"** 오류. 추가가 불가능.

## 원인
`common/excel/ExcelExporter`가 `sheet.protectSheet("")`로 시트를 보호하면서 **이미 채운 데이터 셀만 unlock** → 그 아래 빈 셀은 잠긴 채라 추가 입력 차단.

## 수정
`protectSheet` + 불필요해진 unlocked CellStyle 제거(시트 보호 안 함). 라이더/차량/매칭 벌크 템플릿 공통 적용.
- 안전성: 재업로드 파서(`ExcelParser`)는 헤더를 무시하고 **위치(컬럼 인덱스)** 로만 읽음 → 보호는 파싱과 무관, 헤더 편집돼도 영향 없음.

## 검증
- `./gradlew compileJava` 통과. 시트 보호를 단언하는 테스트 없음(영향 없음).
- 마이그레이션 없음.

## QA (배포 후)
자원관리에서 엑셀 다운 → 빈 행에 새 차량/라이더 입력 → 저장/재업로드 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)