### PR TITLE
fix: 차량 상세 '마지막 수신' 실시간 갱신(폴링)

### DIFF
--- a/development/front-admin-web/components/management/VehicleDetailDialog.tsx
+++ b/development/front-admin-web/components/management/VehicleDetailDialog.tsx
@@ -134,22 +134,38 @@ export function VehicleDetailDialog({
   // 재발화 — "교환 완료" 후 즉시 갱신이 보이도록.
   useEffect(() => {
     if (!vehicleIdForFetch) return;
+    const bikeId = vehicleIdForFetch;
     let cancelled = false;
-    fetch(`/api/overview/vehicle-maintenance/${encodeURIComponent(vehicleIdForFetch)}`, {
-      cache: "no-store",
-      credentials: "same-origin"
-    })
-      .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
-      .then((next) => {
-        if (cancelled) return;
-        setMaintenance(next ?? { items: [], records: [], currentState: null });
+    // 패널이 열려있는 동안 텔레메트리(마지막 수신·연결상태 등)를 주기적으로
+    // 갱신한다. bike_current_states 는 NT 수신마다 갱신되는데, 폴링이 없으면
+    // 열어둔 패널의 "마지막 수신" 이 연 시점 값에 고정돼 안 움직인다.
+    const POLL_INTERVAL_MS = 15_000;
+
+    function loadBundle() {
+      fetch(`/api/overview/vehicle-maintenance/${encodeURIComponent(bikeId)}`, {
+        cache: "no-store",
+        credentials: "same-origin"
       })
-      .catch(() => {
-        if (cancelled) return;
-        setMaintenance({ items: [], records: [], currentState: null });
-      });
+        .then(async (response) => (response.ok ? ((await response.json()) as VehicleMaintenanceBundle) : null))
+        .then((next) => {
+          if (cancelled) return;
+          setMaintenance(next ?? { items: [], records: [], currentState: null });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setMaintenance({ items: [], records: [], currentState: null });
+        });
+    }
+
+    loadBundle();
+    const timer = setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      loadBundle();
+    }, POLL_INTERVAL_MS);
+
     return () => {
       cancelled = true;
+      clearInterval(timer);
     };
   }, [vehicleIdForFetch, maintenanceReloadTick]);
 


### PR DESCRIPTION
## 문제
차량 상세 패널은 텔레메트리 bundle을 **열 때 1회만** fetch(deps `[vehicleIdForFetch, maintenanceReloadTick]`, 폴링 없음). 새 NT가 `bike_current_states`에 들어와도 **열어둔 패널의 "마지막 수신"이 연 시점 값에 고정**돼 안 움직임.

## 수정
패널 열려있는 동안 **15초마다** bundle 재fetch(`document.hidden`이면 스킵, 닫히면 `clearInterval` 정리). "마지막 수신"·연결상태·배터리 등이 자동 갱신됨.

## 검증
- `tsc` clean / `eslint` clean
- 백엔드 NT가 ~60초마다 갱신되므로 15초 폴링이면 충분히 따라잡음

🤖 Generated with [Claude Code](https://claude.com/claude-code)