### PR TITLE
자원관리 테이블 행별 삭제/종료 버튼

### DIFF
--- a/development/front-admin-web/app/management/matching/actions.ts
+++ b/development/front-admin-web/app/management/matching/actions.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
+  ServiceOpsApiError,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type ServiceOpsRiderBikeContract
@@ -51,4 +52,31 @@ export async function listMatchingAction(): Promise<ServiceOpsRiderBikeContract[
 
   const page = await client.listRiderBikeContracts({ page: 0, size: 200 });
   return page.items;
+}
+
+export async function terminateMatchingAction(contractId: string): Promise<{ ok: boolean; message?: string }> {
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, message: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.terminateRiderBikeContract(contractId, {
+      terminatedAt: new Date().toISOString(),
+      terminatedReason: "OPERATOR_TERMINATE"
+    });
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ServiceOpsApiError) {
+      if (e.status === 409 || e.status === 400) {
+        return { ok: false, message: "이미 종료되었거나 종료할 수 없는 계약입니다." };
+      }
+      return { ok: false, message: e.message || "종료 처리 중 오류가 발생했습니다." };
+    }
+    return { ok: false, message: "종료 처리 중 오류가 발생했습니다." };
+  }
 }

--- a/development/front-admin-web/app/management/riders/actions.ts
+++ b/development/front-admin-web/app/management/riders/actions.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
+  ServiceOpsApiError,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type FrontendRider
@@ -76,4 +77,28 @@ export async function listRidersAction(): Promise<FrontendRider[]> {
 
   const page = await client.listRiders({ page: 0, size: 200 });
   return page.items;
+}
+
+export async function deleteRiderAction(riderId: string): Promise<{ ok: boolean; message?: string }> {
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, message: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.deleteRider(riderId);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ServiceOpsApiError) {
+      if (e.status === 409 || e.status === 400) {
+        return { ok: false, message: "활성 매칭/참조가 있어 삭제할 수 없습니다. 먼저 매칭을 종료하세요." };
+      }
+      return { ok: false, message: e.message || "삭제 처리 중 오류가 발생했습니다." };
+    }
+    return { ok: false, message: "삭제 처리 중 오류가 발생했습니다." };
+  }
 }

--- a/development/front-admin-web/app/management/vehicles/actions.ts
+++ b/development/front-admin-web/app/management/vehicles/actions.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import {
   serviceOpsApiConfigured,
+  ServiceOpsApiError,
   type BulkPreviewResponse,
   type BulkApplyResponse,
   type FrontendVehicle
@@ -51,4 +52,40 @@ export async function listVehiclesAction(): Promise<FrontendVehicle[]> {
 
   const page = await client.listVehicles({ page: 0, size: 200 });
   return page.items;
+}
+
+export async function deleteVehicleAction(vehicleId: string): Promise<{ ok: boolean; message?: string }> {
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, message: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    // IMEI 단말기가 부착되어 있으면 백엔드가 차량 삭제를 거부한다 (FK constraint).
+    // 먼저 활성 bike_device_installation 을 모두 해제한 뒤 차량을 삭제한다.
+    const installations = await client.listBikeDeviceInstallations({ bikeId: vehicleId, size: 200 });
+    const activeInstallations = installations.items.filter(
+      (inst) => inst.bikeId === vehicleId && inst.removedAt === null
+    );
+    for (const inst of activeInstallations) {
+      await client.removeBikeDeviceInstallation(inst.id, {
+        removedAt: new Date().toISOString(),
+        memo: "차량 삭제 전 자동 해제"
+      });
+    }
+    await client.deleteVehicle(vehicleId);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ServiceOpsApiError) {
+      if (e.status === 409 || e.status === 400) {
+        return { ok: false, message: "활성 매칭/참조가 있어 삭제할 수 없습니다. 먼저 매칭을 종료하세요." };
+      }
+      return { ok: false, message: e.message || "삭제 처리 중 오류가 발생했습니다." };
+    }
+    return { ok: false, message: "삭제 처리 중 오류가 발생했습니다." };
+  }
 }

