### PR TITLE
feat: 차량 포커스 모드 (선택 차량 + 배송지 + 좌측 배송 리스트)

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -1134,6 +1134,135 @@ textarea { padding-top: 10px; min-height: 96px; }
 }
 .vehicle-floating-panel-close:hover { background: var(--color-bg-soft); color: var(--color-text-primary); }
 .vehicle-floating-panel label { display: block; margin-bottom: 12px; font-size: 13px; color: var(--color-text-secondary); }
+
+/* ── 포커스 모드 좌측 배송 리스트 패널 ──
+   오른쪽 차량 상세(.vehicle-floating-panel) 와 같은 floating glass 톤을 쓰되
+   왼쪽(헤더 아래) 에 위치한다. left:16px, top:80px(검색/필터 헤더 아래). */
+.vehicle-focus-left-panel {
+  position: absolute;
+  top: 80px;
+  left: 16px;
+  width: 320px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100% - 96px);
+  overflow: auto;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-surface) 84%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-panel), 0 0 0 1px var(--rm-line-subtle);
+  color: var(--color-text-primary);
+  z-index: 50;
+  pointer-events: auto;
+}
+.vehicle-focus-left-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.vehicle-focus-left-panel-header h3 { margin: 0; font-size: 16px; }
+
+.delivery-focus-section { margin-top: 8px; }
+.delivery-focus-section--completed { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--rm-line-subtle); }
+.delivery-focus-section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.delivery-focus-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--rm-accent-soft);
+  color: var(--rm-accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.delivery-focus-empty { margin: 0; font-size: 12px; color: var(--color-text-muted); font-style: italic; }
+.delivery-focus-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.delivery-focus-list li { display: flex; align-items: center; gap: 8px; }
+
+.delivery-focus-row {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--rm-line-subtle);
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.delivery-focus-row:hover { border-color: var(--rm-accent-outline); background: var(--rm-accent-soft); }
+.delivery-focus-row--completed { opacity: 0.7; }
+.delivery-focus-row--completed:hover { border-color: var(--rm-line-subtle); background: var(--color-bg-soft); }
+
+.delivery-focus-seq {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--rm-accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+}
+.delivery-focus-row-main { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
+.delivery-focus-row-head { display: flex; align-items: center; gap: 6px; }
+.delivery-focus-name { font-size: 13px; font-weight: 600; color: var(--color-text-primary); }
+.delivery-focus-kind {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.delivery-focus-kind--pickup { background: var(--rm-battery-mid-soft); color: var(--rm-battery-mid); }
+.delivery-focus-kind--delivery { background: var(--rm-accent-soft); color: var(--rm-accent); }
+.delivery-focus-addr { font-size: 12px; color: var(--color-text-secondary); line-height: 1.4; word-break: break-all; }
+.delivery-focus-state { flex: 0 0 auto; font-size: 11px; font-weight: 600; color: var(--color-text-muted); }
+.delivery-focus-completed-time { flex: 0 0 auto; font-size: 11px; color: var(--color-text-muted); white-space: nowrap; }
+
+.delivery-focus-collapse {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 0 0 8px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.delivery-focus-caret { margin-left: auto; font-size: 10px; }
+
 /* "정비" 탭의 카탈로그 편집 패널 — 세 섹션(전기/내연/공통) 을 세로로 쌓고
    각 섹션 안에 표를 그린다. 그룹 자식 행은 텍스트 prefix "└ " 로 시각 구분. */
 .maintenance-panel { display: flex; flex-direction: column; gap: 16px; }

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -104,6 +104,28 @@ export interface MapShellProps {
    * null 이면 경로선 제거. useTrailWaypoints 훅 결과를 그대로 전달.
    */
   trailWaypoints?: ReadonlyArray<{ lat: number; lng: number }> | null;
+  /**
+   * 포커스 모드에서 선택 차량의 배송지(destination) 마커. tip/station 과 동일한
+   * lifecycle 의 별도 레이어로 렌더된다. 진행 중(`completed: false`)은 컬러 +
+   * (있으면) 순번, 완료(`completed: true`)는 회색 + 체크로 시각 구분한다.
+   * 빈 배열/미전달 이면 배송지 마커 없음(= 포커스 해제 시 제거).
+   */
+  dispatchPins?: Array<{
+    id: string;
+    lat: number;
+    lng: number;
+    label: string;
+    address?: string | null;
+    sequence?: number | null;
+    completed: boolean;
+  }>;
+  /**
+   * 포커스 진입(선택 변경) 시 "선택 차량 + 모든 배송지" 를 한 화면에 맞추는
+   * 1회성 fitBounds 트리거. `trigger` 숫자가 바뀔 때만 발화하므로 폴링으로
+   * dispatchPins 가 갱신돼도 재중심하지 않는다(자동 따라가기 off). null 이면
+   * (= 포커스 해제) 아무 동작 없음.
+   */
+  focusBounds?: { points: ReadonlyArray<{ lat: number; lng: number }>; trigger: number } | null;
 }
 
 const DEFAULT_FIT_BOUNDS_PADDING = { top: 48, right: 48, bottom: 48, left: 48 };
@@ -122,12 +144,21 @@ export function MapShell({
   targetLocation = null,
   fitBoundsPadding = DEFAULT_FIT_BOUNDS_PADDING,
   trailWaypoints = null,
+  dispatchPins = [],
+  focusBounds = null,
 }: MapShellProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<NaverMapInstance | null>(null);
   const bikeMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
   const stationMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
   const tipMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
+  /** 배송지(destination) 마커 캐시. id → marker. tip 레이어와 동일 lifecycle. */
+  const dispatchMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
+  /** 배송지 마커를 만들 때 사용한 completed 플래그. 진행↔완료 전환 시 마커를
+   *  재생성해 색/체크 HTML 이 반영되도록 한다 (setIcon 은 content 미갱신). */
+  const prevDispatchCompletedRef = useRef<Map<string, boolean>>(new Map());
+  /** focusBounds 마지막 처리 trigger. 같은 trigger 면 fit 재실행 안 함. */
+  const lastFocusTriggerRef = useRef<number>(-1);
   /** bikeId → 마지막으로 마커를 만들 때 사용한 servicePhase. phase 가 바뀌면
    *  marker 를 재생성해 서비스 상태 배지 + 시동 말풍선 HTML 이 반영되도록 한다.
    *  NCP setIcon 은 icon.content(HTML) 을 갱신하지 않아 배지 추가/제거가 안 됨. */
@@ -256,9 +287,12 @@ export function MapShell({
       for (const m of bikeMarkerCacheRef.current.values()) m.setMap(null);
       for (const m of stationMarkerCacheRef.current.values()) m.setMap(null);
       for (const m of tipMarkerCacheRef.current.values()) m.setMap(null);
+      for (const m of dispatchMarkerCacheRef.current.values()) m.setMap(null);
       bikeMarkerCacheRef.current.clear();
       stationMarkerCacheRef.current.clear();
       tipMarkerCacheRef.current.clear();
+      dispatchMarkerCacheRef.current.clear();
+      prevDispatchCompletedRef.current.clear();
       prevServicePhaseRef.current.clear();
       trailPolylineRef.current?.setMap(null);
       trailPolylineRef.current = null;
@@ -623,6 +657,91 @@ export function MapShell({
     }
   }, [sdkReady, tipPins, mapVersion, currentZoom]);
 
+  // 배송지(destination) 마커 — 포커스 모드에서 선택 차량의 배차 주문 위치.
+  // tip/station/bike 레이어와 동일 lifecycle: incoming-id set → update-or-create
+  // → 제거된 핀 prune. completed(진행↔완료) 가 바뀌면 색/체크 HTML 이 달라지므로
+  // 마커를 재생성한다(NCP setIcon 은 content 미갱신, bike 레이어와 동일 제약).
+  useEffect(() => {
+    if (!sdkReady) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.Marker) return;
+
+    const cache = dispatchMarkerCacheRef.current;
+    const prevCompleted = prevDispatchCompletedRef.current;
+    const incomingIds = new Set<string>();
+
+    const showLabel = currentZoom >= LABEL_VISIBLE_ZOOM;
+    for (const pin of dispatchPins) {
+      incomingIds.add(pin.id);
+      const position = new naver.maps.LatLng(pin.lat, pin.lng);
+      const html = destinationMarkerHtml(pin.label, pin.address ?? null, showLabel, pin.completed, pin.sequence ?? null);
+      const icon = {
+        content: html,
+        anchor: new naver.maps.Point(ICON_ANCHOR, ICON_ANCHOR),
+        size: new naver.maps.Size(ICON_PX, ICON_PX)
+      };
+      const existing = cache.get(pin.id);
+      const wasCompleted = prevCompleted.get(pin.id);
+
+      // completed 가 동일하면 position/icon 만 갱신, 바뀌었으면 재생성.
+      if (existing && wasCompleted === pin.completed) {
+        existing.setPosition?.(position);
+        existing.setIcon?.(icon);
+        continue;
+      }
+      if (existing) {
+        existing.setMap(null);
+        cache.delete(pin.id);
+      }
+      prevCompleted.set(pin.id, pin.completed);
+      const marker = new naver.maps.Marker({
+        position,
+        map,
+        title: pin.address ?? pin.label,
+        icon,
+        clickable: false
+      });
+      cache.set(pin.id, marker);
+    }
+
+    for (const [id, marker] of cache.entries()) {
+      if (!incomingIds.has(id)) {
+        marker.setMap(null);
+        cache.delete(id);
+        prevCompleted.delete(id);
+      }
+    }
+  }, [sdkReady, dispatchPins, mapVersion, currentZoom]);
+
+  // 포커스 fitBounds — 첫-fit (hasFittedRef) 와 별개. focusBounds.trigger 가
+  // 바뀔 때만 1회 발화하고, 그 후 폴링으로 dispatchPins 가 갱신돼도 재중심하지
+  // 않는다(자동 따라가기 off — 운영자가 자유롭게 팬/줌). 점이 1개뿐이면
+  // fitBounds 가 max-zoom 까지 끌어버리므로 setCenter 로 대체한다.
+  useEffect(() => {
+    if (!sdkReady || !focusBounds || focusBounds.points.length === 0) return;
+    if (focusBounds.trigger === lastFocusTriggerRef.current) return;
+    const map = mapRef.current;
+    const naver = typeof window !== "undefined" ? window.naver : undefined;
+    if (!map || !naver?.maps?.LatLng || !naver.maps.LatLngBounds) return;
+    lastFocusTriggerRef.current = focusBounds.trigger;
+
+    const points = focusBounds.points;
+    if (points.length === 1) {
+      map.setCenter?.(new naver.maps.LatLng(points[0].lat, points[0].lng));
+      return;
+    }
+    const first = points[0];
+    const bounds = new naver.maps.LatLngBounds(
+      new naver.maps.LatLng(first.lat, first.lng),
+      new naver.maps.LatLng(first.lat, first.lng)
+    );
+    for (let i = 1; i < points.length; i++) {
+      bounds.extend(new naver.maps.LatLng(points[i].lat, points[i].lng));
+    }
+    map.fitBounds?.(bounds, fitBoundsPadding);
+  }, [sdkReady, focusBounds, mapVersion, fitBoundsPadding]);
+
   // 경로 trail Polyline — 두 effect 로 분리해 깜빡임 방지.
   //
   // [Lifecycle effect] Polyline 인스턴스 생성/삭제.
@@ -850,6 +969,21 @@ function tipIconSvg(): string {
 }
 
 /**
+ * 배송지 silhouette — 깃발 핀(목적지). 진행 중이면 컬러 stroke 를 currentColor
+ * 로 따라가고, 완료면 가운데에 체크를 추가로 그린다.
+ */
+function destinationIconSvg(completed: boolean): string {
+  const check = completed
+    ? `<path d="M9 9.5 L11 11.5 L15 7" stroke-width="2"/>`
+    : "";
+  return `<svg ${ICON_SVG_PROPS}>
+    <path d="M6 21 V4"/>
+    <path d="M6 4 H17 L14.5 8 L17 12 H6"/>
+    ${check}
+  </svg>`;
+}
+
+/**
  * 마커 래퍼. `color: var(...)` 가 SVG `stroke="currentColor"` 로 전파되어
  * 색을 가르고, drop-shadow 로 지도 배경 위 가시성을 확보한다. `line-height: 0`
  * 은 SVG 가 inline-element 라 기본적으로 baseline 여백을 만드는 걸 잘라 — 그
@@ -889,6 +1023,41 @@ function tipMarkerHtml(address: string, showLabel: boolean): string {
   const wrapped = markerWrapper(tipIconSvg(), "--rm-tip");
   if (!showLabel) return wrapped;
   return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(address)}${wrapped}</div>`;
+}
+
+/** 순번 배지 — 배송지 핀 좌상단에 작은 원형 숫자. (sequence 가 있을 때만) */
+function sequenceBadgeMarkup(sequence: number, completed: boolean): string {
+  const bg = completed ? "var(--rm-text-muted)" : "var(--rm-accent)";
+  return (
+    `<div style="position:absolute;top:-6px;right:-6px;min-width:16px;height:16px;` +
+    `display:flex;align-items:center;justify-content:center;padding:0 3px;border-radius:8px;` +
+    `background:${bg};color:#fff;font-size:10px;font-weight:700;line-height:1;` +
+    `box-shadow:0 0 0 1.5px #fff;pointer-events:none;">${sequence}</div>`
+  );
+}
+
+/**
+ * 배송지(destination) 마커 — 깃발 핀 아이콘 + (옵션) 주소 라벨 + (옵션) 순번 배지.
+ *
+ * 진행 중(`completed: false`): `--rm-accent` 컬러 핀, sequence 가 있으면 순번 배지.
+ * 완료(`completed: true`):     `--rm-text-muted` 회색 + 체크(✓), 순번 배지도 회색.
+ *
+ * bike/tip 마커와 동일하게 markerWrapper(overflow:visible) 안에 순번 배지를
+ * position:absolute 자식으로 내장한다.
+ */
+function destinationMarkerHtml(
+  label: string,
+  address: string | null,
+  showLabel: boolean,
+  completed: boolean,
+  sequence: number | null
+): string {
+  const colorVar = completed ? "--rm-text-muted" : "--rm-accent";
+  const badge = sequence != null ? sequenceBadgeMarkup(sequence, completed) : undefined;
+  const wrapped = markerWrapper(destinationIconSvg(completed), colorVar, badge);
+  if (!showLabel) return wrapped;
+  const labelText = address ?? label;
+  return `<div style="position:relative;pointer-events:auto;width:${ICON_PX}px;height:${ICON_PX}px;">${labelMarkup(labelText)}${wrapped}</div>`;
 }
 
 /**

--- a/development/front-admin-web/components/dashboard/MapShell.tsx
+++ b/development/front-admin-web/components/dashboard/MapShell.tsx
@@ -366,6 +366,8 @@ export function MapShell({
   // 한 프레임 차이는 GL canvas 가 자연스럽게 메꿔준다.
   useEffect(() => {
     hasFittedRef.current = false;
+    // 맵 인스턴스 재생성(테마 토글 등) 시 포커스 fit 도 다시 발화하도록 리셋.
+    lastFocusTriggerRef.current = -1;
   }, [mapVersion]);
   useEffect(() => {
     if (!sdkReady || hasFittedRef.current) return;
@@ -1027,7 +1029,7 @@ function tipMarkerHtml(address: string, showLabel: boolean): string {
 
 /** 순번 배지 — 배송지 핀 좌상단에 작은 원형 숫자. (sequence 가 있을 때만) */
 function sequenceBadgeMarkup(sequence: number, completed: boolean): string {
-  const bg = completed ? "var(--rm-text-muted)" : "var(--rm-accent)";
+  const bg = completed ? "var(--rm-text-muted)" : "var(--rm-battery-mid)";
   return (
     `<div style="position:absolute;top:-6px;right:-6px;min-width:16px;height:16px;` +
     `display:flex;align-items:center;justify-content:center;padding:0 3px;border-radius:8px;` +
@@ -1039,7 +1041,7 @@ function sequenceBadgeMarkup(sequence: number, completed: boolean): string {
 /**
  * 배송지(destination) 마커 — 깃발 핀 아이콘 + (옵션) 주소 라벨 + (옵션) 순번 배지.
  *
- * 진행 중(`completed: false`): `--rm-accent` 컬러 핀, sequence 가 있으면 순번 배지.
+ * 진행 중(`completed: false`): `--rm-battery-mid` 컬러 핀(차량 마커 --rm-accent 와 구분), sequence 가 있으면 순번 배지.
  * 완료(`completed: true`):     `--rm-text-muted` 회색 + 체크(✓), 순번 배지도 회색.
  *
  * bike/tip 마커와 동일하게 markerWrapper(overflow:visible) 안에 순번 배지를
@@ -1052,7 +1054,7 @@ function destinationMarkerHtml(
   completed: boolean,
   sequence: number | null
 ): string {
-  const colorVar = completed ? "--rm-text-muted" : "--rm-accent";
+  const colorVar = completed ? "--rm-text-muted" : "--rm-battery-mid";
   const badge = sequence != null ? sequenceBadgeMarkup(sequence, completed) : undefined;
   const wrapped = markerWrapper(destinationIconSvg(completed), colorVar, badge);
   if (!showLabel) return wrapped;

--- a/development/front-admin-web/components/overview/DeliveryFocusPanel.tsx
+++ b/development/front-admin-web/components/overview/DeliveryFocusPanel.tsx
@@ -2,15 +2,18 @@
 
 import { useState } from "react";
 
-import { useFocusDispatchOrders } from "@/components/overview/use-focus-dispatch-orders";
 import type {
   ServiceOpsDispatchOrder,
   ServiceOpsDispatchOrderKind
 } from "@/lib/services/service-ops-api";
 
 export interface DeliveryFocusPanelProps {
-  /** 포커스 중인 차량 id. */
-  bikeId: string;
+  /** 진행 중(ASSIGNED) 배차 — sequence 정렬된 상태로 받는다. (호스트에서 1회 조회) */
+  active: ServiceOpsDispatchOrder[];
+  /** 완료(COMPLETED) 배차. */
+  completed: ServiceOpsDispatchOrder[];
+  /** 배차 데이터 조회 중. */
+  loading: boolean;
   /** 순차배차(SEQUENTIAL/ROUND) 여부. true 면 순번 + 현재/대기 표기. */
   isSequential: boolean;
   /** 패널 닫기(= 선택 해제). */
@@ -45,7 +48,12 @@ function ActiveRow({
   onSelect: () => void;
 }) {
   return (
-    <button type="button" className="delivery-focus-row" onClick={onSelect}>
+    <button
+      type="button"
+      className="delivery-focus-row"
+      onClick={onSelect}
+      disabled={!hasCoords(order)}
+    >
       {badge ? <span className="delivery-focus-seq">{badge}</span> : null}
       <span className="delivery-focus-row-main">
         <span className="delivery-focus-row-head">
@@ -72,12 +80,13 @@ function ActiveRow({
  * 목록으로 렌더한다. 완료 섹션은 접을 수 있고 완료 시각을 표시한다.
  */
 export function DeliveryFocusPanel({
-  bikeId,
+  active,
+  completed,
+  loading,
   isSequential,
   onClose,
   onSelectDestination
 }: DeliveryFocusPanelProps) {
-  const { active, completed, loading } = useFocusDispatchOrders(bikeId);
   const [completedOpen, setCompletedOpen] = useState(false);
 
   const activeWithCoords = active.filter(hasCoords);
@@ -156,6 +165,7 @@ export function DeliveryFocusPanel({
                   <button
                     type="button"
                     className="delivery-focus-row delivery-focus-row--completed"
+                    disabled={!hasCoords(order)}
                     onClick={() =>
                       onSelectDestination({ lat: order.latitude, lng: order.longitude })
                     }

--- a/development/front-admin-web/components/overview/DeliveryFocusPanel.tsx
+++ b/development/front-admin-web/components/overview/DeliveryFocusPanel.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+
+import { useFocusDispatchOrders } from "@/components/overview/use-focus-dispatch-orders";
+import type {
+  ServiceOpsDispatchOrder,
+  ServiceOpsDispatchOrderKind
+} from "@/lib/services/service-ops-api";
+
+export interface DeliveryFocusPanelProps {
+  /** 포커스 중인 차량 id. */
+  bikeId: string;
+  /** 순차배차(SEQUENTIAL/ROUND) 여부. true 면 순번 + 현재/대기 표기. */
+  isSequential: boolean;
+  /** 패널 닫기(= 선택 해제). */
+  onClose: () => void;
+  /** 행 클릭 시 해당 배송지로 지도 팬. */
+  onSelectDestination: (p: { lat: number; lng: number }) => void;
+}
+
+function kindLabel(kind: ServiceOpsDispatchOrderKind): string {
+  return kind === "PICKUP" ? "수거" : "배송";
+}
+
+function hasCoords(o: ServiceOpsDispatchOrder): boolean {
+  return Boolean(o.latitude || o.longitude);
+}
+
+function formatCompletedAt(value: string | null): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
+}
+
+/** 진행 중 한 행 — 고객명 + 종류 배지 + 주소. 클릭 시 지도 팬. */
+function ActiveRow({
+  order,
+  badge,
+  onSelect
+}: {
+  order: ServiceOpsDispatchOrder;
+  badge?: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button type="button" className="delivery-focus-row" onClick={onSelect}>
+      {badge ? <span className="delivery-focus-seq">{badge}</span> : null}
+      <span className="delivery-focus-row-main">
+        <span className="delivery-focus-row-head">
+          <span className="delivery-focus-name">{order.customerName || "—"}</span>
+          <span
+            className={`delivery-focus-kind delivery-focus-kind--${
+              order.kind === "PICKUP" ? "pickup" : "delivery"
+            }`}
+          >
+            {kindLabel(order.kind)}
+          </span>
+        </span>
+        <span className="delivery-focus-addr">{order.address || "주소 없음"}</span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * 좌측 배송 리스트 패널 (포커스 모드). 읽기 전용 — 진행 중 + 완료 배차를
+ * 상태 구분해 보여주고, 행 클릭 시 해당 배송지로 지도를 이동한다.
+ *
+ * 순차배차(isSequential)면 진행 중 섹션을 순번 + 현재/대기 로, 그 외엔 평면
+ * 목록으로 렌더한다. 완료 섹션은 접을 수 있고 완료 시각을 표시한다.
+ */
+export function DeliveryFocusPanel({
+  bikeId,
+  isSequential,
+  onClose,
+  onSelectDestination
+}: DeliveryFocusPanelProps) {
+  const { active, completed, loading } = useFocusDispatchOrders(bikeId);
+  const [completedOpen, setCompletedOpen] = useState(false);
+
+  const activeWithCoords = active.filter(hasCoords);
+
+  return (
+    <aside className="vehicle-focus-left-panel" aria-label="배송 리스트">
+      <div className="vehicle-focus-left-panel-header">
+        <h3>배송</h3>
+        <button
+          type="button"
+          className="vehicle-floating-panel-close"
+          onClick={onClose}
+          aria-label="닫기"
+          title="닫기"
+        >
+          ×
+        </button>
+      </div>
+
+      <section className="delivery-focus-section">
+        <p className="delivery-focus-section-title">
+          진행 중<span className="delivery-focus-count">{active.length}</span>
+        </p>
+        {loading ? (
+          <p className="delivery-focus-empty">불러오는 중…</p>
+        ) : active.length === 0 ? (
+          <p className="delivery-focus-empty">진행 중인 배송이 없습니다.</p>
+        ) : (
+          <ul className="delivery-focus-list">
+            {active.map((order, idx) => {
+              const badge = isSequential
+                ? String(order.sequence ?? idx + 1)
+                : undefined;
+              return (
+                <li key={order.id}>
+                  <ActiveRow
+                    order={order}
+                    badge={badge}
+                    onSelect={() =>
+                      onSelectDestination({ lat: order.latitude, lng: order.longitude })
+                    }
+                  />
+                  {isSequential ? (
+                    <span className="delivery-focus-state">
+                      {idx === 0 ? "현재" : "대기"}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {!loading && active.length > 0 && activeWithCoords.length === 0 ? (
+          <p className="delivery-focus-empty">표시할 배송지 좌표가 없습니다.</p>
+        ) : null}
+      </section>
+
+      {completed.length > 0 ? (
+        <section className="delivery-focus-section delivery-focus-section--completed">
+          <button
+            type="button"
+            className="delivery-focus-collapse"
+            aria-expanded={completedOpen}
+            onClick={() => setCompletedOpen((open) => !open)}
+          >
+            완료 내역
+            <span className="delivery-focus-count">{completed.length}</span>
+            <span className="delivery-focus-caret" aria-hidden="true">
+              {completedOpen ? "▲" : "▼"}
+            </span>
+          </button>
+          {completedOpen ? (
+            <ul className="delivery-focus-list">
+              {completed.map((order) => (
+                <li key={order.id}>
+                  <button
+                    type="button"
+                    className="delivery-focus-row delivery-focus-row--completed"
+                    onClick={() =>
+                      onSelectDestination({ lat: order.latitude, lng: order.longitude })
+                    }
+                  >
+                    <span className="delivery-focus-row-main">
+                      <span className="delivery-focus-row-head">
+                        <span className="delivery-focus-name">
+                          {order.customerName || "—"}
+                        </span>
+                        <span
+                          className={`delivery-focus-kind delivery-focus-kind--${
+                            order.kind === "PICKUP" ? "pickup" : "delivery"
+                          }`}
+                        >
+                          {kindLabel(order.kind)}
+                        </span>
+                      </span>
+                      <span className="delivery-focus-addr">
+                        {order.address || "주소 없음"}
+                      </span>
+                    </span>
+                    {order.completedAt ? (
+                      <span className="delivery-focus-completed-time">
+                        {formatCompletedAt(order.completedAt)}
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      ) : null}
+    </aside>
+  );
+}

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -121,7 +121,11 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!selectedBikeId) return;
-    const handle = window.requestAnimationFrame(() => setFocusTrigger((t) => t + 1));
+    const handle = window.requestAnimationFrame(() => {
+      setFocusTrigger((t) => t + 1);
+      // 어느 경로로 선택하든(마커·검색·하단 차량표) 포커스 진입 시 하단 패널 접기.
+      setBottomPanelOpen(false);
+    });
     return () => window.cancelAnimationFrame(handle);
   }, [selectedBikeId]);
 
@@ -223,7 +227,7 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
   // 배송지 마커, 왼쪽 배송 리스트, 하단 패널 접힘, 자동 따라가기 off.
   const focusMode = selectedBikeId != null;
 
-  const { active: activeOrders, completed: completedOrders } =
+  const { active: activeOrders, completed: completedOrders, loading: ordersLoading } =
     useFocusDispatchOrders(selectedBikeId);
 
   const selectedPin = selectedBikeId ? bikePinById.get(selectedBikeId) ?? null : null;
@@ -358,7 +362,9 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
         />
         {focusMode && selectedBikeId ? (
           <DeliveryFocusPanel
-            bikeId={selectedBikeId}
+            active={activeOrders}
+            completed={completedOrders}
+            loading={ordersLoading}
             isSequential={isSequential}
             onClose={() => setSelectedBikeId(null)}
             onSelectDestination={(p) => setSearchOverride(p)}

--- a/development/front-admin-web/components/overview/FullscreenMapHost.tsx
+++ b/development/front-admin-web/components/overview/FullscreenMapHost.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { MapShell } from "@/components/dashboard/MapShell";
 import { VehicleDetailDialog, type VehicleDetailRow } from "@/components/management/VehicleDetailDialog";
 import { BottomMapPanel } from "@/components/overview/BottomMapPanel";
+import { DeliveryFocusPanel } from "@/components/overview/DeliveryFocusPanel";
+import { useFocusDispatchOrders } from "@/components/overview/use-focus-dispatch-orders";
 import { TipsPanel } from "@/components/overview/TipsPanel";
 import { useFleetSimulation } from "@/components/overview/FleetSimulationContext";
 import { usePollingBikePins } from "@/components/overview/use-polling-bike-pins";
@@ -12,6 +14,7 @@ import { useRealVehiclePlayback } from "@/components/overview/use-real-vehicle-p
 import { useSimulatedBikePins } from "@/components/overview/use-simulated-bike-pins";
 import { useTrailWaypoints } from "@/components/overview/use-trail-waypoints";
 import { useVehicleFilter } from "@/components/overview/VehicleFilterContext";
+import { isCleaningServiceType } from "@/lib/services/fleet-simulation";
 import { ServiceTypeFilterTabs, type ServiceTypeFilter } from "@/components/overview/ServiceTypeFilterTabs";
 import { OverviewMapSearch, type OverviewMapSearchMatch } from "@/components/overview/OverviewMapSearch";
 import { NotificationBell } from "@/components/layout/NotificationBell";
@@ -109,6 +112,18 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
 
   const [serviceTypeFilter, setServiceTypeFilter] = useState<ServiceTypeFilter>("ALL");
   const [searchOverride, setSearchOverride] = useState<{ lat: number; lng: number } | null>(null);
+  // 포커스 진입(차량 선택) 시 1회 fit 을 발화시키는 trigger. selectedBikeId 가
+  // 바뀔 때마다 증가시켜 entry point(마커 클릭 / 검색 / 하단 차량표) 와 무관하게
+  // 새 선택을 감지한다. setState 는 effect 본문이 아니라 rAF 콜백 안에서 호출해
+  // react-hooks/set-state-in-effect 를 피한다(아래 searchOverride 리셋 effect 와
+  // 동일 관용구).
+  const [focusTrigger, setFocusTrigger] = useState(0);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!selectedBikeId) return;
+    const handle = window.requestAnimationFrame(() => setFocusTrigger((t) => t + 1));
+    return () => window.cancelAnimationFrame(handle);
+  }, [selectedBikeId]);
 
   const { seedBikePins } = useFleetSimulation();
 
@@ -162,15 +177,16 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
 
   const visibleStationPins = useMemo(() => [...stationPins], [stationPins]);
 
+  // 포커스 모드에선 자동 따라가기를 끈다 — 진입 시 focusBounds 로 1회 fit 한 뒤
+  // 운영자가 자유롭게 팬/줌한다. 그래서 targetLocation 은 검색/배송행 클릭의
+  // one-shot 팬(searchOverride) 만 담당하고, 선택 차량을 매 tick 재중심하던
+  // 옛 분기는 제거했다.
   const targetLocation = useMemo(() => {
     if (searchOverride) {
       return { lat: searchOverride.lat, lng: searchOverride.lng };
     }
-    if (!selectedBikeId) return null;
-    const pin = bikePinById.get(selectedBikeId);
-    if (!pin) return null;
-    return { lat: pin.latitude, lng: pin.longitude };
-  }, [searchOverride, selectedBikeId, bikePinById]);
+    return null;
+  }, [searchOverride]);
 
   // 검색 override 는 그 클릭 한 번에만 의미가 있다. selectedBikeId 가 다음에
   // 다른 차량으로 바뀌면 follow 흐름에 양보. override 가 없으면 no-op short-
@@ -182,12 +198,121 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
     return () => window.cancelAnimationFrame(handle);
   }, [selectedBikeId, searchOverride]);
 
+  // 지도에서의 차량 선택 진입점(마커 클릭 / 검색). 포커스 진입 시 하단 패널을
+  // 접어 지도 가운데 공간을 확보한다(이 side-effect 는 이벤트에서 처리해
+  // react-hooks/set-state-in-effect 를 피한다). fit 트리거는 selectedBikeId
+  // 변경을 render 단계에서 감지하는 focusTriggerRef 가 담당하므로 여기서
+  // 별도로 올리지 않는다(하단 차량표 등 다른 entry point 도 동일하게 fit 됨).
+  const handleSelectBike = useCallback(
+    (bikeId: string) => {
+      setSelectedBikeId(bikeId);
+      setBottomPanelOpen(false);
+    },
+    [setSelectedBikeId]
+  );
+
   const handleSearchSelect = (match: OverviewMapSearchMatch) => {
     setSearchOverride({ lat: match.latitude, lng: match.longitude });
     if (match.kind === "bike") {
-      setSelectedBikeId(match.bikeId);
+      handleSelectBike(match.bikeId);
     }
   };
+
+  // ── 포커스 모드 ──
+  // selectedBikeId != null 이면 포커스 모드: 지도에 선택 차량 1대 + 그 차량의
+  // 배송지 마커, 왼쪽 배송 리스트, 하단 패널 접힘, 자동 따라가기 off.
+  const focusMode = selectedBikeId != null;
+
+  const { active: activeOrders, completed: completedOrders } =
+    useFocusDispatchOrders(selectedBikeId);
+
+  const selectedPin = selectedBikeId ? bikePinById.get(selectedBikeId) ?? null : null;
+  const selectedVehicle = selectedBikeId ? vehicleById.get(selectedBikeId) ?? null : null;
+  const isSequential = isCleaningServiceType(selectedVehicle?.serviceType);
+
+  // 배송지 핀 — 실차량은 active+completed 주문의 좌표, 좌표 없음/0,0 은 스킵.
+  // 시뮬 차량(배차가 client-synthesized 라 listDispatchOrders 에 없음)은
+  // 선택 pin 의 currentDispatch 좌표가 있으면 그 1건만 active 배송지로 합성한다.
+  const dispatchPins = useMemo(() => {
+    if (!focusMode) return [];
+    const pins: Array<{
+      id: string;
+      lat: number;
+      lng: number;
+      label: string;
+      address?: string | null;
+      sequence?: number | null;
+      completed: boolean;
+    }> = [];
+    for (const o of activeOrders) {
+      if (!o.latitude && !o.longitude) continue;
+      pins.push({
+        id: o.id,
+        lat: o.latitude,
+        lng: o.longitude,
+        label: o.customerName,
+        address: o.address,
+        sequence: o.sequence,
+        completed: false
+      });
+    }
+    for (const o of completedOrders) {
+      if (!o.latitude && !o.longitude) continue;
+      pins.push({
+        id: o.id,
+        lat: o.latitude,
+        lng: o.longitude,
+        label: o.customerName,
+        address: o.address,
+        sequence: o.sequence,
+        completed: true
+      });
+    }
+    // 시뮬 fallback: 실 주문이 하나도 없고 선택 pin 의 현재 배송지 좌표가 있으면
+    // 그 1건만 active 배송지로 표시(시뮬 차량은 완료 이력 소스 없음).
+    if (
+      pins.length === 0 &&
+      selectedPin &&
+      selectedPin.currentDispatchLatitude != null &&
+      selectedPin.currentDispatchLongitude != null &&
+      (selectedPin.currentDispatchLatitude !== 0 || selectedPin.currentDispatchLongitude !== 0)
+    ) {
+      pins.push({
+        id: `sim-${selectedPin.bikeId}`,
+        lat: selectedPin.currentDispatchLatitude,
+        lng: selectedPin.currentDispatchLongitude,
+        label: selectedPin.currentDispatchCustomerName ?? "배송지",
+        address: selectedPin.currentDispatchAddress,
+        sequence: null,
+        completed: false
+      });
+    }
+    return pins;
+  }, [focusMode, activeOrders, completedOrders, selectedPin]);
+
+  const focusBounds = useMemo(() => {
+    if (!focusMode || !selectedPin) return null;
+    const points: Array<{ lat: number; lng: number }> = [
+      { lat: selectedPin.latitude, lng: selectedPin.longitude }
+    ];
+    for (const p of dispatchPins) points.push({ lat: p.lat, lng: p.lng });
+    // trigger: 선택 변경(focusTrigger)마다 1회 fit. 추가로, 배송지가 비어서
+    // 차량만 잡고 fit 한 뒤 배송 주문이 늦게 로드돼 처음 비어있지 않게 되는
+    // 순간 한 번 더 fit 해 "차량 + 모든 배송지" 를 담는다(empty→non-empty 1회만
+    // 값이 바뀌므로 폴링 중 재중심은 없다).
+    const trigger = focusTrigger * 2 + (points.length > 1 ? 1 : 0);
+    return { points, trigger };
+  }, [focusMode, selectedPin, dispatchPins, focusTrigger]);
+
+  // 포커스 시 지도에 넘기는 차량 핀: 선택 1대만(station/tip 은 그대로). 해제 시
+  // 전체 visibleBikePins 복원.
+  const mapBikePins = useMemo(
+    () =>
+      focusMode
+        ? overlaidBikePins.filter((p) => p.bikeId === selectedBikeId)
+        : [...visibleBikePins],
+    [focusMode, overlaidBikePins, selectedBikeId, visibleBikePins]
+  );
 
   const detailRow: VehicleDetailRow | null = useMemo(() => {
     if (!selectedBikeId) return null;
@@ -219,16 +344,26 @@ export function FullscreenMapHost(props: FullscreenMapHostProps) {
       </header>
       <main className="fullscreen-map-canvas">
         <MapShell
-          bikePins={[...visibleBikePins]}
+          bikePins={mapBikePins}
           stationPins={[...visibleStationPins]}
           tipPins={[...tipPins]}
           targetLocation={targetLocation}
           selectedBikeId={selectedBikeId}
-          onBikeSelect={setSelectedBikeId}
+          onBikeSelect={handleSelectBike}
           onTipSelect={setSelectedTipId}
           fitBoundsPadding={FULLSCREEN_FIT_BOUNDS_PADDING}
           trailWaypoints={trailWaypoints}
+          dispatchPins={dispatchPins}
+          focusBounds={focusBounds}
         />
+        {focusMode && selectedBikeId ? (
+          <DeliveryFocusPanel
+            bikeId={selectedBikeId}
+            isSequential={isSequential}
+            onClose={() => setSelectedBikeId(null)}
+            onSelectDestination={(p) => setSearchOverride(p)}
+          />
+        ) : null}
         <VehicleDetailDialog
           key={detailRow ? (detailRow.vehicle.id ?? detailRow.vehicle.slug) : "none"}
           row={detailRow}

--- a/development/front-admin-web/components/overview/use-focus-dispatch-orders.ts
+++ b/development/front-admin-web/components/overview/use-focus-dispatch-orders.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  listCompletedDispatchOrdersAction,
+  listDispatchOrdersAction
+} from "@/app/dispatch/actions";
+import type { ServiceOpsDispatchOrder } from "@/lib/services/service-ops-api";
+
+export interface FocusDispatchOrders {
+  /** 진행 중(ASSIGNED) 배차 주문. sequence 오름차순 정렬. */
+  active: ServiceOpsDispatchOrder[];
+  /** 완료(COMPLETED) 배차 주문. */
+  completed: ServiceOpsDispatchOrder[];
+  loading: boolean;
+}
+
+/**
+ * 조회 완료 결과. `key` 는 어떤 bikeId 에 대한 결과인지 — 현재 bikeId 와 다르면
+ * stale 로 보고 loading 으로 파생한다. null 이면 아직 한 번도 안 받음.
+ */
+type FetchedOrders = {
+  key: string;
+  active: ServiceOpsDispatchOrder[];
+  completed: ServiceOpsDispatchOrder[];
+} | null;
+
+const EMPTY_RESULT: FocusDispatchOrders = { active: [], completed: [], loading: false };
+
+/**
+ * 포커스 모드에서 선택 차량의 배차 주문(진행 중 + 완료)을 조회한다.
+ *
+ * 기존 server action(`listDispatchOrdersAction` / `listCompletedDispatchOrdersAction`)
+ * 을 그대로 재사용한다(둘 다 미인증/오류 시 빈 배열). bikeId 가 null 이면
+ * 빈 상태로 단락한다(= 포커스 해제). cancelled 가드로 빠른 선택 전환 시
+ * stale 응답이 state 를 덮어쓰지 않게 한다.
+ *
+ * loading 은 "받은 결과의 key 가 현재 bikeId 와 다른가" 에서 파생한다 —
+ * effect 본문에서 동기 setState 를 호출하지 않기 위함
+ * (react-hooks/set-state-in-effect).
+ */
+export function useFocusDispatchOrders(bikeId: string | null): FocusDispatchOrders {
+  const [fetched, setFetched] = useState<FetchedOrders>(null);
+
+  useEffect(() => {
+    if (!bikeId) return;
+
+    let cancelled = false;
+    Promise.all([
+      listDispatchOrdersAction(bikeId),
+      listCompletedDispatchOrdersAction(bikeId)
+    ])
+      .then(([active, completed]) => {
+        if (cancelled) return;
+        const sortedActive = [...active].sort((a, b) => a.sequence - b.sequence);
+        setFetched({ key: bikeId, active: sortedActive, completed });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetched({ key: bikeId, active: [], completed: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bikeId]);
+
+  if (!bikeId) return EMPTY_RESULT;
+  if (!fetched || fetched.key !== bikeId) {
+    // 현재 bikeId 에 대한 결과를 아직 못 받음 → 로딩 중.
+    return { active: [], completed: [], loading: true };
+  }
+  return { active: fetched.active, completed: fetched.completed, loading: false };
+}

--- a/docs/superpowers/plans/2026-06-29-vehicle-focus-mode.md
+++ b/docs/superpowers/plans/2026-06-29-vehicle-focus-mode.md
@@ -1,0 +1,100 @@
+# 차량 포커스 모드 Implementation Plan
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** 차량 선택 시 포커스 모드 — 지도에 선택 차량 1대 + station/tip 유지 + 그 차량의 배송지 마커, 진입 시 1회 fitBounds 후 수동 조작, 오른쪽 차량상세 + 왼쪽 배송 리스트, 하단 패널 접힘.
+
+**Architecture:** 프론트엔드 전용(백엔드 무변경). 데이터 소스 기존 재사용(`listDispatchOrdersAction`/`listCompletedDispatchOrdersAction`). MapShell에 배송지 마커 레이어 + 트리거 기반 focus fitBounds 추가. FullscreenMapHost가 포커스 상태(=selectedBikeId)에 따라 마커 필터·배송지 데이터·좌패널·하단접기·follow off를 조율.
+
+**Spec:** [docs/superpowers/specs/2026-06-29-vehicle-focus-mode-design.md](../specs/2026-06-29-vehicle-focus-mode-design.md)
+
+---
+
+## Task 1: MapShell — 배송지 마커 레이어 + focus fitBounds
+
+**File:** `components/dashboard/MapShell.tsx`
+
+- [ ] **Step 1: props 추가**
+  - `dispatchPins?: Array<{ id: string; lat: number; lng: number; label: string; address?: string | null; sequence?: number | null; completed: boolean }>` — 선택 차량 배송지.
+  - `focusBounds?: { points: ReadonlyArray<{ lat: number; lng: number }>; trigger: number } | null` — 포커스 진입 시 1회 fit.
+
+- [ ] **Step 2: 배송지 마커 레이어** (tip 레이어 ~578-624 패턴 복제)
+  - `const dispatchMarkerCacheRef = useRef<Map<string, NaverMarkerInstance>>(new Map())`
+  - 새 `useEffect` deps `[sdkReady, dispatchPins, mapVersion, currentZoom]`: incoming-id-set → update-or-create → prune. 마커 icon content = `destinationMarkerHtml(label, address, showLabel, completed, sequence)`.
+  - `destinationMarkerHtml`: 진행 중 = 컬러 핀(+sequence 숫자가 있으면 표기), 완료 = 회색 + 체크(✓). 기존 `markerWrapper`/색 변수 컨벤션 따름(진행 `var(--rm-battery-mid)` 등, 완료 `var(--rm-text-muted)`). bike/tip 마커 html 헬퍼 스타일 미러.
+  - cleanup 시 dispatchMarkerCacheRef도 비움(언마운트 정리 블록 ~256-261에 추가).
+
+- [ ] **Step 3: focus fitBounds 효과** (기존 첫-fit ~319-449와 별개, hasFittedRef로 게이트하지 않음)
+  - `const lastFocusTriggerRef = useRef<number>(-1)`
+  - `useEffect([sdkReady, focusBounds, mapVersion])`: `if (!sdkReady || !focusBounds || focusBounds.points.length === 0) return; if (focusBounds.trigger === lastFocusTriggerRef.current) return; lastFocusTriggerRef.current = focusBounds.trigger;` → LatLngBounds 생성(첫 점으로 init, 나머지 extend) → `map.fitBounds(bounds, fitBoundsPadding)`.
+
+- [ ] **Step 4: 타입체크/커밋**
+  - `cd development/front-admin-web && npx tsc --noEmit` (focusBounds/dispatchPins는 optional이라 기존 호출 안 깨짐).
+  - commit: `feat: MapShell dispatch destination markers + focus fitBounds`
+
+---
+
+## Task 2: 좌측 배송 리스트 패널 + 데이터 훅
+
+**Files:**
+- Create: `components/overview/DeliveryFocusPanel.tsx`
+- Create: `components/overview/use-focus-dispatch-orders.ts`
+
+- [ ] **Step 1: 데이터 훅** `useFocusDispatchOrders(bikeId: string | null)`
+  - `useEffect([bikeId])`: bikeId 있으면 `Promise.all([listDispatchOrdersAction(bikeId), listCompletedDispatchOrdersAction(bikeId)])` → `{ active: ServiceOpsDispatchOrder[]; completed: ServiceOpsDispatchOrder[]; loading: boolean }`. bikeId null이면 빈 상태. cancelled 가드.
+  - active는 `status==="ASSIGNED"` + `sequence` 정렬. 반환.
+
+- [ ] **Step 2: 패널 컴포넌트** `DeliveryFocusPanel({ bikeId, isSequential, onClose, onSelectDestination })`
+  - 훅으로 active/completed 받아 렌더. 읽기 전용(완료/취소 버튼 없음 — YAGNI).
+  - 진행 중 섹션: 순차면 순번 + "현재/대기", 단일이면 평면 목록. 각 행: 고객명 + 종류 배지(수거/배송) + 주소. 행 클릭 → `onSelectDestination({lat,lng})`(지도 팬).
+  - 완료 섹션: 회색/접기(`완료 내역 ▼`) — 옛 `CompletedOrdersSection` 구조 차용. 완료 시각 표시.
+  - 헤더 "배송" + 닫기(X) → `onClose`.
+  - 기존 CSS 클래스 재사용(`dispatch-queue-section`, `dispatch-queue-list`, `dispatch-order-row`, `delivery-meta`, `dispatch-kind-badge`, `dispatch-completed-*` 등) + 패널 래퍼 새 클래스.
+
+- [ ] **Step 3: 타입체크/커밋**
+  - `npx tsc --noEmit`. commit: `feat: DeliveryFocusPanel + focus dispatch orders hook`
+
+---
+
+## Task 3: FullscreenMapHost 포커스 배선 + CSS
+
+**Files:**
+- Modify: `components/overview/FullscreenMapHost.tsx`
+- Modify: `app/globals.css`
+
+- [ ] **Step 1: 포커스 상태 파생**
+  - `const focusMode = selectedBikeId != null`.
+  - 포커스 시 MapShell `bikePins`: `focusMode ? overlaidBikePins.filter(p => p.bikeId === selectedBikeId) : [...visibleBikePins]`. (station/tip 그대로.)
+
+- [ ] **Step 2: 배송지 데이터**
+  - 훅 `useFocusDispatchOrders(selectedBikeId)`로 active+completed 받음.
+  - `dispatchPins` 계산: 실차량 = active+completed 각 주문 → `{id, lat:latitude, lng:longitude, label:customerName, address, sequence, completed: status==="COMPLETED"}`, 좌표 없음/`0,0` 스킵. 시뮬 차량(IMEI "-", 선택 pin의 `currentDispatchLatitude/Longitude` 존재 시) → 그 1건만 active 배송지로. MapShell에 전달.
+
+- [ ] **Step 3: focusBounds + follow off**
+  - `targetLocation`에서 "선택 차량 따라가기" 분기 제거 → searchOverride + 배송행 클릭(one-shot)만 남김. (포커스 중 연속 재중심 안 함.)
+  - `focusBounds`: `useMemo` — focusMode면 `{ points: [선택차량 좌표, ...dispatchPins 좌표], trigger: <selectedBikeId 바뀔 때 증가하는 카운터> }` else null. trigger는 `useEffect([selectedBikeId])`로 증가시키는 ref/state.
+  - MapShell에 `dispatchPins`, `focusBounds` 전달.
+
+- [ ] **Step 4: 좌패널 + 하단 접기**
+  - focusMode면 `<DeliveryFocusPanel bikeId={selectedBikeId} isSequential={isCleaningServiceType(selectedVehicle.serviceType)} onClose={() => setSelectedBikeId(null)} onSelectDestination={(p) => setSearchOverride(p)} />` 를 `<main className="fullscreen-map-canvas">` 안 MapShell 뒤에 마운트.
+  - 포커스 진입 시 `setBottomPanelOpen(false)` (`useEffect([selectedBikeId])`).
+
+- [ ] **Step 5: CSS** (`app/globals.css`)
+  - `.vehicle-focus-left-panel`: `.vehicle-floating-panel` 스타일 미러하되 `left:16px`(레일 있으면 그대로 overlay가 이미 left:rail-width 오프셋), `top:80px`(헤더 아래). max-width/maxheight 동일.
+  - `.map-marker-destination` (+ `--completed` 변형): 배송지 핀 색/체크/순번 배지 스타일.
+
+- [ ] **Step 6: 검증/커밋**
+  - `npx tsc --noEmit && npm run lint && npm run test:service-ops` 모두 clean.
+  - commit: `feat: vehicle focus mode wiring in overview map`
+
+---
+
+## Task 4: 최종 검증 + PR
+- [ ] 전체 `tsc`/`lint`/`test:service-ops` 재확인.
+- [ ] 런타임은 배포 후 prod에서 관측(프리뷰 경쟁서버 금지 [[feedback_preview_workflow]]) — 차량 선택 → 1대만+배송지마커+좌패널+하단접힘, 해제 복원.
+- [ ] PR → dev.
+
+## Self-Review
+- Spec 항목 매핑: 마커 필터(T3)·배송지 레이어(T1)·fit-then-manual(T1+T3)·좌패널(T2)·완료구분(T2 리스트 + T1 마커)·하단접기(T3)·해제복원(T3). ✅
+- 백엔드/마이그레이션 없음. 기존 CSS·액션 최대 재사용.
+- YAGNI: 배송 완료/취소 액션, 마커↔행 양방향 하이라이트, 다중 포커스 제외.

--- a/docs/superpowers/specs/2026-06-29-vehicle-focus-mode-design.md
+++ b/docs/superpowers/specs/2026-06-29-vehicle-focus-mode-design.md
@@ -1,0 +1,47 @@
+# 차량 포커스 모드 (Vehicle focus mode)
+
+**Date:** 2026-06-29
+**Status:** Design (approved)
+
+## 배경 / 목표
+
+오버뷰 지도에서 차량을 선택하면 현재는 그 차량을 **따라가며** 오른쪽에 차량 상세(VehicleDetailDialog)가 뜬다. 이를 **포커스 모드**로 바꾼다: 선택한 차량 한 대와 그 차량의 **배송지**에 집중해 운영자가 배송 현황을 한눈에 보게 한다.
+
+## 동작
+
+### 진입 — 차량 선택 시
+- **지도 마커**
+  - 선택 차량 1대만 표시(다른 차량 핀 숨김)
+  - station·tip 마커는 **그대로 유지**
+  - 선택 차량의 **배송지 마커를 새로 표시**(MapShell의 4번째 마커 레이어). 진행 중/완료를 시각 구분(진행 중=컬러+순번, 완료=회색+체크). 순차배차(SEQUENTIAL)는 순번 표기.
+- **fitBounds**: 진입(선택 변경) 시 "선택 차량 + 모든 배송지"가 한 화면에 보이도록 **1회** 맞춘다. 그 후 **자동 따라가기는 끈다** — 운영자가 자유롭게 팬/줌. 폴링으로 차량 위치가 갱신돼도 마커만 움직이고 지도 재중심은 하지 않는다.
+- **오른쪽 패널**: 기존 VehicleDetailDialog (변경 없음).
+- **왼쪽 패널(신규)**: "현재 배송 리스트" — 진행 중 + 완료 배송을 **상태 구분**해 보여준다. 행 클릭 시 해당 배송지로 지도 이동(팬).
+- **하단 BottomMapPanel**: 포커스 모드에선 접는다(지도 가운데 공간 확보).
+
+### 해제 — 선택 해제(빈 지도 클릭 / 패널 닫기)
+- 전체 차량 마커 복원, 배송지 마커 제거, 왼쪽 배송 리스트 닫힘, 자동 따라가기 원복.
+- 선택 차량이 폴링 중 사라지면(매칭 종료 등) 포커스 자동 해제.
+
+## 데이터
+
+- **배송 리스트/배송지**: 실차량은 `listDispatchOrders(bikeId)`(진행 중) + `listCompletedDispatchOrders(bikeId)`(완료)로 합쳐 상태 구분. 각 주문의 latitude/longitude가 배송지 마커. 좌표 없음/`0,0`은 마커 스킵.
+- **순서**: 순차배차는 `sequence` 순. 단일/콜은 무순서(들어온 순).
+- **시뮬 차량(IMEI "-")**: 배차가 client-synthesized라 `listDispatchOrders`에 없음 → 핀의 `currentDispatch*`(현재 1건)만 배송지로 표시, 완료 이력 없음. 실차량은 전체 리스트.
+
+## 컴포넌트 영향
+
+- `components/dashboard/MapShell.tsx`: 배송지(destination) 마커 레이어 추가(prop `dispatchMarkers` 등 + 렌더/캐시/정리/HTML). 포커스 모드용 1회 fitBounds 트리거 + 기존 follow 비활성화 분기.
+- `components/overview/FullscreenMapHost.tsx`: 포커스 상태(선택 차량) 기반으로 (1) MapShell에 넘기는 bikePins를 선택 1대로 필터, (2) 배송지 마커 데이터 계산/전달, (3) 왼쪽 패널 마운트, (4) 하단 패널 접기, (5) 진입 시 fit / follow off.
+- 신규 `components/overview/DeliveryListPanel.tsx`(가칭): 왼쪽 배송 리스트 UI.
+- 데이터 fetch: 선택 시 dispatch 주문 조회(기존 `listDispatchOrdersAction` / `listCompletedDispatchOrdersAction` 재사용).
+- CSS: 왼쪽 패널 레이아웃 + 배송지 마커 스타일.
+
+## 비목표 (YAGNI)
+- 배송지 마커에서의 편집/배차 변경(읽기 전용 표시).
+- 시뮬 차량의 완료 이력(소스 없음).
+- 다중 차량 동시 포커스.
+
+## 미해결 / 후속
+- 배송지 마커 클릭 ↔ 리스트 행 하이라이트 연동(있으면 좋지만 1차는 단방향: 행→지도).
+- 좁은 화면에서 좌/우 패널 + 지도 폭 — 1차는 데스크톱 기준.


### PR DESCRIPTION
## 요약
오버뷰 지도에서 차량 선택 시 **포커스 모드** — 선택 차량 1대 + 그 차량의 **배송지 마커**에 집중하고, 오른쪽 차량상세 + **왼쪽 배송 리스트**를 띄운다. 백엔드 무변경(기존 dispatch 액션 재사용).

## 동작
- **지도**: 선택 차량만(다른 차량 숨김), station·tip 유지, 배송지 마커 신규(진행 중=노란 핀+순번, 완료=회색+✓)
- **fit-then-manual**: 진입 시 차량+배송지 전체 1회 fitBounds → 이후 자동 따라가기 끔(운영자 자유 조작), 폴링은 마커만 갱신
- **오른쪽**: 기존 차량상세 / **왼쪽**: 배송 리스트(진행 중+완료 구분, 행 클릭 시 해당 배송지로 팬)
- 포커스 진입 시 하단 패널 접힘(마커·검색·하단 차량표 어느 경로든), 해제 시 전체 복원

## 구현
- `MapShell`: 배송지 마커 레이어 + 트리거 기반 focus fitBounds(테마 토글 시 리셋 포함). 신규 props는 optional → DashboardCanvas 무영향
- `DeliveryFocusPanel` + `useFocusDispatchOrders` (호스트가 1회 조회해 패널에 props로 전달 → 중복호출 없음)
- `FullscreenMapHost`: 포커스 배선(마커 필터·배송지 데이터·좌패널·하단접기·follow off)
- 좌표 없는 배송 행은 클릭 비활성(0,0 팬 방지)

## 검증
- `tsc`/`lint`/`test:service-ops 46` 모두 clean, 코드리뷰(스펙준수 + 5개 이슈 수정) 통과
- 런타임은 배포 후 prod 관측

스펙/플랜: docs/superpowers/specs(plans)/2026-06-29-vehicle-focus-mode*

🤖 Generated with [Claude Code](https://claude.com/claude-code)