### PR TITLE
feat(rider): 전화번호 자동 대시 포맷 (입력 + 저장/엑셀)

### DIFF
--- a/development/front-admin-web/app/rider/login/page.tsx
+++ b/development/front-admin-web/app/rider/login/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { AsYouType } from "libphonenumber-js";
 
 import { loginRiderAction } from "./login-action";
 
 export default function RiderLoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [phone, setPhone] = useState("");
 
   function onSubmit(formData: FormData) {
     setError(null);
@@ -34,6 +36,8 @@ export default function RiderLoginPage() {
             autoComplete="username"
             placeholder="010-0000-0000"
             required
+            value={phone}
+            onChange={(e) => setPhone(new AsYouType("KR").input(e.target.value))}
           />
         </label>
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/development/front-admin-web/app/rider/register/page.tsx
+++ b/development/front-admin-web/app/rider/register/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { AsYouType } from "libphonenumber-js";
 
 import { registerRiderAction } from "./register-action";
 
 export default function RiderRegisterPage() {
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [phone, setPhone] = useState("");
 
   function onSubmit(formData: FormData) {
     setError(null);
@@ -58,6 +60,8 @@ export default function RiderRegisterPage() {
             autoComplete="tel"
             placeholder="010-0000-0000"
             required
+            value={phone}
+            onChange={(e) => setPhone(new AsYouType("KR").input(e.target.value))}
           />
         </label>
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
@@ -1,0 +1,26 @@
+package com.thundercrew.opsapi.common.util;
+
+public final class PhoneNumbers {
+    private PhoneNumbers() {}
+
+    /**
+     * 한국 전화번호를 대시 포맷으로 정규화한다. 숫자만 추출 후:
+     *  - 11자리: XXX-XXXX-XXXX (휴대폰)
+     *  - 10자리: XXX-XXX-XXXX
+     *  - 그 외: 원본을 trim 해서 그대로 반환(알 수 없는 형식은 건드리지 않음).
+     * null/blank 는 그대로 반환.
+     */
+    public static String format(String raw) {
+        if (raw == null) return null;
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) return trimmed;
+        String digits = trimmed.replaceAll("[^0-9]", "");
+        if (digits.length() == 11) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
+        }
+        if (digits.length() == 10) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 6) + "-" + digits.substring(6);
+        }
+        return trimmed;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.rider.service;
 import com.thundercrew.opsapi.common.bulk.BulkApplyResponse;
 import com.thundercrew.opsapi.common.bulk.BulkPreviewResponse;
 import com.thundercrew.opsapi.common.bulk.BulkRowResult;
+import com.thundercrew.opsapi.common.util.PhoneNumbers;
 import com.thundercrew.opsapi.common.excel.ExcelExporter;
 import com.thundercrew.opsapi.common.excel.ExcelParser;
 import com.thundercrew.opsapi.rider.domain.Rider;
@@ -46,8 +47,8 @@ public class RiderBulkService {
         for (List<String> cols : rows) {
             try {
                 String name = cell(cols, 0);
-                String phone = cell(cols, 1);
-                if (name.isBlank() || phone.isBlank()) {
+                String phone = PhoneNumbers.format(cell(cols, 1));
+                if (name.isBlank() || phone == null || phone.isBlank()) {
                     skipped++;
                     continue;
                 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderCommandService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderCommandService.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.rider.service;
 import com.thundercrew.opsapi.common.api.DuplicateActiveResourceException;
 import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.common.util.PhoneNumbers;
 import com.thundercrew.opsapi.rider.domain.Rider;
 import com.thundercrew.opsapi.rider.dto.RiderAppAccountLinkRequest;
 import com.thundercrew.opsapi.rider.dto.RiderCreateRequest;
@@ -33,10 +34,11 @@ public class RiderCommandService {
 
     @Transactional
     public RiderReadResponse create(RiderCreateRequest request) {
-        assertPhoneIsNotDuplicated(request.phoneNumber());
+        String phoneNumber = PhoneNumbers.format(request.phoneNumber());
+        assertPhoneIsNotDuplicated(phoneNumber);
         Rider rider = Rider.create(
                 request.name(),
-                request.phoneNumber(),
+                phoneNumber,
                 request.teamName(),
                 request.areaName(),
                 request.memo()
@@ -55,14 +57,15 @@ public class RiderCommandService {
     public RiderReadResponse update(UUID id, RiderUpdateRequest request) {
         Rider rider = riderRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Rider", id));
-        if (StringUtils.hasText(request.phoneNumber())
-                && riderRepository.existsByPhoneNumberAndIdNotAndDeletedAtIsNull(request.phoneNumber(), id)) {
+        String phoneNumber = PhoneNumbers.format(request.phoneNumber());
+        if (StringUtils.hasText(phoneNumber)
+                && riderRepository.existsByPhoneNumberAndIdNotAndDeletedAtIsNull(phoneNumber, id)) {
             throw new DuplicateActiveResourceException("Rider", "phoneNumber");
         }
         try {
             rider.updateBasicProfile(
                     request.name(),
-                    request.phoneNumber(),
+                    phoneNumber,
                     request.teamName(),
                     request.areaName(),
                     request.memo()


### PR DESCRIPTION
## 개요
전화번호를 **대시 포맷으로 자동 생성**:
1. **라이더 앱 입력**(로그인/가입): `AsYouType('KR')`로 입력 즉시 `010-1234-5678` 자동 포맷
2. **저장 경로**(엑셀 일괄등록 + 수동 생성/수정): 백엔드 `PhoneNumbers.format`로 저장값을 항상 대시 포맷으로 정규화 — 소스 무관 일관성

## 변경
- 백엔드: `common/util/PhoneNumbers`(11자리→XXX-XXXX-XXXX, 10자리→XXX-XXX-XXXX) + `RiderCommandService`(생성/수정) + `RiderBulkService`(엑셀) 적용
- 프론트: `app/rider/login`·`app/rider/register` phoneNumber input controlled + AsYouType
- 매칭용 숫자 정규화(#472)는 안전망으로 유지. 기존 행 재포맷 마이그레이션은 없음(신규/수정분부터 대시).

## 검증
- 백엔드 compile + ArchUnit(common 규칙 통과), 프론트 typecheck/lint/build 통과. 마이그레이션 없음.

## QA (배포 후)
- 라이더 가입/로그인 전화번호 칸에 숫자만 쳐도 `-` 자동 삽입
- 엑셀로 대시 없이 올려도 저장값이 `010-1234-5678` 형식

🤖 Generated with [Claude Code](https://claude.com/claude-code)