### PR TITLE
feat: OTOPLUG NT raw payload 로깅

### DIFF
--- a/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
+++ b/development/front-admin-web/app/api/otoplug/nt/[type]/route.ts
@@ -137,6 +137,11 @@ export async function POST(
       return Response.json({ result: 1 }, { status: 400 });
     }
 
+    // Full raw payload dump so operators can inspect exactly what OTOPLUG sent
+    // (mirrors the old webhook_listener .log capture). One line per callback —
+    // grep with `grep '\[otoplug\] raw'` on front-admin-web.log.
+    console.log(`[otoplug] raw type=${type} payload=${JSON.stringify(body)}`);
+
     // Safe nested-access helpers for an untyped JSON blob.
     function asObj(v: unknown): Record<string, unknown> | undefined {
       return v !== null && typeof v === "object" && !Array.isArray(v)


### PR DESCRIPTION
## 요약
- OTOPLUG NT 수신기(`/api/otoplug/nt/[type]`)가 `imei`+건수만 찍어서 실제 좌표/속도 raw 값을 로그에서 볼 수 없었음
- body 파싱 직후 원본 payload 전체를 한 줄(JSON)로 로깅 → 옛 webhook_listener `.log` 캡처와 동일한 가시성

## 관측
배포 후 prod에서:
```
sudo tail -f /var/log/thundercrew/front-admin-web.log | grep '\[otoplug\] raw'
```
주행 중인 단말의 NT 콜백 원본이 한 줄씩 찍힘.

## 영향
- 로그만 추가, 동작/응답 변화 없음