### PR TITLE
feat(rider): 엑셀 전화번호 형식 강제 (데이터 유효성 검사)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
@@ -6,10 +6,15 @@ import java.io.InputStream;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataValidation;
+import org.apache.poi.ss.usermodel.DataValidationConstraint;
+import org.apache.poi.ss.usermodel.DataValidationHelper;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.ss.util.CellRangeAddressList;
+import org.apache.poi.ss.util.CellReference;
 
 /**
  * Utility for exporting data into a pre-existing Excel template.
@@ -45,6 +50,17 @@ public class ExcelExporter {
      */
     public static byte[] export(Class<?> resourceBase, String templateName,
                                 int dataStartRow, List<List<String>> rows, int[] textColumns) throws IOException {
+        return export(resourceBase, templateName, dataStartRow, rows, textColumns, new int[0]);
+    }
+
+    /**
+     * {@link #export(Class, String, int, List, int[])} 에 더해, {@code phoneFormatColumns} 로 지정한
+     * 0-based 컬럼에 "전화번호 형식(XXX-XXXX-XXXX, 대시 포함)" 데이터 유효성 검사를 건다. 형식이
+     * 맞지 않으면 엑셀이 입력을 차단(STOP)한다. 빈 셀은 허용. (붙여넣기는 엑셀 특성상 우회 가능.)
+     */
+    public static byte[] export(Class<?> resourceBase, String templateName,
+                                int dataStartRow, List<List<String>> rows,
+                                int[] textColumns, int[] phoneFormatColumns) throws IOException {
         InputStream tpl = resourceBase.getResourceAsStream("/templates/excel/" + templateName);
         if (tpl == null) {
             throw new IllegalStateException("Excel template not found on classpath: /templates/excel/" + templateName);
@@ -61,6 +77,10 @@ public class ExcelExporter {
                 }
             }
 
+            if (phoneFormatColumns != null && phoneFormatColumns.length > 0) {
+                applyPhoneFormatValidation(sheet, dataStartRow, phoneFormatColumns);
+            }
+
             for (int i = 0; i < rows.size(); i++) {
                 Row row = sheet.createRow(dataStartRow + i);
                 List<String> cols = rows.get(i);
@@ -74,6 +94,30 @@ public class ExcelExporter {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             wb.write(out);
             return out.toByteArray();
+        }
+    }
+
+    private static void applyPhoneFormatValidation(Sheet sheet, int dataStartRow, int[] phoneFormatColumns) {
+        DataValidationHelper helper = sheet.getDataValidationHelper();
+        int lastRow = dataStartRow + 1000;
+        for (int col : phoneFormatColumns) {
+            // 유효성 검사 수식은 검증 영역 좌상단 셀(첫 데이터 셀)을 기준으로 상대 평가된다.
+            String anchor = CellReference.convertNumToColString(col) + (dataStartRow + 1);
+            String formula = "AND(LEN(" + anchor + ")=13,"
+                    + "MID(" + anchor + ",4,1)=\"-\","
+                    + "MID(" + anchor + ",9,1)=\"-\","
+                    + "ISNUMBER(VALUE(LEFT(" + anchor + ",3))),"
+                    + "ISNUMBER(VALUE(MID(" + anchor + ",5,4))),"
+                    + "ISNUMBER(VALUE(MID(" + anchor + ",10,4))))";
+            DataValidationConstraint constraint = helper.createCustomConstraint(formula);
+            CellRangeAddressList regions = new CellRangeAddressList(dataStartRow, lastRow, col, col);
+            DataValidation validation = helper.createValidation(constraint, regions);
+            validation.setEmptyCellAllowed(true);
+            validation.setSuppressDropDownArrow(true);
+            validation.setShowErrorBox(true);
+            validation.setErrorStyle(DataValidation.ErrorStyle.STOP);
+            validation.createErrorBox("전화번호 형식 오류", "010-1234-5678 형식(숫자 3-4-4, 대시 포함)으로 입력하세요.");
+            sheet.addValidationData(validation);
         }
     }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderBulkService.java
@@ -83,10 +83,10 @@ public class RiderBulkService {
                         trainingLabel(r.getTrainingStatus()),
                         r.getTeamName() != null ? r.getTeamName() : ""))
                 .toList();
-        // 전화번호 열(인덱스 1)은 텍스트 서식으로 고정 — 사용자가 입력할 때 엑셀이 휴대폰
-        // 번호를 숫자로 인식해 선행 0을 날리는 것을 방지(예: 01012345678 → 1012345678).
+        // 전화번호 열(인덱스 1): 텍스트 서식 고정(선행 0 보존) + 형식 데이터 유효성 검사
+        // (010-1234-5678 형식 아니면 입력 차단).
         return ExcelExporter.export(RiderBulkService.class, "riders-template.xlsx",
-                DATA_START_ROW, rows, new int[] {1});
+                DATA_START_ROW, rows, new int[] {1}, new int[] {1});
     }
 
     private BulkRowResult evaluateRow(List<String> cols, int rowNum) {


### PR DESCRIPTION
## 개요
라이더 자원관리 엑셀 템플릿의 전화 열에 **데이터 유효성 검사** 추가 — `010-1234-5678`(XXX-XXXX-XXXX, 대시 포함) 형식이 아니면 엑셀이 **입력을 차단(STOP)** 하고 오류 메시지 표시. 빈 셀은 허용.

## 변경
- `ExcelExporter`: `phoneFormatColumns` 오버로드 + `applyPhoneFormatValidation`(POI DataValidation, 커스텀 수식 `LEN=13 & 대시@4,9 & 3-4-4 숫자`)
- `RiderBulkService`: 전화 열(1)에 텍스트 서식 + 형식 검증 동시 적용

## 한계(엑셀 특성)
- 대시까지 직접 입력해야 통과(숫자만 치면 차단). 단, **붙여넣기는 우회 가능** — 그래서 서버 정규화/복구(#480)는 안전망으로 유지.

## 검증
compileJava 통과. 마이그레이션 없음. (엑셀 유효성 동작은 배포 후 템플릿 다운로드로 QA 권장.)

## QA (배포 후)
새 라이더 템플릿 다운로드 → 전화 칸에 `123` 입력 시 차단/경고, `010-1234-5678` 입력 시 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)