### PR TITLE
fix(rider): 엑셀 전화번호 선행 0 손실 (104-177-5801 → 010-4177-5801)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -34,6 +35,16 @@ public class ExcelExporter {
      */
     public static byte[] export(Class<?> resourceBase, String templateName,
                                 int dataStartRow, List<List<String>> rows) throws IOException {
+        return export(resourceBase, templateName, dataStartRow, rows, new int[0]);
+    }
+
+    /**
+     * {@link #export(Class, String, int, List)} 와 동일하되, {@code textColumns} 로 지정한
+     * 0-based 컬럼을 텍스트(@) 서식으로 고정한다. 전화번호처럼 선행 0이 있는 값을 사용자가
+     * 입력했을 때 엑셀이 숫자로 변환해 0을 날리는 것을 막는다(빈 셀 기본 서식이 텍스트가 됨).
+     */
+    public static byte[] export(Class<?> resourceBase, String templateName,
+                                int dataStartRow, List<List<String>> rows, int[] textColumns) throws IOException {
         InputStream tpl = resourceBase.getResourceAsStream("/templates/excel/" + templateName);
         if (tpl == null) {
             throw new IllegalStateException("Excel template not found on classpath: /templates/excel/" + templateName);
@@ -41,6 +52,14 @@ public class ExcelExporter {
         try (tpl; Workbook wb = WorkbookFactory.create(tpl)) {
             Sheet sheet = wb.getSheetAt(0);
             clearDataRows(sheet, dataStartRow);
+
+            if (textColumns != null && textColumns.length > 0) {
+                CellStyle textStyle = wb.createCellStyle();
+                textStyle.setDataFormat(wb.createDataFormat().getFormat("@"));
+                for (int col : textColumns) {
+                    sheet.setDefaultColumnStyle(col, textStyle);
+                }
+            }
 
             for (int i = 0; i < rows.size(); i++) {
                 Row row = sheet.createRow(dataStartRow + i);

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
@@ -9,12 +9,20 @@ public final class PhoneNumbers {
      *  - 10자리: XXX-XXX-XXXX
      *  - 그 외: 원본을 trim 해서 그대로 반환(알 수 없는 형식은 건드리지 않음).
      * null/blank 는 그대로 반환.
+     *
+     * 엑셀에서 휴대폰 번호가 숫자로 인식돼 선행 0이 사라진 경우(예: 01041775801 →
+     * 1041775801)를 복구한다. 한국 전화번호 중 "10"으로 시작하는 10자리는 존재하지 않으므로
+     * (지역번호·휴대폰 모두 0으로 시작) "10"으로 시작하는 10자리는 010 휴대폰의 0 누락으로 보고
+     * 0을 복원한다.
      */
     public static String format(String raw) {
         if (raw == null) return null;
         String trimmed = raw.trim();
         if (trimmed.isEmpty()) return trimmed;
         String digits = trimmed.replaceAll("[^0-9]", "");
+        if (digits.length() == 10 && digits.startsWith("10")) {
+            digits = "0" + digits;
+        }
         if (digits.length() == 11) {
             return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
         }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
@@ -83,8 +83,10 @@ public class RiderBulkService {
                         trainingLabel(r.getTrainingStatus()),
                         r.getTeamName() != null ? r.getTeamName() : ""))
                 .toList();
+        // 전화번호 열(인덱스 1)은 텍스트 서식으로 고정 — 사용자가 입력할 때 엑셀이 휴대폰
+        // 번호를 숫자로 인식해 선행 0을 날리는 것을 방지(예: 01012345678 → 1012345678).
         return ExcelExporter.export(RiderBulkService.class, "riders-template.xlsx",
-                DATA_START_ROW, rows);
+                DATA_START_ROW, rows, new int[] {1});
     }
 
     private BulkRowResult evaluateRow(List<String> cols, int rowNum) {


### PR DESCRIPTION
## 문제
엑셀로 라이더 등록 시 `010-4177-5801`이 **`104-177-5801`로 저장**됨. 엑셀이 `01041775801`을 숫자로 인식 → 선행 0 소실 → `1041775801`(10자리) → 서버가 10자리로 포맷.

## 수정 (이중 방어)
1. **서버 복구** `PhoneNumbers.format`: 10자리이고 `10`으로 시작하면 010 휴대폰의 0 누락으로 보고 0 복원 → `010-4177-5801`. (한국 번호 중 "10" 시작 10자리는 없어 안전.) 어떤 경로로 들어와도 교정.
2. **엑셀단 예방** `ExcelExporter` textColumns 오버로드 + `RiderBulkService`가 전화 열(1)을 **텍스트 서식으로 고정** → 사용자 입력 시 엑셀이 0을 안 날림.

## 검증
compileJava 통과. 마이그레이션 없음.

## QA (배포 후)
- 엑셀에 `01041775801` 또는 `010-4177-5801` 입력 → 업로드 → `010-4177-5801`로 저장
- 새 템플릿 다운로드 시 전화 열이 텍스트 서식

## 기존 데이터
이미 `104-177-5801`로 저장된 행은 라이더 상세에서 전화번호 재저장하거나 재업로드하면 복구 로직으로 교정됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)