--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewMatchingAction,
   bulkApplyMatchingAction,
-  listMatchingAction
+  listMatchingAction,
+  terminateMatchingAction
 } from "@/app/management/matching/actions";
 import type {
   ServiceOpsRiderBikeContract,
@@ -51,6 +52,8 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
     let active = true;
@@ -93,6 +96,12 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
         </p>
       ) : null}
 
+      {actionError ? (
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
+          {actionError}
+        </p>
+      ) : null}
+
       <div className="table-card">
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
@@ -106,16 +115,17 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>시작일</th>
               <th>종료일</th>
               <th>상태</th>
+              <th>관리</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={9} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={10} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : contracts.length === 0 ? (
               <tr>
-                <td colSpan={9} className="table-empty-cell">계약 없음</td>
+                <td colSpan={10} className="table-empty-cell">계약 없음</td>
               </tr>
             ) : (
               contracts.map((c) => (
@@ -129,6 +139,33 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td>{c.startAt.slice(0, 10)}</td>
                   <td>{c.endAt ? c.endAt.slice(0, 10) : <span className="muted">—</span>}</td>
                   <td><ContractStatusBadge contract={c} /></td>
+                  <td>
+                    {!c.terminatedAt ? (
+                      <button
+                        type="button"
+                        className="button-neutral"
+                        disabled={isPending}
+                        onClick={() => {
+                          if (!window.confirm("계약을 종료하시겠습니까?")) return;
+                          setActionError(null);
+                          startTransition(async () => {
+                            const res = await terminateMatchingAction(c.id);
+                            if (res.ok) {
+                              router.refresh();
+                              setLoading(true);
+                              setRefreshKey(k => k + 1);
+                            } else {
+                              setActionError(res.message ?? "종료 실패");
+                            }
+                          });
+                        }}
+                      >
+                        종료
+                      </button>
+                    ) : (
+                      <span className="muted">—</span>
+                    )}
+                  </td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewRidersAction,
   bulkApplyRidersAction,
-  listRidersAction
+  listRidersAction,
+  deleteRiderAction
 } from "@/app/management/riders/actions";
 import type { FrontendRider, ServiceOpsRiderTrainingStatus } from "@/lib/services/service-ops-api";
 
@@ -24,6 +25,8 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
     let active = true;
@@ -66,6 +69,12 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
         </p>
       ) : null}
 
+      {actionError ? (
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
+          {actionError}
+        </p>
+      ) : null}
+
       <div className="table-card">
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
@@ -74,16 +83,17 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>연락처</th>
               <th>교육이수</th>
               <th>팀</th>
