### PR TITLE
자원관리: 단말 데이터 수신 시작/중지 버튼 (OTOPLUG observer)

### DIFF
--- a/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
+++ b/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
@@ -109,13 +109,12 @@ export async function POST(
 
     // ------------------------------------------------------------------
     // 2. Channel token check.
+    //
+    // Both NT observers (driving · drivingDetail) are registered by the
+    // backend with the same shared channel token, so we validate against a
+    // single env var rather than per-type ones.
     // ------------------------------------------------------------------
-    const tokenEnvKey =
-      type === "driving"
-        ? "OTOPLUG_CHANNEL_TOKEN_DRIVING"
-        : "OTOPLUG_CHANNEL_TOKEN_DRIVING_DETAIL";
-
-    const expectedToken = process.env[tokenEnvKey];
+    const expectedToken = process.env.OTOPLUG_CHANNEL_TOKEN;
     const receivedToken = req.headers.get("OTOPLUG-Channel-Token");
 
     if (expectedToken) {

--- a/development/front-admin-web/app/management/resources/page.tsx
+++ b/development/front-admin-web/app/management/resources/page.tsx
@@ -2,6 +2,8 @@ import { VehiclesManagementPanel } from "@/components/management/VehiclesManagem
 import { RidersManagementPanel } from "@/components/management/RidersManagementPanel";
 import { MatchingManagementPanel } from "@/components/management/MatchingManagementPanel";
 import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
+import { TelemetryReceiveControl } from "@/components/management/TelemetryReceiveControl";
+import { getTelemetryReceiveStatusAction } from "@/app/management/telemetry/actions";
 
 export const dynamic = "force-dynamic";
 
@@ -11,10 +13,13 @@ const SECTIONS = [
   { id: "mgmt-matching", label: "매칭" }
 ];
 
-export default function ManagementResourcesPage() {
+export default async function ManagementResourcesPage() {
+  const telemetryStatus = await getTelemetryReceiveStatusAction();
+
   return (
     <div className="management-page">
       <ManagementSectionNav sections={SECTIONS} />
+      <TelemetryReceiveControl initialActive={telemetryStatus?.active ?? false} />
       <section id="mgmt-vehicles" className="management-anchor">
         <VehiclesManagementPanel exportUrl="/api/management/vehicles/export" />
       </section>

--- a/development/front-admin-web/app/management/telemetry/actions.ts
+++ b/development/front-admin-web/app/management/telemetry/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import {
+  serviceOpsApiConfigured,
+  ServiceOpsApiError
+} from "@/lib/services/service-ops-api";
+import { createAuthenticatedServiceOpsApiClient } from "@/lib/services/service-ops-session";
+
+/**
+ * OTOPLUG NT observer (단말 데이터 수신) 제어 server actions.
+ *
+ * register/ignore 는 백엔드가 driving · drivingDetail observer 를 등록/해제해
+ * 단말 텔레메트리 유입을 켜고 끈다. 자원관리 페이지의
+ * `TelemetryReceiveControl` 이 이 액션들을 호출한다.
+ */
+
+export async function getTelemetryReceiveStatusAction(): Promise<{ active: boolean } | null> {
+  if (!serviceOpsApiConfigured()) {
+    return null;
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    const status = await client.getOtoplugObserverStatus();
+    return { active: status.active };
+  } catch {
+    return null;
+  }
+}
+
+export async function startTelemetryReceiveAction(): Promise<{ ok: boolean; message?: string }> {
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, message: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.registerOtoplugObservers();
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ServiceOpsApiError) {
+      return { ok: false, message: e.message || "수신 시작 실패 — OTOPLUG 설정을 확인하세요." };
+    }
+    return { ok: false, message: "수신 시작 실패 — OTOPLUG 설정을 확인하세요." };
+  }
+}
+
+export async function stopTelemetryReceiveAction(): Promise<{ ok: boolean; message?: string }> {
+  if (!serviceOpsApiConfigured()) {
+    return { ok: false, message: "서버가 구성되지 않았습니다." };
+  }
+
+  const client = await createAuthenticatedServiceOpsApiClient({ refreshIfMissing: true });
+  if (!client) {
+    redirect("/login?status=session-required");
+  }
+
+  try {
+    await client.ignoreOtoplugObservers();
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ServiceOpsApiError) {
+      return { ok: false, message: e.message ?? "수신 중지 실패." };
+    }
+    return { ok: false, message: "수신 중지 실패." };
+  }
+}

--- a/development/front-admin-web/components/management/TelemetryReceiveControl.tsx
+++ b/development/front-admin-web/components/management/TelemetryReceiveControl.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  startTelemetryReceiveAction,
+  stopTelemetryReceiveAction
+} from "@/app/management/telemetry/actions";
+
+/**
+ * 자원관리 페이지 상단의 "단말 데이터 수신" 제어 카드.
+ *
+ * 시작 버튼은 백엔드가 OTOPLUG NT observer(driving · drivingDetail)를 등록해
+ * 단말 텔레메트리가 유입되게 하고, 중지 버튼은 observer 를 해제한다. 초기
+ * 상태는 server component 가 `initialActive` 로 내려준다.
+ */
+export function TelemetryReceiveControl({ initialActive }: { initialActive: boolean }) {
+  const router = useRouter();
+  const [active, setActive] = useState(initialActive);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const handleStart = () => {
+    if (active || pending) return;
+    setActionError(null);
+    startTransition(async () => {
+      const result = await startTelemetryReceiveAction();
+      if (result.ok) {
+        setActive(true);
+        router.refresh();
+      } else {
+        setActionError(result.message ?? "수신 시작 실패 — OTOPLUG 설정을 확인하세요.");
+      }
+    });
+  };
+
+  const handleStop = () => {
+    if (!active || pending) return;
+    if (!window.confirm("단말 데이터 수신을 중지할까요? OTOPLUG observer가 해제됩니다.")) return;
+    setActionError(null);
+    startTransition(async () => {
+      const result = await stopTelemetryReceiveAction();
+      if (result.ok) {
+        setActive(false);
+        router.refresh();
+      } else {
+        setActionError(result.message ?? "수신 중지 실패.");
+      }
+    });
+  };
+
+  return (
+    <div className="management-panel">
+      <div className="mgmt-panel-header">
+        <div className="mgmt-panel-header-left">
+          <span className="mgmt-panel-title">단말 데이터 수신</span>
+          {active ? (
+            <span className="status-badge status-badge-green">수신 중</span>
+          ) : (
+            <span className="status-badge status-badge-gray">중지됨</span>
+          )}
+        </div>
+        <div className="mgmt-panel-header-actions">
+          <button
+            type="button"
+            className="button-primary"
+            onClick={handleStart}
+            disabled={active || pending}
+          >
+            단말 데이터 수신 시작
+          </button>
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={handleStop}
+            disabled={!active || pending}
+          >
+            수신 중지
+          </button>
+        </div>
+      </div>
+
+      {actionError ? (
+        <p role="alert" style={{ color: "red", marginBottom: 8 }}>
+          {actionError}
+        </p>
+      ) : null}
+
+      <p className="muted" style={{ margin: 0, fontSize: 13 }}>
+        OTOPLUG NT observer(driving · drivingDetail) 등록/해제
+      </p>
+    </div>
+  );
+}

--- a/development/front-admin-web/lib/services/service-ops-api.ts
+++ b/development/front-admin-web/lib/services/service-ops-api.ts
@@ -1153,6 +1153,13 @@ export type AuditLogCreateInput = {
   newValue?: string | null;
 };
 
+/**
+ * OTOPLUG NT observer registration status — backend `ObserverStatusResponse`.
+ * `active` 는 driving · drivingDetail observer 가 등록되어 텔레메트리가
+ * 유입되는 상태인지, `registeredApis` 는 현재 등록된 NT API 식별자 목록.
+ */
+export type OtoplugObserverStatus = { active: boolean; registeredApis: string[] };
+
 export type ServiceOpsApiClient = {
   login: (request: { loginId: string; password: string }) => Promise<ServiceOpsAuthResponse>;
   refresh: (request: { refreshToken: string }) => Promise<ServiceOpsAuthResponse>;
@@ -1318,6 +1325,14 @@ export type ServiceOpsApiClient = {
 
   /** 관리자가 라이더 비밀번호를 강제 재설정. PATCH /riders/{id}/credential */
   setRiderCredential: (id: string, newPassword: string) => Promise<void>;
+
+  // ── OTOPLUG NT observers (단말 데이터 수신) ──
+  /** 현재 observer 등록 상태 조회. GET /otoplug/observers */
+  getOtoplugObserverStatus: () => Promise<OtoplugObserverStatus>;
+  /** driving · drivingDetail observer 등록 → 텔레메트리 수신 시작. POST /otoplug/observers/register */
+  registerOtoplugObservers: () => Promise<OtoplugObserverStatus>;
+  /** observer 해제 → 텔레메트리 수신 중지. POST /otoplug/observers/ignore */
+  ignoreOtoplugObservers: () => Promise<OtoplugObserverStatus>;
 };
 
 type ServiceOpsApiOptions = {
@@ -2018,6 +2033,12 @@ export function createServiceOpsApiClient(options: ServiceOpsApiOptions = {}): S
         body: JSON.stringify({ newPassword })
       });
     },
