### PR TITLE
fix: OTOPLUG 웹훅 수신기를 인증 미들웨어에서 예외

### DIFF
--- a/development/front-admin-web/middleware.ts
+++ b/development/front-admin-web/middleware.ts
@@ -50,6 +50,15 @@ function isRiderHost(request: NextRequest): boolean {
  */
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // OTOPLUG NT 웹훅 수신기(/api/otoplug/nt/*)는 외부 단말 플랫폼이 세션 없이
+  // 호출하는 공개 콜백 엔드포인트다. 인증게이트/호스트 리다이렉트보다 먼저
+  // 통과시킨다 — 안 그러면 OTOPLUG POST 가 /login 으로 307 되어 핸들러까지
+  // 못 간다. 실제 인증은 route handler 가 OTOPLUG-Channel-Token 헤더로 한다.
+  if (pathname.startsWith("/api/otoplug/")) {
+    return NextResponse.next();
+  }
+
   const riderHost = isRiderHost(request);
   const isRiderPath = pathname === "/rider" || pathname.startsWith("/rider/");
 


### PR DESCRIPTION
## 문제
nginx 로그상 `/api/otoplug/nt` 요청이 전부 **307**(→/login). 미들웨어 인증게이트가 외부 단말 콜백(세션 없음)을 막아서 OTOPLUG NT POST가 수신기 핸들러까지 도달 못 함 → `device_telemetry_logs` 0행.

## 수정
`middleware.ts` 최상단에서 `/api/otoplug/*` 를 인증/호스트 분기 전에 `NextResponse.next()` 로 통과. 실제 인증은 route handler가 `OTOPLUG-Channel-Token` 헤더로 수행하므로 안전.

## 검증
typecheck/lint/build 통과. 배포 후 OTOPLUG POST가 307이 아니라 200으로 처리되는지 nginx/DB로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)