### PR TITLE
CI: OTOPLUG_CHANNEL_TOKEN을 Next.js .env.local에 와이어링

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -44,6 +44,12 @@ jobs:
       # 친다. 빈 문자열이거나 미설정이면 더미 비활성화. 실제 차량이 들어오면
       # 값을 비우거나 변수를 제거하면 자동으로 사라진다.
       SHOW_DUMMY_BIKES: ${{ vars.SHOW_DUMMY_BIKES }}
+      # OTOPLUG NT 웹훅 수신기(app/api/otoplug/nt/[type])가 콜백 헤더
+      # OTOPLUG-Channel-Token 을 검증하는 공유 시크릿. 백엔드가 observer 등록
+      # 시 쓰는 토큰과 동일 값이어야 한다. 미설정이면 수신기가 검증을 건너뛴다.
+      # (백엔드측 OTOPLUG_* 환경변수는 EC2 호스트 systemd EnvironmentFile 에서
+      # 별도 관리 — 이 워크플로는 Next.js .env.local 만 작성한다.)
+      OTOPLUG_CHANNEL_TOKEN: ${{ secrets.OTOPLUG_CHANNEL_TOKEN }}
     steps:
       - name: Validate deployment configuration
         env:
@@ -130,6 +136,7 @@ jobs:
              NCP_MAP_STYLE_ID_DARK='${NCP_MAP_STYLE_ID_DARK}' \
              NCP_MAP_CLIENT_SECRET='${NCP_MAP_CLIENT_SECRET}' \
              SHOW_DUMMY_BIKES='${SHOW_DUMMY_BIKES}' \
+             OTOPLUG_CHANNEL_TOKEN='${OTOPLUG_CHANNEL_TOKEN}' \
              bash -s" <<'REMOTE'
           set -euo pipefail
 
@@ -153,6 +160,7 @@ jobs:
           NEXT_PUBLIC_NCP_MAP_STYLE_ID_DARK=${NCP_MAP_STYLE_ID_DARK}
           NCP_MAP_CLIENT_SECRET=${NCP_MAP_CLIENT_SECRET}
           SHOW_DUMMY_BIKES=${SHOW_DUMMY_BIKES}
+          OTOPLUG_CHANNEL_TOKEN=${OTOPLUG_CHANNEL_TOKEN}
           EOF_ENV
 
           # Stale `.next/types/validator.ts` from a previous deploy can


### PR DESCRIPTION
## Summary
- `aws-ec2-deploy.yml`: `OTOPLUG_CHANNEL_TOKEN`(secret) → SSH 전달 → Next.js `.env.local` 작성. 수신기 콜백 토큰 검증용.

## 범위 한계 (중요)
- 이 워크플로는 **Next.js env만** 작성합니다. **백엔드 service-ops-api의 OTOPLUG_* env는 EC2 호스트 systemd EnvironmentFile에서 별도 관리**(DB·JWT와 동일 위치) — 이 워크플로가 못 건드림.
- 따라서 **백엔드 OTOPLUG creds는 ops가 호스트에서 직접** 넣어야 함(아래).

## ops 후속 (배포 전/후)
1. **GitHub Secret 등록**: `OTOPLUG_CHANNEL_TOKEN` (이 워크플로가 Next.js로 전달).
2. **EC2 호스트** systemd EnvironmentFile(thundercrew-service-ops-api)에 추가 후 `systemctl restart`:
   - `OTOPLUG_CLIENT_ID=...`
   - `OTOPLUG_SECURED_CODE=...`
   - `OTOPLUG_CHANNEL_TOKEN=...` (Next.js와 **동일 값**)
   - (선택) `OTOPLUG_CALLBACK_BASE_URL` / `OTOPLUG_SERVER_URL` — 미설정 시 코드 기본값 사용
3. 자원관리 "단말 데이터 수신 시작" 버튼 → observer 등록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)