+    getOtoplugObserverStatus: () =>
+      request<OtoplugObserverStatus>("/otoplug/observers", { method: "GET" }),
+    registerOtoplugObservers: () =>
+      request<OtoplugObserverStatus>("/otoplug/observers/register", { method: "POST" }),
+    ignoreOtoplugObservers: () =>
+      request<OtoplugObserverStatus>("/otoplug/observers/ignore", { method: "POST" }),
   };
 }
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugClient.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugClient.java
@@ -1,0 +1,183 @@
+package com.thundercrew.opsapi.otoplug;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Thin HTTP client for the OTOPLUG NT (notification) API. Handles the two-step
+ * authentication flow, caches the bearer token, and registers / ignores
+ * observers. See {@code scripts/otoplug/OTOPLUG_NT_API.md} for the wire shapes.
+ */
+@Component
+public class OtoplugClient {
+
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(60);
+    private static final Duration TOKEN_REFRESH_MARGIN = Duration.ofMinutes(5);
+    private static final String OBSERVER_TYPE = "otoplug-api@notification";
+
+    private final OtoplugProperties properties;
+    private final RestClient restClient;
+
+    private String cachedToken;
+    private Instant tokenExpiresAt = Instant.MIN;
+
+    public OtoplugClient(OtoplugProperties properties) {
+        this.properties = properties;
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.serverUrl())
+                .build();
+    }
+
+    /**
+     * Returns a bearer token, reusing the cached value until it is close to
+     * expiry. Performs the OTOPLUG two-step auth handshake when a refresh is
+     * needed.
+     */
+    public synchronized String authenticate() {
+        requireCredentials();
+        Instant now = Instant.now();
+        if (cachedToken != null && now.isBefore(tokenExpiresAt.minus(TOKEN_REFRESH_MARGIN))) {
+            return cachedToken;
+        }
+
+        String authorizeCode = requestAuthorizeCode();
+        String token = requestToken(authorizeCode);
+        this.cachedToken = token;
+        this.tokenExpiresAt = now.plus(TOKEN_TTL);
+        return token;
+    }
+
+    public void registerObserver(String api, String observerId, String callbackUrl, String channelToken) {
+        String token = authenticate();
+        Map<String, Object> body = new HashMap<>();
+        body.put("id", observerId);
+        body.put("type", OBSERVER_TYPE);
+        body.put("address", callbackUrl);
+        body.put("token", channelToken);
+        body.put("expiration", "-1");
+        body.put("dataOutputType", "simple");
+
+        Map<?, ?> response = post("/ccgf/v1/" + api + "/" + properties.clientId() + "/observer", token, body,
+                "observer 등록", api);
+        int result = readResult(response);
+        if (result != 0) {
+            throw new IllegalStateException(
+                    "OTOPLUG observer 등록 실패 (api=" + api + ", result=" + result + ")");
+        }
+    }
+
+    public void ignoreObserver(String api, String observerId, String channelToken) {
+        String token = authenticate();
+        // OTOPLUG rejects ignore requests with extra fields (result 8000016);
+        // send exactly id/type/token.
+        Map<String, Object> body = new HashMap<>();
+        body.put("id", observerId);
+        body.put("type", OBSERVER_TYPE);
+        body.put("token", channelToken);
+
+        Map<?, ?> response = post("/ccgf/v1/" + api + "/" + properties.clientId() + "/ignore", token, body,
+                "observer 해제", api);
+        int result = readResult(response);
+        if (result != 0) {
+            throw new IllegalStateException(
+                    "OTOPLUG observer 해제 실패 (api=" + api + ", result=" + result + ")");
+        }
+    }
+
+    private String requestAuthorizeCode() {
+        try {
+            Map<?, ?> response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/ccgf/v1/common.auth/")
+                            .queryParam("clientID", properties.clientId())
+                            .queryParam("securedCode", properties.securedCode())
+                            .queryParam("sessionID", UUID.randomUUID().toString())
+                            .build())
+                    .retrieve()
+                    .body(Map.class);
+            String authorizeCode = response == null ? null : asString(response.get("authorizeCode"));
+            if (!StringUtils.hasText(authorizeCode)) {
+                throw new IllegalStateException("OTOPLUG 인증 실패: authorizeCode가 응답에 없습니다.");
+            }
+            return authorizeCode;
+        } catch (RestClientException exception) {
+            throw new IllegalStateException("OTOPLUG 인증 요청(common.auth) 실패: " + exception.getMessage(), exception);
+        }
+    }
+
+    private String requestToken(String authorizeCode) {
+        try {
+            Map<String, Object> body = new HashMap<>();
+            body.put("clientID", properties.clientId());
+            body.put("authorizeCode", authorizeCode);
+            body.put("redirectURI", null);
+
+            Map<?, ?> response = restClient.post()
+                    .uri("/ccgf/v1/common.auth.token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+            String token = response == null ? null : asString(response.get("token"));
+            if (!StringUtils.hasText(token)) {
+                throw new IllegalStateException("OTOPLUG 인증 실패: token이 응답에 없습니다.");
+            }
+            return token;
+        } catch (RestClientException exception) {
+            throw new IllegalStateException(
+                    "OTOPLUG 토큰 요청(common.auth.token) 실패: " + exception.getMessage(), exception);
+        }
+    }
+
+    private Map<?, ?> post(String uri, String token, Map<String, Object> body, String action, String api) {
+        try {
+            return restClient.post()
+                    .uri(uri)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.parseMediaType("application/json;charset=utf-8"))
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+        } catch (RestClientException exception) {
+            throw new IllegalStateException(
+                    "OTOPLUG " + action + " 요청 실패 (api=" + api + "): " + exception.getMessage(), exception);
+        }
+    }
+
+    private void requireCredentials() {
+        if (!StringUtils.hasText(properties.clientId()) || !StringUtils.hasText(properties.securedCode())) {
+            throw new IllegalStateException(
+                    "OTOPLUG 미설정: 환경변수(OTOPLUG_CLIENT_ID/SECURED_CODE)를 설정하세요.");
+        }
+    }
+
+    private static int readResult(Map<?, ?> response) {
+        if (response == null) {
+            throw new IllegalStateException("OTOPLUG 응답이 비어 있습니다.");
+        }
+        Object result = response.get("result");
+        if (result instanceof Number number) {
+            return number.intValue();
+        }
+        if (result instanceof String string && StringUtils.hasText(string)) {
+            try {
+                return Integer.parseInt(string.trim());
+            } catch (NumberFormatException ignored) {
+                // fall through to error below
+            }
+        }
+        throw new IllegalStateException("OTOPLUG 응답에서 result 값을 해석할 수 없습니다: " + result);
+    }
+
+    private static String asString(Object value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugConfig.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugConfig.java
@@ -1,0 +1,9 @@
+package com.thundercrew.opsapi.otoplug;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OtoplugProperties.class)
+public class OtoplugConfig {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugPackage.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugPackage.java
@@ -1,0 +1,8 @@
+package com.thundercrew.opsapi.otoplug;
+
+/** Marker for the otoplug bounded package. */
+public final class OtoplugPackage {
+
+    private OtoplugPackage() {
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugProperties.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/OtoplugProperties.java
@@ -1,0 +1,18 @@
+package com.thundercrew.opsapi.otoplug;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for the OTOPLUG NT observer integration. All values are sourced
+ * from environment variables (see {@code application.properties}); credentials
+ * intentionally default to blank so missing configuration fails loudly.
+ */
+@ConfigurationProperties(prefix = "thundercrew.otoplug")
+public record OtoplugProperties(
+        String serverUrl,
+        String clientId,
+        String securedCode,
+        String channelToken,
+        String callbackBaseUrl
+) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/controller/OtoplugObserverController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/controller/OtoplugObserverController.java
@@ -1,0 +1,34 @@
+package com.thundercrew.opsapi.otoplug.controller;
+
+import com.thundercrew.opsapi.otoplug.dto.OtoplugObserverStatusResponse;
+import com.thundercrew.opsapi.otoplug.service.OtoplugObserverService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/otoplug/observers")
+public class OtoplugObserverController {
+
+    private final OtoplugObserverService service;
+
+    public OtoplugObserverController(OtoplugObserverService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/register")
+    OtoplugObserverStatusResponse register() {
+        return service.register();
+    }
+
+    @PostMapping("/ignore")
+    OtoplugObserverStatusResponse ignore() {
+        return service.ignore();
+    }
+
+    @GetMapping
+    OtoplugObserverStatusResponse status() {
+        return service.status();
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/domain/OtoplugObserver.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/domain/OtoplugObserver.java
@@ -1,0 +1,95 @@
+package com.thundercrew.opsapi.otoplug.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Persisted record of an OTOPLUG NT observer registration. One active row per
+ * {@code api} (enforced by a unique index) so the observer can be ignored
+ * (unregistered) later using the id/token returned at registration time.
+ */
+@Entity
+@Table(name = "otoplug_observers")
+public class OtoplugObserver {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private Long idx;
+
+    @Column(nullable = false, length = 100)
+    private String api;
+
+    @Column(name = "observer_id", nullable = false, length = 100)
+    private String observerId;
+
+    @Column(name = "channel_token", nullable = false, length = 200)
+    private String channelToken;
+
+    @Column(name = "callback_url", nullable = false)
+    private String callbackUrl;
+
+    @Column(name = "registered_at", nullable = false)
+    private Instant registeredAt;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private Instant createdAt;
+
+    protected OtoplugObserver() {
+    }
+
+    public static OtoplugObserver create(
+            String api,
+            String observerId,
+            String channelToken,
+            String callbackUrl,
+            Instant registeredAt
+    ) {
+        OtoplugObserver observer = new OtoplugObserver();
+        observer.id = UUID.randomUUID();
+        observer.api = api;
+        observer.observerId = observerId;
+        observer.channelToken = channelToken;
+        observer.callbackUrl = callbackUrl;
+        observer.registeredAt = registeredAt;
+        return observer;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public String getApi() {
+        return api;
+    }
+
+    public String getObserverId() {
+        return observerId;
+    }
+
+    public String getChannelToken() {
+        return channelToken;
+    }
+
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public Instant getRegisteredAt() {
+        return registeredAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/dto/OtoplugObserverStatusResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/dto/OtoplugObserverStatusResponse.java
@@ -1,0 +1,6 @@
+package com.thundercrew.opsapi.otoplug.dto;
+
+import java.util.List;
+
+public record OtoplugObserverStatusResponse(boolean active, List<String> registeredApis) {
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/repository/OtoplugObserverRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/repository/OtoplugObserverRepository.java
@@ -1,0 +1,20 @@
+package com.thundercrew.opsapi.otoplug.repository;
+
+import com.thundercrew.opsapi.otoplug.domain.OtoplugObserver;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface OtoplugObserverRepository extends Repository<OtoplugObserver, UUID> {
+
+    OtoplugObserver save(OtoplugObserver observer);
+
+    List<OtoplugObserver> findAll();
+
+    Optional<OtoplugObserver> findByApi(String api);
+
+    boolean existsByApi(String api);
+
+    void delete(OtoplugObserver observer);
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/service/OtoplugObserverService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/service/OtoplugObserverService.java
@@ -1,0 +1,87 @@
+package com.thundercrew.opsapi.otoplug.service;
+
+import com.thundercrew.opsapi.otoplug.OtoplugClient;
+import com.thundercrew.opsapi.otoplug.OtoplugProperties;
+import com.thundercrew.opsapi.otoplug.domain.OtoplugObserver;
+import com.thundercrew.opsapi.otoplug.dto.OtoplugObserverStatusResponse;
+import com.thundercrew.opsapi.otoplug.repository.OtoplugObserverRepository;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class OtoplugObserverService {
+
+    /** OTOPLUG NT APIs this service registers, paired with their callback suffix. */
+    private static final List<TargetApi> TARGET_APIS = List.of(
+            new TargetApi("csi.terminal.status.data.driving", "/driving"),
+            new TargetApi("csi.terminal.status.data.drivingDetail", "/driving-detail")
+    );
+
+    private final OtoplugObserverRepository repository;
+    private final OtoplugClient client;
+    private final OtoplugProperties properties;
+    private final Clock clock;
+
+    public OtoplugObserverService(
+            OtoplugObserverRepository repository,
+            OtoplugClient client,
+            OtoplugProperties properties,
+            Clock clock
+    ) {
+        this.repository = repository;
+        this.client = client;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public OtoplugObserverStatusResponse register() {
+        for (TargetApi target : TARGET_APIS) {
+            if (repository.existsByApi(target.api())) {
+                continue;
+            }
+            String observerId = UUID.randomUUID().toString();
+            String callbackUrl = properties.callbackBaseUrl() + target.callbackSuffix();
+            client.registerObserver(target.api(), observerId, callbackUrl, properties.channelToken());
+            repository.save(OtoplugObserver.create(
+                    target.api(),
+                    observerId,
+                    properties.channelToken(),
+                    callbackUrl,
+                    clock.instant()
+            ));
+        }
+        return status();
+    }
+
+    public OtoplugObserverStatusResponse ignore() {
+        for (OtoplugObserver observer : repository.findAll()) {
+            client.ignoreObserver(observer.getApi(), observer.getObserverId(), observer.getChannelToken());
+            repository.delete(observer);
+        }
+        return status();
+    }
+
+    @Transactional(readOnly = true)
+    public OtoplugObserverStatusResponse status() {
+        List<String> registeredApis = new ArrayList<>();
+        boolean active = true;
+        for (TargetApi target : TARGET_APIS) {
+            Optional<OtoplugObserver> existing = repository.findByApi(target.api());
+            if (existing.isPresent()) {
+                registeredApis.add(target.api());
+            } else {
+                active = false;
+            }
+        }
+        return new OtoplugObserverStatusResponse(active, registeredApis);
+    }
+
+    private record TargetApi(String api, String callbackSuffix) {
+    }
+}

--- a/development/service-ops-api/src/main/resources/application.properties
+++ b/development/service-ops-api/src/main/resources/application.properties
@@ -21,3 +21,11 @@ thundercrew.vendor-telemetry.enabled=${THUNDERCREW_VENDOR_TELEMETRY_ENABLED:fals
 thundercrew.vendor-telemetry.feed-implementation=${THUNDERCREW_VENDOR_TELEMETRY_FEED:stub}
 thundercrew.vendor-telemetry.poll-interval-ms=${THUNDERCREW_VENDOR_TELEMETRY_POLL_MS:60000}
 thundercrew.vendor-telemetry.initial-delay-ms=${THUNDERCREW_VENDOR_TELEMETRY_INITIAL_DELAY_MS:30000}
+# OTOPLUG NT observer integration. Credentials must come from environment
+# variables — leave the defaults blank so misconfigured environments fail
+# loudly instead of calling the real OTOPLUG API with empty credentials.
+thundercrew.otoplug.server-url=${OTOPLUG_SERVER_URL:https://otoplug.kt.com}
+thundercrew.otoplug.client-id=${OTOPLUG_CLIENT_ID:}
+thundercrew.otoplug.secured-code=${OTOPLUG_SECURED_CODE:}
+thundercrew.otoplug.channel-token=${OTOPLUG_CHANNEL_TOKEN:}
+thundercrew.otoplug.callback-base-url=${OTOPLUG_CALLBACK_BASE_URL:https://thcr.cleversystem.ai/api/otoplug/nt}

--- a/development/service-ops-api/src/main/resources/db/migration/V48__init_otoplug_observers.sql
+++ b/development/service-ops-api/src/main/resources/db/migration/V48__init_otoplug_observers.sql
@@ -1,0 +1,11 @@
+create table otoplug_observers (
+    id uuid primary key,
+    idx bigserial not null unique,
+    api varchar(100) not null,
+    observer_id varchar(100) not null,
+    channel_token varchar(200) not null,
+    callback_url text not null,
+    registered_at timestamptz not null default now(),
+    created_at timestamptz not null default now()
+);
+create unique index ux_otoplug_observers_active_api on otoplug_observers(api);

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ArchitectureBoundaryTests.java
@@ -115,7 +115,8 @@ class ArchitectureBoundaryTests {
                         || isAuditLogCommand(method)
                         || isRiderAuthCommand(method)
                         || isRiderCredentialCommand(method)
-                        || isRiderSelfCommand(method)) {
+                        || isRiderSelfCommand(method)
+                        || isOtoplugObserverCommand(method)) {
                     return;
                 }
 
@@ -323,6 +324,13 @@ class ArchitectureBoundaryTests {
     private static boolean isRiderSelfCommand(JavaMethod method) {
         return method.getOwner().getName()
                 .equals("com.thundercrew.opsapi.rider.controller.RiderSelfCommandController");
+    }
+
+    private static boolean isOtoplugObserverCommand(JavaMethod method) {
+        return method.getOwner().getName()
+                .equals("com.thundercrew.opsapi.otoplug.controller.OtoplugObserverController")
+                && (method.getName().equals("register")
+                || method.getName().equals("ignore"));
     }
 
 }

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/OtoplugObserverApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/OtoplugObserverApiTests.java
@@ -1,0 +1,146 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.thundercrew.opsapi.otoplug.OtoplugClient;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class OtoplugObserverApiTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\\\"accessToken\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private OtoplugClient otoplugClient;
+
+    private String accessToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from otoplug_observers");
+        List.of("admin_auth_sessions", "admin_users")
+                .forEach(table -> jdbcTemplate.update("delete from " + table));
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin', 'ops@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+        accessToken = loginAndExtractToken();
+
+        doNothing().when(otoplugClient).registerObserver(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(otoplugClient).ignoreObserver(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void statusReturnsInactiveWithEmptyApisWhenNothingRegistered() throws Exception {
+        mockMvc.perform(get("/api/v1/otoplug/observers")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(false))
+                .andExpect(jsonPath("$.registeredApis.length()").value(0));
+    }
+
+    @Test
+    void otoplugObserverEndpointsRequireAdminAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/otoplug/observers"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/v1/otoplug/observers/register"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/v1/otoplug/observers/ignore"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void registerCreatesObserverRowsAndIgnoreRemovesThem() throws Exception {
+        mockMvc.perform(post("/api/v1/otoplug/observers/register")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.registeredApis.length()").value(2));
+
+        Integer rowsAfterRegister = jdbcTemplate.queryForObject(
+                "select count(*) from otoplug_observers", Integer.class);
+        assertThat(rowsAfterRegister).isEqualTo(2);
+
+        List<String> apis = jdbcTemplate.queryForList(
+                "select api from otoplug_observers order by api", String.class);
+        assertThat(apis).containsExactly(
+                "csi.terminal.status.data.driving",
+                "csi.terminal.status.data.drivingDetail");
+
+        // register is idempotent: re-running must not duplicate rows
+        mockMvc.perform(post("/api/v1/otoplug/observers/register")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true));
+        Integer rowsAfterReRegister = jdbcTemplate.queryForObject(
+                "select count(*) from otoplug_observers", Integer.class);
+        assertThat(rowsAfterReRegister).isEqualTo(2);
+
+        mockMvc.perform(post("/api/v1/otoplug/observers/ignore")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(false))
+                .andExpect(jsonPath("$.registeredApis.length()").value(0));
+
+        Integer rowsAfterIgnore = jdbcTemplate.queryForObject(
+                "select count(*) from otoplug_observers", Integer.class);
+        assertThat(rowsAfterIgnore).isZero();
+    }
+
+    private String loginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId":"ops-admin","password":"correct-password"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Matcher matcher = ACCESS_TOKEN_PATTERN.matcher(result.getResponse().getContentAsString());
+        if (!matcher.find()) {
+            throw new AssertionError("accessToken was not present in login response: "
+                    + result.getResponse().getContentAsString());
+        }
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/specs/2026-06-23-otoplug-observer-buttons-design.md
+++ b/docs/superpowers/specs/2026-06-23-otoplug-observer-buttons-design.md
@@ -1,0 +1,85 @@
+# OTOPLUG observer 등록/해제 버튼 설계
+
+**작성일:** 2026-06-23
+
+## 목표
+
+자원관리 페이지에서 운영자가 버튼으로 OTOPLUG NT observer(`driving`, `drivingDetail`)를
+**등록(수신 시작) / 해제(수신 중지)** 할 수 있게 한다. python 스크립트(ops 수동)를 대체.
+
+- 버튼 텍스트: **"단말 데이터 수신 시작"**(등록), **"수신 중지"**(해제). 현재 상태("수신 중"/"중지됨") 표시.
+- observer는 계정 단위 1쌍(driving + drivingDetail)이면 충분 — 버튼은 그 1쌍을 일괄 등록/해제.
+
+## 결정
+
+- **채널토큰 = 단일 공유 시크릿** `OTOPLUG_CHANNEL_TOKEN`(env). 백엔드가 등록 시 이 토큰으로 observer를 등록하고, 인앱 수신기(Next.js)도 같은 토큰으로 검증. (수신기의 기존 per-type env는 단일 토큰으로 정리.)
+- observer `id`는 백엔드가 등록 시 `UUID.randomUUID()`로 생성하고 **DB에 저장** — 해제 시 `id`+`token` 필요하므로.
+- 시크릿 값 입력·env 등록은 **ops/사용자** (클로드는 값 안 넣음).
+
+## 백엔드 (service-ops-api)
+
+### 설정 (application.properties)
+```
+thundercrew.otoplug.server-url=${OTOPLUG_SERVER_URL:https://otoplug.kt.com}
+thundercrew.otoplug.client-id=${OTOPLUG_CLIENT_ID:}
+thundercrew.otoplug.secured-code=${OTOPLUG_SECURED_CODE:}
+thundercrew.otoplug.channel-token=${OTOPLUG_CHANNEL_TOKEN:}
+thundercrew.otoplug.callback-base-url=${OTOPLUG_CALLBACK_BASE_URL:https://thcr.cleversystem.ai/api/otoplug/nt}
+```
+
+### 마이그레이션 V48 — otoplug_observers
+```sql
+create table otoplug_observers (
+    id uuid primary key,
+    idx bigserial not null unique,
+    api varchar(100) not null,          -- csi.terminal.status.data.driving 등
+    observer_id varchar(100) not null,  -- 등록 시 우리가 생성한 UUID
+    channel_token varchar(200) not null,
+    callback_url text not null,
+    registered_at timestamptz not null default now(),
+    created_at timestamptz not null default now()
+);
+create unique index ux_otoplug_observers_active_api on otoplug_observers(api);
+```
+(등록=row insert, 해제=row delete. 활성 1건/api.)
+
+### OTOPLUG 클라이언트 (`otoplug/OtoplugClient.java`)
+Spring `RestClient` 사용. server-url/client-id/secured-code 주입.
+- `authenticate()`: `GET /ccgf/v1/common.auth/?clientID=&securedCode=&sessionID={uuid}` → `authorizeCode` → `POST /ccgf/v1/common.auth.token` body `{clientID, authorizeCode, redirectURI:null}` → `token`. **60분 캐시**(만료 전 재발급). client-id/secured-code 비어있으면 명확한 예외("OTOPLUG 미설정").
+- `registerObserver(api, observerId, callbackUrl, channelToken)`: `POST /ccgf/v1/{api}/{clientId}/observer` body `{id:observerId, type:"otoplug-api@notification", address:callbackUrl, token:channelToken, expiration:"-1", dataOutputType:"simple"}`. 응답 `result==0` 아니면 예외(result 코드 메시지).
+- `ignoreObserver(api, observerId, channelToken)`: `POST /ccgf/v1/{api}/{clientId}/ignore` body `{id:observerId, type:"otoplug-api@notification", token:channelToken}`. `result==0` 확인.
+
+### 서비스 (`OtoplugObserverService.java`)
+대상 api 2개: `csi.terminal.status.data.driving`(콜백 `/driving`), `csi.terminal.status.data.drivingDetail`(콜백 `/driving-detail`).
+- `register()`: 각 api에 대해 DB에 활성 row 있으면 skip, 없으면 `observerId=UUID`, `registerObserver(...)` 성공 시 row 저장. 멱등.
+- `ignore()`: 각 활성 row에 대해 `ignoreObserver(...)` 호출 후 row 삭제. (OTOPLUG 호출 실패해도 row는 정리할지 옵션 — 기본: 성공해야 삭제, 실패 메시지 반환.)
+- `status()`: 등록된 api 목록 + 전체 등록여부(둘 다 등록=ACTIVE).
+
+### 컨트롤러 (`OtoplugObserverController.java`) — 관리자 권한
+- `POST /api/v1/otoplug/observers/register` → `OtoplugObserverStatusResponse`
+- `POST /api/v1/otoplug/observers/ignore` → `OtoplugObserverStatusResponse`
+- `GET /api/v1/otoplug/observers` → `OtoplugObserverStatusResponse { active: boolean, registeredApis: string[] }`
+- SecurityConfig: 별도 permit 불필요(기본 ADMIN 권한 경로).
+
+### 테스트
+계약 테스트(Testcontainers) 추가 — register/ignore/status 경로. OTOPLUG 외부 호출은 mock/stub(RestClient를 주입형으로 만들어 테스트에서 가짜 응답). 최소 status 조회 + 미설정 시 에러 케이스.
+
+## 인앱 수신기 토큰 정리 (Next.js)
+- `app/api/otoplug/nt/[type]/route.ts`: per-type env(`OTOPLUG_CHANNEL_TOKEN_DRIVING`/`_DRIVING_DETAIL`) → **단일 `OTOPLUG_CHANNEL_TOKEN`** 으로 변경(백엔드 등록 토큰과 일치). 미설정 시 경고+통과 동작 유지.
+
+## 프론트엔드
+- api 클라이언트: `registerOtoplugObservers()`, `ignoreOtoplugObservers()`, `getOtoplugObserverStatus()`.
+- 서버 액션(자원관리): `startTelemetryReceiveAction`, `stopTelemetryReceiveAction`(결과 `{ok, message?}`), 상태는 서버컴포넌트/route로 조회.
+- UI: 자원관리 차량 섹션 헤더 근처에 **"단말 데이터 수신" 카드/줄**:
+  - 상태 배지: 등록됨="수신 중"(초록) / 안됨="중지됨"(회색).
+  - 버튼 **"단말 데이터 수신 시작"**(미등록일 때 활성) / **"수신 중지"**(등록됨일 때 활성). 처리 중 disable, 실패 시 인라인 에러.
+  - 툴팁/보조문구로 "OTOPLUG NT observer 등록/해제" 명시.
+
+## ops (사용자/배포)
+- env: `OTOPLUG_CLIENT_ID`, `OTOPLUG_SECURED_CODE`, `OTOPLUG_SERVER_URL`, `OTOPLUG_CHANNEL_TOKEN`, `OTOPLUG_CALLBACK_BASE_URL`. backend + (CHANNEL_TOKEN은) Next.js 양쪽.
+- 기존 python으로 등록한 observer가 있으면 **먼저 `test_nt.py unregister-all`** 로 정리(중복 방지) 후, 버튼으로 등록.
+- ※ observer가 운영과 같은 OTOPLUG 계정인지 확인.
+
+## 비목표
+- RR 폴링, device/driving-result NT — 범위 외(driving + drivingDetail만).
+- 채널토큰 자동 회전 — 고정 공유 시크릿.


### PR DESCRIPTION
## Summary
자원관리 페이지에서 버튼으로 OTOPLUG NT observer(driving + drivingDetail)를 등록/해제 — python ops 수동 등록을 대체.

**백엔드**
- `otoplug` 도메인 신규: `OtoplugClient`(RestClient, 2단계 인증 60분 캐시 + observer register/ignore), `otoplug_observers` 테이블(V48), 서비스(멱등 register/ignore/status), 관리자 엔드포인트 `POST /api/v1/otoplug/observers/{register,ignore}` + `GET`.
- 설정: `thundercrew.otoplug.*` (env 백킹). 미설정 시 명확한 에러.

**프론트**
- 자원관리 상단 "단말 데이터 수신" 카드: 상태 배지(수신 중/중지됨) + **"단말 데이터 수신 시작"** / **"수신 중지"** 버튼.
- 수신기 채널토큰 검증을 단일 `OTOPLUG_CHANNEL_TOKEN` 으로 정리(백엔드 등록 토큰과 일치).

## 검증
- 백엔드 compileJava/compileTestJava 통과(테스트는 Testcontainers 필요, CI 실행). 프론트 typecheck/lint/build 통과.

## ⚠️ ops 필수 (이게 있어야 버튼이 동작)
배포 환경에 env 주입 필요 (값은 ops):
- 백엔드 서비스: `OTOPLUG_CLIENT_ID`, `OTOPLUG_SECURED_CODE`, `OTOPLUG_SERVER_URL`(기본 https://otoplug.kt.com), `OTOPLUG_CHANNEL_TOKEN`(우리가 정하는 공유 비밀), `OTOPLUG_CALLBACK_BASE_URL`(기본 https://thcr.cleversystem.ai/api/otoplug/nt)
- Next.js: `OTOPLUG_CHANNEL_TOKEN`(백엔드와 동일 값)
- `aws-ec2-deploy.yml`에 위 env 주입 + GitHub Secrets 등록 필요(현재 미연결 — 원하면 워크플로 env 와이어링 도와드림).
- 기존 python으로 등록한 observer 있으면 먼저 `test_nt.py unregister-all` 로 정리(중복 방지) 후 버튼으로 등록.

## QA (env 세팅 후)
- 자원관리 상단 "단말 데이터 수신 시작" 클릭 → "수신 중"으로 바뀌는지 → 실제 단말 데이터가 지도에 들어오는지
- "수신 중지" → observer 해제 + "중지됨"

🤖 Generated with [Claude Code](https://claude.com/claude-code)