### PR TITLE
release: 라이더 로그아웃 풀로드 수정 (dev→main)

### DIFF
--- a/development/front-admin-web/app/rider/RiderLogoutButton.tsx
+++ b/development/front-admin-web/app/rider/RiderLogoutButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { logoutRiderAction } from "./actions";
+
+export default function RiderLogoutButton() {
+  const [pending, startTransition] = useTransition();
+
+  function onLogout() {
+    startTransition(async () => {
+      await logoutRiderAction();
+      // 풀 페이지 로드 — 서버액션 redirect() 시 클라이언트가 stale RSC(관리자 로그인 UI)를
+      // 그리는 문제가 있어, 비워진 세션으로 미들웨어가 새로 평가하도록 강제 이동한다.
+      window.location.href = "/rider/login";
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onLogout}
+      disabled={pending}
+      style={{
+        width: "100%",
+        padding: "12px 0",
+        borderRadius: 8,
+        border: "1px solid #e5e7eb",
+        background: "#f9fafb",
+        color: "#374151",
+        fontSize: 14,
+        fontWeight: 500,
+        cursor: "pointer",
+      }}
+    >
+      {pending ? "로그아웃 중…" : "로그아웃"}
+    </button>
+  );
+}

--- a/development/front-admin-web/app/rider/actions.ts
+++ b/development/front-admin-web/app/rider/actions.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
-
 import { riderApiConfigured, riderLogout } from "@/lib/services/rider-api";
 import { clearRiderSession, getRiderAccessToken } from "@/lib/services/rider-session";
 
@@ -15,5 +13,6 @@ export async function logoutRiderAction(): Promise<void> {
     // 무상태 — 서버 로그아웃 실패해도 쿠키 정리가 최종 기준.
   }
   await clearRiderSession();
-  redirect("/rider/login");
+  // redirect() 하지 않는다 — 클라이언트(RiderLogoutButton)가 window.location 으로 풀 로드해
+  // 미들웨어가 비워진 세션과 함께 평가하도록. redirect() 시 stale RSC(관리자 로그인 UI) 문제.
 }

--- a/development/front-admin-web/app/rider/page.tsx
+++ b/development/front-admin-web/app/rider/page.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/lib/services/rider-api";
 import { getRiderAccessToken } from "@/lib/services/rider-session";
 
-import { logoutRiderAction } from "./actions";
 import RiderMap from "@/components/rider/RiderMap";
+import RiderLogoutButton from "./RiderLogoutButton";
 
 export const dynamic = "force-dynamic";
 
@@ -253,24 +253,7 @@ export default async function RiderHomePage() {
         >
           비밀번호 변경
         </a>
-        <form action={logoutRiderAction}>
-          <button
-            type="submit"
-            style={{
-              width: "100%",
-              padding: "12px 0",
-              borderRadius: 8,
-              border: "1px solid #e5e7eb",
-              background: "#f9fafb",
-              color: "#374151",
-              fontSize: 14,
-              fontWeight: 500,
-              cursor: "pointer",
-            }}
-          >
-            로그아웃
-          </button>
-        </form>
+        <RiderLogoutButton />
       </div>
     </main>
   );


### PR DESCRIPTION
로그아웃 후 stale 관리자 로그인 UI → 풀 페이지 로드로 해결. 마이그레이션 없음. 배포 후 QA: 로그아웃 → 라이더 로그인 화면 바로 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)