### PR TITLE
OTOPLUG 단말 연동: 인앱 NT 수신기 + 차량등록 IMEI/terminalID

### DIFF
--- a/development/front-admin-web/app/actions.ts
+++ b/development/front-admin-web/app/actions.ts
@@ -109,8 +109,12 @@ export async function createVehicleFromOverviewAction(formData: FormData): Promi
     redirect("/login?status=session-required");
   }
 
+  const imei = optionalText(formData.get("imei"));
+  const terminalId = optionalText(formData.get("terminalId"));
+
+  let newVehicleId: string;
   try {
-    await client.createVehicle({
+    const bike = await client.createVehicle({
       plateNumber: requiredText(formData.get("plateNumber")),
       // VIN is optional at register time (see BikeCreateRequest). Operator
       // updates the row later via the (future) edit flow once the VIN
@@ -118,10 +122,38 @@ export async function createVehicleFromOverviewAction(formData: FormData): Promi
       vin: null,
       modelName: optionalText(formData.get("modelName")),
       engineType: parseEngineType(formData.get("engineType")),
-      operationStatus: String(formData.get("operationStatus") ?? "READY") as ServiceOpsBikeOperationStatus
+      operationStatus: String(formData.get("operationStatus") ?? "READY") as ServiceOpsBikeOperationStatus,
+      imei: imei ?? null,
+      terminalId: terminalId ?? null
     });
+    newVehicleId = bike.id ?? bike.slug;
   } catch {
     redirect("/?tab=vehicles&status=create-error");
+  }
+
+  // IMEI 가 입력된 경우 단말기 연동: 기존 device 재사용 또는 신규 생성 후 부착.
+  // 차량 생성은 이미 성공한 상태이므로, 연동 실패는 create-device-error 로 별도 표시.
+  if (imei) {
+    try {
+      let deviceId: string;
+      const devicePage = await client.listDevices({ page: 0, size: 200 });
+      const existing = devicePage.items.find((row) => row.deviceUid === imei);
+      if (existing) {
+        deviceId = existing.id;
+      } else {
+        const created = await client.createDevice({ deviceUid: imei, enabled: true });
+        deviceId = created.id;
+      }
+      await client.createBikeDeviceInstallation({
+        bikeId: newVehicleId,
+        deviceId,
+        installedAt: new Date().toISOString(),
+        memo: "차량 등록 시 IMEI 연동"
+      });
+    } catch {
+      revalidatePath("/");
+      redirect("/?tab=vehicles&status=create-device-error");
+    }
   }
 
   revalidatePath("/");

--- a/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
+++ b/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
@@ -1,0 +1,245 @@
+export const dynamic = "force-dynamic";
+
+/**
+ * OTOPLUG NT (Notification) webhook receiver.
+ *
+ * OTOPLUG calls this endpoint when a registered NT event fires. We parse the
+ * payload, skip records with bad GPS, convert each record to the internal
+ * telemetry ingest format, and POST to the Java service-ops-api.
+ *
+ * Supported `type` path segments:
+ *   - driving        → single drivingData record (~60 s periodic)
+ *   - driving-detail → array of tripData records (10 s batches)
+ *
+ * All other types are acknowledged (result: 0) and silently ignored so OTOPLUG
+ * does not keep retrying unknown notification channels.
+ *
+ * OTOPLUG retry semantics: result != 0 OR status >= 400 → retry. We only
+ * return non-zero / non-200 for auth failures and upstream 5xx errors.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IngestBody {
+  deviceUid: string;
+  vendorEventId: string;
+  receivedAt: string;
+  latitude: number;
+  longitude: number;
+  speedKph: number;
+  telemetrySource: "WEBHOOK";
+  rawPayload: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a KST timestamp string "yyyyMMddHHmmss" to a UTC ISO-8601 string.
+ * Returns null when the string is missing or not exactly 14 digits.
+ */
+function kstToIso(s?: string): string | null {
+  if (!s || !/^\d{14}$/.test(s)) return null;
+  const y = +s.slice(0, 4),
+    mo = +s.slice(4, 6),
+    d = +s.slice(6, 8);
+  const h = +s.slice(8, 10),
+    mi = +s.slice(10, 12),
+    se = +s.slice(12, 14);
+  // KST = UTC+9 → subtract 9 h to get UTC epoch
+  const utcMs = Date.UTC(y, mo - 1, d, h, mi, se) - 9 * 3600 * 1000;
+  return new Date(utcMs).toISOString();
+}
+
+/**
+ * Build an ingest body for one telemetry record.
+ * Returns null when the record's GPS coordinates are absent or zero (bad fix).
+ */
+function toIngest(
+  imei: string,
+  rec: Record<string, unknown>,
+  timeStr: string | undefined
+): IngestBody | null {
+  const lat = Number(rec.latitude);
+  const lng = Number(rec.longitude);
+
+  // Skip records with missing or zero GPS — OTOPLUG sends "0" for no-fix.
+  if (Number.isNaN(lat) || Number.isNaN(lng) || (lat === 0 && lng === 0)) {
+    return null;
+  }
+
+  const speedRaw = Number(rec.speed);
+  const speedKph =
+    Number.isFinite(speedRaw) && speedRaw >= 0 ? speedRaw : 0;
+
+  const receivedAt = kstToIso(timeStr) ?? new Date().toISOString();
+
+  return {
+    deviceUid: imei,
+    vendorEventId: `${imei}:${timeStr ?? Date.now()}`,
+    receivedAt,
+    latitude: lat,
+    longitude: lng,
+    speedKph,
+    telemetrySource: "WEBHOOK",
+    rawPayload: rec,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ type: string }> }
+) {
+  try {
+    const { type } = await context.params;
+
+    // ------------------------------------------------------------------
+    // 1. Validate type — only driving and driving-detail are handled.
+    // ------------------------------------------------------------------
+    if (type !== "driving" && type !== "driving-detail") {
+      return Response.json({ result: 0 }, { status: 200 });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Channel token check.
+    // ------------------------------------------------------------------
+    const tokenEnvKey =
+      type === "driving"
+        ? "OTOPLUG_CHANNEL_TOKEN_DRIVING"
+        : "OTOPLUG_CHANNEL_TOKEN_DRIVING_DETAIL";
+
+    const expectedToken = process.env[tokenEnvKey];
+    const receivedToken = req.headers.get("OTOPLUG-Channel-Token");
+
+    if (expectedToken) {
+      if (receivedToken !== expectedToken) {
+        return Response.json({ result: 1 }, { status: 401 });
+      }
+    } else {
+      console.warn(
+        "[otoplug] channel token not configured, skipping validation"
+      );
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Parse body + extract IMEI.
+    // ------------------------------------------------------------------
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json({ result: 1 }, { status: 400 });
+    }
+
+    // Safe nested-access helpers for an untyped JSON blob.
+    function asObj(v: unknown): Record<string, unknown> | undefined {
+      return v !== null && typeof v === "object" && !Array.isArray(v)
+        ? (v as Record<string, unknown>)
+        : undefined;
+    }
+    function asStr(v: unknown): string | undefined {
+      return typeof v === "string" ? v : undefined;
+    }
+
+    const data = asObj(asObj(body)?.data);
+    const imei = asStr(data?.imei);
+    if (!imei) {
+      return Response.json({ result: 1 }, { status: 400 });
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Build records list depending on type.
+    // ------------------------------------------------------------------
+    const records: Array<{ rec: Record<string, unknown>; timeStr?: string }> =
+      [];
+
+    if (type === "driving") {
+      const drivingData = asObj(data?.drivingData);
+      if (drivingData) {
+        records.push({
+          rec: drivingData,
+          timeStr: asStr(drivingData.msgdate),
+        });
+      }
+    } else {
+      // driving-detail
+      const tripDataRaw = data?.tripData;
+      if (Array.isArray(tripDataRaw)) {
+        for (const item of tripDataRaw) {
+          const rec = asObj(item);
+          if (rec) {
+            records.push({
+              rec,
+              timeStr: asStr(rec.timeOfOccurrence),
+            });
+          }
+        }
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // 5 + 6. Convert and ingest each record.
+    // ------------------------------------------------------------------
+    const base = (process.env.SERVICE_OPS_API_BASE_URL ?? "").replace(
+      /\/$/,
+      ""
+    );
+    const ingestUrl = `${base}/api/v1/telemetry/device-events`;
+
+    let hasServerError = false;
+
+    for (const { rec, timeStr } of records) {
+      const ingestBody = toIngest(imei, rec, timeStr);
+
+      if (!ingestBody) {
+        // Bad/empty GPS — skip silently.
+        continue;
+      }
+
+      let res: Response;
+      try {
+        res = await fetch(ingestUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(ingestBody),
+          cache: "no-store",
+        });
+      } catch (fetchErr) {
+        console.error("[otoplug] fetch to ingest endpoint failed:", fetchErr);
+        hasServerError = true;
+        continue;
+      }
+
+      if (res.status >= 500) {
+        console.error(
+          `[otoplug] ingest endpoint returned ${res.status} for imei=${imei} vendorEventId=${ingestBody.vendorEventId}`
+        );
+        hasServerError = true;
+      } else if (res.status >= 400) {
+        // 4xx from ingest (e.g. validation error) — log but don't retry-storm.
+        console.warn(
+          `[otoplug] ingest rejected record (${res.status}) for imei=${imei} vendorEventId=${ingestBody.vendorEventId}`
+        );
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // 7. Return result.
+    // ------------------------------------------------------------------
+    if (hasServerError) {
+      return Response.json({ result: 1 }, { status: 500 });
+    }
+
+    return Response.json({ result: 0 }, { status: 200 });
+  } catch (err) {
+    console.error("[otoplug] unexpected error in NT webhook handler:", err);
+    return Response.json({ result: 1 }, { status: 500 });
+  }
+}

--- a/development/front-admin-web/components/management/CreateVehicleDialog.tsx
+++ b/development/front-admin-web/components/management/CreateVehicleDialog.tsx
@@ -71,6 +71,14 @@ export function CreateVehicleDialog() {
               <option value="IN_SERVICE">운행</option>
             </select>
           </label>
+          <label>
+            IMEI
+            <input name="imei" maxLength={15} placeholder="예: 012345678901234" />
+          </label>
+          <label>
+            단말기 ID
+            <input name="terminalId" maxLength={64} placeholder="단말기 고유 ID" />
+          </label>
           <div className="overview-create-dialog-actions">
             <button type="button" className="button-neutral" onClick={() => dialogRef.current?.close()}>
               취소

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/auth/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -74,6 +75,7 @@ public class SecurityConfig {
                                 "/api/v1/rider-auth/login",
                                 "/api/v1/rider-auth/refresh",
                                 "/api/v1/rider-auth/register").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/telemetry/device-events").permitAll()
                         .requestMatchers("/api/v1/rider/**", "/api/v1/rider-auth/logout").hasRole("RIDER")
                         .anyRequest().hasRole("ADMIN"))
                 .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))

--- a/docs/superpowers/plans/2026-06-23-otoplug-device-integration.md
+++ b/docs/superpowers/plans/2026-06-23-otoplug-device-integration.md
@@ -1,0 +1,84 @@
+# OTOPLUG 단말 연동 (수신기 + 폼) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** OTOPLUG NT 콜백을 인앱에서 받아 telemetry로 적재하고, 차량 등록 시 IMEI/terminalID로 device를 자동 연결한다. observer 등록은 범위 외(ops 1회).
+
+**Architecture:** Next.js route handler가 공개 콜백을 받아(채널토큰 검증) `data.imei` 기준으로 레코드를 `TelemetryIngestRequest`로 변환 → 내부(localhost) Java ingest(`/api/v1/telemetry/device-events`, permitAll) 호출. 차량 등록 폼에 IMEI/terminalID 추가 → device(`device_uid=IMEI`) 생성 + bike 연결.
+
+**Base dir:** `C:/Users/user/repositories/clever/thundercrew-domain`
+- 백엔드 빌드: `cd development/service-ops-api && ./gradlew compileJava compileTestJava`
+- 프론트 빌드: `cd development/front-admin-web && npm run typecheck && npm run lint && npm run build`
+
+---
+
+### Task 1: Java ingest 엔드포인트 내부 permit
+
+**Files:**
+- Modify: service-ops-api 의 Spring Security 설정 (SecurityConfig / *SecurityConfiguration — 위치 확인)
+- (확인) `telemetry/dto/TelemetryIngestRequest.java`, `telemetry/domain/TelemetrySource.java` 에 `WEBHOOK` 존재
+
+- [ ] **Step 1:** SecurityConfig에서 인증 예외 경로 확인(기존 rider 공개경로/`/actuator` 등 패턴). `POST /api/v1/telemetry/device-events` 를 `permitAll` 에 추가. (이미 permit이면 변경 없음 — 확인만.)
+- [ ] **Step 2:** `TelemetrySource` 에 `WEBHOOK` 값 있는지 확인(없으면 추가). `TelemetryIngestRequest` 필드 확인(deviceUid, vendorEventId, receivedAt, latitude, longitude, speedKph, telemetrySource, rawPayload).
+- [ ] **Step 3:** 빌드 `./gradlew compileJava compileTestJava` → 성공.
+- [ ] **Step 4:** 커밋 `feat: permit telemetry ingest endpoint for internal webhook`.
+
+**주의:** ingest는 nginx가 외부로 노출하지 않음(localhost:8080 전용). permitAll은 내부 호출용.
+
+---
+
+### Task 2: 인앱 NT 웹훅 수신기 (Next.js route handler)
+
+**Files:**
+- Create: `development/front-admin-web/app/api/otoplug/nt/[type]/route.ts`
+- (확인) `lib/services/service-ops-api.ts` 의 `SERVICE_OPS_API_BASE_URL` 사용 패턴
+
+- [ ] **Step 1:** route handler 작성 (`export const dynamic = "force-dynamic"`, `export async function POST(req, { params })`).
+  - `type` = params.type (`driving` | `driving-detail`). 그 외는 200 ack + 무시.
+  - 헤더 `OTOPLUG-Channel-Token` 읽기. env `OTOPLUG_CHANNEL_TOKEN_DRIVING` / `OTOPLUG_CHANNEL_TOKEN_DRIVING_DETAIL`(타입별) 있으면 비교 → 불일치 401. 미설정이면 `console.warn` 후 통과.
+  - body JSON 파싱. `data.imei`(필수, 없으면 400). 
+  - 레코드 추출:
+    - `driving`: `[ data.drivingData ]` (단건), 시각 = `data.drivingData.msgdate`.
+    - `driving-detail`: `data.tripData` 배열, 각 시각 = `timeOfOccurrence`.
+  - 각 레코드 → `toIngest(imei, rec, timeStr)`:
+    - lat/lng = `Number(rec.latitude)`, `Number(rec.longitude)`; 유효하지 않거나(`NaN`/`0`) 둘 다 0이면 그 레코드 skip.
+    - speedKph = `Number(rec.speed)` (음수/NaN → 0).
+    - receivedAt = `kstToIso(timeStr)` — `yyyyMMddHHmmss` 를 KST(UTC+9)로 보고 ISO(UTC) 변환. timeStr 없으면 `new Date().toISOString()`.
+    - body = `{ deviceUid: imei, vendorEventId: \`${imei}:${timeStr}\`, receivedAt, latitude, longitude, speedKph, telemetrySource: "WEBHOOK", rawPayload: rec }`.
+  - 각 body를 `POST ${SERVICE_OPS_API_BASE_URL}/api/v1/telemetry/device-events` (Content-Type json) 로 순차 전송. (인증 헤더 불필요 — permitAll.)
+  - 하나라도 5xx면 500 반환(OTOPLUG 재시도 유도), 그 외 `{ result: 0 }` 200.
+- [ ] **Step 2:** `kstToIso` 헬퍼: `"20260610155540"` → `Date.UTC(2026,5,10,15,55,40) - 9h` → ISO. (월 0-based 주의.)
+- [ ] **Step 3:** 빌드 `npm run typecheck && npm run lint && npm run build` → 성공.
+- [ ] **Step 4:** 커밋 `feat: in-app OTOPLUG NT webhook receiver`.
+
+**검증(로컬 불가 시 메모):** 실제 검증은 dev 배포 후 OTOPLUG 데이터 또는 curl 샘플로. 샘플 페이로드는 spec/OTOPLUG_NT_API.md 참고.
+
+---
+
+### Task 3: 차량 등록 폼 IMEI/terminalID + device 자동 연결
+
+**Files:**
+- Modify: `development/front-admin-web/components/management/CreateVehicleDialog.tsx`
+- Modify: `development/front-admin-web/app/actions.ts` (`createVehicleFromOverviewAction`)
+- (참고) `VehicleDetailDialog.tsx` + `updateVehicleFromOverviewAction` 의 device 생성/설치 로직 재사용
+
+- [ ] **Step 1:** `CreateVehicleDialog` 에 입력 추가: `imei`(maxLength 15), `terminalId`(maxLength 64). 기존 필드(plateNumber/engineType/modelName/operationStatus) 유지.
+- [ ] **Step 2:** `createVehicleFromOverviewAction`:
+  - bike 생성 시 imei/terminalId 반영. `createVehicle` DTO가 imei/terminalId 받으면 그대로, 아니면 생성 후 `updateVehicle`로 set(또는 create DTO/Bike.create 확장 — 백엔드 확인). 
+  - 생성된 vehicleId + `imei` 있으면: 기존 device 목록에서 `deviceUid===imei` 찾고 없으면 `createDevice({deviceUid: imei, enabled:true})` → `createBikeDeviceInstallation({bikeId, deviceId, installedAt: now, memo:"차량 등록 시 IMEI 연동"})`. (updateVehicleFromOverviewAction의 로직 그대로 차용.)
+  - device/설치 실패는 차량 생성과 분리해 에러 처리(차량은 생성됐는데 device 실패 시 메시지). 
+- [ ] **Step 3:** 백엔드: `createVehicle`/Bike.create 가 imei/terminalId 미지원이면 DTO + 서비스 + (필요시) 계약테스트 확장. 지원하면 변경 없음.
+- [ ] **Step 4:** 빌드(프론트 + 백엔드 변경 시 백엔드도) → 성공.
+- [ ] **Step 5:** 커밋 `feat: vehicle create form IMEI/terminalID + auto device link`.
+
+---
+
+### Task 4: 최종 검증 + PR
+
+- [ ] 백엔드 `./gradlew compileJava compileTestJava` + 프론트 `npm run typecheck && npm run lint && npm run build`.
+- [ ] PR → dev. PR 본문에 **ops 후속 작업**(observer 콜백을 인앱 URL로 재등록 + python 해제 + 채널토큰 env) 명시.
+
+## Self-Review
+- 스펙 커버리지: 수신기(T2), ingest permit(T1), 폼+device(T3) — 매핑됨. observer는 범위 외(ops).
+- 타입 일관성: deviceUid=imei, telemetrySource="WEBHOOK", vendorEventId=`imei:시각` — 태스크 간 일치.
+- 미확정 실런타임(SecurityConfig 경로, createVehicle DTO의 imei 지원 여부)은 각 태스크 "확인 후"로 명시.

--- a/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
+++ b/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
@@ -1,0 +1,109 @@
+# OTOPLUG 단말 자동 연동 설계
+
+**작성일:** 2026-06-23
+
+## 목표
+
+자원관리에서 차량을 등록할 때 **IMEI + terminalID**를 입력하면:
+1. 차량(bike) 저장 + device(`device_uid = terminalID`) 자동 생성 + bike 연결,
+2. OTOPLUG NT observer(`driving`, `drivingDetail`)가 없으면 1회 자동 등록(콜백 = 우리 인앱 URL),
+3. OTOPLUG가 보내는 NT 콜백을 **인앱 수신기**가 받아 `terminalID → device → bike`로 매핑해 기존 telemetry ingest에 투입 → 지도/대시보드 반영.
+
+## 확정된 결정
+
+- **deviceUid = terminalID** (OTOPLUG가 RR 쿼리에 쓰는 단말 핸들). IMEI는 bike 표시/참조용.
+- **수신기 = Next.js route handler** (`app/api/otoplug/...`). 이유: nginx가 모든 경로를 Next.js(3000)로 보내고 Java(8080)는 localhost 전용 → 공개 콜백은 Next.js만 가능. **인프라 변경 0.**
+- **내부 ingest 인증**: Java telemetry ingest 엔드포인트를 **localhost 내부용으로 permit**(JWT 없이). 외부 노출이 없으므로 안전. 수신기가 엣지에서 **OTOPLUG 채널토큰**으로 1차 검증.
+
+## 비목표 (YAGNI)
+
+- RR(Request/Response) 폴링 연동 — 이번 범위 아님(NT 웹훅만).
+- `device`/`driving-result` NT — P1은 `driving`, `drivingDetail`만. 나머지는 수신만 하고 무시(추후).
+- 시뮬레이션 device(`-1`) 경로 변경 — 기존 그대로 둠.
+
+## 라우팅 (기존 컨벤션 그대로)
+
+```
+OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route handler, 공개)
+            ↳ 채널토큰 검증 + tripData[] 펼침
+            ↳ http://localhost:8080/api/v1/telemetry/device-events  (Java ingest, 내부 permit)
+```
+- `{type}` ∈ `driving | driving-detail` (P1). 콜백 base = `OTOPLUG_CALLBACK_BASE_URL`(env, 기본 `https://thcr.cleversystem.ai/api/otoplug/nt`).
+
+---
+
+## P1 — 데이터 흐름 확보 (수신기 + 폼 + device 매핑)
+
+### P1-A. 인앱 NT 웹훅 수신기 (frontend)
+- `app/api/otoplug/nt/[type]/route.ts` (`export const dynamic = "force-dynamic"`, POST 핸들러).
+- 동작:
+  1. 헤더 `OTOPLUG-Channel-Token` 을 env `OTOPLUG_CHANNEL_TOKEN`(우리가 observer 등록 시 쓴 토큰)과 비교 — 불일치면 401. (P1 단독 배포 시 토큰 미설정이면 검증 skip + 경고 로그. P2에서 강제.)
+  2. body 파싱. `driving-detail` 은 `data.tripData[]` 배열 → 각 레코드를 1건씩. `driving` 은 단건.
+  3. 각 레코드를 `TelemetryIngestRequest` 로 변환:
+     - `deviceUid` = payload `terminalID`
+     - `receivedAt` = `timeOfOccurrence`(yyyyMMddHHmmss, KST) → ISO. 없으면 수신시각.
+     - `latitude`/`longitude`/`speedKph` = payload(문자열 → number). `-9999`/`null`/빈값은 제외(좌표 없으면 그 레코드 skip).
+     - `vendorEventId` = `terminalID + ":" + timeOfOccurrence`(멱등키).
+     - `telemetrySource` = `WEBHOOK`. `rawPayload` = 원본 레코드.
+  4. 내부 ingest 호출(서버사이드, `SERVICE_OPS_API_BASE_URL`). 실패해도 200 반환은 하지 않음 — OTOPLUG 재시도 정책상 5xx 반환(단, 파싱불가/좌표없음 등 "버릴 데이터"는 200으로 ack).
+- 응답: 성공 `{ "result": 0 }`(OTOPLUG가 result 확인). 토큰불일치 401, 서버오류 500.
+
+### P1-B. Java ingest 내부 permit + WEBHOOK 허용
+- `SecurityConfig` 에서 `POST /api/v1/telemetry/device-events` 를 `permitAll` (이미 그런지 확인 후, 아니면 추가). 외부 노출 없음(nginx가 Java로 안 보냄).
+- `TelemetryIngestRequest`/`TelemetrySource` 에 `WEBHOOK` 이미 존재(확인). 변환은 수신기(P1-A)에서 수행하므로 Java 변경 최소.
+
+### P1-C. 차량 단건 등록 폼에 IMEI/terminalID (frontend)
+- `CreateVehicleDialog` 에 입력 추가: `imei`(maxLength 15), `terminalId`(maxLength 64).
+- `createVehicleFromOverviewAction`:
+  1. 기존대로 bike 생성(+ imei/terminalId 포함 — `createVehicle` DTO가 imei/terminalId 받는지 확인, 없으면 생성 후 `updateVehicle` 로 set, 또는 create DTO 확장).
+  2. `terminalId` 있으면: device(`device_uid = terminalId`) 없으면 생성 → `createBikeDeviceInstallation(bikeId, deviceId)` (수정 다이얼로그 로직 재사용).
+  3. (P2에서) observer ensure 호출 추가.
+- 백엔드 `createVehicle`/Bike.create 가 imei/terminalId 를 받지 않으면 DTO/서비스 확장(있으면 그대로).
+
+### P1 검증
+- 수신기: 샘플 drivingDetail JSON(OTOPLUG_NT_API.md 예시)을 `curl` 로 `/api/otoplug/nt/driving-detail` 에 POST → ingest 거쳐 `bike_current_states` 갱신, 지도 반영 확인.
+- 폼: 차량 등록 시 device + installation 생성 확인.
+
+---
+
+## P2 — observer 자동 등록 (Java + 설정)
+
+### P2-A. OTOPLUG 클라이언트 (Java)
+- `vendor/otoplug/OtoplugClient` (또는 신규 `otoplug` 패키지):
+  - `authenticate()`: `GET common.auth`(authorizeCode) → `POST common.auth.token`(Bearer). 토큰 60분 캐시(만료 전 재발급).
+  - `registerObserver(api, callbackUrl, channelToken)`: `POST /ccgf/v1/{api}/{CLIENT_ID}/observer` body `{id, type, address, token, expiration:-1, dataOutputType:"simple"}`. `result==0` 확인.
+  - `unregisterObserver(api, id, token)`: `/ignore`.
+  - HTTP는 Spring `RestClient`/`WebClient`.
+
+### P2-B. observer 상태 저장 + ensure (Java)
+- 신규 테이블 `otoplug_observers` (Flyway VNN): `api`, `observer_id`, `channel_token`, `registered_at`. (활성 1건/ api.)
+- `OtoplugObserverService.ensureRegistered()`:
+  - 대상 api = `csi.terminal.status.data.driving`, `csi.terminal.status.data.drivingDetail`.
+  - 각 api에 대해 DB에 활성 등록 있으면 skip, 없으면 `OtoplugClient.registerObserver(callbackUrl = OTOPLUG_CALLBACK_BASE + "/" + shortType, channelToken = OTOPLUG_CHANNEL_TOKEN)` → 성공 시 DB 저장.
+  - **멱등**: 동시/중복 호출 안전(DB unique + 트랜잭션).
+- 노출: `POST /api/v1/otoplug/observers/ensure` (관리자 권한). 프론트 차량등록 액션이 호출.
+
+### P2-C. 차량 등록 시 ensure 트리거 (frontend)
+- `createVehicleFromOverviewAction` 에서 device 연결 후 `client.ensureOtoplugObservers()` 호출(실패해도 차량등록은 성공 — best effort, 에러는 로그/토스트).
+
+### P2-D. 설정/시크릿 (ops — 사용자/배포 담당)
+- env 추가: `OTOPLUG_SERVER_URL`(기본 https://otoplug.kt.com), `OTOPLUG_CLIENT_ID`, `OTOPLUG_SECURED_CODE`, `OTOPLUG_CHANNEL_TOKEN`(우리가 정하는 비밀), `OTOPLUG_CALLBACK_BASE_URL`.
+- `application.properties` 에 `${ENV:default}` 패턴 추가. `aws-ec2-deploy.yml` 에 시크릿 주입(NCP 패턴 동일).
+- **클로드는 시크릿 값을 입력하지 않음** — 키 등록/배포는 사용자/ops.
+
+### P2 운영 전환 (ops)
+- 인앱 observer로 일원화: 기존 python `test_nt.py unregister-all` 로 python 리스너용 observer 해제(중복 수신 방지) 후, 인앱 ensure 1회 실행.
+
+---
+
+## 보안/주의
+
+- 수신기는 **공개 엔드포인트** — 채널토큰 검증 필수(P2부터 강제). 토큰 없는 요청 거부.
+- ingest permit 는 **localhost 전용**이라 외부에서 직접 호출 불가(nginx가 Java로 안 보냄). 확인 필수.
+- 좌표 없는/`-9999` 레코드는 저장하지 않음(현재상태 오염 방지).
+- 멱등키(`terminalID:timeOfOccurrence`)로 중복 콜백/재시도 방어(기존 ingest 멱등성 재사용).
+
+## 단계 정리
+
+- **P1**(데이터 흐름): 수신기 + ingest permit + 차량폼 IMEI/terminalID + device 자동연결. 별도 PR.
+- **P2**(자동 등록): OTOPLUG 클라이언트 + observer 테이블/ensure + 차량등록 트리거 + 설정. 별도 PR. 시크릿/python 해제는 ops.

--- a/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
+++ b/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
@@ -6,8 +6,9 @@
 
 자원관리에서 차량을 등록할 때 **IMEI + terminalID**를 입력하면:
 1. 차량(bike) 저장 + device(`device_uid = IMEI`) 자동 생성 + bike 연결,
-2. OTOPLUG NT observer(`driving`, `drivingDetail`)가 없으면 1회 자동 등록(콜백 = 우리 인앱 URL),
-3. OTOPLUG가 보내는 NT 콜백을 **인앱 수신기**가 받아 `imei → device → bike`로 매핑해 기존 telemetry ingest에 투입 → 지도/대시보드 반영.
+2. OTOPLUG가 보내는 NT 콜백을 **인앱 수신기**가 받아 `imei → device → bike`로 매핑해 기존 telemetry ingest에 투입 → 지도/대시보드 반영.
+
+**observer 등록은 범위 외(ops 1회):** NT observer는 계정(clientID) 단위 + 영구(expiration -1)라 한 번만 등록하면 됨. 앱이 등록하지 않고, ops가 `test_nt.py`로 **콜백 URL을 인앱 수신기로 지정해 1회 재등록**한다(기존 python-리스너용 observer는 `unregister-all` 후 재등록). → 앱 코드 0줄.
 
 ## 확정된 결정
 
@@ -60,7 +61,7 @@ OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route 
 - `createVehicleFromOverviewAction`:
   1. 기존대로 bike 생성(+ imei/terminalId 포함 — `createVehicle` DTO가 imei/terminalId 받는지 확인, 없으면 생성 후 `updateVehicle` 로 set, 또는 create DTO 확장).
   2. `imei` 있으면: device(`device_uid = imei`) 없으면 생성 → `createBikeDeviceInstallation(bikeId, deviceId)` (수정 다이얼로그 로직 재사용). terminalId는 bike 컬럼에만 저장(표시용).
-  3. (P2에서) observer ensure 호출 추가.
+  3. observer 호출 없음(ops가 1회 등록, 범위 외).
 - 백엔드 `createVehicle`/Bike.create 가 imei/terminalId 를 받지 않으면 DTO/서비스 확장(있으면 그대로).
 
 ### P1 검증
@@ -69,44 +70,25 @@ OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route 
 
 ---
 
-## P2 — observer 자동 등록 (Java + 설정)
+## observer 등록 — 범위 외 (ops 1회)
 
-### P2-A. OTOPLUG 클라이언트 (Java)
-- `vendor/otoplug/OtoplugClient` (또는 신규 `otoplug` 패키지):
-  - `authenticate()`: `GET common.auth`(authorizeCode) → `POST common.auth.token`(Bearer). 토큰 60분 캐시(만료 전 재발급).
-  - `registerObserver(api, callbackUrl, channelToken)`: `POST /ccgf/v1/{api}/{CLIENT_ID}/observer` body `{id, type, address, token, expiration:-1, dataOutputType:"simple"}`. `result==0` 확인.
-  - `unregisterObserver(api, id, token)`: `/ignore`.
-  - HTTP는 Spring `RestClient`/`WebClient`.
-
-### P2-B. observer 상태 저장 + ensure (Java)
-- 신규 테이블 `otoplug_observers` (Flyway VNN): `api`, `observer_id`, `channel_token`, `registered_at`. (활성 1건/ api.)
-- `OtoplugObserverService.ensureRegistered()`:
-  - 대상 api = `csi.terminal.status.data.driving`, `csi.terminal.status.data.drivingDetail`.
-  - 각 api에 대해 DB에 활성 등록 있으면 skip, 없으면 `OtoplugClient.registerObserver(callbackUrl = OTOPLUG_CALLBACK_BASE + "/" + shortType, channelToken = OTOPLUG_CHANNEL_TOKEN)` → 성공 시 DB 저장.
-  - **멱등**: 동시/중복 호출 안전(DB unique + 트랜잭션).
-- 노출: `POST /api/v1/otoplug/observers/ensure` (관리자 권한). 프론트 차량등록 액션이 호출.
-
-### P2-C. 차량 등록 시 ensure 트리거 (frontend)
-- `createVehicleFromOverviewAction` 에서 device 연결 후 `client.ensureOtoplugObservers()` 호출(실패해도 차량등록은 성공 — best effort, 에러는 로그/토스트).
-
-### P2-D. 설정/시크릿 (ops — 사용자/배포 담당)
-- env 추가: `OTOPLUG_SERVER_URL`(기본 https://otoplug.kt.com), `OTOPLUG_CLIENT_ID`, `OTOPLUG_SECURED_CODE`, `OTOPLUG_CHANNEL_TOKEN`(우리가 정하는 비밀), `OTOPLUG_CALLBACK_BASE_URL`.
-- `application.properties` 에 `${ENV:default}` 패턴 추가. `aws-ec2-deploy.yml` 에 시크릿 주입(NCP 패턴 동일).
-- **클로드는 시크릿 값을 입력하지 않음** — 키 등록/배포는 사용자/ops.
-
-### P2 운영 전환 (ops)
-- 인앱 observer로 일원화: 기존 python `test_nt.py unregister-all` 로 python 리스너용 observer 해제(중복 수신 방지) 후, 인앱 ensure 1회 실행.
+앱에서 observer를 등록하지 않는다(계정 단위 + 영구라 1회면 충분). ops가 `scripts/otoplug/test_nt.py`로:
+1. `test_nt.py`의 `BASE_CALLBACK`을 **인앱 수신기**(`https://thcr.cleversystem.ai/api/otoplug/nt`)로 수정.
+2. `python3 test_nt.py unregister-all` (기존 python-리스너용 observer 해제 → 중복 수신 방지).
+3. `python3 test_nt.py register` (driving + drivingDetail, 콜백=인앱 URL).
+- 등록 시 생성된 **채널토큰**(state 파일의 `token`)을 수신기 검증용 env `OTOPLUG_CHANNEL_TOKENS`(타입별)로 넣는다(선택 — 미설정 시 검증 skip).
+- Java OTOPLUG 클라이언트·observer 테이블·시크릿(CLIENT_ID 등)은 **불필요**(앱이 OTOPLUG를 호출하지 않으므로).
 
 ---
 
 ## 보안/주의
 
-- 수신기는 **공개 엔드포인트** — 채널토큰 검증 필수(P2부터 강제). 토큰 없는 요청 거부.
+- 수신기는 **공개 엔드포인트** — 가능하면 채널토큰(`OTOPLUG-Channel-Token`) 검증. 검증 토큰 env 미설정 시 경고 로그 + 통과(초기 도입 편의), 설정 시 불일치 거부.
 - ingest permit 는 **localhost 전용**이라 외부에서 직접 호출 불가(nginx가 Java로 안 보냄). 확인 필수.
-- 좌표 없는/`-9999` 레코드는 저장하지 않음(현재상태 오염 방지).
+- 좌표 없는/`-9999`/`0,0` 레코드는 저장하지 않음(현재상태 오염 방지).
 - 멱등키(`imei:시각`)로 중복 콜백/재시도 방어(기존 ingest 멱등성 재사용).
 
-## 단계 정리
+## 범위 정리 (축소됨)
 
-- **P1**(데이터 흐름): 수신기 + ingest permit + 차량폼 IMEI/terminalID + device 자동연결. 별도 PR.
-- **P2**(자동 등록): OTOPLUG 클라이언트 + observer 테이블/ensure + 차량등록 트리거 + 설정. 별도 PR. 시크릿/python 해제는 ops.
+- **이번 구현**: ① 인앱 NT 수신기(`/api/otoplug/nt/{type}`) + ② Java ingest 내부 permit + ③ 차량폼 IMEI/terminalID + device 자동연결. 단일 PR.
+- **앱 밖(ops 1회)**: observer 재등록(콜백=인앱 URL) + python 리스너용 해제.

--- a/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
+++ b/docs/superpowers/specs/2026-06-23-otoplug-device-integration-design.md
@@ -5,13 +5,13 @@
 ## 목표
 
 자원관리에서 차량을 등록할 때 **IMEI + terminalID**를 입력하면:
-1. 차량(bike) 저장 + device(`device_uid = terminalID`) 자동 생성 + bike 연결,
+1. 차량(bike) 저장 + device(`device_uid = IMEI`) 자동 생성 + bike 연결,
 2. OTOPLUG NT observer(`driving`, `drivingDetail`)가 없으면 1회 자동 등록(콜백 = 우리 인앱 URL),
-3. OTOPLUG가 보내는 NT 콜백을 **인앱 수신기**가 받아 `terminalID → device → bike`로 매핑해 기존 telemetry ingest에 투입 → 지도/대시보드 반영.
+3. OTOPLUG가 보내는 NT 콜백을 **인앱 수신기**가 받아 `imei → device → bike`로 매핑해 기존 telemetry ingest에 투입 → 지도/대시보드 반영.
 
 ## 확정된 결정
 
-- **deviceUid = terminalID** (OTOPLUG가 RR 쿼리에 쓰는 단말 핸들). IMEI는 bike 표시/참조용.
+- **deviceUid = IMEI** (`data.imei`). 실제 NT 페이로드(driving / drivingDetail) 둘 다 `data.imei`를 일관되게 포함. terminalID는 보조 식별/표시용.
 - **수신기 = Next.js route handler** (`app/api/otoplug/...`). 이유: nginx가 모든 경로를 Next.js(3000)로 보내고 Java(8080)는 localhost 전용 → 공개 콜백은 Next.js만 가능. **인프라 변경 0.**
 - **내부 ingest 인증**: Java telemetry ingest 엔드포인트를 **localhost 내부용으로 permit**(JWT 없이). 외부 노출이 없으므로 안전. 수신기가 엣지에서 **OTOPLUG 채널토큰**으로 1차 검증.
 
@@ -25,7 +25,7 @@
 
 ```
 OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route handler, 공개)
-            ↳ 채널토큰 검증 + tripData[] 펼침
+            ↳ 채널토큰 검증 + data.imei 추출 + (driving-detail) tripData[] 펼침
             ↳ http://localhost:8080/api/v1/telemetry/device-events  (Java ingest, 내부 permit)
 ```
 - `{type}` ∈ `driving | driving-detail` (P1). 콜백 base = `OTOPLUG_CALLBACK_BASE_URL`(env, 기본 `https://thcr.cleversystem.ai/api/otoplug/nt`).
@@ -38,12 +38,15 @@ OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route 
 - `app/api/otoplug/nt/[type]/route.ts` (`export const dynamic = "force-dynamic"`, POST 핸들러).
 - 동작:
   1. 헤더 `OTOPLUG-Channel-Token` 을 env `OTOPLUG_CHANNEL_TOKEN`(우리가 observer 등록 시 쓴 토큰)과 비교 — 불일치면 401. (P1 단독 배포 시 토큰 미설정이면 검증 skip + 경고 로그. P2에서 강제.)
-  2. body 파싱. `driving-detail` 은 `data.tripData[]` 배열 → 각 레코드를 1건씩. `driving` 은 단건.
+  2. body 파싱(실제 페이로드 기준):
+     - `driving`(단건): 위치/속도 = `data.drivingData.{latitude,longitude,speed}`, 시각 = `data.drivingData.msgdate`(yyyyMMddHHmmss).
+     - `driving-detail`(배열): `data.tripData[]` 각 레코드 = `{latitude,longitude,speed,gpsSpeed}`, 시각 = `timeOfOccurrence`(yyyyMMddHHmmss) → 레코드 수만큼 1건씩.
+     - 공통 식별: `data.imei`(필수), `data.terminalID`(보조).
   3. 각 레코드를 `TelemetryIngestRequest` 로 변환:
-     - `deviceUid` = payload `terminalID`
-     - `receivedAt` = `timeOfOccurrence`(yyyyMMddHHmmss, KST) → ISO. 없으면 수신시각.
-     - `latitude`/`longitude`/`speedKph` = payload(문자열 → number). `-9999`/`null`/빈값은 제외(좌표 없으면 그 레코드 skip).
-     - `vendorEventId` = `terminalID + ":" + timeOfOccurrence`(멱등키).
+     - `deviceUid` = `data.imei`
+     - `receivedAt` = 해당 시각(yyyyMMddHHmmss, **KST**) → ISO(UTC). 없으면 수신시각.
+     - `latitude`/`longitude`/`speedKph` = 문자열 → number. `-9999`/`null`/빈값/`0,0`좌표는 제외(좌표 없으면 그 레코드 skip).
+     - `vendorEventId` = `imei + ":" + 시각`(멱등키).
      - `telemetrySource` = `WEBHOOK`. `rawPayload` = 원본 레코드.
   4. 내부 ingest 호출(서버사이드, `SERVICE_OPS_API_BASE_URL`). 실패해도 200 반환은 하지 않음 — OTOPLUG 재시도 정책상 5xx 반환(단, 파싱불가/좌표없음 등 "버릴 데이터"는 200으로 ack).
 - 응답: 성공 `{ "result": 0 }`(OTOPLUG가 result 확인). 토큰불일치 401, 서버오류 500.
@@ -56,7 +59,7 @@ OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route 
 - `CreateVehicleDialog` 에 입력 추가: `imei`(maxLength 15), `terminalId`(maxLength 64).
 - `createVehicleFromOverviewAction`:
   1. 기존대로 bike 생성(+ imei/terminalId 포함 — `createVehicle` DTO가 imei/terminalId 받는지 확인, 없으면 생성 후 `updateVehicle` 로 set, 또는 create DTO 확장).
-  2. `terminalId` 있으면: device(`device_uid = terminalId`) 없으면 생성 → `createBikeDeviceInstallation(bikeId, deviceId)` (수정 다이얼로그 로직 재사용).
+  2. `imei` 있으면: device(`device_uid = imei`) 없으면 생성 → `createBikeDeviceInstallation(bikeId, deviceId)` (수정 다이얼로그 로직 재사용). terminalId는 bike 컬럼에만 저장(표시용).
   3. (P2에서) observer ensure 호출 추가.
 - 백엔드 `createVehicle`/Bike.create 가 imei/terminalId 를 받지 않으면 DTO/서비스 확장(있으면 그대로).
 
@@ -101,7 +104,7 @@ OTOPLUG → https://thcr.cleversystem.ai/api/otoplug/nt/{type}   (Next.js route 
 - 수신기는 **공개 엔드포인트** — 채널토큰 검증 필수(P2부터 강제). 토큰 없는 요청 거부.
 - ingest permit 는 **localhost 전용**이라 외부에서 직접 호출 불가(nginx가 Java로 안 보냄). 확인 필수.
 - 좌표 없는/`-9999` 레코드는 저장하지 않음(현재상태 오염 방지).
-- 멱등키(`terminalID:timeOfOccurrence`)로 중복 콜백/재시도 방어(기존 ingest 멱등성 재사용).
+- 멱등키(`imei:시각`)로 중복 콜백/재시도 방어(기존 ingest 멱등성 재사용).
 
 ## 단계 정리
 


### PR DESCRIPTION
## Summary
OTOPLUG NT 콜백을 인앱에서 받아 telemetry로 적재하고, 차량 등록 시 IMEI/terminalID로 device를 자동 연결.

- **인앱 NT 수신기** `app/api/otoplug/nt/[type]` (driving / driving-detail)
  - `OTOPLUG-Channel-Token` 검증(env 설정 시), `data.imei` 추출
  - driving=drivingData 단건, driving-detail=tripData[] 펼침
  - 좌표 없는/`0,0` 레코드 skip, `imei:시각` 멱등키, KST→UTC 변환
  - 내부 `localhost:8080/api/v1/telemetry/device-events` 로 전달(WEBHOOK)
- **Java ingest 내부 permit** — `POST /api/v1/telemetry/device-events` permitAll (Java는 외부 비노출, localhost 전용)
- **차량 등록 폼** IMEI/terminalID 추가 → device(`device_uid=IMEI`) 생성 + bike 연결(기존 edit 로직 재사용)
- observer 등록은 **앱 코드 없음**(범위 외, 계정 단위 1회)

## 검증
- 백엔드 compileJava/compileTestJava 통과, 프론트 typecheck/lint/build 통과
- 실제 데이터 검증은 dev 배포 후 (아래 ops 작업 필요)

## ⚠️ ops 후속 작업 (배포 후 1회)
데이터가 인앱으로 흐르려면:
1. `scripts/otoplug/test_nt.py`의 `BASE_CALLBACK`을 **`https://thcr.cleversystem.ai/api/otoplug/nt`** 로 수정
2. `python3 test_nt.py unregister-all` (기존 python-리스너용 observer 해제 — 중복 수신 방지)
3. `python3 test_nt.py register` (driving + drivingDetail 재등록, 콜백=인앱)
4. (선택) 등록 시 생성된 채널토큰을 env `OTOPLUG_CHANNEL_TOKEN_DRIVING` / `OTOPLUG_CHANNEL_TOKEN_DRIVING_DETAIL` 에 넣어 수신기 검증 활성화 (미설정 시 검증 skip + 경고로그)

## 보안 노트
- ingest permitAll은 Java가 외부에 노출 안 됨(nginx→Next.js만) → localhost 전용. 사용자 승인 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)