+              <th>관리</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={4} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={5} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : riders.length === 0 ? (
               <tr>
-                <td colSpan={4} className="table-empty-cell">라이더 없음</td>
+                <td colSpan={5} className="table-empty-cell">라이더 없음</td>
               </tr>
             ) : (
               riders.map((r) => (
@@ -92,6 +102,32 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td>{r.phone}</td>
                   <td><TrainingStatusBadge status={r.trainingStatus} /></td>
                   <td>{r.team}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="delete-icon-button"
+                      disabled={isPending || !r.id}
+                      title={`라이더 "${r.name}" 삭제`}
+                      aria-label={`라이더 "${r.name}" 삭제`}
+                      onClick={() => {
+                        if (!r.id) return;
+                        if (!window.confirm(`라이더 "${r.name}"을(를) 삭제하시겠습니까?`)) return;
+                        setActionError(null);
+                        startTransition(async () => {
+                          const res = await deleteRiderAction(r.id!);
+                          if (res.ok) {
+                            router.refresh();
+                            setLoading(true);
+                            setRefreshKey(k => k + 1);
+                          } else {
+                            setActionError(res.message ?? "삭제 실패");
+                          }
+                        });
+                      }}
+                    >
+                      삭제
+                    </button>
+                  </td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { ExcelImportButton } from "./ExcelImportButton";
 import {
   bulkPreviewVehiclesAction,
   bulkApplyVehiclesAction,
-  listVehiclesAction
+  listVehiclesAction,
+  deleteVehicleAction
 } from "@/app/management/vehicles/actions";
 import type { FrontendVehicle } from "@/lib/services/service-ops-api";
 
@@ -27,6 +28,8 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
     let active = true;
@@ -69,6 +72,12 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
         </p>
       ) : null}
 
+      {actionError ? (
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
+          {actionError}
+        </p>
+      ) : null}
+
       <div className="table-card">
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
@@ -78,16 +87,17 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>엔진</th>
               <th>IMEI</th>
               <th>단말기 ID</th>
+              <th>관리</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">불러오는 중…</td>
+                <td colSpan={6} className="table-empty-cell">불러오는 중…</td>
               </tr>
             ) : vehicles.length === 0 ? (
               <tr>
-                <td colSpan={5} className="table-empty-cell">차량 없음</td>
+                <td colSpan={6} className="table-empty-cell">차량 없음</td>
               </tr>
             ) : (
               vehicles.map((v) => (
@@ -97,6 +107,32 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
                   <td><EngineTypeBadge value={v.engineType} /></td>
                   <td>{v.imei ?? <span className="muted">—</span>}</td>
                   <td>{v.terminalId ?? <span className="muted">—</span>}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="delete-icon-button"
+                      disabled={isPending || !v.id}
+                      title={`차량 "${v.plateNumber}" 삭제`}
+                      aria-label={`차량 "${v.plateNumber}" 삭제`}
+                      onClick={() => {
+                        if (!v.id) return;
+                        if (!window.confirm(`차량 "${v.plateNumber}"을(를) 삭제하시겠습니까?`)) return;
+                        setActionError(null);
+                        startTransition(async () => {
+                          const res = await deleteVehicleAction(v.id!);
+                          if (res.ok) {
+                            router.refresh();
+                            setLoading(true);
+                            setRefreshKey(k => k + 1);
+                          } else {
+                            setActionError(res.message ?? "삭제 실패");
+                          }
+                        });
+                      }}
+                    >
+                      삭제
+                    </button>
+                  </td>
                 </tr>
               ))
             )}


### PR DESCRIPTION
## Summary
- `/management/resources` 자원관리 테이블 각 행에 **관리** 컬럼 추가:
  - 라이더/차량 → **삭제** 버튼 (소프트 삭제)
  - 매칭 → **종료** 버튼 (활성 계약일 때만 노출)
- 자원관리 전용 비-redirect 서버액션 신규(`deleteRiderAction`/`deleteVehicleAction`/`terminateMatchingAction`) — 성공 시 테이블 자리에서 새로고침, 실패 시 인라인 에러 표시.
- 활성 매칭/참조로 삭제가 막히면(409/400) "활성 매칭/참조가 있어 삭제할 수 없습니다. 먼저 매칭을 종료하세요." 인라인 안내.
- 차량 삭제는 기존 오버뷰 액션처럼 단말 설치 선해제 후 삭제.
- 기존 오버뷰 redirect 액션/고아 버튼 컴포넌트는 건드리지 않음.

## Test
- typecheck + lint + build 통과. (인증 게이트 페이지라 런타임 동작은 dev 배포 후 QA)

## QA
- 자원관리 > 라이더/차량 행 **삭제** → 확인창 → 목록에서 사라지는지.
- 활성 매칭 걸린 라이더/차량 삭제 → 빨간 인라인 에러로 막히는지.
- 매칭 행 **종료** → 상태가 "종료"로 바뀌는지. 이미 종료된 행엔 버튼 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)