### PR TITLE
지도 합성 핀을 시뮬 차량(IMEI '-')으로만 한정

### DIFF
--- a/development/front-admin-web/.env.example
+++ b/development/front-admin-web/.env.example
@@ -21,11 +21,6 @@ NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=<ncp-style-editor-dark-uuid>
 # lat/lng. Do NOT prefix with NEXT_PUBLIC_ — the secret must stay server-side.
 NCP_MAP_CLIENT_SECRET=<ncp-maps-application-client-secret>
 
-# Inject 8 dummy motorcycle pins onto /monitoring so the map UI is testable
-# while real vehicles are not yet streaming telemetry. Accepts 1/true/yes/on.
-# Remove (or set to anything else) once real bikes come online.
-SHOW_DUMMY_BIKES=1
-
 # Server-only secrets. Never expose to browser/client bundles.
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres

--- a/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
+++ b/development/front-admin-web/lib/services/dashboard-dummy-bikes.ts
@@ -29,6 +29,14 @@ const ODOMETER_KM_MIN = 800;
 const ODOMETER_KM_MAX = 15_000;
 
 /**
+ * 시뮬레이션 대상 차량 판별: IMEI가 "-" 로 시작하면(예: "-1") 실제 단말이 아닌
+ * 데모/시뮬 차량으로 본다. 실제 단말(숫자 IMEI) / IMEI 미입력 차량은 시뮬 아님.
+ */
+function isSimVehicle(v: FrontendVehicle): boolean {
+  return typeof v.imei === "string" && v.imei.startsWith("-");
+}
+
+/**
  * 문자열을 seed 로 0~1 사이 deterministic 숫자를 생성하는 간단한 해시. 암호
  * 학적 보안 불필요 — bike 별 분산만 되면 충분.
  */
@@ -85,9 +93,10 @@ function simulateBikeTelemetry(bikeId: string, now: Date = new Date()): Simulate
 }
 
 /**
- * 등록된 차량 목록과 현재 텔레메트리 핀 목록을 비교해서, 텔레메트리가 없는
- * 차량에 대해 시뮬레이션 핀을 생성한다. 표 컬럼(속도/잔량/연결/시동) 이 이
- * 핀에서 값을 가져온다.
+ * 시뮬레이션 대상 차량(IMEI가 "-" 로 시작 — 실제 단말이 아닌 데모/시뮬 차량)
+ * 중 텔레메트리 핀이 없는 차량에 대해 시뮬레이션 핀을 생성한다. 이 핀이
+ * 있어야 IMEI="-1" 플릿 시뮬 UI(FleetSimulation)가 overlay 할 base 핀을 갖는다.
+ * 실제 IMEI(숫자) / IMEI 없는 차량은 합성하지 않는다 — 가짜 위치를 지도에 띄우지 않기 위함.
  */
 export function generatePinsForUntrackedVehicles(
   vehicles: FrontendVehicle[],
@@ -96,7 +105,7 @@ export function generatePinsForUntrackedVehicles(
   const now = new Date();
 
   return vehicles
-    .filter((v) => v.slug && !existingBikeIds.has(v.slug))
+    .filter((v) => v.slug && !existingBikeIds.has(v.slug) && isSimVehicle(v))
     .map((vehicle) => {
       const id = vehicle.slug;
       const sim = simulateBikeTelemetry(id, now);

--- a/development/front-admin-web/lib/services/dashboard-map-state-data.ts
+++ b/development/front-admin-web/lib/services/dashboard-map-state-data.ts
@@ -37,8 +37,9 @@ function emptyMapState(): FrontendDashboardMapState {
 }
 
 /**
- * 등록된 차량 중 텔레메트리 핀이 없는 차량에 대해 시뮬레이션 좌표를
- * 생성해서 합친다. 실제 텔레메트리가 들어오면 자동으로 건너뛴다.
+ * 시뮬 대상 차량(IMEI가 "-" 로 시작)에 한해 텔레메트리 핀이 없을 때 시뮬레이션
+ * 좌표를 생성해 합친다. 실제 단말 차량(숫자 IMEI)·IMEI 없는 차량은 합성하지
+ * 않으므로, 단말 미연동 차량의 가짜 위치가 지도에 뜨지 않는다.
  */
 async function withSimulatedPins(
   state: FrontendDashboardMapState,


### PR DESCRIPTION
## Summary
- 텔레메트리 없는 **모든** 등록 차량에 가짜 GPS 핀을 무조건 띄우던 동작 제거.
- 이제 **시뮬 차량(IMEI가 `-`로 시작, 예 `-1`)** 만 합성 핀을 받음.
  - 실제 단말 차량(숫자 IMEI) → 실제 텔레메트리 핀만.
  - IMEI 없는/미연동 차량 → 텔레메트리 없으면 지도에 안 뜸(가짜 위치 제거).
- **IMEI=-1 플릿 시뮬 UI는 유지** — base 핀을 계속 받아 overlay 동작.
- obsolete `SHOW_DUMMY_BIKES` env 문서 제거(코드에서 쓰이지 않던 항목).

## 동작
`generatePinsForUntrackedVehicles` 필터에 `isSimVehicle`(imei가 `-` 시작) 조건 추가.
차량 상세 패널 fallback은 지도 핀 클릭으로만 열려서 자연히 sim/실데이터 차량에만 닿음 — 별도 수정 불필요.

typecheck + lint + build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)