### PR TITLE
feat(management): 활성 배차 현황 모니터 테이블

### DIFF
--- a/development/front-admin-web/app/globals.css
+++ b/development/front-admin-web/app/globals.css
@@ -324,6 +324,9 @@ button, input, select, textarea { font: inherit; }
 .mgmt-panel-title { font-size: 14px; font-weight: 700; color: var(--color-text-primary); }
 .mgmt-panel-count { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 20px; padding: 0 6px; border-radius: 999px; background: var(--color-bg-muted); color: var(--color-text-muted); font-size: 12px; font-weight: 600; }
 .mgmt-panel-header-actions { display: flex; align-items: center; gap: 8px; }
+/* 활성 배차 모니터(DispatchMonitorTable) 툴바 — 건수 + 새로고침 */
+.dispatch-monitor-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
+.dispatch-monitor-count { font-size: 12px; font-weight: 600; color: var(--color-text-muted); }
 .status-badge { display: inline-flex; align-items: center; height: 22px; padding: 0 8px; border-radius: 999px; font-size: 12px; font-weight: 600; white-space: nowrap; }
 .status-badge-green { background: color-mix(in srgb, #22c55e 12%, transparent); color: #16a34a; }
 .status-badge-gray { background: var(--color-bg-muted); color: var(--color-text-muted); }

--- a/development/front-admin-web/app/management/operations/page.tsx
+++ b/development/front-admin-web/app/management/operations/page.tsx
@@ -3,7 +3,11 @@ import { SequentialDispatchPanel } from "@/components/management/SequentialDispa
 import { StrollerRoundPanel } from "@/components/management/StrollerRoundPanel";
 import { BaeminCallPanel } from "@/components/management/BaeminCallPanel";
 import { ManagementSectionNav } from "@/components/management/ManagementSectionNav";
-import { getActiveRoundAction, listOfferedCallsAction } from "@/app/dispatch/actions";
+import {
+  getActiveRoundAction,
+  listOfferedCallsAction,
+  listActiveDispatchOrdersAction
+} from "@/app/dispatch/actions";
 import { listVehiclesAction } from "@/app/management/vehicles/actions";
 
 export const dynamic = "force-dynamic";
@@ -16,16 +20,22 @@ const SECTIONS = [
 ];
 
 export default async function ManagementOperationsPage() {
-  const [activeRound, offeredCalls, vehiclesPage] = await Promise.all([
+  const [activeRound, offeredCalls, vehiclesPage, activeOrders] = await Promise.all([
     getActiveRoundAction(),
     listOfferedCallsAction(),
-    listVehiclesAction()
+    listVehiclesAction(),
+    listActiveDispatchOrdersAction()
   ]);
 
   // 배민 콜 후보 차량 = CALL∪SINGLE (systemDispatch 자동 배차 후보와 동일; OTHER·청소형 제외)
   const deliveryVehicles = vehiclesPage
     .filter((v) => v.serviceType === "CALL" || v.serviceType === "SINGLE")
     .map((v) => ({ id: v.id ?? v.slug, plateNumber: v.plateNumber }));
+
+  // 활성 배차 모니터용 차량번호 매핑 — 배차의 bikeId(전 차종)를 차량번호로 해석한다.
+  const plateById: Record<string, string> = Object.fromEntries(
+    vehiclesPage.map((v) => [v.id ?? v.slug, v.plateNumber])
+  );
 
   return (
     <div className="management-page">
@@ -34,7 +44,11 @@ export default async function ManagementOperationsPage() {
         <BaeminCallPanel initialOffered={offeredCalls} deliveryVehicles={deliveryVehicles} />
       </section>
       <section id="mgmt-dispatch" className="management-anchor">
-        <DispatchPanel exportUrl="/api/management/dispatch/export" />
+        <DispatchPanel
+          exportUrl="/api/management/dispatch/export"
+          activeOrders={activeOrders}
+          plateById={plateById}
+        />
       </section>
       <section id="mgmt-sequential" className="management-anchor">
         <SequentialDispatchPanel exportUrl="/api/management/dispatch/export" />

--- a/development/front-admin-web/components/management/DispatchMonitorTable.tsx
+++ b/development/front-admin-web/components/management/DispatchMonitorTable.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { ServiceOpsDispatchOrder } from "@/lib/services/service-ops-api";
+
+/**
+ * 활성(ASSIGNED) 배차를 차량별로 묶어 보여주는 fleet-wide 읽기 전용 모니터 테이블.
+ *
+ * 단일·순차 배차는 같은 DispatchOrder 풀이라(업로드 방식만 다르고 저장된 주문을
+ * 구분하는 필드가 없다) 한 곳에서 통합 표시한다. 차량번호는 `plateById` 로 해석하고,
+ * 각 차량 내에서는 방문 순번(sequence) 오름차순으로 정렬한다.
+ *
+ * 변경(업로드/완료/취소)은 각 패널·라이더 앱이 담당하고 이 컴포넌트는 현황만 보여준다.
+ */
+export function DispatchMonitorTable({
+  orders,
+  plateById,
+  onRefresh,
+  refreshing = false
+}: {
+  orders: ServiceOpsDispatchOrder[];
+  plateById: Record<string, string>;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+}) {
+  const plateFor = (bikeId: string | null): string => {
+    if (!bikeId) return "—";
+    return plateById[bikeId] ?? bikeId.slice(0, 8);
+  };
+
+  // 차량번호 → 순번 순으로 안정 정렬. (bikeId 없는 주문은 목록 뒤로.)
+  const sorted = [...orders].sort((a, b) => {
+    const pa = plateFor(a.bikeId);
+    const pb = plateFor(b.bikeId);
+    if (pa !== pb) return pa.localeCompare(pb, "ko");
+    return a.sequence - b.sequence;
+  });
+
+  return (
+    <div className="dispatch-monitor">
+      <div className="dispatch-monitor-toolbar">
+        <span className="dispatch-monitor-count">활성 배차 {sorted.length}건</span>
+        {onRefresh ? (
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={onRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? "새로고침 중..." : "새로고침"}
+          </button>
+        ) : null}
+      </div>
+      <div className="table-card">
+        <table className="table" style={{ tableLayout: "fixed" }}>
+          <thead>
+            <tr>
+              <th>차량</th>
+              <th>고객명</th>
+              <th>연락처</th>
+              <th>배송지주소</th>
+              <th>순번</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="table-empty-cell">
+                  현재 활성 배차가 없습니다. 업로드하면 차량별로 여기에 표시됩니다.
+                </td>
+              </tr>
+            ) : (
+              sorted.map((order) => (
+                <tr key={order.id}>
+                  <td>{plateFor(order.bikeId)}</td>
+                  <td>{order.customerName}</td>
+                  <td>{order.customerPhone}</td>
+                  <td>{order.address}</td>
+                  <td>{order.sequence}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/development/front-admin-web/components/management/DispatchPanel.tsx
+++ b/development/front-admin-web/components/management/DispatchPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import {
@@ -8,7 +8,12 @@ import {
   applyDispatchAction,
   type DispatchPreviewRow
 } from "@/app/dispatch/actions";
-import type { DispatchBulkApplyRow, DispatchBulkSummary } from "@/lib/services/service-ops-api";
+import type {
+  DispatchBulkApplyRow,
+  DispatchBulkSummary,
+  ServiceOpsDispatchOrder
+} from "@/lib/services/service-ops-api";
+import { DispatchMonitorTable } from "./DispatchMonitorTable";
 import "./BulkPreviewModal.css";
 
 /**
@@ -20,8 +25,9 @@ import "./BulkPreviewModal.css";
  * 않고 받은 행을 그대로 표시/전달만 한다. apply 는 excel 재업로드가 아니라 좌표
  * 포함 JSON 이라 공용 `ExcelImportButton`/`BulkPreviewModal` 대신 전용 모달을 쓴다.
  *
- * 현재 ASSIGNED 배차 목록 list-all 엔드포인트가 없어(클라이언트는 bikeId 별
- * 조회만 제공) 테이블은 비워두고 업로드/내려받기에 집중한다.
+ * 테이블에는 현재 활성(ASSIGNED) 배차를 차량별로 보여준다(`DispatchMonitorTable`).
+ * 단일·순차 배차는 같은 DispatchOrder 풀이라 여기서 통합 모니터한다. 새로고침은
+ * server action 을 다시 부르는 `router.refresh()` 로 처리한다.
  */
 
 interface DispatchPreviewState {
@@ -29,13 +35,22 @@ interface DispatchPreviewState {
   summary: DispatchBulkSummary;
 }
 
-export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
+export function DispatchPanel({
+  exportUrl,
+  activeOrders,
+  plateById
+}: {
+  exportUrl: string;
+  activeOrders: ServiceOpsDispatchOrder[];
+  plateById: Record<string, string>;
+}) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<DispatchPreviewState | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [refreshing, startRefresh] = useTransition();
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -144,26 +159,12 @@ export function DispatchPanel({ exportUrl }: { exportUrl: string }) {
         </p>
       ) : null}
 
-      <div className="table-card">
-        <table className="table" style={{ tableLayout: "fixed" }}>
-          <thead>
-            <tr>
-              <th>차량</th>
-              <th>고객명</th>
-              <th>연락처</th>
-              <th>배송지주소</th>
-              <th>순번</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td colSpan={5} className="table-empty-cell">
-                업로드한 배차는 라이더 앱 / 대시보드에서 확인하세요.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <DispatchMonitorTable
+        orders={activeOrders}
+        plateById={plateById}
+        onRefresh={() => startRefresh(() => router.refresh())}
+        refreshing={refreshing}
+      />
 
       {preview ? (
         <div className="bulk-preview-overlay">

--- a/development/front-admin-web/components/management/SequentialDispatchPanel.tsx
+++ b/development/front-admin-web/components/management/SequentialDispatchPanel.tsx
@@ -159,7 +159,7 @@ export function SequentialDispatchPanel({ exportUrl }: { exportUrl: string }) {
           <tbody>
             <tr>
               <td colSpan={5} className="table-empty-cell">
-                업로드한 배차는 라이더 앱 / 대시보드에서 확인하세요. (엑셀에 순번 컬럼 포함 — 차량별 방문 순서)
+                업로드한 순차 배차는 &ldquo;단일 배차&rdquo; 현황판에 차량별로 함께 표시됩니다. (엑셀에 순번 컬럼 포함 — 차량별 방문 순서)
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
## 요약
드라이버 앱 연동 **Phase 2(웹 업무관리)** 첫 슬라이스. 업로드해 둔 배차를 웹에서도 확인할 수 있도록, **현재 활성(ASSIGNED) 배차**를 차량별로 보여주는 읽기 전용 모니터를 배차 패널에 추가한다.

단일·순차 배차는 저장 시 동일한 `DispatchOrder` 풀(구분 필드 없음)이므로 **"단일 배차" 패널 한 곳에 통합 표시**하고, 순차 패널은 안내 문구만 그쪽을 가리키도록 조정했다. 데이터/클라이언트/서버액션 배관(`listActiveDispatchOrdersAction` → `listActiveDispatchOrders`)은 이미 존재해 **UI 배선만** 추가한다. Additive — 업로드/내려받기 흐름은 그대로.

## 변경
- **`components/management/DispatchMonitorTable.tsx`** (신규): 활성 배차를 `plateById` 로 차량번호 해석 → 차량번호·순번 순 정렬해 표시. 건수 + 새로고침 툴바, 빈 상태 안내.
- **`app/management/operations/page.tsx`**: `listActiveDispatchOrdersAction()` 를 `Promise.all` 에 추가, 전 차량 `plateById` 구성 후 `DispatchPanel` 에 전달.
- **`components/management/DispatchPanel.tsx`**: 빈 테이블 → `DispatchMonitorTable`. 새로고침은 `useTransition` + `router.refresh()`(server action 재호출). 오래된 주석 갱신.
- **`components/management/SequentialDispatchPanel.tsx`**: 빈 안내 문구를 "단일 배차 현황판에 함께 표시"로 조정.
- **`app/globals.css`**: `.dispatch-monitor-toolbar` / `.dispatch-monitor-count` 스타일.

## 검증
- `tsc --noEmit` ✅ 통과 (prop/타입 배선 전반 검증)
- `eslint` (변경 4파일) ✅ 통과
- 런타임 UI 확인은 보류: 이 저장소 규칙상 경쟁 dev 서버를 띄우지 않고, 해당 페이지는 admin 인증 + 라이브 백엔드 데이터가 필요합니다. 실제 렌더/데이터 표시는 **기존 워크플로대로 사용자 dev 서버 / dev→main 릴리즈 후 QA**로 확인합니다.

## 참고
- 완료내역/사진 조회 슬라이스는 별도(인증 프록시 라우트 필요 + 앱 라이브 후 완료 데이터 발생). Phase 2 후속으로 남김.

🤖 Generated with [Claude Code](https://claude.com/claude-code)