### PR TITLE
Release: 자원관리 액션 열 너비 축소

### DIFF
--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -106,7 +106,7 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
-              <th aria-label="관리" />
+              <th aria-label="관리" style={{ width: 64 }} />
               <th>차량번호</th>
               <th>서비스 유형</th>
               <th>라이더 이름</th>

--- a/development/front-admin-web/components/management/RidersManagementPanel.tsx
+++ b/development/front-admin-web/components/management/RidersManagementPanel.tsx
@@ -79,7 +79,7 @@ export function RidersManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
-              <th aria-label="관리" />
+              <th aria-label="관리" style={{ width: 44 }} />
               <th>이름</th>
               <th>연락처</th>
               <th>교육이수</th>

--- a/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
+++ b/development/front-admin-web/components/management/VehiclesManagementPanel.tsx
@@ -82,7 +82,7 @@ export function VehiclesManagementPanel({ exportUrl }: { exportUrl: string }) {
         <table className="table" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
-              <th aria-label="관리" />
+              <th aria-label="관리" style={{ width: 44 }} />
               <th>차량번호</th>
               <th>구분</th>
               <th>엔진</th>


### PR DESCRIPTION
## Release (dev → main)

- [#490](https://github.com/EVNSolution/thundercrew-domain/pull/490) — 자원관리 액션(삭제/종료) 열 너비 고정(라이더/차량 44px, 매칭 64px). 아이콘/버튼 옆 빈 공간 축소.

## 배포 후 QA
- 자원관리 테이블에서 🗑/종료 버튼 옆 간격이 줄었는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)