### PR TITLE
fix: 텔레메트리 ingest를 차량 IMEI로 직접 매핑(폴백)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/repository/TelemetryWriteRepository.java
@@ -20,6 +20,18 @@ public class TelemetryWriteRepository {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    public UUID findBikeIdByImei(String imei) {
+        if (imei == null || imei.isBlank()) {
+            return null;
+        }
+        List<UUID> bikeIds = jdbcTemplate.query(
+                "select id from bikes where imei = ? and deleted_at is null limit 1",
+                (rs, rowNum) -> (UUID) rs.getObject("id"),
+                imei
+        );
+        return bikeIds.stream().findFirst().orElse(null);
+    }
+
     public Optional<UUID> insertDeviceTelemetryLogIfAbsent(DeviceTelemetryLog log) {
         String sql = """
                 insert into device_telemetry_logs (

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
@@ -78,14 +78,22 @@ public class TelemetryIngestionService {
                 .filter(Device::isEnabled)
                 .flatMap(activeDevice -> installationRepository.findActiveAtByDeviceId(activeDevice.getId(), request.receivedAt()));
 
-        TelemetryIgnitionStatus derivedIgnition = deriveIgnition(
-                installation.map(BikeDeviceInstallation::getBikeId).orElse(null),
-                request.receivedAt());
+        // Resolve the bike. Preferred path is the device -> installation chain. When that yields no
+        // bike (e.g. OTOPLUG vehicles imported with bikes.imei but no devices/installation row), fall
+        // back to matching the device UID directly against bikes.imei. The OTOPLUG receiver sends
+        // deviceUid = payload.imei, so an IMEI on the vehicle is sufficient to map telemetry.
+        boolean deviceDisabled = device.isPresent() && !device.get().isEnabled();
+        UUID bikeId = installation.map(BikeDeviceInstallation::getBikeId).orElse(null);
+        if (bikeId == null && !deviceDisabled && StringUtils.hasText(request.deviceUid())) {
+            bikeId = telemetryWriteRepository.findBikeIdByImei(request.deviceUid());
+        }
+
+        TelemetryIgnitionStatus derivedIgnition = deriveIgnition(bikeId, request.receivedAt());
 
         DeviceTelemetryLog log = DeviceTelemetryLog.create(
                 device.map(Device::getId).orElse(null),
                 request.deviceUid(),
-                installation.map(BikeDeviceInstallation::getBikeId).orElse(null),
+                bikeId,
                 blankToNull(request.vendorEventId()),
                 payloadHash,
                 request.receivedAt(),
@@ -107,17 +115,20 @@ public class TelemetryIngestionService {
         }
         DeviceTelemetryLog saved = log;
 
-        if (device.isEmpty()) {
-            recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_NOT_FOUND",
-                    "Device UID is not registered or is deleted.");
-            return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_UNRESOLVED");
-        }
-        if (!device.get().isEnabled()) {
-            recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_DISABLED",
-                    "Device is disabled and cannot update bike current state.");
-            return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_DISABLED");
-        }
-        if (installation.isEmpty()) {
+        // Only emit device/installation resolution errors when the bike is still unresolved. A
+        // successful imei fallback above means bikeId is set even without a device row, so we must
+        // not short-circuit into an error path in that case.
+        if (bikeId == null) {
+            if (device.isEmpty()) {
+                recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_NOT_FOUND",
+                        "Device UID is not registered or is deleted.");
+                return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_UNRESOLVED");
+            }
+            if (!device.get().isEnabled()) {
+                recordError(saved, TelemetryIngestionStage.DEVICE_RESOLUTION, "DEVICE_DISABLED",
+                        "Device is disabled and cannot update bike current state.");
+                return TelemetryIngestResponse.of(saved, false, false, false, "DEVICE_DISABLED");
+            }
             recordError(saved, TelemetryIngestionStage.BIKE_ASSOCIATION, "BIKE_INSTALLATION_NOT_FOUND",
                     "No active bike-device installation exists for the telemetry timestamp.");
             return TelemetryIngestResponse.of(saved, false, false, false, "BIKE_UNRESOLVED");

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TelemetryApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/TelemetryApiContractTests.java
@@ -208,6 +208,35 @@ class TelemetryApiContractTests extends PostgresContainerSupport {
     }
 
     @Test
+    void ingestResolvesBikeByImeiWhenNoDeviceIsRegistered() throws Exception {
+        // OTOPLUG vehicles are imported with bikes.imei set but no devices/installation row.
+        // The receiver sends deviceUid = imei, so ingest must map telemetry to the bike via imei.
+        Instant receivedAt = Instant.now().minusSeconds(60);
+        String imei = "867953065266555";
+        seedBikeWithImei(BIKE_ID, "서울T-1004", "VIN-TELEMETRY-004", imei);
+
+        mockMvc.perform(postTelemetry(imei, "evt-imei", receivedAt, "9.00"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceId").doesNotExist())
+                .andExpect(jsonPath("$.deviceUid").value(imei))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.recentStateCreated").value(true))
+                .andExpect(jsonPath("$.currentStateUpdated").value(true))
+                .andExpect(jsonPath("$.ingestionStatus").value("ACCEPTED"));
+
+        assertThat(countRows("device_telemetry_logs")).isEqualTo(1);
+        assertThat(countRows("bike_recent_states")).isEqualTo(1);
+        assertThat(countRows("bike_current_states")).isEqualTo(1);
+        assertThat(countRows("telemetry_ingestion_error_logs")).isZero();
+
+        mockMvc.perform(get("/api/v1/telemetry/bikes/{bikeId}/current-state", BIKE_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()))
+                .andExpect(jsonPath("$.connectionStatus").value("ONLINE"));
+    }
+
+    @Test
     void staleConnectionStatusIsOfflineAfter120Minutes() throws Exception {
         // Within 120 min → ONLINE; beyond 120 min → OFFLINE regardless of ignition
         Instant recentReceivedAt = Instant.now().minusSeconds(60);
@@ -324,6 +353,13 @@ class TelemetryApiContractTests extends PostgresContainerSupport {
                 insert into bikes (id, plate_number, vin, model_name, operation_status)
                 values (?, ?, ?, 'Thunder M1', 'IN_SERVICE')
                 """, id, plateNumber, vin);
+    }
+
+    private void seedBikeWithImei(UUID id, String plateNumber, String vin, String imei) {
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, vin, model_name, operation_status, imei)
+                values (?, ?, ?, 'Thunder M1', 'IN_SERVICE', ?)
+                """, id, plateNumber, vin, imei);
     }
 
     private void seedDevice(UUID id, String deviceUid, boolean enabled) {


### PR DESCRIPTION
## 문제
ingest는 device/installation 체인으로 bike를 찾는데, 엑셀/일괄로 등록된 OTOPLUG 차량은 `bikes.imei`만 있고 device 연결이 없어 `bike_id`가 NULL → 지도에 안 뜸.

## 수정
device 체인이 bike를 못 찾으면 **`bikes.imei == deviceUid`로 직접 차량 조회** 폴백 추가. OTOPLUG 수신기가 `deviceUid=payload.imei`를 보내므로, **차량에 IMEI만 들어있으면 자동 매핑.**
- telemetry 도메인 내부 native query(UUID 반환) — ArchUnit 경계 안 깨짐.
- device 경로/시뮬(-1)/disabled 처리 그대로(하위호환).

## 검증
compileJava/compileTestJava 통과. ArchUnit 신규 위반 없음(기존 issue_70 2건만, base에도 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)