### PR TITLE
release: 라이더 비밀번호 변경/재설정 (dev→main)

### DIFF
--- a/development/front-admin-web/app/management/riders/actions.ts
+++ b/development/front-admin-web/app/management/riders/actions.ts
@@ -10,6 +10,31 @@ import {
 } from "@/lib/services/service-ops-api";
 import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
 
+export async function resetRiderCredentialAction(
+  riderId: string,
+  newPassword: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!riderId) return { ok: false, error: "라이더 ID가 없습니다." };
+  if (!newPassword || newPassword.length < 8) {
+    return { ok: false, error: "새 비밀번호는 8자 이상이어야 합니다." };
+  }
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, error: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.setRiderCredential(riderId, newPassword);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "비밀번호 재설정에 실패했습니다. 잠시 후 다시 시도하세요." };
+  }
+}
+
 export async function bulkPreviewRidersAction(formData: FormData): Promise<BulkPreviewResponse> {
   if (!serviceOpsApiConfigured()) {
     throw new Error("Service OPS API is not configured");

--- a/development/front-admin-web/app/rider/page.tsx
+++ b/development/front-admin-web/app/rider/page.tsx
@@ -232,10 +232,11 @@ export default async function RiderHomePage() {
         </div>
       )}
 
-      <form action={logoutRiderAction} style={{ marginTop: 32 }}>
-        <button
-          type="submit"
+      <div style={{ marginTop: 32, display: "flex", flexDirection: "column", gap: 8 }}>
+        <a
+          href="/rider/password"
           style={{
+            display: "block",
             width: "100%",
             padding: "12px 0",
             borderRadius: 8,
@@ -245,11 +246,32 @@ export default async function RiderHomePage() {
             fontSize: 14,
             fontWeight: 500,
             cursor: "pointer",
+            textAlign: "center",
+            textDecoration: "none",
+            boxSizing: "border-box",
           }}
         >
-          로그아웃
-        </button>
-      </form>
+          비밀번호 변경
+        </a>
+        <form action={logoutRiderAction}>
+          <button
+            type="submit"
+            style={{
+              width: "100%",
+              padding: "12px 0",
+              borderRadius: 8,
+              border: "1px solid #e5e7eb",
+              background: "#f9fafb",
+              color: "#374151",
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            로그아웃
+          </button>
+        </form>
+      </div>
     </main>
   );
 }

--- a/development/front-admin-web/app/rider/password/page.tsx
+++ b/development/front-admin-web/app/rider/password/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { changeRiderPasswordAction } from "./password-action";
+
+export default function RiderPasswordPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function onSubmit(formData: FormData) {
+    const newPassword = String(formData.get("newPassword") ?? "");
+    const confirmPassword = String(formData.get("confirmPassword") ?? "");
+    if (newPassword !== confirmPassword) {
+      setError("새 비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await changeRiderPasswordAction(formData);
+      if (result?.error) {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: "0 auto", padding: "48px 16px" }}>
+      <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 24 }}>비밀번호 변경</h1>
+      <form action={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>현재 비밀번호</span>
+          <input
+            name="currentPassword"
+            type="password"
+            autoComplete="current-password"
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>새 비밀번호</span>
+          <input
+            name="newPassword"
+            type="password"
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>새 비밀번호 확인</span>
+          <input
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+        </label>
+        {error ? <p style={{ color: "#dc2626", fontSize: 14, margin: 0 }}>{error}</p> : null}
+        <button type="submit" disabled={pending} style={{ marginTop: 8, padding: "10px 0" }}>
+          {pending ? "변경 중…" : "비밀번호 변경"}
+        </button>
+      </form>
+      <p style={{ marginTop: 16, fontSize: 14, textAlign: "center" }}>
+        <a href="/rider" style={{ color: "#2563eb" }}>← 홈으로</a>
+      </p>
+    </main>
+  );
+}

--- a/development/front-admin-web/app/rider/password/password-action.ts
+++ b/development/front-admin-web/app/rider/password/password-action.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { RiderApiError, riderApiConfigured, riderChangePassword } from "@/lib/services/rider-api";
+import { getRiderAccessToken } from "@/lib/services/rider-session";
+
+export async function changeRiderPasswordAction(
+  formData: FormData
+): Promise<{ error: string } | void> {
+  const currentPassword = String(formData.get("currentPassword") ?? "");
+  const newPassword = String(formData.get("newPassword") ?? "");
+  const confirmPassword = String(formData.get("confirmPassword") ?? "");
+
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    return { error: "모든 항목을 입력하세요." };
+  }
+  if (newPassword !== confirmPassword) {
+    return { error: "새 비밀번호가 일치하지 않습니다." };
+  }
+  if (newPassword.length < 8) {
+    return { error: "새 비밀번호는 8자 이상이어야 합니다." };
+  }
+  if (!riderApiConfigured()) {
+    return { error: "서버가 구성되지 않았습니다. 관리자에게 문의하세요." };
+  }
+
+  const accessToken = await getRiderAccessToken();
+  if (!accessToken) {
+    return { error: "로그인이 필요합니다." };
+  }
+
+  try {
+    await riderChangePassword(accessToken, currentPassword, newPassword);
+  } catch (e) {
+    if (e instanceof RiderApiError) {
+      if (e.status === 401) return { error: "현재 비밀번호가 올바르지 않습니다." };
+      if (e.status === 400) return { error: "새 비밀번호는 8자 이상이어야 합니다." };
+    }
+    return { error: "비밀번호 변경에 실패했습니다. 잠시 후 다시 시도하세요." };
+  }
+
+  redirect("/rider");
+}

