### PR TITLE
Drop phone leading-zero recovery; rely on Excel validation

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/util/PhoneNumbers.java
@@ -9,20 +9,12 @@ public final class PhoneNumbers {
      *  - 10자리: XXX-XXX-XXXX
      *  - 그 외: 원본을 trim 해서 그대로 반환(알 수 없는 형식은 건드리지 않음).
      * null/blank 는 그대로 반환.
-     *
-     * 엑셀에서 휴대폰 번호가 숫자로 인식돼 선행 0이 사라진 경우(예: 01041775801 →
-     * 1041775801)를 복구한다. 한국 전화번호 중 "10"으로 시작하는 10자리는 존재하지 않으므로
-     * (지역번호·휴대폰 모두 0으로 시작) "10"으로 시작하는 10자리는 010 휴대폰의 0 누락으로 보고
-     * 0을 복원한다.
      */
     public static String format(String raw) {
         if (raw == null) return null;
         String trimmed = raw.trim();
         if (trimmed.isEmpty()) return trimmed;
         String digits = trimmed.replaceAll("[^0-9]", "");
-        if (digits.length() == 10 && digits.startsWith("10")) {
-            digits = "0" + digits;
-        }
         if (digits.length() == 11) {
             return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
         }


### PR DESCRIPTION
## Summary
- Excel 데이터 유효성 검사가 `010-XXXX-XXXX` 대시 형식을 입력 단에서 강제하므로, 서버측 선행 0 복구 로직(10자리 "10" 시작 → 0 복원)을 제거.
- 기본 대시 정규화(`XXX-XXXX-XXXX`)는 유지 — 라이더 앱/관리자 폼 등 비-엑셀 경로에서 여전히 사용.

## Note
- 이미 잘못 저장된 기존 행(예: 박상현 `104-177-5801`)은 자동 교정되지 않음. 필요 시 수동 재입력.

🤖 Generated with [Claude Code](https://claude.com/claude-code)