### PR TITLE
CI: OTOPLUG secret 이름을 GitHub 등록값에 맞춤

### DIFF
--- a/.github/workflows/aws-ec2-deploy.yml
+++ b/.github/workflows/aws-ec2-deploy.yml
@@ -44,18 +44,20 @@ jobs:
       # 친다. 빈 문자열이거나 미설정이면 더미 비활성화. 실제 차량이 들어오면
       # 값을 비우거나 변수를 제거하면 자동으로 사라진다.
       SHOW_DUMMY_BIKES: ${{ vars.SHOW_DUMMY_BIKES }}
-      # OTOPLUG 연동 환경변수.
+      # OTOPLUG 연동 환경변수. 모두 GitHub Secrets 로 등록돼 있다.
       #  - CHANNEL_TOKEN: 수신기(app/api/otoplug/nt)의 콜백 토큰 검증용 +
       #    백엔드 observer 등록 시 쓰는 토큰. 양쪽 동일 값. 수신기는 Next.js
       #    .env.local 로, 백엔드는 아래 전용 /etc/thundercrew/otoplug.env 로 전달.
-      #  - CLIENT_ID/SECURED_CODE: OTOPLUG 자격증명(백엔드만). Secret.
-      #  - CALLBACK_BASE_URL/SERVER_URL: 공개 URL(백엔드만). Variable, 미설정 시
+      #  - CLIENT_ID / CLIENT_SECURITY_CODE: OTOPLUG 자격증명(백엔드만).
+      #    런타임 env 이름은 백엔드 application.properties 의 OTOPLUG_SECURED_CODE
+      #    이라, GitHub Secret(OTOPLUG_CLIENT_SECURITY_CODE) 을 그 이름으로 매핑한다.
+      #  - CALLBACK_BASE_URL / SERVER_URL: 공개 URL(백엔드만). 미설정/빈 값이면
       #    백엔드 코드 기본값 사용 — 그래서 빈 값은 파일에 쓰지 않는다(아래 append_env).
       OTOPLUG_CHANNEL_TOKEN: ${{ secrets.OTOPLUG_CHANNEL_TOKEN }}
       OTOPLUG_CLIENT_ID: ${{ secrets.OTOPLUG_CLIENT_ID }}
-      OTOPLUG_SECURED_CODE: ${{ secrets.OTOPLUG_SECURED_CODE }}
-      OTOPLUG_CALLBACK_BASE_URL: ${{ vars.OTOPLUG_CALLBACK_BASE_URL }}
-      OTOPLUG_SERVER_URL: ${{ vars.OTOPLUG_SERVER_URL }}
+      OTOPLUG_SECURED_CODE: ${{ secrets.OTOPLUG_CLIENT_SECURITY_CODE }}
+      OTOPLUG_CALLBACK_BASE_URL: ${{ secrets.OTOPLUG_CALLBACK_BASE_URL }}
+      OTOPLUG_SERVER_URL: ${{ secrets.OTOPLUG_SERVER_URL }}
     steps:
       - name: Validate deployment configuration
         env:


### PR DESCRIPTION
## Summary
배포 워크플로의 OTOPLUG env 소스를 **실제 GitHub Secret 이름**에 맞춤:
- `OTOPLUG_SECURED_CODE`(런타임) ← `secrets.OTOPLUG_CLIENT_SECURITY_CODE`
- `OTOPLUG_CALLBACK_BASE_URL` ← `secrets.*` (Variable 아님)
- `OTOPLUG_SERVER_URL` ← `secrets.*`

백엔드 런타임 env 이름(`OTOPLUG_SECURED_CODE`)은 그대로라 application.properties 변경 불필요.

## 등록된 GitHub Secrets (확인됨)
OTOPLUG_CHANNEL_TOKEN, OTOPLUG_CLIENT_ID, OTOPLUG_CLIENT_SECURITY_CODE, OTOPLUG_CALLBACK_BASE_URL, OTOPLUG_SERVER_URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)