--- a/development/front-admin-web/components/management/RiderDetailDialog.tsx
+++ b/development/front-admin-web/components/management/RiderDetailDialog.tsx
@@ -9,6 +9,7 @@ import {
   setVehicleIgnitionBlockFromOverviewAction,
   updateRiderFromOverviewAction
 } from "@/app/actions";
+import { resetRiderCredentialAction } from "@/app/management/riders/actions";
 import { useScrollLockedDialog } from "@/lib/hooks/use-scroll-locked-dialog";
 import type { FrontendRider } from "@/lib/services/service-ops-api";
 
@@ -59,6 +60,11 @@ export function RiderDetailDialog({
   // 토글 클릭 직후 화면이 즉시 바뀌게 optimistic 처리. 페이지 revalidate 후
   // row prop 이 갱신되면 자동으로 정정된다.
   const [ignitionBlockedOptimistic, setIgnitionBlockedOptimistic] = useState<boolean | null>(null);
+
+  // 비밀번호 재설정 섹션 상태
+  const [credentialPending, startCredentialTransition] = useTransition();
+  const [credentialPassword, setCredentialPassword] = useState("");
+  const [credentialMessage, setCredentialMessage] = useState<{ ok: boolean; text: string } | null>(null);
 
   // 다이얼로그를 native <dialog> 모달로 띄우거나 닫기만 한다. 자동 포커스로
   // 인한 페이지 스크롤 점프는 훅 안에서 잡는다. mode 초기화나 입력 상태
@@ -139,6 +145,52 @@ export function RiderDetailDialog({
           <DetailField label="형태" value={row.returnType ?? "—"} />
           <DetailField label="기간" value={row.durationLabel ?? "—"} />
           <DetailField label="보험" value={currentInsuranceLabel} />
+
+          {/* 비밀번호 재설정 섹션 */}
+          <div style={{ gridColumn: "1 / -1", marginTop: 8 }}>
+            <p style={{ fontSize: 13, fontWeight: 600, margin: "0 0 6px" }}>비밀번호 재설정</p>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input
+                type="password"
+                placeholder="새 비밀번호 (8자 이상)"
+                minLength={8}
+                value={credentialPassword}
+                onChange={(e) => setCredentialPassword(e.target.value)}
+                style={{ flex: 1, padding: "8px 10px", fontSize: 14 }}
+              />
+              <button
+                type="button"
+                className="button-neutral"
+                disabled={credentialPending || credentialPassword.length < 8}
+                onClick={() => {
+                  setCredentialMessage(null);
+                  startCredentialTransition(async () => {
+                    const result = await resetRiderCredentialAction(riderId, credentialPassword);
+                    if (result.ok) {
+                      setCredentialPassword("");
+                      setCredentialMessage({ ok: true, text: "비밀번호가 재설정되었습니다." });
+                    } else {
+                      setCredentialMessage({ ok: false, text: result.error });
+                    }
+                  });
+                }}
+              >
+                {credentialPending ? "처리 중…" : "재설정"}
+              </button>
+            </div>
+            {credentialMessage ? (
+              <p
+                style={{
+                  margin: "6px 0 0",
+                  fontSize: 13,
+                  color: credentialMessage.ok ? "#16a34a" : "#dc2626",
+                }}
+              >
+                {credentialMessage.text}
+              </p>
+            ) : null}
+          </div>
+
           <div className="overview-create-dialog-actions">
             {row.activeContractId ? (
               <TerminateContractButton

--- a/development/front-admin-web/lib/services/rider-api.ts
+++ b/development/front-admin-web/lib/services/rider-api.ts
@@ -149,3 +149,14 @@ export async function riderGetVehicle(accessToken: string): Promise<RiderVehicle
     throw e;
   }
 }
+
+export function riderChangePassword(
+  accessToken: string,
+  currentPassword: string,
+  newPassword: string
+): Promise<void> {
+  return call<void>("/rider/me/password", {
+    method: "POST",
+    body: JSON.stringify({ currentPassword, newPassword })
+  }, accessToken);
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1315,6 +1315,9 @@ export type ServiceOpsApiClient = {
   // ── Audit logs ──
   recordAuditLog: (input: AuditLogCreateInput) => Promise<ServiceOpsAuditLog>;
   listAuditLogs: (entityId?: string) => Promise<ServiceOpsAuditLog[]>;
+
+  /** 관리자가 라이더 비밀번호를 강제 재설정. PATCH /riders/{id}/credential */
+  setRiderCredential: (id: string, newPassword: string) => Promise<void>;
 };
 
 type ServiceOpsApiOptions = {
@@ -2006,6 +2009,14 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
     },
     acknowledgeNotification: async (id) => {
       await request<void>(`/notifications/${encodeURIComponent(id)}/acknowledge`, { method: "POST" });
+    },
+
+    // ── Rider credential ──
+    setRiderCredential: async (id, newPassword) => {
+      await request<void>(`/riders/${encodeURIComponent(id)}/credential`, {
+        method: "PATCH",
+        body: JSON.stringify({ newPassword })
+      });
     },
   };
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfCommandController.java
@@ -1,0 +1,34 @@
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.rider.dto.RiderPasswordChangeRequest;
+import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider")
+public class RiderSelfCommandController {
+
+    private final RiderAuthService riderAuthService;
+
+    public RiderSelfCommandController(RiderAuthService riderAuthService) {
+        this.riderAuthService = riderAuthService;
+    }
+
+    @PostMapping("/me/password")
+    ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody RiderPasswordChangeRequest request
+    ) {
+        UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+        riderAuthService.changePassword(riderId, request.currentPassword(), request.newPassword());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderPasswordChangeRequest.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderPasswordChangeRequest.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderPasswordChangeRequest(
+        @NotBlank String currentPassword,
+        @NotBlank @Size(min = 8, max = 100) String newPassword
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/controller/RiderAuthExceptionHandler.java
@@ -2,6 +2,7 @@ package com.thundercrew.opsapi.riderauth.controller;
 
 import com.thundercrew.opsapi.common.api.ApiErrorResponse;
 import com.thundercrew.opsapi.common.api.ErrorCode;
+import com.thundercrew.opsapi.rider.controller.RiderSelfCommandController;
 import com.thundercrew.opsapi.riderauth.service.RiderAlreadyRegisteredException;
 import com.thundercrew.opsapi.riderauth.service.RiderAuthenticationException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = {RiderAuthController.class, RiderCredentialAdminController.class})
+@RestControllerAdvice(assignableTypes = {RiderAuthController.class, RiderCredentialAdminController.class, RiderSelfCommandController.class})
 public class RiderAuthExceptionHandler {
 
     private final Clock clock;

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
@@ -83,6 +83,15 @@ public class RiderAuthService {
     }
 
     @Transactional
+    public void changePassword(UUID riderId, String currentPassword, String newPassword) {
+        RiderCredential credential = riderCredentialRepository.findByRiderId(riderId)
+                .filter(c -> passwordEncoder.matches(currentPassword, c.getPasswordHash()))
+                .orElseThrow(RiderAuthenticationException::new);
+        credential.updatePasswordHash(passwordEncoder.encode(newPassword));
+        riderCredentialRepository.save(credential);
+    }
+
+    @Transactional
     public void setPassword(UUID riderId, String rawPassword) {
         if (riderRepository.findByIdAndDeletedAtIsNull(riderId).isEmpty()) {
             throw new ResourceNotFoundException("Rider", riderId);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -114,7 +114,8 @@ class ArchitectureBoundaryTests {
                         || isNotificationCommand(method)
                         || isAuditLogCommand(method)
                         || isRiderAuthCommand(method)
-                        || isRiderCredentialCommand(method)) {
+                        || isRiderCredentialCommand(method)
+                        || isRiderSelfCommand(method)) {
                     return;
                 }
 
@@ -158,7 +159,8 @@ class ArchitectureBoundaryTests {
                         && !isNotificationCommand(method)
                         && !isAuditLogCommand(method)
                         && !isRiderAuthCommand(method)
-                        && !isRiderCredentialCommand(method)) {
+                        && !isRiderCredentialCommand(method)
+                        && !isRiderSelfCommand(method)) {
                     events.add(SimpleConditionEvent.violated(
                             method,
                             method.getFullName() + " must not declare @RequestBody parameters outside allowed command controllers"
@@ -316,6 +318,11 @@ class ArchitectureBoundaryTests {
     private static boolean isRiderCredentialCommand(JavaMethod method) {
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.riderauth.controller.RiderCredentialAdminController");
+    }
+
+    private static boolean isRiderSelfCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.rider.controller.RiderSelfCommandController");
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderAuthApiContractTests.java
@@ -240,6 +240,65 @@ class RiderAuthApiContractTests extends PostgresContainerSupport {
                 .andExpect(status().isBadRequest());
     }
 
+    // ── changePassword scenarios ─────────────────────────────────────────────
+
+    @Test
+    void riderChangesPasswordAndCanLoginWithNewPassword() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn());
+        String newPassword = "new-secret-1";
+
+        mockMvc.perform(post("/api/v1/rider/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}".formatted(RIDER_PASSWORD, newPassword)))
+                .andExpect(status().isNoContent());
+
+        // Login with new password succeeds
+        riderLogin(RIDER_PHONE, newPassword)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rider.id").value(RIDER_ID.toString()));
+
+        // Login with old password fails
+        riderLogin(RIDER_PHONE, RIDER_PASSWORD)
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void changePasswordWithWrongCurrentPasswordIsUnauthorized() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn());
+
+        mockMvc.perform(post("/api/v1/rider/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"wrong-password\",\"newPassword\":\"new-secret-1\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
+    @Test
+    void changePasswordWithWeakNewPasswordIsBadRequest() throws Exception {
+        issueRiderCredential(RIDER_ID, RIDER_PASSWORD);
+        String riderToken = extract(ACCESS_TOKEN_PATTERN, riderLogin(RIDER_PHONE, RIDER_PASSWORD).andReturn());
+
+        mockMvc.perform(post("/api/v1/rider/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + riderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"%s\",\"newPassword\":\"short1\"}".formatted(RIDER_PASSWORD)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void changePasswordWithoutAuthIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/rider/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"any-password\",\"newPassword\":\"new-secret-1\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private void issueRiderCredential(UUID riderId, String password) throws Exception {

--- a/docs/superpowers/plans/2026-06-17-rider-password-management.md
+++ b/docs/superpowers/plans/2026-06-17-rider-password-management.md
@@ -1,0 +1,171 @@
+# 라이더 비번 변경/재설정 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** 라이더 본인 비번 변경(신규 엔드포인트+UI) + 관리자 비번 재설정 UI(기존 PATCH 연결).
+
+**Architecture:** 백엔드는 riderauth/rider 슬라이스에 changePassword + RiderSelfCommandController 추가. 프론트는 라이더 비번변경 페이지 + admin RiderDetailDialog 재설정 버튼.
+
+스펙: `docs/superpowers/specs/2026-06-17-rider-password-management-design.md`.
+
+---
+
+## Task 1 — 백엔드 라이더 본인 비번 변경
+
+**Files (development/service-ops-api/src/main/java/com/thundercrew/opsapi):**
+- Modify: `riderauth/service/RiderAuthService.java` (changePassword)
+- Create: `rider/dto/RiderPasswordChangeRequest.java`
+- Create: `rider/controller/RiderSelfCommandController.java`
+- Modify: `riderauth/controller/RiderAuthExceptionHandler.java` (advice 대상에 새 컨트롤러 추가)
+- Modify: `src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java` (allow-list)
+- Test: 기존 `RiderAuthApiContractTests`에 추가 또는 신규
+
+### Step 1: `RiderAuthService.changePassword`
+기존 필드(riderCredentialRepository, passwordEncoder) 재사용. READ the file first for exact field names.
+```java
+@Transactional
+public void changePassword(java.util.UUID riderId, String currentPassword, String newPassword) {
+    RiderCredential credential = riderCredentialRepository.findByRiderId(riderId)
+            .filter(c -> passwordEncoder.matches(currentPassword, c.getPasswordHash()))
+            .orElseThrow(RiderAuthenticationException::new);
+    credential.updatePasswordHash(passwordEncoder.encode(newPassword));
+    riderCredentialRepository.save(credential);
+}
+```
+(RiderCredential.getPasswordHash()/updatePasswordHash() 존재 확인됨 — P0.)
+
+### Step 2: `RiderPasswordChangeRequest` (rider/dto)
+```java
+package com.thundercrew.opsapi.rider.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderPasswordChangeRequest(
+        @NotBlank String currentPassword,
+        @NotBlank @Size(min = 8, max = 100) String newPassword
+) {
+}
+```
+
+### Step 3: `RiderSelfCommandController` (rider/controller)
+```java
+package com.thundercrew.opsapi.rider.controller;
+
+import com.thundercrew.opsapi.rider.dto.RiderPasswordChangeRequest;
+import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider")
+public class RiderSelfCommandController {
+
+    private final RiderAuthService riderAuthService;
+
+    public RiderSelfCommandController(RiderAuthService riderAuthService) {
+        this.riderAuthService = riderAuthService;
+    }
+
+    @PostMapping("/me/password")
+    ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody RiderPasswordChangeRequest request
+    ) {
+        UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
+        riderAuthService.changePassword(riderId, request.currentPassword(), request.newPassword());
+        return ResponseEntity.noContent().build();
+    }
+}
+```
+
+### Step 4: 예외 매핑
+READ `riderauth/controller/RiderAuthExceptionHandler.java`. 그 `@RestControllerAdvice(assignableTypes = {...})` 목록에 `com.thundercrew.opsapi.rider.controller.RiderSelfCommandController.class` 추가(import). 이러면 현재 비번 불일치 시 RiderAuthenticationException → 401.
+> 만약 전역 핸들러가 이미 RiderAuthenticationException → 401을 매핑한다면 이 단계 불필요 — 먼저 확인. 계약 테스트로 401 나오는지 검증할 것.
+
+### Step 5: ArchUnit allow-list
+`ArchitectureBoundaryTests.java`: predicate 추가
+```java
+    private static boolean isRiderSelfCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.rider.controller.RiderSelfCommandController");
+    }
+```
+그리고 두 체인에 등록: `onlyAllowedAuthCommandsMayUseWriteRouteMappings`의 `|| ...` 에 `|| isRiderSelfCommand(method)`, `onlyAllowedAuthCommandsMayHaveRequestBodyParameters`의 `&& !...` 에 `&& !isRiderSelfCommand(method)`.
+
+### Step 6: 계약 테스트
+`RiderAuthApiContractTests` 패턴(라이더 시드+credential 발급+로그인). 시나리오: 로그인→`POST /api/v1/rider/me/password {current,new}`→204→새 비번 재로그인 200; 현재 비번 틀림→401; 새 비번 7자→400; 미인증→401.
+
+### Step 7: 빌드 + 커밋
+`cd development/service-ops-api && ./gradlew compileJava compileTestJava -q` 통과 + ArchUnit 신규 위반 0(RiderSelfCommandController allow-list됨). (Docker 없으면 계약테스트 env 실패=정상 보고.)
+`git add -A && git commit -m "feat(rider): self password-change endpoint"`
+
+---
+
+## Task 2 — 프론트 (라이더 변경 + 관리자 재설정)
+
+**Files (development/front-admin-web):**
+- Modify: `lib/services/rider-api.ts` (riderChangePassword)
+- Create: `app/rider/password/password-action.ts`, `app/rider/password/page.tsx`
+- Modify: `app/rider/page.tsx` (비번변경 링크)
+- Modify: `lib/services/service-ops-api.ts` (admin: setRiderCredential)
+- Modify: `app/management/riders/actions.ts` (resetRiderCredentialAction)
+- Modify: `components/management/RiderDetailDialog.tsx` (재설정 UI)
+
+### Step 1: rider-api.ts
+```ts
+export function riderChangePassword(
+  accessToken: string, currentPassword: string, newPassword: string
+): Promise<void> {
+  return call<void>("/rider/me/password", {
+    method: "POST",
+    body: JSON.stringify({ currentPassword, newPassword })
+  }, accessToken);
+}
+```
+
+### Step 2: app/rider/password/password-action.ts ("use server")
+login-action 패턴. 입력 검증(빈값/new!==confirm/8자) → getRiderAccessToken → riderChangePassword → 성공 시 redirect("/rider"). 실패: RiderApiError 401 → "현재 비밀번호가 올바르지 않습니다", 400 → "새 비밀번호는 8자 이상", 기타 일반.
+
+### Step 3: app/rider/password/page.tsx ("use client")
+login/page 패턴(useState/useTransition). 필드: 현재 비밀번호, 새 비밀번호, 새 비밀번호 확인. 제출 전 new!==confirm 클라이언트 검증. 하단 "← 홈으로"(`/rider`) 링크.
+
+### Step 4: app/rider/page.tsx
+프로필 헤더 영역 또는 로그아웃 근처에 "비밀번호 변경" 링크(`/rider/password`) 추가. 기존 로직 변경 최소.
+
+### Step 5: service-ops-api.ts (admin client)
+READ the file for the client structure (interface ServiceOpsApiClient + createServiceOpsApiClient request() helper). 추가:
+- 인터페이스에 `setRiderCredential(id: string, newPassword: string): Promise<void>;`
+- 구현에 `setRiderCredential: (id, newPassword) => request<void>(\`/riders/\${id}/credential\`, { method: "PATCH", body: JSON.stringify({ newPassword }) })` (실제 request 헬퍼 시그니처에 맞춰 조정; 204 응답 처리 방식은 기존 PATCH/DELETE 메서드 따라).
+
+### Step 6: app/management/riders/actions.ts
+기존 액션 패턴(인증 admin 클라이언트 생성) 따라:
+```ts
+export async function resetRiderCredentialAction(riderId: string, newPassword: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  // createAuthenticatedServiceOpsApiClient() → client.setRiderCredential(riderId, newPassword)
+  // 성공 { ok: true }, 실패 시 메시지
+}
+```
+(기존 actions.ts의 다른 rider 액션 시그니처/에러 처리 패턴을 그대로 따를 것 — READ first.)
+
+### Step 7: components/management/RiderDetailDialog.tsx
+READ first. 다이얼로그 내 적절한 위치에 "비밀번호 재설정" 섹션 추가: 새 비번 input(8자+) + 버튼 → resetRiderCredentialAction(riderId, pw) 호출(useTransition) → 성공/오류 메시지. 기존 다이얼로그의 상태/스타일 패턴 따름.
+
+### Step 8: 검증 + 커밋
+`cd development/front-admin-web && npm run typecheck && npm run lint && npm run build` 통과 + `/rider/password` 라우트 생성. 경쟁 dev 서버 금지.
+`git add -A && git commit -m "feat(rider): password-change page + admin reset UI"`
+
+---
+
+## Self-Review
+- 스펙 커버: A(엔드포인트+페이지), B(admin 재설정 UI). 일치.
+- 타입: RiderPasswordChangeRequest(current,new) ↔ riderChangePassword 인자. setRiderCredential ↔ PATCH {newPassword}.
+- 보안/arch: /rider/** RIDER 게이트(변경 없음), RiderSelfCommandController allow-list 추가.
+- Placeholder: 일부 프론트 식별자(request 헬퍼·actions 패턴·다이얼로그 구조)는 "READ first"로 표기 — 구현 시 실제에 맞춤.

--- a/docs/superpowers/specs/2026-06-17-rider-password-management-design.md
+++ b/docs/superpowers/specs/2026-06-17-rider-password-management-design.md
@@ -1,0 +1,42 @@
+# 라이더 비밀번호 변경/재설정 — 설계 (계정관리 마무리)
+
+## 목표
+- **A. 라이더 본인 비번 변경**: 로그인한 라이더가 `/rider`에서 현재 비번 확인 후 새 비번으로 변경.
+- **B. 관리자 비번 재설정 UI**: 관리자가 라이더 관리(라이더 상세)에서 비번을 재설정 — 기존 `PATCH /api/v1/riders/{id}/credential`(P0) 연결만, 백엔드 무변경.
+
+자가가입(이전)으로 온보딩은 됐지만 분실/변경 경로가 없던 갭을 메운다.
+
+## A. 라이더 본인 비번 변경
+
+### 백엔드 (신규 write 엔드포인트)
+- `POST /api/v1/rider/me/password` (RIDER 인증) — body `{currentPassword, newPassword}`.
+- `RiderAuthService.changePassword(UUID riderId, String current, String newPassword)`:
+  - `riderCredentialRepository.findByRiderId(riderId)` → 현재 비번 `passwordEncoder.matches(current, hash)` 검증. 없거나 불일치 → `RiderAuthenticationException`(401).
+  - `credential.updatePasswordHash(passwordEncoder.encode(newPassword))` + save.
+- DTO `RiderPasswordChangeRequest` `{@NotBlank currentPassword, @NotBlank @Size(min=8,max=100) newPassword}`.
+- 신규 컨트롤러 `rider/controller/RiderSelfCommandController` `@RequestMapping("/api/v1/rider")`, `POST /me/password` → riderId from JWT → 서비스 호출 → 204. (write라 read 컨트롤러와 분리.)
+- 보안: `/api/v1/rider/**` 는 이미 `hasRole("RIDER")` → 변경 없음.
+- **ArchUnit**: `isRiderSelfCommand`(owner=RiderSelfCommandController) predicate 추가 + 두 allow 체인에 등록(POST write route).
+- **예외 매핑**: `RiderAuthExceptionHandler`의 `@RestControllerAdvice(assignableTypes=...)`에 `RiderSelfCommandController` 추가 → 현재 비번 불일치 시 401 응답(기존 핸들러 재사용). (전역 핸들러가 RiderAuthenticationException을 이미 매핑하면 그걸 따른다 — 구현 시 확인.)
+- 계약 테스트: 정상 변경(새 비번으로 재로그인 성공) / 현재 비번 틀림 401 / 새 비번 7자 400 / 미인증 401.
+
+### 프론트
+- `lib/services/rider-api.ts`: `riderChangePassword(token, current, newPassword): Promise<void>` → POST `/rider/me/password`(204).
+- `app/rider/password/password-action.ts` ("use server"): 검증(빈값/새≠확인/8자) → `riderChangePassword` → 성공 시 `/rider`로(성공 표시). 401 → "현재 비밀번호가 올바르지 않습니다", 400 → "새 비밀번호는 8자 이상".
+- `app/rider/password/page.tsx` ("use client", login 패턴): 현재·새·새확인 + 제출.
+- `/rider` 홈: "비밀번호 변경" 링크(`/rider/password`).
+- 미들웨어: `/rider/password`는 `/rider/*` 게이트 적용(인증 필요) — 변경 없음(공개 경로 아님).
+
+## B. 관리자 비번 재설정 UI (백엔드 무변경)
+- admin 클라이언트(`lib/services/service-ops-api.ts`): `setRiderCredential(id, newPassword)` → `PATCH /api/v1/riders/{id}/credential` body `{newPassword}`. ServiceOpsApiClient 인터페이스 + 구현에 추가.
+- `app/management/riders/actions.ts`: `resetRiderCredentialAction(riderId, newPassword)` — 인증 admin 클라이언트로 호출, 성공/실패 반환.
+- `components/management/RiderDetailDialog.tsx`: **"비밀번호 재설정"** 섹션/버튼 → 새 비번 입력(8자+) → 액션 호출 → 성공/오류 피드백. (관리자가 새 비번 타이핑 → 라이더에게 전달, 라이더는 A로 변경 가능.)
+  - 기존 다이얼로그 패턴(편집/액션) 따라 구현. RiderDetailDialog가 받는 rider id 사용.
+
+## 검증
+- 백엔드: compileJava/compileTestJava + 계약 테스트(위 4종), ArchUnit 신규 위반 0(RiderSelfCommandController allow-list 등록).
+- 프론트: typecheck/lint/build, `/rider/password` 라우트 생성.
+- prod(배포 후): 라이더가 `/rider`에서 비번 변경 → 새 비번 재로그인 / 관리자가 라이더 상세에서 재설정 → 라이더 새 비번 로그인.
+
+## 범위 밖
+- 비번 분실 시 자가 재설정(SMS/이메일), 재설정=credential 삭제 후 재가입 대안, 비번 정책 강화(복잡도).


### PR DESCRIPTION
## 릴리스 내용
계정관리 마무리 (#470) — 라이더 본인 비번 변경 + 관리자 재설정 UI.

- 백엔드: `POST /api/v1/rider/me/password`(본인 변경, 현재 비번 검증). 마이그레이션 없음.
- 프론트: `/rider/password` 페이지 + `/rider` 링크 + 라이더 상세 "비밀번호 재설정" 섹션.

## 검증
- 백엔드 compile/ArchUnit OK(계약테스트 CI), 프론트 typecheck/lint/build OK.

## QA (배포 후)
1. 라이더: `/rider` → 비밀번호 변경 → 현재 비번 확인 → 새 비번으로 재로그인
2. 관리자: 자원관리 라이더 상세 → 비밀번호 재설정 → 라이더가 새 비번으로 로그인

🤖 Generated with [Claude Code](https://claude.com/claude-code)