### PR TITLE
release: 매칭 종료건 숨김 + 매칭로그 다운로드

### DIFF
--- a/development/front-admin-web/app/api/management/matching/log-export/route.ts
+++ b/development/front-admin-web/app/api/management/matching/log-export/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+import { serviceOpsApiBaseUrl } from "@/lib/services/service-ops-api";
+import { getServiceOpsAccessToken } from "@/lib/services/service-ops-session";
+
+/**
+ * 매칭 로그 다운로드 — 종료된 계약까지 포함한 전체 이력(상태·종료시각 컬럼 포함).
+ * 활성만 받는 `/export`(재업로드용 템플릿)와 별개의 읽기 전용 로그다.
+ */
+export async function GET() {
+  const accessToken = await getServiceOpsAccessToken();
+  if (!accessToken) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const baseUrl = serviceOpsApiBaseUrl();
+  if (!baseUrl) {
+    return new NextResponse("Service OPS API not configured", { status: 503 });
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/contracts/log-export`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    return new NextResponse("Log export failed", { status: response.status });
+  }
+
+  const data = await response.arrayBuffer();
+  return new NextResponse(data, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": 'attachment; filename="matching-log.xlsx"',
+    },
+  });
+}

--- a/development/front-admin-web/app/management/resources/page.tsx
+++ b/development/front-admin-web/app/management/resources/page.tsx
@@ -27,7 +27,10 @@ export default async function ManagementResourcesPage() {
         <RidersManagementPanel exportUrl="/api/management/riders/export" />
       </section>
       <section id="mgmt-matching" className="management-anchor">
-        <MatchingManagementPanel exportUrl="/api/management/matching/export" />
+        <MatchingManagementPanel
+          exportUrl="/api/management/matching/export"
+          logExportUrl="/api/management/matching/log-export"
+        />
       </section>
     </div>
   );

--- a/development/front-admin-web/components/management/MatchingManagementPanel.tsx
+++ b/development/front-admin-web/components/management/MatchingManagementPanel.tsx
@@ -46,7 +46,13 @@ function serviceTypeLabel(serviceType?: ServiceOpsBikeServiceType | null): React
   return <span className="muted">—</span>;
 }
 
-export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
+export function MatchingManagementPanel({
+  exportUrl,
+  logExportUrl
+}: {
+  exportUrl: string;
+  logExportUrl: string;
+}) {
   const router = useRouter();
   const [contracts, setContracts] = useState<ServiceOpsRiderBikeContract[]>([]);
   const [loading, setLoading] = useState(true);
@@ -69,16 +75,23 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
     setRefreshKey(k => k + 1);
   };
 
+  // 종료된 계약은 테이블에서 숨긴다 — 활성 매칭만 표시. 종료 포함 전체 이력은
+  // "매칭로그" 다운로드로 받는다.
+  const activeContracts = contracts.filter((c) => !c.terminatedAt);
+
   return (
     <div className="management-panel">
       <div className="mgmt-panel-header">
         <div className="mgmt-panel-header-left">
           <span className="mgmt-panel-title">매칭</span>
-          <span className="mgmt-panel-count">{loading ? "…" : contracts.length}</span>
+          <span className="mgmt-panel-count">{loading ? "…" : activeContracts.length}</span>
         </div>
         <div className="mgmt-panel-header-actions">
           <a href={exportUrl} target="_blank" rel="noreferrer">
             <button type="button" className="button-secondary">내려받기</button>
+          </a>
+          <a href={logExportUrl} target="_blank" rel="noreferrer">
+            <button type="button" className="button-secondary">매칭로그</button>
           </a>
           <ExcelImportButton
             onPreview={bulkPreviewMatchingAction}
@@ -123,12 +136,12 @@ export function MatchingManagementPanel({ exportUrl }: { exportUrl: string }) {
               <tr>
                 <td colSpan={10} className="table-empty-cell">불러오는 중…</td>
               </tr>
-            ) : contracts.length === 0 ? (
+            ) : activeContracts.length === 0 ? (
               <tr>
                 <td colSpan={10} className="table-empty-cell">계약 없음</td>
               </tr>
             ) : (
-              contracts.map((c) => (
+              activeContracts.map((c) => (
                 <tr key={c.id}>
                   <td>
                     {!c.terminatedAt ? (

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/excel/ExcelExporter.java
@@ -15,6 +15,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellRangeAddressList;
 import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 /**
  * Utility for exporting data into a pre-existing Excel template.
@@ -91,6 +92,30 @@ public class ExcelExporter {
             }
             // 시트 보호(protectSheet)는 하지 않는다 — 다운로드 후 빈 행에 차량/라이더를 추가
             // 입력하는 라운드트립 용도라, 보호하면 빈 셀이 잠겨 "보호된 셀" 오류가 난다.
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            wb.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    /**
+     * 템플릿 없이 헤더 + 데이터로 새 워크북을 생성한다. 로그/리포트처럼 재업로드용이
+     * 아닌 읽기 전용 내보내기에 쓴다.
+     */
+    public static byte[] exportWithHeaders(List<String> headers, List<List<String>> rows) throws IOException {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("매칭로그");
+            Row header = sheet.createRow(0);
+            for (int j = 0; j < headers.size(); j++) {
+                header.createCell(j).setCellValue(headers.get(j));
+            }
+            for (int i = 0; i < rows.size(); i++) {
+                Row row = sheet.createRow(i + 1);
+                List<String> cols = rows.get(i);
+                for (int j = 0; j < cols.size(); j++) {
+                    row.createCell(j).setCellValue(cols.get(j) != null ? cols.get(j) : "");
+                }
+            }
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             wb.write(out);
             return out.toByteArray();

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractBulkController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/controller/ContractBulkController.java
@@ -43,4 +43,14 @@ public class ContractBulkController {
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
                 .body(bytes);
     }
+
+    @GetMapping("/log-export")
+    ResponseEntity<byte[]> exportLog() throws IOException {
+        byte[] bytes = contractBulkService.exportLog();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"matching-log.xlsx\"")
+                .contentType(MediaType.parseMediaType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(bytes);
+    }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/repository/RiderBikeContractRepository.java
@@ -76,6 +76,8 @@ public interface RiderBikeContractRepository extends Repository<RiderBikeContrac
 
     List<RiderBikeContract> findAllByTerminatedAtIsNullAndDeletedAtIsNull();
 
+    List<RiderBikeContract> findAllByDeletedAtIsNullOrderByStartAtDesc();
+
     @Query(value = """
             select * from rider_bike_contracts
             where bike_id = :bikeId

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractBulkService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/contract/service/ContractBulkService.java
@@ -161,6 +161,38 @@ public class ContractBulkService {
                 DATA_START_ROW, rows);
     }
 
+    public byte[] exportLog() throws IOException {
+        List<RiderBikeContract> contracts = contractRepository.findAllByDeletedAtIsNullOrderByStartAtDesc();
+        List<String> headers = List.of(
+                "차량번호", "서비스유형", "라이더이름", "연락처",
+                "계약형태", "인수방식", "시작일", "종료예정일", "상태", "종료시각");
+        List<List<String>> rows = new ArrayList<>();
+        for (RiderBikeContract c : contracts) {
+            // 로그는 이력 보존이 목적이라, 차량/라이더/템플릿이 (이후) 삭제됐어도 행을 남긴다 — 누락 필드는 "—".
+            Bike bike = bikeRepository.findByIdAndDeletedAtIsNull(c.getBikeId()).orElse(null);
+            Rider rider = riderRepository.findByIdAndDeletedAtIsNull(c.getRiderId()).orElse(null);
+            ContractTemplate template = templateRepository.findByIdAndDeletedAtIsNull(c.getContractTemplateId()).orElse(null);
+
+            String plate = bike != null ? bike.getPlateNumber() : "—";
+            String svcType = bike != null ? serviceTypeLabel(bike.getServiceType()) : "—";
+            String riderName = rider != null ? rider.getName() : "—";
+            String riderPhone = rider != null ? rider.getPhoneNumber() : "—";
+            String category = template == null ? "—"
+                    : (template.getCategory() == ContractCategory.SUBSCRIPTION ? "구독" : "렌탈");
+            String returnType = template == null ? "—"
+                    : (template.getReturnType() == ContractReturnType.TAKEOVER ? "인수형" : "반납형");
+            String startDate = LocalDate.ofInstant(c.getStartAt(), ZoneOffset.UTC).toString();
+            String endDate = c.getEndAt() != null ? LocalDate.ofInstant(c.getEndAt(), ZoneOffset.UTC).toString() : "";
+            boolean terminated = c.getTerminatedAt() != null;
+            String status = terminated ? "종료" : "진행 중";
+            String terminatedAt = terminated ? LocalDate.ofInstant(c.getTerminatedAt(), ZoneOffset.UTC).toString() : "";
+
+            rows.add(List.of(plate, svcType, riderName, riderPhone, category, returnType,
+                    startDate, endDate, status, terminatedAt));
+        }
+        return ExcelExporter.exportWithHeaders(headers, rows);
+    }
+
     private BulkRowResult evaluateRow(List<String> cols, int rowNum) {
         // 9-column layout:
         // col0=차량번호, col1=서비스유형, col2=라이더이름, col3=연락처,

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/ContractBulkApiTests.java
@@ -1,6 +1,9 @@
 package com.thundercrew.opsapi;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,10 +35,12 @@ import org.springframework.test.web.servlet.MvcResult;
 @ActiveProfiles("test")
 class ContractBulkApiTests extends PostgresContainerSupport {
 
-    private static final UUID ADMIN_ID    = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    private static final UUID TEMPLATE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-    private static final UUID BIKE_ID     = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-    private static final UUID RIDER_ID    = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID ADMIN_ID       = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID TEMPLATE_ID    = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID BIKE_ID        = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID RIDER_ID       = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID CONTRACT_ID    = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID CONTRACT_ID_2  = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
     private static final Pattern TOKEN_PATTERN =
             Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
 
@@ -176,6 +181,37 @@ class ContractBulkApiTests extends PostgresContainerSupport {
         String serviceType = jdbcTemplate.queryForObject(
                 "select service_type from bikes where id = ?", String.class, BIKE_ID);
         org.assertj.core.api.Assertions.assertThat(serviceType).isEqualTo("SINGLE");
+    }
+
+    @Test
+    void logExportReturnsXlsxWithActiveAndTerminatedContracts() throws Exception {
+        // Seed one ACTIVE contract
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts
+                    (id, idx, rider_id, bike_id, contract_template_id, start_at, end_at)
+                values (?, nextval('rider_bike_contracts_idx_seq'), ?, ?, ?,
+                        '2026-01-01T00:00:00Z', '2027-01-01T00:00:00Z')
+                """, CONTRACT_ID, RIDER_ID, BIKE_ID, TEMPLATE_ID);
+
+        // Seed one TERMINATED contract (terminated_at set)
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts
+                    (id, idx, rider_id, bike_id, contract_template_id, start_at, end_at, terminated_at)
+                values (?, nextval('rider_bike_contracts_idx_seq'), ?, ?, ?,
+                        '2025-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2025-06-01T00:00:00Z')
+                """, CONTRACT_ID_2, RIDER_ID, BIKE_ID, TEMPLATE_ID);
+
+        MvcResult result = mockMvc.perform(get("/api/v1/contracts/log-export")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"matching-log.xlsx\""))
+                .andReturn();
+
+        byte[] body = result.getResponse().getContentAsByteArray();
+        org.assertj.core.api.Assertions.assertThat(body).isNotEmpty();
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
dev → main 릴리즈.

## 매칭 종료건 테이블 숨김 + 매칭로그 다운로드 (#515)
- 자원관리 → 매칭 테이블: **종료된 매칭 숨김**(활성만), 카운트도 활성 기준
- **"매칭로그" 버튼** 추가 → 종료 포함 전체 이력 엑셀(상태·종료시각 포함). 기존 "내려받기"(활성 템플릿)는 유지
- 백엔드: `GET /api/v1/contracts/log-export` + `ExcelExporter.exportWithHeaders`

## 배포 주의
- DB 마이그레이션 없음
- ⚠️ 백엔드 계약 테스트는 dev에 Docker 없어 미실행 — Docker 환경 권장. 프론트 tsc/lint clean

## 배포 후 확인
- 매칭 테이블에 종료건 안 보이는지
- "매칭로그" 클릭 → matching-log.xlsx 다운로드(종료건 + 상태/종료시각 컬럼 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)