### PR TITLE
Release: 자원관리 삭제 버튼 휴지통 아이콘(맨 앞 열)

### DIFF
--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -106,6 +106,7 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
+              <th aria-label="관리" />
               <th>차량번호</th>
               <th>서비스 유형</th>
               <th>라이더 이름</th>
@@ -115,7 +116,6 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
               <th>시작일</th>
               <th>종료일</th>
               <th>상태</th>
-              <th>관리</th>
             </tr>
           </thead>
           <tbody>
@@ -130,15 +130,6 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
             ) : (
               contracts.map((c) => (
                 <tr key={c.id}>
-                  <td>{c.plateNumber ?? <span className="muted">—</span>}</td>
-                  <td>{serviceTypeLabel(c.serviceType)}</td>
-                  <td>{c.riderName ?? <span className="muted">—</span>}</td>
-                  <td>{c.riderPhoneNumber ?? <span className="muted">—</span>}</td>
-                  <td>{categoryLabel(c.category)}</td>
-                  <td>{returnTypeLabel(c.returnType)}</td>
-                  <td>{c.startAt.slice(0, 10)}</td>
-                  <td>{c.endAt ? c.endAt.slice(0, 10) : <span className="muted">—</span>}</td>
-                  <td><ContractStatusBadge contract={c} /></td>
                   <td>
                     {!c.terminatedAt ? (
                       <button
@@ -162,10 +153,17 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
                       >
                         종료
                       </button>
-                    ) : (
-                      <span className="muted">—</span>
-                    )}
+                    ) : null}
                   </td>
+                  <td>{c.plateNumber ?? <span className="muted">—</span>}</td>
+                  <td>{serviceTypeLabel(c.serviceType)}</td>
+                  <td>{c.riderName ?? <span className="muted">—</span>}</td>
+                  <td>{c.riderPhoneNumber ?? <span className="muted">—</span>}</td>
+                  <td>{categoryLabel(c.category)}</td>
+                  <td>{returnTypeLabel(c.returnType)}</td>
+                  <td>{c.startAt.slice(0, 10)}</td>
+                  <td>{c.endAt ? c.endAt.slice(0, 10) : <span className="muted">—</span>}</td>
+                  <td><ContractStatusBadge contract={c} /></td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -79,11 +79,11 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
+              <th aria-label="관리" />
               <th>이름</th>
               <th>연락처</th>
               <th>교육이수</th>
               <th>팀</th>
-              <th>관리</th>
             </tr>
           </thead>
           <tbody>
@@ -98,10 +98,6 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
             ) : (
               riders.map((r) => (
                 <tr key={r.slug}>
-                  <td>{r.name}</td>
-                  <td>{r.phone}</td>
-                  <td><TrainingStatusBadge status={r.trainingStatus} /></td>
-                  <td>{r.team}</td>
                   <td>
                     <button
                       type="button"
@@ -125,9 +121,29 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
                         });
                       }}
                     >
-                      삭제
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.7"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M3 6h18" />
+                        <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+                        <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                      </svg>
                     </button>
                   </td>
+                  <td>{r.name}</td>
+                  <td>{r.phone}</td>
+                  <td><TrainingStatusBadge status={r.trainingStatus} /></td>
+                  <td>{r.team}</td>
                 </tr>
               ))
             )}

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -82,12 +82,12 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
+              <th aria-label="관리" />
               <th>차량번호</th>
               <th>구분</th>
               <th>엔진</th>
               <th>IMEI</th>
               <th>단말기 ID</th>
-              <th>관리</th>
             </tr>
           </thead>
           <tbody>
@@ -102,11 +102,6 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
             ) : (
               vehicles.map((v) => (
                 <tr key={v.slug}>
-                  <td>{v.plateNumber}</td>
-                  <td><WheelTypeBadge value={v.wheelType} /></td>
-                  <td><EngineTypeBadge value={v.engineType} /></td>
-                  <td>{v.imei ?? <span className="muted">—</span>}</td>
-                  <td>{v.terminalId ?? <span className="muted">—</span>}</td>
                   <td>
                     <button
                       type="button"
@@ -130,9 +125,30 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
                         });
                       }}
                     >
-                      삭제
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.7"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M3 6h18" />
+                        <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+                        <path d="M5 6l1 14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1l1-14" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                      </svg>
                     </button>
                   </td>
+                  <td>{v.plateNumber}</td>
+                  <td><WheelTypeBadge value={v.wheelType} /></td>
+                  <td><EngineTypeBadge value={v.engineType} /></td>
+                  <td>{v.imei ?? <span className="muted">—</span>}</td>
+                  <td>{v.terminalId ?? <span className="muted">—</span>}</td>
                 </tr>
               ))
             )}


### PR DESCRIPTION
## Release (dev → main)

- [#488](https://github.com/EVNSolution/thundercrew-domain/pull/488) — 자원관리 테이블 행 액션을 맨 앞 열로 이동. 라이더/차량 = 휴지통 아이콘, 매칭 = "종료" 텍스트.

## 배포 후 QA
1. 자원관리 라이더/차량 행 맨 앞에 🗑 아이콘, 매칭 맨 앞에 "종료" 버튼 보이는지
2. 차량/라이더 🗑 클릭 → 확인창 → 삭제되는지
3. 활성 매칭 걸린 건 삭제 시 빨간 인라인 에러로 막히는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)