### PR TITLE
fix: OTOPLUG ignore 복원력 (8000014에도 row 정리)

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/service/OtoplugObserverService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/otoplug/service/OtoplugObserverService.java
@@ -10,12 +10,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 public class OtoplugObserverService {
+
+    private static final Logger log = LoggerFactory.getLogger(OtoplugObserverService.class);
 
     /** OTOPLUG NT APIs this service registers, paired with their callback suffix. */
     private static final List<TargetApi> TARGET_APIS = List.of(
@@ -61,7 +65,15 @@ public class OtoplugObserverService {
 
     public OtoplugObserverStatusResponse ignore() {
         for (OtoplugObserver observer : repository.findAll()) {
-            client.ignoreObserver(observer.getApi(), observer.getObserverId(), observer.getChannelToken());
+            // OTOPLUG 해제가 "이미 없음"(result 8000014 등)이거나 일시 오류여도 우리 추적
+            // row 는 무조건 정리한다. 안 그러면 stale row 가 남아 "수신 중지" 가 영구히
+            // 500 으로 막힌다 — 해제의 목적은 우리 상태 제거이므로 OTOPLUG 측 실패는 로그만.
+            try {
+                client.ignoreObserver(observer.getApi(), observer.getObserverId(), observer.getChannelToken());
+            } catch (RuntimeException exception) {
+                log.warn("OTOPLUG observer 해제 실패(무시하고 row 정리) api={}: {}",
+                        observer.getApi(), exception.getMessage());
+            }
             repository.delete(observer);
         }
         return status();


### PR DESCRIPTION
## 문제
OTOPLUG observer 해제 시 하나라도 `result=8000014`(이미 없음) 나면 예외→@Transactional 롤백→stale row 잔존→ '수신 중지'가 영구 500.

## 수정
`ignore()`가 OTOPLUG 실패(8000014 등)여도 DB row는 무조건 삭제(로그만). 해제 목적은 우리 상태 정리이므로 OTOPLUG 측 실패는 비치명적. → 멱등/복원력.

compileJava 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)