### PR TITLE
fix(rider): 로그인/가입 후 풀 페이지 로드로 stale 화면 제거

### DIFF
--- a/development/front-admin-web/app/rider/login/login-action.ts
+++ b/development/front-admin-web/app/rider/login/login-action.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
-
 import { riderApiConfigured, riderLogin } from "@/lib/services/rider-api";
 import { setRiderSession } from "@/lib/services/rider-session";
 
@@ -23,7 +21,6 @@ export async function loginRiderAction(formData: FormData): Promise<{ error: str
     return { error: "전화번호 또는 비밀번호가 올바르지 않습니다." };
   }
 
-  // 쿼리로 클라이언트 라우터 캐시를 버스팅 — 없으면 로그인 전 프리페치된 stale RSC가
-  // 잠깐 보였다가 새로고침해야 정상화되는 문제가 있다(관리자 로그인의 ?auth=... 와 동일 원리).
-  redirect("/rider?from=login");
+  // 성공 — 여기서 redirect() 하면 클라이언트 라우터가 stale RSC(관리자 로그인 UI)를
+  // 그리는 문제가 있어, 호출한 클라이언트가 window.location 으로 풀 로드하도록 void 반환한다.
 }

--- a/development/front-admin-web/app/rider/login/page.tsx
+++ b/development/front-admin-web/app/rider/login/page.tsx
@@ -14,7 +14,10 @@ export default function RiderLoginPage() {
       const result = await loginRiderAction(formData);
       if (result?.error) {
         setError(result.error);
+        return;
       }
+      // 풀 페이지 로드로 이동 — 미들웨어가 새 세션 쿠키와 함께 평가돼 라이더 홈이 바로 렌더된다.
+      window.location.href = "/rider";
     });
   }
 

--- a/development/front-admin-web/app/rider/password/page.tsx
+++ b/development/front-admin-web/app/rider/password/page.tsx
@@ -20,7 +20,10 @@ export default function RiderPasswordPage() {
       const result = await changeRiderPasswordAction(formData);
       if (result?.error) {
         setError(result.error);
+        return;
       }
+      // 풀 페이지 로드로 이동 — stale RSC 없이 라이더 홈이 바로 렌더된다.
+      window.location.href = "/rider";
     });
   }
 

--- a/development/front-admin-web/app/rider/password/password-action.ts
+++ b/development/front-admin-web/app/rider/password/password-action.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
-
 import { RiderApiError, riderApiConfigured, riderChangePassword } from "@/lib/services/rider-api";
 import { getRiderAccessToken } from "@/lib/services/rider-session";
 
@@ -40,6 +38,5 @@ export async function changeRiderPasswordAction(
     return { error: "비밀번호 변경에 실패했습니다. 잠시 후 다시 시도하세요." };
   }
 
-  // 쿼리로 클라이언트 라우터 캐시 버스팅 — stale RSC 방지.
-  redirect("/rider?pw=changed");
+  // 성공 — 클라이언트가 window.location 으로 풀 로드(아래 페이지). redirect() 시 stale RSC 문제.
 }

--- a/development/front-admin-web/app/rider/register/page.tsx
+++ b/development/front-admin-web/app/rider/register/page.tsx
@@ -28,7 +28,10 @@ export default function RiderRegisterPage() {
       const result = await registerRiderAction(formData);
       if (result?.error) {
         setError(result.error);
+        return;
       }
+      // 풀 페이지 로드로 이동 — stale RSC 없이 라이더 홈이 바로 렌더된다.
+      window.location.href = "/rider";
     });
   }
 

--- a/development/front-admin-web/app/rider/register/register-action.ts
+++ b/development/front-admin-web/app/rider/register/register-action.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
-
 import { RiderApiError, riderApiConfigured, riderRegister } from "@/lib/services/rider-api";
 import { setRiderSession } from "@/lib/services/rider-session";
 
@@ -23,6 +21,5 @@ export async function registerRiderAction(formData: FormData): Promise<{ error: 
     }
     return { error: "가입에 실패했습니다. 잠시 후 다시 시도하세요." };
   }
-  // 쿼리로 클라이언트 라우터 캐시 버스팅 — stale RSC(로그인 전 프리페치) 방지.
-  redirect("/rider?from=register");
+  // 성공 — 클라이언트가 window.location 으로 풀 로드(아래 페이지). redirect() 시 stale RSC 문제.
 }


### PR DESCRIPTION
## 문제 (재발)
쿼리 캐시버스팅(#472/#473) 배포 후에도 회원가입/로그인/비번변경 직후 `/rider`(URL은 정상)에 **관리자 로그인 UI(stale RSC)** 가 뜨고 새로고침해야 정상화됨.

## 원인
서버액션 `redirect()` → Next 클라이언트 라우터가 잘못된/stale RSC를 렌더. 쿼리 버스팅으론 부족.

## 수정
라이더 인증 액션 3개(login/register/password)에서 **redirect() 제거 → 성공 시 void 반환**, 호출한 클라이언트 페이지가 **`window.location.href = "/rider"` 풀 페이지 로드**. 미들웨어가 새 세션 쿠키와 함께 평가돼 stale RSC 없이 라이더 홈이 즉시 렌더됨. (쿠키는 액션 응답 Set-Cookie로 이미 적용된 뒤 풀 로드.)

## 검증
- typecheck/lint/build 통과. 마이그레이션 없음.

## QA (배포 후)
가입/로그인/비번변경 → 새로고침 없이 `/rider` 홈 즉시 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)