### PR TITLE
release: 드라이버 앱 연동 — 라이더 API Phase 1

### DIFF
--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/ErrorCode.java
@@ -3,6 +3,7 @@ package com.thundercrew.opsapi.common.api;
 public enum ErrorCode {
     VALIDATION_FAILED,
     AUTHENTICATION_FAILED,
+    ACCESS_DENIED,
     RESOURCE_NOT_FOUND,
     REFERENCE_NOT_FOUND,
     REFERENCE_DELETED,

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/common/api/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -168,6 +169,20 @@ public class GlobalExceptionHandler {
                 Instant.now(clock)
         );
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(body);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    ResponseEntity<ApiErrorResponse> handleAccessDenied(
+            AccessDeniedException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorCode.ACCESS_DENIED,
+                exception.getMessage(),
+                request.getRequestURI(),
+                Instant.now(clock)
+        );
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
     }
 
     @ExceptionHandler(Exception.class)

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/NotificationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/repository/NotificationRepository.java
@@ -4,7 +4,10 @@ import com.thundercrew.opsapi.notification.domain.Notification;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
@@ -20,4 +23,10 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
             String type,
             Instant after
     );
+
+    @Query("select n from Notification n where n.deletedAt is null "
+         + "and (n.refRiderId = :riderId or n.refBikeId = :bikeId) order by n.occurredAt desc")
+    List<Notification> findRecentForRiderOrBike(@Param("riderId") UUID riderId,
+                                                @Param("bikeId") UUID bikeId,
+                                                Pageable pageable);
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/notification/service/NotificationReadService.java
@@ -3,6 +3,8 @@ package com.thundercrew.opsapi.notification.service;
 import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
 import com.thundercrew.opsapi.notification.repository.NotificationRepository;
 import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,14 @@ public class NotificationReadService {
 
     public NotificationReadService(NotificationRepository notificationRepository) {
         this.notificationRepository = notificationRepository;
+    }
+
+    public List<NotificationReadResponse> listForRiderOrBike(UUID riderId, UUID bikeId) {
+        UUID effectiveBikeId = bikeId != null ? bikeId : new UUID(0, 0);
+        return notificationRepository.findRecentForRiderOrBike(riderId, effectiveBikeId, PageRequest.of(0, 100))
+                .stream()
+                .map(NotificationReadResponse::from)
+                .toList();
     }
 
     public List<NotificationReadResponse> listRecent(boolean unacknowledgedOnly, String typeOrNull) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfCommandController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfCommandController.java
@@ -1,25 +1,37 @@
 package com.thundercrew.opsapi.rider.controller;
 
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
 import com.thundercrew.opsapi.rider.dto.RiderPasswordChangeRequest;
+import com.thundercrew.opsapi.rider.service.RiderSelfDispatchService;
 import com.thundercrew.opsapi.riderauth.service.RiderAuthService;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.UUID;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/rider")
 public class RiderSelfCommandController {
 
     private final RiderAuthService riderAuthService;
+    private final RiderSelfDispatchService riderSelfDispatchService;
 
-    public RiderSelfCommandController(RiderAuthService riderAuthService) {
+    public RiderSelfCommandController(
+            RiderAuthService riderAuthService,
+            RiderSelfDispatchService riderSelfDispatchService
+    ) {
         this.riderAuthService = riderAuthService;
+        this.riderSelfDispatchService = riderSelfDispatchService;
     }
 
     @PostMapping("/me/password")
@@ -30,5 +42,26 @@ public class RiderSelfCommandController {
         UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
         riderAuthService.changePassword(riderId, request.currentPassword(), request.newPassword());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/me/offered-calls/{id}/accept")
+    DispatchOrderReadResponse acceptCall(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id
+    ) {
+        return riderSelfDispatchService.acceptOfferedCall(riderId(jwt), id);
+    }
+
+    @PostMapping(value = "/me/dispatch-orders/{id}/complete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    DispatchOrderReadResponse complete(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id,
+            @RequestPart("photo") MultipartFile photo
+    ) throws IOException {
+        return riderSelfDispatchService.completeMyDispatch(riderId(jwt), id, photo.getBytes(), photo.getContentType());
+    }
+
+    private static UUID riderId(Jwt jwt) {
+        return UUID.fromString(jwt.getClaimAsString("riderId"));
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/controller/RiderSelfReadController.java
@@ -1,11 +1,22 @@
 package com.thundercrew.opsapi.rider.controller;
 
 import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.service.DeliveryCallService;
 import com.thundercrew.opsapi.dispatch.service.DispatchOrderReadService;
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import com.thundercrew.opsapi.maintenance.service.MaintenanceReadService;
+import com.thundercrew.opsapi.notification.dto.NotificationReadResponse;
+import com.thundercrew.opsapi.notification.service.NotificationReadService;
+import com.thundercrew.opsapi.rider.dto.RiderMaintenanceResponse;
 import com.thundercrew.opsapi.rider.dto.RiderMeResponse;
 import com.thundercrew.opsapi.rider.dto.RiderVehicleResponse;
 import com.thundercrew.opsapi.rider.service.RiderSelfReadService;
 import com.thundercrew.opsapi.rider.service.RiderVehicleReadService;
+import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
+import com.thundercrew.opsapi.station.service.StationReadService;
+import com.thundercrew.opsapi.tip.dto.TipReadResponse;
+import com.thundercrew.opsapi.tip.service.TipReadService;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,15 +32,30 @@ public class RiderSelfReadController {
     private final RiderSelfReadService riderSelfReadService;
     private final DispatchOrderReadService dispatchOrderReadService;
     private final RiderVehicleReadService riderVehicleReadService;
+    private final DeliveryCallService deliveryCallService;
+    private final TipReadService tipReadService;
+    private final StationReadService stationReadService;
+    private final MaintenanceReadService maintenanceReadService;
+    private final NotificationReadService notificationReadService;
 
     public RiderSelfReadController(
             RiderSelfReadService riderSelfReadService,
             DispatchOrderReadService dispatchOrderReadService,
-            RiderVehicleReadService riderVehicleReadService
+            RiderVehicleReadService riderVehicleReadService,
+            DeliveryCallService deliveryCallService,
+            TipReadService tipReadService,
+            StationReadService stationReadService,
+            MaintenanceReadService maintenanceReadService,
+            NotificationReadService notificationReadService
     ) {
         this.riderSelfReadService = riderSelfReadService;
         this.dispatchOrderReadService = dispatchOrderReadService;
         this.riderVehicleReadService = riderVehicleReadService;
+        this.deliveryCallService = deliveryCallService;
+        this.tipReadService = tipReadService;
+        this.stationReadService = stationReadService;
+        this.maintenanceReadService = maintenanceReadService;
+        this.notificationReadService = notificationReadService;
     }
 
     @GetMapping("/me")
@@ -48,9 +74,53 @@ public class RiderSelfReadController {
         return dispatchOrderReadService.listAssignedByBike(bikeId);
     }
 
+    @GetMapping("/me/dispatch-orders/completed")
+    List<DispatchOrderReadResponse> myCompletedDispatchOrders(@AuthenticationPrincipal Jwt jwt) {
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+        return bikeId == null ? List.of() : dispatchOrderReadService.listCompletedByBike(bikeId);
+    }
+
+    @GetMapping("/me/offered-calls")
+    List<DispatchOrderReadResponse> myOfferedCalls(@AuthenticationPrincipal Jwt jwt) {
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+        if (bikeId == null) return List.of();
+        if (!riderVehicleReadService.isCallBike(bikeId)) return List.of();
+        return deliveryCallService.listOffered();
+    }
+
+    @GetMapping("/me/tips")
+    List<TipReadResponse> myTips() {
+        return tipReadService.listPublished();
+    }
+
+    @GetMapping("/me/stations")
+    List<BatteryStationReadResponse> myStations() {
+        return stationReadService.listActive();
+    }
+
+    @GetMapping("/me/maintenance")
+    RiderMaintenanceResponse myMaintenance(@AuthenticationPrincipal Jwt jwt) {
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+        if (bikeId == null) return new RiderMaintenanceResponse(List.of(), List.of());
+        return new RiderMaintenanceResponse(
+                maintenanceReadService.listItemsForBike(bikeId),
+                maintenanceReadService.listRecordsForBike(bikeId));
+    }
+
+    @GetMapping("/me/notifications")
+    List<NotificationReadResponse> myNotifications(@AuthenticationPrincipal Jwt jwt) {
+        UUID rid = riderId(jwt);
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(rid);
+        return notificationReadService.listForRiderOrBike(rid, bikeId);
+    }
+
     @GetMapping("/me/vehicle")
     RiderVehicleResponse myVehicle(@AuthenticationPrincipal Jwt jwt) {
         UUID riderId = UUID.fromString(jwt.getClaimAsString("riderId"));
         return riderVehicleReadService.getMyVehicle(riderId);
+    }
+
+    private static UUID riderId(Jwt jwt) {
+        return UUID.fromString(jwt.getClaimAsString("riderId"));
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderMaintenanceResponse.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/dto/RiderMaintenanceResponse.java
@@ -1,0 +1,10 @@
+package com.thundercrew.opsapi.rider.dto;
+
+import com.thundercrew.opsapi.maintenance.dto.MaintenanceItemReadResponse;
+import com.thundercrew.opsapi.maintenance.dto.VehicleMaintenanceRecordReadResponse;
+import java.util.List;
+
+public record RiderMaintenanceResponse(
+        List<MaintenanceItemReadResponse> items,
+        List<VehicleMaintenanceRecordReadResponse> records
+) {}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderSelfDispatchService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderSelfDispatchService.java
@@ -1,0 +1,54 @@
+package com.thundercrew.opsapi.rider.service;
+
+import com.thundercrew.opsapi.common.api.InvalidStateTransitionException;
+import com.thundercrew.opsapi.dispatch.domain.DispatchOrder;
+import com.thundercrew.opsapi.dispatch.dto.DispatchOrderReadResponse;
+import com.thundercrew.opsapi.dispatch.service.DeliveryCallService;
+import com.thundercrew.opsapi.dispatch.service.DispatchOrderCommandService;
+import com.thundercrew.opsapi.dispatch.service.DispatchOrderReadService;
+import java.util.UUID;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class RiderSelfDispatchService {
+
+    private final RiderVehicleReadService riderVehicleReadService;
+    private final DeliveryCallService deliveryCallService;
+    private final DispatchOrderReadService dispatchOrderReadService;
+    private final DispatchOrderCommandService dispatchOrderCommandService;
+
+    public RiderSelfDispatchService(
+            RiderVehicleReadService riderVehicleReadService,
+            DeliveryCallService deliveryCallService,
+            DispatchOrderReadService dispatchOrderReadService,
+            DispatchOrderCommandService dispatchOrderCommandService
+    ) {
+        this.riderVehicleReadService = riderVehicleReadService;
+        this.deliveryCallService = deliveryCallService;
+        this.dispatchOrderReadService = dispatchOrderReadService;
+        this.dispatchOrderCommandService = dispatchOrderCommandService;
+    }
+
+    public DispatchOrderReadResponse acceptOfferedCall(UUID riderId, UUID orderId) {
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+        if (bikeId == null) {
+            throw new InvalidStateTransitionException("활성 차량이 없습니다.");
+        }
+        return deliveryCallService.acceptCall(orderId, bikeId);
+    }
+
+    public DispatchOrderReadResponse completeMyDispatch(UUID riderId, UUID orderId, byte[] photo, String contentType) {
+        UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+        if (bikeId == null) {
+            throw new InvalidStateTransitionException("활성 차량이 없습니다.");
+        }
+        DispatchOrder order = dispatchOrderReadService.findOrderForPhoto(orderId);
+        if (!bikeId.equals(order.getBikeId())) {
+            throw new AccessDeniedException("본인 배차가 아닙니다.");
+        }
+        return dispatchOrderCommandService.complete(orderId, photo, contentType, riderId);
+    }
+}

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
@@ -1,6 +1,7 @@
 package com.thundercrew.opsapi.rider.service;
 
 import com.thundercrew.opsapi.bike.domain.Bike;
+import com.thundercrew.opsapi.bike.domain.BikeServiceType;
 import com.thundercrew.opsapi.bike.repository.BikeRepository;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
 import com.thundercrew.opsapi.contract.repository.RiderBikeContractRepository;
@@ -62,5 +63,12 @@ public class RiderVehicleReadService {
     @Transactional(readOnly = true)
     public UUID activeBikeIdOrNull(UUID riderId) {
         return contractRepository.findActiveByRiderId(riderId).map(c -> c.getBikeId()).orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isCallBike(UUID bikeId) {
+        return bikeRepository.findByIdAndDeletedAtIsNull(bikeId)
+                .map(b -> b.getServiceType() == BikeServiceType.CALL)
+                .orElse(false);
     }
 }

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/repository/BatteryStationRepository.java
@@ -1,6 +1,8 @@
 package com.thundercrew.opsapi.station.repository;
 
 import com.thundercrew.opsapi.station.domain.BatteryStation;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -10,6 +12,8 @@ import org.springframework.data.repository.Repository;
 public interface BatteryStationRepository extends Repository<BatteryStation, UUID> {
 
     Page<BatteryStation> findByDeletedAtIsNull(Pageable pageable);
+
+    List<BatteryStation> findByStatusAndDeletedAtIsNull(BatteryStationStatus status);
 
     Optional<BatteryStation> findById(UUID id);
 

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/station/service/StationReadService.java
@@ -2,10 +2,12 @@ package com.thundercrew.opsapi.station.service;
 
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.station.domain.BatteryStationStatus;
 import com.thundercrew.opsapi.station.dto.BatteryStationReadResponse;
 import com.thundercrew.opsapi.station.dto.StationBatteryCountLogReadResponse;
 import com.thundercrew.opsapi.station.repository.BatteryStationRepository;
 import com.thundercrew.opsapi.station.repository.StationBatteryCountLogRepository;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,12 @@ public class StationReadService {
     public StationReadService(BatteryStationRepository batteryStationRepository, StationBatteryCountLogRepository countLogRepository) {
         this.batteryStationRepository = batteryStationRepository;
         this.countLogRepository = countLogRepository;
+    }
+
+    public List<BatteryStationReadResponse> listActive() {
+        return batteryStationRepository.findByStatusAndDeletedAtIsNull(BatteryStationStatus.ACTIVE).stream()
+                .map(BatteryStationReadResponse::from)
+                .toList();
     }
 
     public PageResponse<BatteryStationReadResponse> listStations(Pageable pageable) {

--- a/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/service/TipReadService.java
+++ b/development/service-ops-api/src/main/java/com/thundercrew/opsapi/tip/service/TipReadService.java
@@ -2,8 +2,10 @@ package com.thundercrew.opsapi.tip.service;
 
 import com.thundercrew.opsapi.common.api.PageResponse;
 import com.thundercrew.opsapi.common.api.ResourceNotFoundException;
+import com.thundercrew.opsapi.tip.domain.TipStatus;
 import com.thundercrew.opsapi.tip.dto.TipReadResponse;
 import com.thundercrew.opsapi.tip.repository.TipRepository;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,12 @@ public class TipReadService {
 
     public TipReadService(TipRepository tipRepository) {
         this.tipRepository = tipRepository;
+    }
+
+    public List<TipReadResponse> listPublished() {
+        return tipRepository.findByStatusAndDeletedAtIsNull(TipStatus.PUBLISHED).stream()
+                .map(TipReadResponse::from)
+                .toList();
     }
 
     public PageResponse<TipReadResponse> listTips(Pageable pageable) {

--- a/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderDriverApiContractTests.java
+++ b/development/service-ops-api/src/test/java/com/thundercrew/opsapi/RiderDriverApiContractTests.java
@@ -1,0 +1,427 @@
+package com.thundercrew.opsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RiderDriverApiContractTests extends PostgresContainerSupport {
+
+    private static final UUID ADMIN_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID RIDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID RIDER_NO_VEHICLE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID BIKE_ID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID BIKE_NON_CALL_ID = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static final UUID CONTRACT_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String RIDER_PHONE = "010-9999-1111";
+    private static final String RIDER_NO_VEHICLE_PHONE = "010-9999-2222";
+    private static final String RIDER_NON_CALL_PHONE = "010-9999-3333";
+    private static final UUID RIDER_NON_CALL_ID = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    private static final String RIDER_PASSWORD = "rider-test-secret";
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String adminToken;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registerPostgresProperties(registry);
+    }
+
+    @BeforeEach
+    void resetRows() throws Exception {
+        jdbcTemplate.update("delete from notifications");
+        jdbcTemplate.update("delete from bike_current_states");
+        jdbcTemplate.update("delete from dispatch_orders");
+        jdbcTemplate.update("delete from rider_credentials");
+        jdbcTemplate.update("delete from rider_bike_contracts");
+        jdbcTemplate.update("delete from bikes");
+        jdbcTemplate.update("delete from riders");
+        jdbcTemplate.update("delete from tips");
+        jdbcTemplate.update("delete from battery_stations");
+        jdbcTemplate.update("delete from admin_users");
+
+        jdbcTemplate.update("""
+                insert into admin_users (id, login_id, email, password_hash, display_name, enabled)
+                values (?, 'ops-admin-dr', 'ops-dr@example.test', ?, 'Ops Admin', true)
+                """, ADMIN_ID, passwordEncoder.encode("correct-password"));
+
+        // Rider with CALL vehicle
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더A', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_ID, RIDER_PHONE);
+
+        // Rider without vehicle
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더B', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_NO_VEHICLE_ID, RIDER_NO_VEHICLE_PHONE);
+
+        // Rider with non-CALL vehicle
+        jdbcTemplate.update("""
+                insert into riders (id, name, phone_number, team_name, area_name, app_account_linked, memo, deleted_at)
+                values (?, '라이더C', ?, '강남팀', '서울 강남', false, 'fixture', null)
+                """, RIDER_NON_CALL_ID, RIDER_NON_CALL_PHONE);
+
+        // CALL bike for RIDER_ID
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, operation_status, engine_type, wheel_type,
+                    service_type, ignition_blocked, created_at, updated_at)
+                values (?, '12가3456', 'IN_SERVICE', 'ELECTRIC', 'TWO_WHEEL', 'CALL', false, now(), now())
+                """, BIKE_ID);
+
+        // SINGLE bike for RIDER_NON_CALL_ID
+        jdbcTemplate.update("""
+                insert into bikes (id, plate_number, operation_status, engine_type, wheel_type,
+                    service_type, ignition_blocked, created_at, updated_at)
+                values (?, '99나9999', 'IN_SERVICE', 'ELECTRIC', 'TWO_WHEEL', 'SINGLE', false, now(), now())
+                """, BIKE_NON_CALL_ID);
+
+        // Active contract: RIDER_ID → BIKE_ID
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, created_at, updated_at)
+                values (?, ?, ?, ?, ?, now(), now())
+                """,
+                UUID.randomUUID(), RIDER_ID, BIKE_ID, CONTRACT_TEMPLATE_ID,
+                Instant.parse("2026-01-01T00:00:00Z"));
+
+        // Active contract: RIDER_NON_CALL_ID → BIKE_NON_CALL_ID
+        jdbcTemplate.update("""
+                insert into rider_bike_contracts (id, rider_id, bike_id, contract_template_id, start_at, created_at, updated_at)
+                values (?, ?, ?, ?, ?, now(), now())
+                """,
+                UUID.randomUUID(), RIDER_NON_CALL_ID, BIKE_NON_CALL_ID, CONTRACT_TEMPLATE_ID,
+                Instant.parse("2026-01-01T00:00:00Z"));
+
+        adminToken = loginAdminAndExtractAccessToken();
+    }
+
+    // ────────────────────────── /me/dispatch-orders/completed ──────────────────────────
+
+    @Test
+    void completedOrders_returns200AndCompletedOrders() throws Exception {
+        seedCompletedOrder(BIKE_ID, "고객A", "010-1111-0001", "서울 강남구 테헤란로 1", 37.5000, 127.0000);
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/dispatch-orders/completed")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].status").value("COMPLETED"));
+    }
+
+    @Test
+    void completedOrders_noVehicle_returns200AndEmpty() throws Exception {
+        String token = riderToken(RIDER_NO_VEHICLE_ID, RIDER_NO_VEHICLE_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/dispatch-orders/completed")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ────────────────────────── /me/offered-calls ──────────────────────────────────────
+
+    @Test
+    void offeredCalls_callBike_returns200AndOfferedOrders() throws Exception {
+        seedOfferedOrder("고객X", "010-2222-0001", "서울 마포구 1", 37.5500, 126.9200);
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/offered-calls")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].status").value("OFFERED"));
+    }
+
+    @Test
+    void offeredCalls_nonCallBike_returns200AndEmpty() throws Exception {
+        seedOfferedOrder("고객X", "010-2222-0001", "서울 마포구 1", 37.5500, 126.9200);
+
+        String token = riderToken(RIDER_NON_CALL_ID, RIDER_NON_CALL_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/offered-calls")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void offeredCalls_noVehicle_returns200AndEmpty() throws Exception {
+        seedOfferedOrder("고객X", "010-2222-0001", "서울 마포구 1", 37.5500, 126.9200);
+
+        String token = riderToken(RIDER_NO_VEHICLE_ID, RIDER_NO_VEHICLE_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/offered-calls")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ────────────────────────── /me/tips ───────────────────────────────────────────────
+
+    @Test
+    void tips_returnsOnlyPublished() throws Exception {
+        seedTip(UUID.randomUUID(), "서울 강남구 테헤란로 1", "팁 내용 1", 37.5, 127.0, "PUBLISHED");
+        seedTip(UUID.randomUUID(), "서울 강남구 테헤란로 2", "팁 내용 2", 37.5, 127.1, "PENDING");
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/tips")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].status").value("PUBLISHED"));
+    }
+
+    // ────────────────────────── /me/stations ───────────────────────────────────────────
+
+    @Test
+    void stations_returnsOnlyActive() throws Exception {
+        seedBatteryStation(UUID.randomUUID(), "강남 충전소", "서울 강남구 1", "ACTIVE");
+        seedBatteryStation(UUID.randomUUID(), "마포 충전소", "서울 마포구 1", "INACTIVE");
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/stations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"));
+    }
+
+    // ────────────────────────── /me/maintenance ────────────────────────────────────────
+
+    @Test
+    void maintenance_withVehicle_returns200AndItemsAndRecords() throws Exception {
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/maintenance")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.records").isArray());
+    }
+
+    @Test
+    void maintenance_noVehicle_returns200AndEmptyLists() throws Exception {
+        String token = riderToken(RIDER_NO_VEHICLE_ID, RIDER_NO_VEHICLE_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/maintenance")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(0))
+                .andExpect(jsonPath("$.records").isArray())
+                .andExpect(jsonPath("$.records.length()").value(0));
+    }
+
+    // ────────────────────────── /me/notifications ──────────────────────────────────────
+
+    @Test
+    void notifications_returnsRiderScopedOnly() throws Exception {
+        UUID otherId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID otherBikeId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        seedNotification(UUID.randomUUID(), "MAINT", "My Rider Notif", RIDER_ID, null, otherId);
+        seedNotification(UUID.randomUUID(), "MAINT", "My Bike Notif", null, BIKE_ID, otherId);
+        seedNotification(UUID.randomUUID(), "MAINT", "Other Notif", otherId, otherBikeId, otherId);
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(get("/api/v1/rider/me/notifications")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    // ────────────────────────── POST /me/offered-calls/{id}/accept ─────────────────────
+
+    @Test
+    void acceptCall_assignsOrderToMyBike() throws Exception {
+        UUID offeredOrderId = seedOfferedOrder("고객Y", "010-3333-0001", "서울 용산구 1", 37.5400, 126.9800);
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(post("/api/v1/rider/me/offered-calls/{id}/accept", offeredOrderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ASSIGNED"))
+                .andExpect(jsonPath("$.bikeId").value(BIKE_ID.toString()));
+    }
+
+    // ────────────────────────── POST /me/dispatch-orders/{id}/complete ─────────────────
+
+    @Test
+    void complete_ownershipViolation_returns403() throws Exception {
+        // Seed an ASSIGNED order for BIKE_NON_CALL_ID (belongs to another rider)
+        UUID othersOrderId = seedAssignedOrder(BIKE_NON_CALL_ID, "고객Z", "010-4444-0001", "서울 종로구 1", 37.5700, 126.9800);
+
+        // RIDER_ID tries to complete an order that belongs to BIKE_NON_CALL_ID
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(multipart("/api/v1/rider/me/dispatch-orders/{id}/complete", othersOrderId)
+                        .file(new MockMultipartFile("photo", "photo.jpg", "image/jpeg", "fake-image".getBytes()))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void complete_ownOrder_returnsCompleted() throws Exception {
+        UUID myOrderId = seedAssignedOrder(BIKE_ID, "고객W", "010-5555-0001", "서울 서초구 1", 37.4900, 127.0100);
+
+        String token = riderToken(RIDER_ID, RIDER_PHONE);
+
+        mockMvc.perform(multipart("/api/v1/rider/me/dispatch-orders/{id}/complete", myOrderId)
+                        .file(new MockMultipartFile("photo", "photo.jpg", "image/jpeg", "fake-image-bytes".getBytes()))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    // ────────────────────────── helpers ────────────────────────────────────────────────
+
+    private UUID seedAssignedOrder(UUID bikeId, String customerName, String customerPhone,
+            String address, double lat, double lng) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into dispatch_orders
+                    (id, bike_id, customer_name, customer_phone, address,
+                     latitude, longitude, sequence, status, kind, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?, 'ASSIGNED', 'DELIVERY', now(), now())
+                """,
+                id, bikeId, customerName, customerPhone, address, lat, lng, 1L);
+        return id;
+    }
+
+    private void seedCompletedOrder(UUID bikeId, String customerName, String customerPhone,
+            String address, double lat, double lng) {
+        jdbcTemplate.update("""
+                insert into dispatch_orders
+                    (id, bike_id, customer_name, customer_phone, address,
+                     latitude, longitude, sequence, status, kind, completed_at, completed_by,
+                     created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?, 'COMPLETED', 'DELIVERY', now(), ?, now(), now())
+                """,
+                UUID.randomUUID(), bikeId, customerName, customerPhone, address, lat, lng, 1L, bikeId);
+    }
+
+    private UUID seedOfferedOrder(String customerName, String customerPhone, String address,
+            double lat, double lng) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update("""
+                insert into dispatch_orders
+                    (id, bike_id, customer_name, customer_phone, address,
+                     latitude, longitude, sequence, status, kind, created_at, updated_at)
+                values (?, null, ?, ?, ?, ?, ?, 0, 'OFFERED', 'DELIVERY', now(), now())
+                """,
+                id, customerName, customerPhone, address, lat, lng);
+        return id;
+    }
+
+    private void seedTip(UUID id, String address, String content, double lat, double lng, String status) {
+        jdbcTemplate.update("""
+                insert into tips (id, address, content, latitude, longitude, status, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, now(), now())
+                """,
+                id, address, content, lat, lng, status);
+    }
+
+    private void seedBatteryStation(UUID id, String name, String address, String status) {
+        jdbcTemplate.update("""
+                insert into battery_stations
+                    (id, name, address, latitude, longitude, status,
+                     max_battery_capacity, current_battery_count, available_battery_count,
+                     created_at, updated_at)
+                values (?, ?, ?, 37.5000, 127.0000, ?, 10, 5, 5, now(), now())
+                """,
+                id, name, address, status);
+    }
+
+    private void seedNotification(UUID id, String type, String title,
+            UUID refRiderId, UUID refBikeId, UUID refEntityId) {
+        jdbcTemplate.update("""
+                insert into notifications
+                    (id, type, title, body, ref_rider_id, ref_bike_id, ref_entity_id,
+                     occurred_at, created_at, updated_at)
+                values (?, ?, ?, null, ?, ?, ?, now(), now(), now())
+                """,
+                id, type, title, refRiderId, refBikeId, refEntityId);
+    }
+
+    private String riderToken(UUID riderId, String phone) throws Exception {
+        issueRiderCredential(riderId);
+        MvcResult result = riderLogin(phone, RIDER_PASSWORD)
+                .andExpect(status().isOk())
+                .andReturn();
+        return extract(ACCESS_TOKEN_PATTERN, result);
+    }
+
+    private void issueRiderCredential(UUID riderId) throws Exception {
+        mockMvc.perform(patch("/api/v1/riders/{id}/credential", riderId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newPassword\":\"%s\"}".formatted(RIDER_PASSWORD)))
+                .andExpect(status().isNoContent());
+    }
+
+    private ResultActions riderLogin(String phone, String password) throws Exception {
+        return mockMvc.perform(post("/api/v1/rider-auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"phoneNumber\":\"%s\",\"password\":\"%s\"}".formatted(phone, password)));
+    }
+
+    private String loginAdminAndExtractAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"loginId\":\"ops-admin-dr\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return extract(ACCESS_TOKEN_PATTERN, result);
+    }
+
+    private String extract(Pattern pattern, MvcResult result) throws Exception {
+        Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-29-driver-api-phase1.md
+++ b/docs/superpowers/plans/2026-06-29-driver-api-phase1.md
@@ -1,0 +1,205 @@
+# 드라이버 API Phase 1 (thundercrew 백엔드) Implementation Plan
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** `clever-driver-app`이 쓸 라이더(드라이버)용 REST 엔드포인트를 `/api/v1/rider/me/*`에 추가한다. 읽기(완료배차·오퍼콜·팁·충전소·정비·알림) + 쓰기(콜 수락·배송 완료 사진), 전부 **본인 소유 검증**.
+
+**Architecture:** 기존 `RiderSelfReadController`/`RiderSelfCommandController`(`/api/v1/rider`, JWT `riderId` → `activeBikeIdOrNull`) 패턴 확장. 기존 dispatch/tip/station/maintenance/notification 서비스 **재사용**. SecurityConfig(`/api/v1/rider/**`=ROLE_RIDER)·ArchUnit(`isRiderSelfCommand` 클래스 단위 allowlist) **변경 불필요**. 마이그레이션 없음.
+
+**Spec:** [docs/superpowers/specs/2026-06-29-driver-app-integration-design.md](../specs/2026-06-29-driver-app-integration-design.md)
+
+**확정 결정:**
+- 완료 `completedBy` = `riderId`.
+- 완료 소유권: 주문 `bikeId == 내 activeBikeId` 아니면 403.
+- 오퍼콜: 내 차량 `serviceType==CALL`일 때만 목록 노출(아니면 빈 배열); accept는 서비스가 CALL 검증.
+- 팁=PUBLISHED만, 충전소=ACTIVE만, 알림=`ref_rider_id==riderId OR ref_bike_id==내 bikeId`.
+- 정비=내 차량 items+records 묶음(앱이 상태 파생).
+
+---
+
+## Task 1: 보강 read (data access) + DTO
+
+**Files:**
+- Modify: `tip/service/TipReadService.java` (+ repo if needed)
+- Modify: `station/service/StationReadService.java` + `station/repository/BatteryStationRepository.java`
+- Modify: `notification/service/NotificationReadService.java` + `notification/repository/NotificationRepository.java`
+- Create: `rider/dto/RiderMaintenanceResponse.java`
+
+- [ ] **Step 1: 팁 PUBLISHED 목록**
+  `TipReadService`에 추가 (repo엔 `findByStatusAndDeletedAtIsNull(TipStatus)` 이미 있음):
+  ```java
+  public List<TipReadResponse> listPublished() {
+      return tipRepository.findByStatusAndDeletedAtIsNull(TipStatus.PUBLISHED).stream()
+              .map(TipReadResponse::from).toList();
+  }
+  ```
+  (`TipReadResponse.from` 매핑이 기존에 있으면 재사용; 없으면 `listTips`가 쓰는 매핑 방식 그대로.)
+
+- [ ] **Step 2: 충전소 ACTIVE 목록**
+  `BatteryStationRepository`에 `List<BatteryStation> findByStatusAndDeletedAtIsNull(BatteryStationStatus status);` 추가.
+  `StationReadService`에:
+  ```java
+  public List<BatteryStationReadResponse> listActive() {
+      return stationRepository.findByStatusAndDeletedAtIsNull(BatteryStationStatus.ACTIVE).stream()
+              .map(BatteryStationReadResponse::from).toList();
+  }
+  ```
+  (매핑은 `listStations`가 쓰는 방식 재사용.)
+
+- [ ] **Step 3: 알림 rider/bike 스코프**
+  `NotificationRepository`에 JPQL 추가:
+  ```java
+  @Query("select n from Notification n where n.deletedAt is null "
+       + "and (n.refRiderId = :riderId or n.refBikeId = :bikeId) order by n.occurredAt desc")
+  List<Notification> findRecentForRiderOrBike(@Param("riderId") UUID riderId,
+                                              @Param("bikeId") UUID bikeId, Pageable pageable);
+  ```
+  `NotificationReadService`에:
+  ```java
+  public List<NotificationReadResponse> listForRiderOrBike(UUID riderId, UUID bikeId) {
+      return notificationRepository.findRecentForRiderOrBike(riderId, bikeId, PageRequest.of(0, 100))
+              .stream().map(NotificationReadResponse::from).toList();
+  }
+  ```
+  (bikeId가 null이면 `or n.refBikeId = null`이 되어 ref_bike_id=null 알림이 잡힐 수 있으니, service에서 bikeId null이면 임의의 매칭 안 되는 UUID를 넘기거나 별도 처리 — 안전하게: `bikeId == null ? new UUID(0,0) : bikeId`.)
+
+- [ ] **Step 4: 정비 묶음 DTO**
+  ```java
+  public record RiderMaintenanceResponse(
+      List<MaintenanceItemReadResponse> items,
+      List<VehicleMaintenanceRecordReadResponse> records
+  ) {}
+  ```
+
+- [ ] **Step 5: 컴파일**
+  Run: `cd development/service-ops-api && ./gradlew compileJava` → BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit** `feat: rider-scoped read helpers (published tips, active stations, rider notifications, maintenance dto)`
+
+---
+
+## Task 2: 라이더 read 엔드포인트 + 계약 테스트
+
+**Files:**
+- Modify: `rider/controller/RiderSelfReadController.java`
+- Modify: `rider/service/RiderVehicleReadService.java` (활성차량+CALL 판정 헬퍼가 없으면 bikeId만 재사용)
+- Test: `src/test/java/com/thundercrew/opsapi/RiderDriverApiContractTests.java` (신설)
+
+- [ ] **Step 1: 계약 테스트 작성(실패 확인)**
+  `RiderDriverApiContractTests extends PostgresContainerSupport`. JWT 취득/시드 패턴은 `RiderSelfReadApiContractTests` 그대로(admin 시드 → rider 시드 → `PATCH /riders/{id}/credential` → `POST /rider-auth/login` → accessToken 추출). bike `service_type='CALL'` + 활성 contract 시드.
+  테스트: 각 GET 200 + 모양 단언:
+  - `GET /rider/me/dispatch-orders/completed` → 완료 주문 배열
+  - `GET /rider/me/offered-calls` → (CALL 차량) OFFERED 주문 배열 / (비-CALL) 빈 배열
+  - `GET /rider/me/tips` → PUBLISHED만(PENDING 시드 1건은 제외 확인)
+  - `GET /rider/me/stations` → ACTIVE만(INACTIVE 시드 제외)
+  - `GET /rider/me/maintenance` → `{items:[...], records:[...]}`
+  - `GET /rider/me/notifications` → ref_rider_id/ref_bike_id 매칭만
+  - 활성 차량 없는 라이더 → 배차/오퍼/정비 빈 결과(404 아님)
+
+- [ ] **Step 2: 컨트롤러 GET 추가**
+  `RiderSelfReadController`에 의존성(TipReadService, StationReadService, MaintenanceReadService, NotificationReadService) 주입 후:
+  ```java
+  @GetMapping("/me/dispatch-orders/completed")
+  List<DispatchOrderReadResponse> myCompleted(@AuthenticationPrincipal Jwt jwt) {
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+      return bikeId == null ? List.of() : dispatchOrderReadService.listCompletedByBike(bikeId);
+  }
+
+  @GetMapping("/me/offered-calls")
+  List<DispatchOrderReadResponse> myOfferedCalls(@AuthenticationPrincipal Jwt jwt) {
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+      if (bikeId == null) return List.of();
+      // 내 차량이 CALL 일 때만 노출
+      if (!riderVehicleReadService.isCallBike(bikeId)) return List.of();
+      return deliveryCallService.listOffered();
+  }
+
+  @GetMapping("/me/tips")
+  List<TipReadResponse> myTips() { return tipReadService.listPublished(); }
+
+  @GetMapping("/me/stations")
+  List<BatteryStationReadResponse> myStations() { return stationReadService.listActive(); }
+
+  @GetMapping("/me/maintenance")
+  RiderMaintenanceResponse myMaintenance(@AuthenticationPrincipal Jwt jwt) {
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId(jwt));
+      if (bikeId == null) return new RiderMaintenanceResponse(List.of(), List.of());
+      return new RiderMaintenanceResponse(
+          maintenanceReadService.listItemsForBike(bikeId),
+          maintenanceReadService.listRecordsForBike(bikeId));
+  }
+
+  @GetMapping("/me/notifications")
+  List<NotificationReadResponse> myNotifications(@AuthenticationPrincipal Jwt jwt) {
+      UUID rid = riderId(jwt);
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(rid);
+      return notificationReadService.listForRiderOrBike(rid, bikeId);
+  }
+
+  private static UUID riderId(Jwt jwt) { return UUID.fromString(jwt.getClaimAsString("riderId")); }
+  ```
+  `riderVehicleReadService.isCallBike(UUID bikeId)` 헬퍼 추가(`bikeRepository.findByIdAndDeletedAtIsNull(bikeId).map(b -> b.getServiceType()==BikeServiceType.CALL).orElse(false)`).
+
+- [ ] **Step 3: 테스트 GREEN** `./gradlew test --tests "*RiderDriverApiContractTests*"` (Docker 필요; 없으면 compile + DONE_WITH_CONCERNS).
+
+- [ ] **Step 4: Commit** `feat: rider driver read endpoints (completed/offered/tips/stations/maintenance/notifications)`
+
+---
+
+## Task 3: 라이더 write 엔드포인트(콜 수락·배송 완료) + 테스트
+
+**Files:**
+- Create: `rider/service/RiderSelfDispatchService.java`
+- Modify: `rider/controller/RiderSelfCommandController.java`
+- Test: `RiderDriverApiContractTests.java` (write 케이스 추가)
+
+- [ ] **Step 1: 소유권 서비스**
+  `RiderSelfDispatchService`(@Service @Transactional):
+  ```java
+  public DispatchOrderReadResponse acceptOfferedCall(UUID riderId, UUID orderId) {
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+      if (bikeId == null) throw new InvalidStateTransitionException("활성 차량이 없습니다.");
+      return deliveryCallService.acceptCall(orderId, bikeId); // CALL 차종 + OFFERED 검증은 서비스가 함
+  }
+
+  public DispatchOrderReadResponse completeMyDispatch(UUID riderId, UUID orderId, byte[] photo, String contentType) {
+      UUID bikeId = riderVehicleReadService.activeBikeIdOrNull(riderId);
+      if (bikeId == null) throw new InvalidStateTransitionException("활성 차량이 없습니다.");
+      DispatchOrder order = dispatchOrderReadService.findOrderForPhoto(orderId); // 엔티티
+      if (!bikeId.equals(order.getBikeId())) {
+          throw new ForbiddenOperationException("본인 배차가 아닙니다."); // 403 매핑되는 기존 예외 사용(없으면 적절한 것)
+      }
+      return dispatchOrderCommandService.complete(orderId, photo, contentType, riderId);
+  }
+  ```
+  (403용 예외는 코드베이스에 있는 표준 예외 사용 — 없으면 `AccessDeniedException` 또는 도메인 예외. 구현자가 기존 ExceptionHandler 매핑 확인 후 선택.)
+
+- [ ] **Step 2: 컨트롤러 POST 추가** (`RiderSelfCommandController`, ArchUnit 자동 통과):
+  ```java
+  @PostMapping("/me/offered-calls/{id}/accept")
+  DispatchOrderReadResponse acceptCall(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id) {
+      return riderSelfDispatchService.acceptOfferedCall(riderId(jwt), id);
+  }
+
+  @PostMapping(value = "/me/dispatch-orders/{id}/complete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  DispatchOrderReadResponse complete(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id,
+          @RequestPart("photo") MultipartFile photo) throws IOException {
+      return riderSelfDispatchService.completeMyDispatch(riderId(jwt), id, photo.getBytes(), photo.getContentType());
+  }
+  ```
+
+- [ ] **Step 3: 테스트(write)** — accept: OFFERED 콜 시드 → 라이더 accept → status ASSIGNED + bikeId=내차량. 소유권 위반 complete(다른 bike 주문) → 403. 정상 complete(multipart 사진) → COMPLETED.
+
+- [ ] **Step 4: 컴파일/테스트 + Commit** `feat: rider accept call + complete dispatch (ownership-checked)`
+
+---
+
+## Task 4: 최종 검증 + PR
+- [ ] `cd development/service-ops-api && ./gradlew compileJava compileTestJava` → SUCCESS. 가능하면 `./gradlew test --tests "*RiderDriver*"`(Docker). arch 테스트 pre-red는 무시([[project_archboundary_test_pre_red]]).
+- [ ] PR → dev. 본문에 엔드포인트 목록 + "앱/웹은 이 계약 위에 빌드".
+
+## Self-Review
+- 스펙 Phase 1 엔드포인트 전부 매핑(read 6 + write 2 + 기존 재사용). ✅
+- SecurityConfig/ArchUnit/마이그레이션 변경 없음(맵으로 확인). ✅
+- 소유권 검증(complete) + CALL 검증(accept) 포함. ✅
+- YAGNI: 정비 알람 상태 파생은 앱에서(백엔드 summary 미신설), FCM/위치 ingest 제외.

--- a/docs/superpowers/specs/2026-06-29-driver-app-integration-design.md
+++ b/docs/superpowers/specs/2026-06-29-driver-app-integration-design.md
@@ -1,0 +1,97 @@
+# 드라이버 앱 ↔ 웹 연동 설계 (Driver app integration)
+
+**Date:** 2026-06-29
+**Status:** Design (approved) — Phase 1(백엔드 드라이버 API)부터 구체화
+**Repos:** `thundercrew-domain`(백엔드 + 웹), `clever-driver-app`(Expo/RN Android·iOS)
+
+## 확정 전제 (사용자 승인)
+- 백엔드: **thundercrew `service-ops-api` 직결** (별도 delivery-server 미사용).
+- 위치: 앱은 **본인 위치 표시만**. 웹 지도 차량위치/텔레메트리/OTOPLUG는 **변경 없음**.
+- 배차 전달: **MVP=폴링** → 2차 FCM 푸시.
+- 인증: **rider-auth (전화+비밀번호, RIDER JWT)** — 기존 구현 재사용.
+- 앱 지도: **react-native-maps** (Expo 친화). 추후 필요 시 Naver 전환.
+
+## 앱이 제공할 기능 (사용자 요구)
+1. 웹에서 배정된 배차/콜과 연동 (수신 + 콜 수락 + 완료 보고)
+2. 팁 · 누적주행거리 · 정비 알림을 웹에서 받아 표시
+3. 웹에서 적용된 팁 · 충전소를 앱 지도에 표시
+4. 본인 위치가 찍힌 지도
+
+---
+
+## 아키텍처
+```
+clever-driver-app (Expo/RN)
+  └─ rider-auth 로그인 → RIDER JWT (secure-store)
+  └─ HTTPS REST 폴링 → thundercrew service-ops-api  (/api/v1/rider/** = ROLE_RIDER)
+웹(front-admin-web): 배정·생성·모니터링.  앱: 현장 수행(수락·완료).
+위치: 앱 expo-location 자체 표시 (백엔드 미수집).
+```
+
+기존 패턴: `RiderSelfReadController`(`/api/v1/rider`)가 `@AuthenticationPrincipal Jwt` → `riderId` claim → `riderVehicleReadService.activeBikeIdOrNull(riderId)`로 내 차량을 찾고, 기존 dispatch/tip/station 서비스를 **재사용**한다. 신규 엔드포인트도 동일 패턴.
+
+---
+
+## Phase 1 — thundercrew 드라이버 API 계약 (핵심)
+
+모든 경로 `/api/v1/rider/**` (ROLE_RIDER). JWT `riderId` → 내 활성 차량 `bikeId` 해석 후 동작. 활성 차량 없으면 빈 결과/409.
+
+### 읽기 (기존 Read 서비스 재사용)
+| 엔드포인트 | 동작 | 재사용 |
+|---|---|---|
+| `GET /rider/me` | 내 프로필 | 기존 |
+| `GET /rider/me/vehicle` **확장** | 내 차량 + **누적주행거리(odometer)** + 연결상태 + 마지막수신 | `RiderVehicleResponse`에 필드 추가 (bike_current_states) |
+| `GET /rider/me/dispatch-orders` | 내 진행 중(ASSIGNED) 배차 | 기존 |
+| `GET /rider/me/dispatch-orders/completed` | 내 완료 배차 | `dispatchOrderReadService.listCompletedByBike(bikeId)` |
+| `GET /rider/me/offered-calls` | 내 차종(CALL)으로 온 미배정(OFFERED) 콜 | `DispatchOrderReadService` 확장 |
+| `GET /rider/me/tips` | 공개(PUBLISHED) 팁 — 지도 마커 | `tipRepository` 재사용, status=PUBLISHED만 |
+| `GET /rider/me/stations` | 충전소 — 지도 마커 | `battery_stations` 재사용 |
+| `GET /rider/me/maintenance` | 내 차량 정비 임박/지연 요약 | `MaintenanceReadService` 재사용(bikeId) |
+| `GET /rider/me/notifications` | 내 알림(배차/정비) | `notifications` where ref_rider_id/ref_bike_id |
+
+### 쓰기 (신규 Command — 본인 소유 검증 필수, ArchUnit write-allowlist 등록)
+| 엔드포인트 | 동작 | 위임 |
+|---|---|---|
+| `POST /rider/me/offered-calls/{id}/accept` | 내 차량으로 오퍼 콜 수락 | `deliveryCallService.acceptCall(id, myBikeId)` — 단 **myBikeId 강제**(요청 bikeId 무시) + CALL 차종 검증 |
+| `POST /rider/me/dispatch-orders/{id}/complete` (multipart photo) | 내 배차 완료(사진) | 주문이 **myBikeId 소속인지 검증** 후 `dispatchOrderCommandService.complete(id, photo, contentType, completedBy=riderId)` |
+
+> 어드민 버전(`/dispatch-orders/{id}/complete`, `/calls/{id}/accept`)은 그대로 두고, 라이더 버전은 **소유권 검증을 추가**한 별도 컨트롤러 메서드로 신설한다(서비스 로직은 재사용).
+
+### 계약 테스트
+`RiderSelfApiContractTests`(신설/확장): rider JWT로 각 엔드포인트 200 + 소유권 위반 시 403/404 + 활성차량 없음 빈 결과.
+
+---
+
+## Phase 2 — 웹 "업무관리" 수정 (작음)
+
+수락·완료 주체가 웹 → 앱(현장 라이더)으로 이동. 웹은 배정/생성 + 모니터링.
+
+| 패널 | 수정 |
+|---|---|
+| 콜배차(BaeminCallPanel) | 오퍼 생성 유지. **수락은 앱**으로 — 웹은 "수락 대기/수락됨(누가)" 모니터링 표시. (웹 수동 수락은 fallback로 유지 가능) |
+| 단일/순차/왕복 배차 | 변경 거의 없음 (배정 결과가 앱 `/me/dispatch-orders`로 흐름) |
+| 배송 완료 | 앱에서 완료(사진). 웹은 완료내역/사진 **조회 전용**(이미 차량상세 완료버튼은 제거됨) |
+| 정비·주행거리·지도(관제) | 변경 없음 |
+
+---
+
+## Phase 3+ — 앱 (clever-driver-app, 별도 레포)
+- 인증: 전화번호 lookup → **rider-auth 로그인(전화+비번)** + JWT secure-store.
+- **인앱 지도(react-native-maps)**: 본인 위치(expo-location) + 팁/충전소/배차목적지 마커.
+- 화면: 로그인 → 홈(지도) → 내 콜/배차(폴링) → 콜 수락 / 배송 상세 → **완료(사진)** → 내 차량(주행거리·정비).
+- API 클라이언트 재배선: `clever-delivery-server /driver/*` → thundercrew `/api/v1/rider*`.
+- 재사용: expo-camera/image-picker(완료사진), 오프라인 큐(완료 이벤트 재시도), secure-store.
+- 기존 route/company/stop/consent 도메인은 dispatch 모델로 대체(동의 화면은 스토어 심사 위해 유지).
+
+---
+
+## 비목표 (이번 범위 제외)
+- 앱 GPS → 웹 지도 차량위치 (위치는 앱 표시만으로 결정).
+- FCM 푸시 (2차).
+- Naver 지도 SDK (react-native-maps로 시작).
+- 정산/고객알림/관제 고도화.
+
+## 리스크 / 미해결
+- 앱 리팩터 규모(다른 백엔드 모델 → thundercrew). 인프라는 재사용, 도메인은 교체.
+- 한국 지도 디테일/길찾기: 구글맵 한국 제약 → 인앱은 개요용 + 길찾기 외부 핸드오프로 우회.
+- 두 레포 동시 작업 → 각자 spec/plan/PR. 백엔드 계약(Phase 1)을 먼저 고정해 앱·웹이 그 위에 빌드.


### PR DESCRIPTION
dev → main 릴리즈. 드라이버 앱(clever-driver-app) 연동을 위한 **thundercrew 라이더 API Phase 1** (백엔드).

## 포함 (#519)
`/api/v1/rider/me/*` (ROLE_RIDER) 신규:
- 읽기: 완료배차 / 오퍼콜(CALL 차량) / 팁(PUBLISHED) / 충전소(ACTIVE) / 정비(내 차량) / 알림(rider·bike 스코프). 누적주행거리·연결상태는 기존 `/me/vehicle`에 포함.
- 쓰기: 콜 수락(서버가 내 bikeId 강제) / 배송 완료(사진, 내 차량 주문만 — 아니면 403).
- `AccessDeniedException → 403` 매핑 + `ACCESS_DENIED` 에러코드.
- 기존 dispatch/tip/station/maintenance/notification 서비스 재사용. **마이그레이션·SecurityConfig·ArchUnit 변경 없음.**

## 성격
- **추가 전용 API**(아직 prod 호출자 없음) → 배포해도 기존 동작 무영향.
- 앱(clever-driver-app)이 이 계약 위에 빌드됨(로그인→배차 보기→수락→완료, 내 차량/지도).

## ⚠️ 배포 전 권장
- 백엔드 계약 테스트 `RiderDriverApiContractTests`는 작성됐으나 dev 환경 Docker 없어 **로컬 미실행** + PR CI 테스트 없음 → **Docker 환경에서 `./gradlew test --tests "*RiderDriver*"` 1회** 권장(특히 소유권 403 / 필터).
- 프론트(웹) 빌드/lint는 무관(백엔드만 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)