### PR TITLE
fix(rider): 로그인 후 stale 화면 + 전화번호 '-' 매칭

### DIFF
--- a/development/front-admin-web/app/rider/login/login-action.ts
+++ b/development/front-admin-web/app/rider/login/login-action.ts
@@ -23,5 +23,7 @@ export async function loginRiderAction(formData: FormData): Promise<{ error: str
     return { error: "전화번호 또는 비밀번호가 올바르지 않습니다." };
   }
 
-  redirect("/rider");
+  // 쿼리로 클라이언트 라우터 캐시를 버스팅 — 없으면 로그인 전 프리페치된 stale RSC가
+  // 잠깐 보였다가 새로고침해야 정상화되는 문제가 있다(관리자 로그인의 ?auth=... 와 동일 원리).
+  redirect("/rider?from=login");
 }

--- a/development/front-admin-web/app/rider/password/password-action.ts
+++ b/development/front-admin-web/app/rider/password/password-action.ts
@@ -40,5 +40,6 @@ export async function changeRiderPasswordAction(
     return { error: "비밀번호 변경에 실패했습니다. 잠시 후 다시 시도하세요." };
   }
 
-  redirect("/rider");
+  // 쿼리로 클라이언트 라우터 캐시 버스팅 — stale RSC 방지.
+  redirect("/rider?pw=changed");
 }

--- a/development/front-admin-web/app/rider/register/register-action.ts
+++ b/development/front-admin-web/app/rider/register/register-action.ts
@@ -23,5 +23,6 @@ export async function registerRiderAction(formData: FormData): Promise<{ error: 
     }
     return { error: "가입에 실패했습니다. 잠시 후 다시 시도하세요." };
   }
-  redirect("/rider");
+  // 쿼리로 클라이언트 라우터 캐시 버스팅 — stale RSC(로그인 전 프리페치) 방지.
+  redirect("/rider?from=register");
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/repository/RiderRepository.java
@@ -52,6 +52,13 @@ public interface RiderRepository extends Repository<Rider, UUID> {
 
     Optional<Rider> findByPhoneNumberAndDeletedAtIsNull(String phoneNumber);
 
+    /**
+     * 전화번호를 숫자만으로 정규화해 비교한다 ('-'·공백 유무 무관). 라이더 로그인/가입에서
+     * 입력 전화번호와 저장값의 포맷이 달라도 매칭되도록.
+     */
+    @Query(value = "select * from riders where regexp_replace(phone_number, '[^0-9]', '', 'g') = :digits and deleted_at is null limit 1", nativeQuery = true)
+    Optional<Rider> findActiveByNormalizedPhone(@Param("digits") String digits);
+
     List<Rider> findAllByDeletedAtIsNull();
 
     List<Rider> findAllByIdIn(Iterable<UUID> ids);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/riderauth/service/RiderAuthService.java
@@ -43,7 +43,7 @@ public class RiderAuthService {
 
     @Transactional(readOnly = true)
     public RiderLoginResponse login(RiderLoginRequest request) {
-        Rider rider = riderRepository.findByPhoneNumberAndDeletedAtIsNull(request.phoneNumber())
+        Rider rider = riderRepository.findActiveByNormalizedPhone(normalizePhone(request.phoneNumber()))
                 .orElseThrow(RiderAuthenticationException::new);
         riderCredentialRepository.findByRiderId(rider.getId())
                 .filter(credential -> passwordEncoder.matches(request.password(), credential.getPasswordHash()))
@@ -71,7 +71,7 @@ public class RiderAuthService {
 
     @Transactional
     public RiderLoginResponse register(RiderRegisterRequest request) {
-        Rider rider = riderRepository.findByPhoneNumberAndDeletedAtIsNull(request.phoneNumber())
+        Rider rider = riderRepository.findActiveByNormalizedPhone(normalizePhone(request.phoneNumber()))
                 .filter(r -> r.getName() != null && r.getName().trim().equals(request.name().trim()))
                 .orElseThrow(RiderAuthenticationException::new);
         if (riderCredentialRepository.findByRiderId(rider.getId()).isPresent()) {
@@ -116,6 +116,10 @@ public class RiderAuthService {
                 refreshToken.expiresAt(),
                 RiderIdentityResponse.from(rider)
         );
+    }
+
+    private static String normalizePhone(String phoneNumber) {
+        return phoneNumber == null ? "" : phoneNumber.replaceAll("[^0-9]", "");
     }
 
     private UUID parseRiderId(String value) {


### PR DESCRIPTION
## 버그 2건 수정
### 1) 회원가입/로그인/비번변경 후 로그인 화면으로 보임
URL은 `/rider`로 맞는데 화면만 관리자 로그인 UI, 새로고침하면 정상 — Next App Router **클라이언트 라우터 캐시**가 로그인 전 프리페치된 stale RSC를 보여주던 문제. 라이더 인증 액션 3개(login/register/password) redirect에 **캐시버스팅 쿼리** 추가(관리자 로그인 `?auth=service-ops`와 동일 원리). → 즉시 정상 라이더 홈.

### 2) 전화번호 '-' 빠지면 매칭 실패
로그인/가입이 전화번호를 정확 일치로 비교 → `RiderRepository.findActiveByNormalizedPhone`(regexp_replace 숫자만) + `RiderAuthService` login/register가 입력도 숫자만 정규화 비교. '-'·공백 유무 무관.

## 검증
- 백엔드 compileJava 통과, 프론트 typecheck/lint/build 통과
- 마이그레이션 없음

## QA (배포 후)
- 가입/로그인/비번변경 → /rider 홈 즉시 표시(새로고침 불필요)
- 전화번호 '01012345678'(대시 없이)로도 가입/로그인 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)