### PR TITLE
시동 감지 accStatus 전환 + 연결 이중임계값

### DIFF
--- a/development/backend/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java
@@ -191,7 +191,7 @@ public class DashboardMapStateService {
     }
 
     private String connectionStatus(BikePinRow row, Instant generatedAt) {
-        return TelemetryConnection.status(row.lastReceivedAt(), generatedAt);
+        return TelemetryConnection.status(row.lastReceivedAt(), generatedAt, row.ignitionStatus());
     }
 
     private String batteryStatus(BikePinRow row) {

--- a/development/backend/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java
@@ -53,7 +53,7 @@ public class RiderVehicleReadService {
             lng = state.getLongitude() == null ? null : state.getLongitude().doubleValue();
             odo = state.getOdometerKm();
             lastReceivedAt = state.getLastReceivedAt();
-            connection = TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock));
+            connection = TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus());
         }
         return new RiderVehicleResponse(
                 bike.getId(), bike.getPlateNumber(), bike.getImei(), bike.getServiceType(),

--- a/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnection.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnection.java
@@ -3,18 +3,27 @@ package com.thundercrew.opsapi.telemetry.domain;
 import java.time.Duration;
 import java.time.Instant;
 
-/** 마지막 수신 시각 기준 연결 판정. 120분 무수신이면 OFFLINE. */
+/** 마지막 수신 시각 + 시동 상태 기준 연결 판정. 시동 ON=2분, OFF/UNKNOWN=120분 무수신이면 OFFLINE. */
 public final class TelemetryConnection {
 
-    /** 이 시간 넘게 수신 없으면 미연결. */
-    public static final Duration OFFLINE_THRESHOLD = Duration.ofMinutes(120);
+    /** 시동 ON: 보고 주기 빠름(~1분) → 2분 무수신이면 미연결. */
+    public static final Duration IGNITION_ON_OFFLINE_THRESHOLD = Duration.ofMinutes(2);
+
+    /** 시동 OFF/UNKNOWN: 보고 주기 느림(~1시간 keep-alive) → 120분 무수신이면 미연결. */
+    public static final Duration DEFAULT_OFFLINE_THRESHOLD = Duration.ofMinutes(120);
 
     private TelemetryConnection() {
     }
 
-    /** "ONLINE" (<=120분) / "OFFLINE" (>120분). */
-    public static String status(Instant lastReceivedAt, Instant now) {
+    /** "ONLINE"/"OFFLINE". 임계값은 시동 상태에 종속(ON=2분, 그 외=120분). */
+    public static String status(Instant lastReceivedAt, Instant now, TelemetryIgnitionStatus ignition) {
+        if (lastReceivedAt == null) {
+            return "OFFLINE";
+        }
+        Duration threshold = ignition == TelemetryIgnitionStatus.ON
+                ? IGNITION_ON_OFFLINE_THRESHOLD
+                : DEFAULT_OFFLINE_THRESHOLD;
         Duration age = Duration.between(lastReceivedAt, now);
-        return age.compareTo(OFFLINE_THRESHOLD) <= 0 ? "ONLINE" : "OFFLINE";
+        return age.compareTo(threshold) <= 0 ? "ONLINE" : "OFFLINE";
     }
 }

--- a/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
@@ -58,7 +58,7 @@ public record BikeCurrentStateReadResponse(
     }
 
     private static String connectionStatus(BikeCurrentState state, Clock clock) {
-        return TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock));
+        return TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus());
     }
 
     private static String batteryStatus(BikeCurrentState state) {

--- a/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java
@@ -21,6 +21,7 @@ public record TelemetryIngestRequest(
         @DecimalMin("-90.0") @DecimalMax("90.0") BigDecimal latitude,
         @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
         @PositiveOrZero BigDecimal speedKph,
+        Integer accStatus,
         @NotNull TelemetrySource telemetrySource,
         JsonNode rawPayload
 ) {

--- a/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
+++ b/development/backend/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java
@@ -23,8 +23,6 @@ import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.HexFormat;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,8 +32,6 @@ import org.springframework.util.StringUtils;
 
 @Service
 public class TelemetryIngestionService {
-
-    private static final Duration IGNITION_ON_GAP_THRESHOLD = Duration.ofMinutes(5);
 
     private final DeviceTelemetryLogRepository telemetryLogRepository;
     private final BikeRecentStateRepository recentStateRepository;
@@ -88,7 +84,7 @@ public class TelemetryIngestionService {
             bikeId = telemetryWriteRepository.findBikeIdByImei(request.deviceUid());
         }
 
-        TelemetryIgnitionStatus derivedIgnition = deriveIgnition(bikeId, request.receivedAt());
+        TelemetryIgnitionStatus derivedIgnition = deriveIgnition(bikeId, request.accStatus());
 
         DeviceTelemetryLog log = DeviceTelemetryLog.create(
                 device.map(Device::getId).orElse(null),
@@ -209,18 +205,18 @@ public class TelemetryIngestionService {
         }
     }
 
-    private TelemetryIgnitionStatus deriveIgnition(UUID bikeId, Instant receivedAt) {
+    TelemetryIgnitionStatus deriveIgnition(UUID bikeId, Integer accStatus) {
+        // 명시 ACC 신호 우선: 0 = OFF, 그 외 = ON
+        if (accStatus != null) {
+            return accStatus != 0 ? TelemetryIgnitionStatus.ON : TelemetryIgnitionStatus.OFF;
+        }
+        // accStatus 미수신 → 직전 상태 carry-forward, 없으면 UNKNOWN
         if (bikeId == null) {
             return TelemetryIgnitionStatus.UNKNOWN;
         }
-        Optional<BikeCurrentState> previous = bikeCurrentStateRepository.findByBikeId(bikeId);
-        if (previous.isEmpty()) {
-            return TelemetryIgnitionStatus.ON;
-        }
-        Duration gap = Duration.between(previous.get().getLastReceivedAt(), receivedAt);
-        return gap.compareTo(IGNITION_ON_GAP_THRESHOLD) <= 0
-                ? TelemetryIgnitionStatus.ON
-                : TelemetryIgnitionStatus.OFF;
+        return bikeCurrentStateRepository.findByBikeId(bikeId)
+                .map(BikeCurrentState::getIgnitionStatus)
+                .orElse(TelemetryIgnitionStatus.UNKNOWN);
     }
 
     private String blankToNull(String value) {

--- a/development/backend/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
+++ b/development/backend/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
@@ -102,6 +102,7 @@ class VendorTelemetryAdapterTests {
                 new BigDecimal("37.5005000"),
                 new BigDecimal("127.0270000"),
                 new BigDecimal("12.5"),
+                null,
                 TelemetrySource.POLLING,
                 null);
     }

--- a/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java
+++ b/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java
@@ -1,0 +1,52 @@
+package com.thundercrew.opsapi.telemetry.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class TelemetryConnectionTests {
+
+    private static final Instant NOW = Instant.parse("2026-07-01T00:00:00Z");
+
+    private static Instant ago(Duration d) {
+        return NOW.minus(d);
+    }
+
+    @Test
+    void ignitionOnWithinTwoMinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(1)), NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void ignitionOnBeyondTwoMinutesIsOffline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(3)), NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("OFFLINE");
+    }
+
+    @Test
+    void ignitionOffWithin120MinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(90)), NOW, TelemetryIgnitionStatus.OFF))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void ignitionOffBeyond120MinutesIsOffline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(130)), NOW, TelemetryIgnitionStatus.OFF))
+                .isEqualTo("OFFLINE");
+    }
+
+    @Test
+    void unknownIgnitionUsesLaxThreshold() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(30)), NOW, TelemetryIgnitionStatus.UNKNOWN))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void nullLastReceivedIsOffline() {
+        assertThat(TelemetryConnection.status(null, NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("OFFLINE");
+    }
+}

--- a/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java
+++ b/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java
@@ -49,4 +49,22 @@ class TelemetryConnectionTests {
         assertThat(TelemetryConnection.status(null, NOW, TelemetryIgnitionStatus.ON))
                 .isEqualTo("OFFLINE");
     }
+
+    @Test
+    void ignitionOnAtExactlyTwoMinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(2)), NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void ignitionOffAtExactly120MinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(120)), NOW, TelemetryIgnitionStatus.OFF))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void unknownIgnitionBeyond120MinutesIsOffline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(130)), NOW, TelemetryIgnitionStatus.UNKNOWN))
+                .isEqualTo("OFFLINE");
+    }
 }

--- a/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java
+++ b/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java
@@ -1,0 +1,63 @@
+package com.thundercrew.opsapi.telemetry.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class TelemetryIgnitionDerivationTests {
+
+    private final BikeCurrentStateRepository currentStateRepository =
+            mock(BikeCurrentStateRepository.class);
+
+    // deriveIgnition은 9번째 생성자 인자(bikeCurrentStateRepository)만 사용하므로
+    // 나머지 8개 의존성은 null로 두어도 무방하다.
+    private TelemetryIngestionService newService() {
+        return new TelemetryIngestionService(
+                null, null, null, null, null, null, null, null, currentStateRepository);
+    }
+
+    @Test
+    void accStatusZeroIsOff() {
+        assertThat(newService().deriveIgnition(UUID.randomUUID(), 0))
+                .isEqualTo(TelemetryIgnitionStatus.OFF);
+    }
+
+    @Test
+    void accStatusNonZeroIsOn() {
+        assertThat(newService().deriveIgnition(UUID.randomUUID(), 5))
+                .isEqualTo(TelemetryIgnitionStatus.ON);
+    }
+
+    @Test
+    void nullAccStatusCarriesForwardPreviousStatus() {
+        UUID bikeId = UUID.randomUUID();
+        BikeCurrentState previous = mock(BikeCurrentState.class);
+        when(previous.getIgnitionStatus()).thenReturn(TelemetryIgnitionStatus.ON);
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.of(previous));
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.ON);
+    }
+
+    @Test
+    void nullAccStatusWithNoPreviousIsUnknown() {
+        UUID bikeId = UUID.randomUUID();
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.empty());
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.UNKNOWN);
+    }
+
+    @Test
+    void nullAccStatusWithNullBikeIdIsUnknown() {
+        assertThat(newService().deriveIgnition(null, null))
+                .isEqualTo(TelemetryIgnitionStatus.UNKNOWN);
+    }
+}

--- a/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java
+++ b/development/backend/src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java
@@ -47,6 +47,28 @@ class TelemetryIgnitionDerivationTests {
     }
 
     @Test
+    void nullAccStatusCarriesForwardOffStatus() {
+        UUID bikeId = UUID.randomUUID();
+        BikeCurrentState previous = mock(BikeCurrentState.class);
+        when(previous.getIgnitionStatus()).thenReturn(TelemetryIgnitionStatus.OFF);
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.of(previous));
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.OFF);
+    }
+
+    @Test
+    void nullAccStatusCarriesForwardUnknownStatus() {
+        UUID bikeId = UUID.randomUUID();
+        BikeCurrentState previous = mock(BikeCurrentState.class);
+        when(previous.getIgnitionStatus()).thenReturn(TelemetryIgnitionStatus.UNKNOWN);
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.of(previous));
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.UNKNOWN);
+    }
+
+    @Test
     void nullAccStatusWithNoPreviousIsUnknown() {
         UUID bikeId = UUID.randomUUID();
         when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.empty());

--- a/development/frontend/app/api/otoplug/nt/[type]/route.ts
+++ b/development/frontend/app/api/otoplug/nt/[type]/route.ts
@@ -1,3 +1,5 @@
+import { readAccStatus } from "@/lib/services/otoplug-acc-status";
+
 export const dynamic = "force-dynamic";
 
 /**
@@ -29,6 +31,7 @@ interface IngestBody {
   latitude: number;
   longitude: number;
   speedKph: number;
+  accStatus?: number;
   telemetrySource: "WEBHOOK";
   rawPayload: unknown;
 }
@@ -84,6 +87,7 @@ function toIngest(
     latitude: lat,
     longitude: lng,
     speedKph,
+    accStatus: readAccStatus(rec),
     telemetrySource: "WEBHOOK",
     rawPayload: rec,
   };

--- a/development/frontend/lib/services/otoplug-acc-status.test.mjs
+++ b/development/frontend/lib/services/otoplug-acc-status.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readAccStatus } from "./otoplug-acc-status.ts";
+
+test("accStatus 0 is read as 0 (ignition OFF)", () => {
+  assert.equal(readAccStatus({ accStatus: 0 }), 0);
+});
+
+test("non-zero accStatus is read through (ignition ON)", () => {
+  assert.equal(readAccStatus({ accStatus: 3 }), 3);
+});
+
+test("numeric string accStatus is parsed", () => {
+  assert.equal(readAccStatus({ accStatus: "1" }), 1);
+});
+
+test("missing accStatus is undefined (not 0)", () => {
+  assert.equal(readAccStatus({}), undefined);
+});
+
+test("null accStatus is undefined, avoiding the Number(null)===0 trap", () => {
+  assert.equal(readAccStatus({ accStatus: null }), undefined);
+});
+
+test("non-numeric accStatus is undefined", () => {
+  assert.equal(readAccStatus({ accStatus: "abc" }), undefined);
+});

--- a/development/frontend/lib/services/otoplug-acc-status.ts
+++ b/development/frontend/lib/services/otoplug-acc-status.ts
@@ -7,6 +7,9 @@
  * "not reported" and must NOT be coerced to 0 (which would look like OFF).
  * Returns undefined for absent / non-numeric values so the backend falls back
  * to carrying forward the previous ignition state.
+ *
+ * Numeric strings are coerced via Number() on purpose, so a vendor sending
+ * "0"/"1" instead of 0/1 is still read correctly rather than dropped.
  */
 export function readAccStatus(rec: Record<string, unknown>): number | undefined {
   const value = rec.accStatus;

--- a/development/frontend/lib/services/otoplug-acc-status.ts
+++ b/development/frontend/lib/services/otoplug-acc-status.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely read the OTOPLUG ACC (ignition) signal from a telemetry record.
+ *
+ * accStatus semantics: 0 = ignition OFF, non-zero = ignition ON.
+ *
+ * Guards against the `Number(null) === 0` trap: a missing or null field means
+ * "not reported" and must NOT be coerced to 0 (which would look like OFF).
+ * Returns undefined for absent / non-numeric values so the backend falls back
+ * to carrying forward the previous ignition state.
+ */
+export function readAccStatus(rec: Record<string, unknown>): number | undefined {
+  const value = rec.accStatus;
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/development/frontend/package.json
+++ b/development/frontend/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/real-vehicle-playback.test.mjs"
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/real-vehicle-playback.test.mjs lib/services/otoplug-acc-status.test.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "latest",

--- a/docs/superpowers/plans/2026-07-01-ignition-accstatus-connection.md
+++ b/docs/superpowers/plans/2026-07-01-ignition-accstatus-connection.md
@@ -1,0 +1,606 @@
+# 시동 감지(accStatus) + 연결 이중임계값 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 시동 상태를 OTOPLUG `accStatus`(0=OFF, ≠0=ON) 명시 신호로 파생하고, 연결 판정을 시동 상태 종속 이중 임계값(ON=2분, OFF/UNKNOWN=120분)으로 전환한다.
+
+**Architecture:** 백엔드 `TelemetryIngestRequest`에 nullable `Integer accStatus`를 추가하고 `deriveIgnition`이 이를 직접 사용(미수신 시 직전 상태 carry-forward). `TelemetryConnection.status`는 시동 상태를 인자로 받아 임계값을 선택. NT 수신부(Next.js `route.ts`)는 `Number(null)===0` 함정을 피하는 순수 헬퍼 `readAccStatus`로 `accStatus`를 안전 추출. DB 스키마·마이그레이션 변경 없음.
+
+**Tech Stack:** Java 21 / Spring Boot / Gradle (backend), Next.js 16 App Router / TypeScript (frontend). 백엔드 단위 테스트는 JUnit5+Mockito(Docker 불필요), 프론트 테스트는 `node --experimental-strip-types --test`.
+
+**Worktree:** 모든 경로는 워크트리 루트 기준. 작업 디렉터리:
+`C:\Users\user\.config\superpowers\worktrees\thundercrew-domain\cc-ignition-accstatus`
+(브랜치 `cc-ignition-accstatus`, `dev`에서 분기)
+
+**Reference spec:** `docs/superpowers/specs/2026-07-01-ignition-accstatus-connection-design.md`
+
+---
+
+## Task 1: DTO에 `accStatus` 필드 추가 (컴파일 게이트)
+
+시동 파생이 참조할 `accStatus`를 요청 DTO에 추가한다. 이 record의 유일한 위치 기반 생성자 호출처는 `VendorTelemetryAdapterTests.sampleEvent`이므로 함께 갱신해 스위트가 계속 컴파일되게 한다.
+
+**Files:**
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java`
+- Modify: `development/backend/src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java:96-107`
+
+- [ ] **Step 1: DTO에 `Integer accStatus` 필드 추가**
+
+`TelemetryIngestRequest.java`의 `speedKph`와 `telemetrySource` 사이에 필드를 삽입한다. 최종 record 본문:
+
+```java
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TelemetryIngestRequest(
+        @NotBlank @Size(max = 100) String deviceUid,
+        @Size(max = 200) String vendorEventId,
+        @NotNull Instant receivedAt,
+        Instant deviceReportedAt,
+        @DecimalMin("-90.0") @DecimalMax("90.0") BigDecimal latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
+        @PositiveOrZero BigDecimal speedKph,
+        Integer accStatus,
+        @NotNull TelemetrySource telemetrySource,
+        JsonNode rawPayload
+) {
+}
+```
+
+(검증 애너테이션 없음 — 임의 정수·nullable 허용. `@JsonIgnoreProperties(ignoreUnknown = true)`는 그대로 두어 JSON에 accStatus가 없으면 null 바인딩.)
+
+- [ ] **Step 2: `VendorTelemetryAdapterTests.sampleEvent` 생성자 인자 갱신**
+
+`sampleEvent`(96-107행)의 생성자 호출에 `speedKph` 다음, `telemetrySource` 앞에 `null`(accStatus)을 추가한다. 최종 메서드:
+
+```java
+    private static TelemetryIngestRequest sampleEvent(String deviceUid, Instant receivedAt) {
+        return new TelemetryIngestRequest(
+                deviceUid,
+                "vendor-event-" + deviceUid,
+                receivedAt,
+                receivedAt,
+                new BigDecimal("37.5005000"),
+                new BigDecimal("127.0270000"),
+                new BigDecimal("12.5"),
+                null,
+                TelemetrySource.POLLING,
+                null);
+    }
+```
+
+- [ ] **Step 3: 기존 테스트가 그대로 통과하는지 확인**
+
+Run: `cd development/backend && ./gradlew.bat test --tests "com.thundercrew.opsapi.VendorTelemetryAdapterTests"`
+Expected: BUILD SUCCESSFUL, 관련 테스트 PASS (Docker 불필요).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd development/backend
+git add src/main/java/com/thundercrew/opsapi/telemetry/dto/TelemetryIngestRequest.java src/test/java/com/thundercrew/opsapi/VendorTelemetryAdapterTests.java
+git commit -m "$(cat <<'EOF'
+feat(telemetry): TelemetryIngestRequest에 accStatus 필드 추가
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `deriveIgnition`을 accStatus 기반으로 전환
+
+5분 gap 휴리스틱을 폐기하고 `accStatus`(0=OFF/≠0=ON)를 직접 사용한다. 미수신(null)이면 직전 상태 carry-forward, 없으면 UNKNOWN. 테스트 용이성을 위해 `deriveIgnition`을 package-private으로 승격한다.
+
+**Files:**
+- Create: `development/backend/src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java`
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java` (상수·import 정리, 91행 호출부, 212-224행 메서드)
+
+- [ ] **Step 1: 실패하는 단위 테스트 작성**
+
+새 파일 `.../telemetry/service/TelemetryIgnitionDerivationTests.java`:
+
+```java
+package com.thundercrew.opsapi.telemetry.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.thundercrew.opsapi.telemetry.domain.BikeCurrentState;
+import com.thundercrew.opsapi.telemetry.domain.TelemetryIgnitionStatus;
+import com.thundercrew.opsapi.telemetry.repository.BikeCurrentStateRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class TelemetryIgnitionDerivationTests {
+
+    private final BikeCurrentStateRepository currentStateRepository =
+            mock(BikeCurrentStateRepository.class);
+
+    // deriveIgnition은 9번째 생성자 인자(bikeCurrentStateRepository)만 사용하므로
+    // 나머지 8개 의존성은 null로 두어도 무방하다.
+    private TelemetryIngestionService newService() {
+        return new TelemetryIngestionService(
+                null, null, null, null, null, null, null, null, currentStateRepository);
+    }
+
+    @Test
+    void accStatusZeroIsOff() {
+        assertThat(newService().deriveIgnition(UUID.randomUUID(), 0))
+                .isEqualTo(TelemetryIgnitionStatus.OFF);
+    }
+
+    @Test
+    void accStatusNonZeroIsOn() {
+        assertThat(newService().deriveIgnition(UUID.randomUUID(), 5))
+                .isEqualTo(TelemetryIgnitionStatus.ON);
+    }
+
+    @Test
+    void nullAccStatusCarriesForwardPreviousStatus() {
+        UUID bikeId = UUID.randomUUID();
+        BikeCurrentState previous = mock(BikeCurrentState.class);
+        when(previous.getIgnitionStatus()).thenReturn(TelemetryIgnitionStatus.ON);
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.of(previous));
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.ON);
+    }
+
+    @Test
+    void nullAccStatusWithNoPreviousIsUnknown() {
+        UUID bikeId = UUID.randomUUID();
+        when(currentStateRepository.findByBikeId(bikeId)).thenReturn(Optional.empty());
+
+        assertThat(newService().deriveIgnition(bikeId, null))
+                .isEqualTo(TelemetryIgnitionStatus.UNKNOWN);
+    }
+
+    @Test
+    void nullAccStatusWithNullBikeIdIsUnknown() {
+        assertThat(newService().deriveIgnition(null, null))
+                .isEqualTo(TelemetryIgnitionStatus.UNKNOWN);
+    }
+}
+```
+
+- [ ] **Step 2: 테스트가 실패(컴파일 에러)하는지 확인**
+
+Run: `cd development/backend && ./gradlew.bat test --tests "com.thundercrew.opsapi.telemetry.service.TelemetryIgnitionDerivationTests"`
+Expected: FAIL — 컴파일 에러(`deriveIgnition(UUID, Integer)`가 아직 없고 `deriveIgnition`이 private).
+
+- [ ] **Step 3: `deriveIgnition` 재작성 + 호출부·상수·import 정리**
+
+`TelemetryIngestionService.java`에서:
+
+(a) 38행 상수 삭제:
+```java
+    private static final Duration IGNITION_ON_GAP_THRESHOLD = Duration.ofMinutes(5);
+```
+
+(b) 이제 미사용이 된 import 삭제 (26-27행):
+```java
+import java.time.Duration;
+import java.time.Instant;
+```
+(둘 다 이 변경 후 파일 내에서 참조되지 않는다. 컴파일이 여전히 필요하다고 하면 남긴다 — 정상 구현에서는 삭제된다.)
+
+(c) 91행 호출부 변경:
+```java
+        TelemetryIgnitionStatus derivedIgnition = deriveIgnition(bikeId, request.accStatus());
+```
+
+(d) 212-224행 메서드를 아래로 교체 (가시성 `private` → package-private):
+```java
+    TelemetryIgnitionStatus deriveIgnition(UUID bikeId, Integer accStatus) {
+        // 명시 ACC 신호 우선: 0 = OFF, 그 외 = ON
+        if (accStatus != null) {
+            return accStatus != 0 ? TelemetryIgnitionStatus.ON : TelemetryIgnitionStatus.OFF;
+        }
+        // accStatus 미수신 → 직전 상태 carry-forward, 없으면 UNKNOWN
+        if (bikeId == null) {
+            return TelemetryIgnitionStatus.UNKNOWN;
+        }
+        return bikeCurrentStateRepository.findByBikeId(bikeId)
+                .map(BikeCurrentState::getIgnitionStatus)
+                .orElse(TelemetryIgnitionStatus.UNKNOWN);
+    }
+```
+
+- [ ] **Step 4: 새 테스트 + 기존 어댑터 테스트 통과 확인**
+
+Run: `cd development/backend && ./gradlew.bat test --tests "com.thundercrew.opsapi.telemetry.service.TelemetryIgnitionDerivationTests" --tests "com.thundercrew.opsapi.VendorTelemetryAdapterTests"`
+Expected: BUILD SUCCESSFUL, 5개 신규 테스트 + 어댑터 테스트 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd development/backend
+git add src/main/java/com/thundercrew/opsapi/telemetry/service/TelemetryIngestionService.java src/test/java/com/thundercrew/opsapi/telemetry/service/TelemetryIgnitionDerivationTests.java
+git commit -m "$(cat <<'EOF'
+feat(telemetry): 시동 파생을 accStatus 기반으로 전환 (gap 휴리스틱 제거)
+
+accStatus 0=OFF/≠0=ON, 미수신 시 직전 상태 carry-forward.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `TelemetryConnection` 시동 종속 이중 임계값
+
+단일 120분 임계값을 시동 상태에 종속하는 이중 임계값(ON=2분, OFF/UNKNOWN=120분)으로 바꾸고, 시그니처에 시동 상태를 추가한다. 호출부 3곳을 갱신한다.
+
+**Files:**
+- Create: `development/backend/src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java`
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnection.java`
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java:193-195`
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java:56`
+- Modify: `development/backend/src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java:60-62`
+
+- [ ] **Step 1: 실패하는 단위 테스트 작성**
+
+새 파일 `.../telemetry/domain/TelemetryConnectionTests.java`:
+
+```java
+package com.thundercrew.opsapi.telemetry.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class TelemetryConnectionTests {
+
+    private static final Instant NOW = Instant.parse("2026-07-01T00:00:00Z");
+
+    private static Instant ago(Duration d) {
+        return NOW.minus(d);
+    }
+
+    @Test
+    void ignitionOnWithinTwoMinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(1)), NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void ignitionOnBeyondTwoMinutesIsOffline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(3)), NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("OFFLINE");
+    }
+
+    @Test
+    void ignitionOffWithin120MinutesIsOnline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(90)), NOW, TelemetryIgnitionStatus.OFF))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void ignitionOffBeyond120MinutesIsOffline() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(130)), NOW, TelemetryIgnitionStatus.OFF))
+                .isEqualTo("OFFLINE");
+    }
+
+    @Test
+    void unknownIgnitionUsesLaxThreshold() {
+        assertThat(TelemetryConnection.status(ago(Duration.ofMinutes(30)), NOW, TelemetryIgnitionStatus.UNKNOWN))
+                .isEqualTo("ONLINE");
+    }
+
+    @Test
+    void nullLastReceivedIsOffline() {
+        assertThat(TelemetryConnection.status(null, NOW, TelemetryIgnitionStatus.ON))
+                .isEqualTo("OFFLINE");
+    }
+}
+```
+
+- [ ] **Step 2: 테스트가 실패(컴파일 에러)하는지 확인**
+
+Run: `cd development/backend && ./gradlew.bat test --tests "com.thundercrew.opsapi.telemetry.domain.TelemetryConnectionTests"`
+Expected: FAIL — 컴파일 에러(`status(Instant, Instant, TelemetryIgnitionStatus)` 3-인자 오버로드가 아직 없음).
+
+- [ ] **Step 3: `TelemetryConnection` 교체**
+
+`TelemetryConnection.java` 전체를 아래로 교체:
+
+```java
+package com.thundercrew.opsapi.telemetry.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/** 마지막 수신 시각 + 시동 상태 기준 연결 판정. 시동 ON=2분, OFF/UNKNOWN=120분 무수신이면 OFFLINE. */
+public final class TelemetryConnection {
+
+    /** 시동 ON: 보고 주기 빠름(~1분) → 2분 무수신이면 미연결. */
+    public static final Duration IGNITION_ON_OFFLINE_THRESHOLD = Duration.ofMinutes(2);
+
+    /** 시동 OFF/UNKNOWN: 보고 주기 느림(~1시간 keep-alive) → 120분 무수신이면 미연결. */
+    public static final Duration DEFAULT_OFFLINE_THRESHOLD = Duration.ofMinutes(120);
+
+    private TelemetryConnection() {
+    }
+
+    /** "ONLINE"/"OFFLINE". 임계값은 시동 상태에 종속(ON=2분, 그 외=120분). */
+    public static String status(Instant lastReceivedAt, Instant now, TelemetryIgnitionStatus ignition) {
+        if (lastReceivedAt == null) {
+            return "OFFLINE";
+        }
+        Duration threshold = ignition == TelemetryIgnitionStatus.ON
+                ? IGNITION_ON_OFFLINE_THRESHOLD
+                : DEFAULT_OFFLINE_THRESHOLD;
+        Duration age = Duration.between(lastReceivedAt, now);
+        return age.compareTo(threshold) <= 0 ? "ONLINE" : "OFFLINE";
+    }
+}
+```
+
+- [ ] **Step 4: 호출부 3곳에 시동 상태 전달**
+
+(a) `DashboardMapStateService.java` — `connectionStatus` 메서드(193-195행). `BikePinRow`에 이미 `ignitionStatus()`가 있다. 교체:
+```java
+    private String connectionStatus(BikePinRow row, Instant generatedAt) {
+        return TelemetryConnection.status(row.lastReceivedAt(), generatedAt, row.ignitionStatus());
+    }
+```
+
+(b) `RiderVehicleReadService.java` — 56행. 교체:
+```java
+            connection = TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus());
+```
+
+(c) `BikeCurrentStateReadResponse.java` — `connectionStatus` 메서드(60-62행). 교체:
+```java
+    private static String connectionStatus(BikeCurrentState state, Clock clock) {
+        return TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus());
+    }
+```
+
+- [ ] **Step 5: 새 테스트 통과 + 호출부 컴파일 확인**
+
+Run: `cd development/backend && ./gradlew.bat test --tests "com.thundercrew.opsapi.telemetry.domain.TelemetryConnectionTests"`
+Expected: BUILD SUCCESSFUL, 6개 신규 테스트 PASS. (컴파일 성공 = 3 호출부 시그니처 정합.)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd development/backend
+git add src/main/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnection.java src/test/java/com/thundercrew/opsapi/telemetry/domain/TelemetryConnectionTests.java src/main/java/com/thundercrew/opsapi/dashboard/service/DashboardMapStateService.java src/main/java/com/thundercrew/opsapi/rider/service/RiderVehicleReadService.java src/main/java/com/thundercrew/opsapi/telemetry/dto/BikeCurrentStateReadResponse.java
+git commit -m "$(cat <<'EOF'
+feat(telemetry): 연결 판정을 시동 종속 이중 임계값으로 (ON=2분, OFF=120분)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: NT 수신부 `readAccStatus` 헬퍼 + route.ts 배선
+
+`accStatus`를 안전하게 읽는 순수 헬퍼를 만들고(핵심: `Number(null)===0` 함정 방지), `route.ts`가 이를 사용해 ingest 바디에 `accStatus`를 싣게 한다.
+
+**Files:**
+- Create: `development/frontend/lib/services/otoplug-acc-status.ts`
+- Create: `development/frontend/lib/services/otoplug-acc-status.test.mjs`
+- Modify: `development/frontend/app/api/otoplug/nt/[type]/route.ts` (import, `IngestBody`, `toIngest`)
+- Modify: `development/frontend/package.json:12` (test 스크립트에 새 테스트 추가)
+
+- [ ] **Step 1: 실패하는 단위 테스트 작성**
+
+새 파일 `development/frontend/lib/services/otoplug-acc-status.test.mjs`:
+
+```mjs
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readAccStatus } from "./otoplug-acc-status.ts";
+
+test("accStatus 0 is read as 0 (ignition OFF)", () => {
+  assert.equal(readAccStatus({ accStatus: 0 }), 0);
+});
+
+test("non-zero accStatus is read through (ignition ON)", () => {
+  assert.equal(readAccStatus({ accStatus: 3 }), 3);
+});
+
+test("numeric string accStatus is parsed", () => {
+  assert.equal(readAccStatus({ accStatus: "1" }), 1);
+});
+
+test("missing accStatus is undefined (not 0)", () => {
+  assert.equal(readAccStatus({}), undefined);
+});
+
+test("null accStatus is undefined, avoiding the Number(null)===0 trap", () => {
+  assert.equal(readAccStatus({ accStatus: null }), undefined);
+});
+
+test("non-numeric accStatus is undefined", () => {
+  assert.equal(readAccStatus({ accStatus: "abc" }), undefined);
+});
+```
+
+- [ ] **Step 2: 테스트가 실패하는지 확인**
+
+Run: `cd development/frontend && node --experimental-strip-types --test lib/services/otoplug-acc-status.test.mjs`
+Expected: FAIL — `otoplug-acc-status.ts` 모듈이 없어 import 에러.
+
+- [ ] **Step 3: 순수 헬퍼 구현**
+
+새 파일 `development/frontend/lib/services/otoplug-acc-status.ts`:
+
+```ts
+/**
+ * Safely read the OTOPLUG ACC (ignition) signal from a telemetry record.
+ *
+ * accStatus semantics: 0 = ignition OFF, non-zero = ignition ON.
+ *
+ * Guards against the `Number(null) === 0` trap: a missing or null field means
+ * "not reported" and must NOT be coerced to 0 (which would look like OFF).
+ * Returns undefined for absent / non-numeric values so the backend falls back
+ * to carrying forward the previous ignition state.
+ */
+export function readAccStatus(rec: Record<string, unknown>): number | undefined {
+  const value = rec.accStatus;
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `cd development/frontend && node --experimental-strip-types --test lib/services/otoplug-acc-status.test.mjs`
+Expected: `# pass 6`, `# fail 0`.
+
+- [ ] **Step 5: `route.ts` 배선**
+
+`development/frontend/app/api/otoplug/nt/[type]/route.ts`에서 3곳 수정.
+
+(a) 파일 맨 위(현재 1행 `export const dynamic = "force-dynamic";` 위)에 import 추가:
+```ts
+import { readAccStatus } from "@/lib/services/otoplug-acc-status";
+
+export const dynamic = "force-dynamic";
+```
+
+(b) `IngestBody` 인터페이스(25-34행)에 `speedKph` 다음, `telemetrySource` 앞에 `accStatus?: number;` 추가:
+```ts
+interface IngestBody {
+  deviceUid: string;
+  vendorEventId: string;
+  receivedAt: string;
+  latitude: number;
+  longitude: number;
+  speedKph: number;
+  accStatus?: number;
+  telemetrySource: "WEBHOOK";
+  rawPayload: unknown;
+}
+```
+
+(c) `toIngest`의 return 객체(80-89행)에서 `speedKph` 다음에 `accStatus: readAccStatus(rec),` 추가:
+```ts
+  return {
+    deviceUid: imei,
+    vendorEventId: `${imei}:${timeStr ?? Date.now()}`,
+    receivedAt,
+    latitude: lat,
+    longitude: lng,
+    speedKph,
+    accStatus: readAccStatus(rec),
+    telemetrySource: "WEBHOOK",
+    rawPayload: rec,
+  };
+```
+(`accStatus`가 `undefined`면 `JSON.stringify`가 키를 생략 → 백엔드에서 null → carry-forward.)
+
+- [ ] **Step 6: 프론트 test 스크립트에 새 테스트 추가**
+
+`development/frontend/package.json`의 `test:service-ops`(12행) 끝에 새 테스트 파일을 추가:
+```json
+    "test:service-ops": "node --experimental-strip-types --test lib/services/service-ops-api.test.mjs lib/services/service-ops-session-core.test.mjs lib/services/real-vehicle-playback.test.mjs lib/services/otoplug-acc-status.test.mjs"
+```
+
+- [ ] **Step 7: 프론트 의존성 확인 후 타입체크/린트**
+
+Run:
+```bash
+cd development/frontend
+[ -d node_modules ] || npm install
+npm run typecheck
+npm run lint
+```
+Expected: `typecheck` 에러 없음(`@/lib/services/otoplug-acc-status` import 해석, `IngestBody`/`toIngest` 타입 정합), `lint` 에러 없음.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+cd development/frontend
+git add lib/services/otoplug-acc-status.ts lib/services/otoplug-acc-status.test.mjs app/api/otoplug/nt/\[type\]/route.ts package.json
+git commit -m "$(cat <<'EOF'
+feat(otoplug): NT 수신부에서 accStatus 안전 추출 후 ingest에 전달
+
+readAccStatus가 Number(null)===0 함정을 피해 미전송/비숫자는 undefined 처리.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 최종 검증 + PR
+
+전체 변경을 함께 검증하고 `dev`로 PR을 만든다.
+
+**Files:** (없음 — 검증·PR만)
+
+- [ ] **Step 1: 백엔드 신규/영향 테스트 일괄 실행**
+
+Run:
+```bash
+cd development/backend && ./gradlew.bat test \
+  --tests "com.thundercrew.opsapi.telemetry.domain.TelemetryConnectionTests" \
+  --tests "com.thundercrew.opsapi.telemetry.service.TelemetryIgnitionDerivationTests" \
+  --tests "com.thundercrew.opsapi.VendorTelemetryAdapterTests"
+```
+Expected: BUILD SUCCESSFUL, 전부 PASS.
+
+- [ ] **Step 2: 백엔드 메인 소스 컴파일 확인 (호출부 정합)**
+
+Run: `cd development/backend && ./gradlew.bat compileJava`
+Expected: BUILD SUCCESSFUL (Dashboard/Rider/BikeCurrentStateReadResponse 호출부 정합).
+
+- [ ] **Step 3: 프론트 검증**
+
+Run:
+```bash
+cd development/frontend
+[ -d node_modules ] || npm install
+node --experimental-strip-types --test lib/services/otoplug-acc-status.test.mjs
+npm run typecheck
+npm run lint
+```
+Expected: 테스트 `# fail 0`, typecheck/lint 에러 없음.
+
+- [ ] **Step 4: 브랜치 push + PR 생성 (→ dev)**
+
+```bash
+git push -u origin cc-ignition-accstatus
+gh pr create --base dev --head cc-ignition-accstatus --title "시동 감지 accStatus 전환 + 연결 이중임계값" --body "$(cat <<'EOF'
+## Summary
+- 시동 파생을 5분 gap 휴리스틱 → OTOPLUG `accStatus`(0=OFF/≠0=ON) 명시 신호 기반으로 전환. 미수신 시 직전 상태 carry-forward.
+- 연결 판정을 시동 상태 종속 이중 임계값으로: 시동 ON=2분, OFF/UNKNOWN=120분. 수신이력 null → OFFLINE.
+- NT 수신부(route.ts)에서 `readAccStatus`로 accStatus 안전 추출(`Number(null)===0` 함정 방지) 후 ingest 전달.
+- DB 스키마·마이그레이션 변경 없음.
+
+## Test Plan
+- [ ] 백엔드: `TelemetryConnectionTests`(6), `TelemetryIgnitionDerivationTests`(5), `VendorTelemetryAdapterTests` 통과
+- [ ] 백엔드: `compileJava` 성공(호출부 3곳 정합)
+- [ ] 프론트: `otoplug-acc-status.test.mjs`(6) 통과, typecheck/lint clean
+EOF
+)"
+```
+
+- [ ] **Step 5: finishing-a-development-branch 스킬로 마무리**
+
+REQUIRED: `superpowers:finishing-a-development-branch` 스킬을 사용해 병합/정리 옵션을 진행.
+
+---
+
+## 자기 검토 노트 (플랜 작성자)
+
+- **스펙 커버리지:** 시동 파생(Task 2) · 연결 이중임계값(Task 3) · DTO accStatus(Task 1) · route.ts 추출/배선(Task 4) · 마이그레이션 없음(전 태스크에서 스키마 무변경) · 테스트(각 태스크 + Task 5) 모두 태스크에 매핑됨.
+- **호출부 3곳:** Dashboard/Rider/BikeCurrentStateReadResponse 전부 Task 3 Step 4에 명시.
+- **Docker 불필요:** 신규 백엔드 테스트는 JUnit5+Mockito 순수 단위(컨테이너 미사용). `--tests` 필터로 Testcontainers 계약 테스트를 실행하지 않음.
+- **타입 정합:** `deriveIgnition(UUID, Integer)`, `TelemetryConnection.status(Instant, Instant, TelemetryIgnitionStatus)`, `readAccStatus(Record<string,unknown>): number|undefined` — 사용처 전부 일치.

--- a/docs/superpowers/specs/2026-07-01-ignition-accstatus-connection-design.md
+++ b/docs/superpowers/specs/2026-07-01-ignition-accstatus-connection-design.md
@@ -1,0 +1,283 @@
+# 시동 감지(accStatus) + 연결 판정 재설계 — Design
+
+**Date:** 2026-07-01
+**Branch:** `cc-ignition-accstatus` (off `dev`)
+**Status:** Approved (design), pending spec review
+
+---
+
+## 1. 배경 / 문제
+
+현재 시동(ignition) 상태는 **시간 간격 휴리스틱**으로 추정한다: 직전 수신과의 gap이
+5분 이내면 ON, 넘으면 OFF (`TelemetryIngestionService.deriveIgnition`,
+`IGNITION_ON_GAP_THRESHOLD = 5분`). 이는 실제 시동 신호가 아니라 "데이터가 계속
+들어오는가"에 대한 근사치라 부정확하다.
+
+OTOPLUG 단말은 실제 시동(ACC) 신호를 **`accStatus`** 정수 필드로 보낸다:
+
+- `accStatus == 0` → 시동 OFF
+- `accStatus != 0` → 시동 ON
+
+이 필드는 OTOPLUG NT `drivingDetail`(FMS 실시간) 페이로드의 `tripData[]` 각
+레코드에 포함된다(`scripts/otoplug/OTOPLUG_NT_API.md:142`). 보고 주기는 **시동
+상태에 종속**한다:
+
+- **시동 ON:** 약 1~2분 주기(빠름)
+- **시동 OFF:** 약 1시간 주기 keep-alive(느림)
+- 시동 **전환** 시에도 NT가 발생한다.
+
+현재 이 `accStatus`는 `rawPayload`(JSONB)에만 저장되고 **버려진다**. 이를
+1급 신호로 승격해 시동 파생을 대체한다.
+
+동시에 연결(reachability) 판정도 재검토한다. 현재
+`TelemetryConnection.status`는 마지막 수신 후 **120분** 무수신이면 OFFLINE인
+단일 임계값이다. 보고 주기가 시동 상태에 따라 크게 다르므로(ON 1~2분 / OFF
+1시간), 단일 120분 임계값은 시동 ON 차량의 단선을 너무 늦게 감지한다.
+
+---
+
+## 2. 목표 / 비목표
+
+**목표**
+- 시동 파생을 gap 휴리스틱 → `accStatus` 명시 신호 기반으로 전환.
+- 연결 임계값을 시동 상태에 종속하는 이중 임계값으로 변경: ON=2분, OFF/UNKNOWN=120분.
+- 마이그레이션 없이(스키마 무변경) 구현.
+
+**비목표**
+- `accStatus`를 별도 컬럼으로 영속화하지 않는다(파생에만 사용, 원본은 rawPayload에 이미 보존).
+- 마커/차량상세의 상태 칩 표시 로직(라벨·색)은 변경하지 않는다 — `drivingStatus`/`connectionStatus` 값의 계산 방식만 바뀌고 소비 방식은 동일.
+- 폴링(`VendorTelemetryAdapter`) 경로에 accStatus를 강제하지 않는다 — 폴링 이벤트는 accStatus 없음(null)으로 들어와 carry-forward 폴백을 탄다.
+
+---
+
+## 3. 데이터 흐름
+
+```
+OTOPLUG NT (drivingDetail tripData[].accStatus)
+  → POST /api/otoplug/nt/driving-detail   (Next.js: route.ts)
+      · toIngest(): rec.accStatus 추출 → IngestBody.accStatus
+  → POST /api/v1/telemetry/device-events  (Java: TelemetryIngestionController)
+      · @RequestBody TelemetryIngestRequest.accStatus (신규 필드, JSON 바인딩)
+  → TelemetryIngestionService.ingest()
+      · deriveIgnition(bikeId, request.accStatus())  → ignition_status 저장
+  → 대시보드/라이더/차량상세 read 경로
+      · TelemetryConnection.status(lastReceivedAt, now, ignitionStatus) → ONLINE/OFFLINE
+```
+
+`accStatus`는 시동 파생에만 쓰이고 DB에 별도 저장되지 않는다. 원본은 rawPayload에
+남는다.
+
+---
+
+## 4. 상세 설계
+
+### 4.1 시동 파생 (`TelemetryIngestionService`)
+
+**변경:**
+- `IGNITION_ON_GAP_THRESHOLD` 상수 삭제. 관련 `java.time.Duration` import가 파일 내에서 더 이상 안 쓰이면 함께 삭제(컴파일 시 확인). `java.time.Instant` import도 다른 사용처 없으면 삭제.
+- `deriveIgnition` 시그니처: `deriveIgnition(UUID bikeId, Instant receivedAt)` → `deriveIgnition(UUID bikeId, Integer accStatus)`.
+- `ingest()` 호출부(현재 91행): `deriveIgnition(bikeId, request.receivedAt())` → `deriveIgnition(bikeId, request.accStatus())`.
+
+**새 로직** (가시성은 `private` → **package-private**으로 승격, 단위 테스트 직접 호출용):
+```java
+TelemetryIgnitionStatus deriveIgnition(UUID bikeId, Integer accStatus) {
+    // 명시 신호 우선: 0 = OFF, 그 외 = ON
+    if (accStatus != null) {
+        return accStatus != 0 ? TelemetryIgnitionStatus.ON : TelemetryIgnitionStatus.OFF;
+    }
+    // accStatus 미수신 → 직전 상태 유지(carry-forward)
+    if (bikeId == null) {
+        return TelemetryIgnitionStatus.UNKNOWN;
+    }
+    return bikeCurrentStateRepository.findByBikeId(bikeId)
+            .map(BikeCurrentState::getIgnitionStatus)
+            .orElse(TelemetryIgnitionStatus.UNKNOWN);
+}
+```
+
+**폴백 근거:** `accStatus`가 없는 이벤트(폴링, 또는 `driving` NT가 accStatus를
+안 싣는 경우)에서 gap 휴리스틱을 재도입하면 우리가 없애려는 flapping이 돌아온다.
+직전 상태 carry-forward가 안전하다. `drivingDetail`이 1분마다 명시 신호를
+계속 보내므로 사이사이 carry-forward가 상태를 왜곡하지 않는다.
+
+### 4.2 연결 판정 (`TelemetryConnection`)
+
+**변경:** 단일 `OFFLINE_THRESHOLD`(120분)를 이중 임계값으로 교체하고 시그니처에
+시동 상태를 추가한다.
+
+```java
+public final class TelemetryConnection {
+
+    /** 시동 ON: 보고 주기 빠름(~1분) → 2분 무수신이면 미연결. */
+    public static final Duration IGNITION_ON_OFFLINE_THRESHOLD = Duration.ofMinutes(2);
+
+    /** 시동 OFF/UNKNOWN: 보고 주기 느림(~1시간 keep-alive) → 120분 무수신이면 미연결. */
+    public static final Duration DEFAULT_OFFLINE_THRESHOLD = Duration.ofMinutes(120);
+
+    private TelemetryConnection() {}
+
+    /** "ONLINE"/"OFFLINE". 임계값은 시동 상태에 종속(ON=2분, 그 외=120분). */
+    public static String status(Instant lastReceivedAt, Instant now, TelemetryIgnitionStatus ignition) {
+        if (lastReceivedAt == null) {
+            return "OFFLINE";
+        }
+        Duration threshold = ignition == TelemetryIgnitionStatus.ON
+                ? IGNITION_ON_OFFLINE_THRESHOLD
+                : DEFAULT_OFFLINE_THRESHOLD;
+        Duration age = Duration.between(lastReceivedAt, now);
+        return age.compareTo(threshold) <= 0 ? "ONLINE" : "OFFLINE";
+    }
+}
+```
+
+- `TelemetryIgnitionStatus`는 같은 `...telemetry.domain` 패키지라 import 불필요.
+- `null lastReceivedAt` → OFFLINE(수신 이력 없음). 기존 API는 null을 넘기지 않았으나 방어적으로 처리.
+
+**호출부 3곳** — 각자 보유한 시동 상태를 세 번째 인자로 넘긴다:
+- `DashboardMapStateService.connectionStatus(row, generatedAt)` (194행): `TelemetryConnection.status(row.lastReceivedAt(), generatedAt, row.ignitionStatus())`.
+- `RiderVehicleReadService.getMyVehicle` (56행): `TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus())`.
+- `BikeCurrentStateReadResponse.connectionStatus(state, clock)` (61행): `TelemetryConnection.status(state.getLastReceivedAt(), Instant.now(clock), state.getIgnitionStatus())`.
+
+### 4.3 DTO (`TelemetryIngestRequest`)
+
+`speedKph`와 `telemetrySource` 사이에 nullable `Integer accStatus`를 추가한다
+(위치는 JSON 바인딩에 무관하나 의미상 텔레메트리 측정치 그룹에 배치):
+
+```java
+public record TelemetryIngestRequest(
+        @NotBlank @Size(max = 100) String deviceUid,
+        @Size(max = 200) String vendorEventId,
+        @NotNull Instant receivedAt,
+        Instant deviceReportedAt,
+        @DecimalMin("-90.0") @DecimalMax("90.0") BigDecimal latitude,
+        @DecimalMin("-180.0") @DecimalMax("180.0") BigDecimal longitude,
+        @PositiveOrZero BigDecimal speedKph,
+        Integer accStatus,          // 신규: OTOPLUG ACC 신호(0=OFF, 그 외=ON). null 가능.
+        @NotNull TelemetrySource telemetrySource,
+        JsonNode rawPayload
+) {}
+```
+
+- 검증 애너테이션 없음(임의 정수 허용, nullable).
+- `@JsonIgnoreProperties(ignoreUnknown = true)` 유지 → JSON에 accStatus 없으면 null 바인딩.
+
+### 4.4 NT 수신부 (`route.ts`)
+
+`IngestBody`에 `accStatus?: number` 추가. `toIngest`에서 `rec.accStatus`를
+**안전하게** 읽는다 — **`Number(null) === 0` 함정 주의**: 필드가 없거나 null이면
+`undefined`(미전송=carry-forward), 실제 숫자일 때만 값 사용.
+
+```ts
+interface IngestBody {
+  deviceUid: string;
+  vendorEventId: string;
+  receivedAt: string;
+  latitude: number;
+  longitude: number;
+  speedKph: number;
+  accStatus?: number;          // 신규
+  telemetrySource: "WEBHOOK";
+  rawPayload: unknown;
+}
+
+// toIngest 내부, speedKph 계산 뒤:
+function readAccStatus(rec: Record<string, unknown>): number | undefined {
+  const v = rec.accStatus;
+  if (v === null || v === undefined) return undefined;   // 미전송 → 미포함
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+// ...
+const accStatus = readAccStatus(rec);
+return {
+  deviceUid: imei,
+  vendorEventId: `${imei}:${timeStr ?? Date.now()}`,
+  receivedAt,
+  latitude: lat,
+  longitude: lng,
+  speedKph,
+  accStatus,                   // undefined면 JSON.stringify가 키를 생략 → 백엔드 null
+  telemetrySource: "WEBHOOK",
+  rawPayload: rec,
+};
+```
+
+- `driving`·`driving-detail` 양쪽 모두 같은 `toIngest`를 타므로, `rec`에
+  accStatus가 있으면 자동 추출된다. `driving`의 `drivingData`에 accStatus가
+  없으면 `undefined` → carry-forward(안전).
+
+### 4.5 마이그레이션
+
+**없음.** `ignition_status` 컬럼과 `TelemetryIgnitionStatus` enum
+(UNKNOWN/ON/OFF)은 그대로. accStatus는 파생에만 쓰고 버린다. 연결은 read-time
+계산. DB 스키마 무변경.
+
+---
+
+## 5. 상태 결합(마커/차량상세) 영향
+
+`ignitionStatus`와 `connectionStatus`는 read 응답에서 **직교 필드**로 계속 나간다:
+- `drivingStatus` = f(ignition, speed): UNKNOWN→UNKNOWN, OFF→PARKED, ON→(speed≥3?DRIVING:STOPPED). 로직 불변, 입력 ignition만 accStatus 기반으로 정확해짐.
+- `connectionStatus` = f(lastReceivedAt, now, ignition): 임계값이 ignition에 종속되도록 변경.
+
+동작 변화 예:
+- **주행 중 차량 단선:** ignition 마지막값 ON 유지 → 2분 후 OFFLINE. (기존 gap은 5분 후 OFF로 뒤집었음 → 이제 시동은 마지막 실측 유지, 단선은 연결로 표현되어 더 정확.)
+- **주차 차량:** accStatus=0 → OFF, 1시간 keep-alive, 120분 임계 → 정상 ONLINE 유지(오탐 없음).
+
+---
+
+## 6. 테스트 전략 (TDD)
+
+**신규 백엔드 단위 테스트**
+- `TelemetryConnection.status`:
+  - ON + age 1분 → ONLINE
+  - ON + age 3분 → OFFLINE
+  - OFF + age 90분 → ONLINE
+  - OFF + age 130분 → OFFLINE
+  - UNKNOWN + age 30분 → ONLINE (120분 임계 적용)
+  - lastReceivedAt = null → OFFLINE
+- `TelemetryIngestionService.deriveIgnition` — **package-private으로 승격**해 직접 단위 테스트한다. 인자 없는(accStatus만) 케이스는 순수, carry-forward 케이스만 `bikeCurrentStateRepository`를 Mockito로 목킹:
+  - accStatus=0 → OFF (repo 미접근)
+  - accStatus=5 → ON (repo 미접근)
+  - accStatus=null + repo가 직전 ON 반환 → ON (carry-forward)
+  - accStatus=null + repo empty → UNKNOWN
+  - accStatus=null + bikeId=null → UNKNOWN (repo 미접근)
+  - 테스트는 서비스 생성자에 목 레포지토리들을 주입해 인스턴스를 만들고 `deriveIgnition`를 직접 호출한다(전체 `ingest()` 경유 불필요).
+
+**기존 백엔드 테스트 수정**
+- `VendorTelemetryAdapterTests.sampleEvent`(97행): 새 `accStatus` 인자(예: `null`)를 포함해 10-인자 생성자로 갱신.
+
+**프론트엔드 테스트**
+- `route.ts`용 신규 단위 테스트(`toIngest`/`readAccStatus`):
+  - `rec.accStatus = 0` → body에 `accStatus: 0` 포함
+  - `rec.accStatus = 3` → `accStatus: 3`
+  - `rec.accStatus` 없음/`null` → body에 accStatus 키 없음(undefined)
+  - `readAccStatus`가 `Number(null)===0` 함정을 피하는지(=null→undefined) 명시 검증
+  - 검증 실행: `npx tsx --test <file>` (프로젝트의 npm test는 Windows tsx 버그 있음).
+
+---
+
+## 7. 엣지 케이스
+
+- **`Number(null) === 0` 함정:** JSON `accStatus: null`(미전송)을 0(OFF)으로 오독하면 주행 중 차량이 OFF로 표시될 수 있음. `readAccStatus`가 null/undefined를 명시 배제해 방지.
+- **`full` vs `simple` 출력 모드:** observer가 `full`이면 미전송 필드가 0/null/-9999로 채워질 수 있으나, accStatus=0은 어차피 OFF로 매핑되어 비주행 차량엔 무해. null은 carry-forward.
+- **ON 임계값 2분의 민감도:** 보고 주기(~1~2분)와 근접해 보고 1회 지연 시 잠깐 OFFLINE 깜빡임 가능. "즉시 감지" 우선의 명시 선택으로 수용. (완화 필요 시 `IGNITION_ON_OFFLINE_THRESHOLD`만 3분으로 조정.)
+- **`driving` NT(accStatus 미포함 가능):** 주행 중에만 ~60초 발생하므로 carry-forward가 직전 `drivingDetail` 기반 ON을 유지 → 왜곡 없음.
+- **배치(tripData[]) 순서:** 각 레코드가 개별 ingest되고 `upsertBikeCurrentStateIfNewer`가 최신 수신시각만 반영하므로, 배치 내 가장 마지막 레코드의 accStatus가 current-state 시동을 결정.
+
+---
+
+## 8. 손대는 파일 요약
+
+| 파일 | 변경 |
+|------|------|
+| `development/frontend/app/api/otoplug/nt/[type]/route.ts` | `IngestBody.accStatus`, `readAccStatus`, `toIngest` |
+| `development/backend/.../telemetry/dto/TelemetryIngestRequest.java` | `Integer accStatus` 필드 추가 |
+| `development/backend/.../telemetry/service/TelemetryIngestionService.java` | `deriveIgnition` 재작성, 호출부, 상수/import 정리 |
+| `development/backend/.../telemetry/domain/TelemetryConnection.java` | 이중 임계값 + 시그니처 변경 |
+| `development/backend/.../dashboard/service/DashboardMapStateService.java` | connection 호출부에 ignition 전달 |
+| `development/backend/.../rider/service/RiderVehicleReadService.java` | connection 호출부에 ignition 전달 |
+| `development/backend/.../telemetry/dto/BikeCurrentStateReadResponse.java` | connection 호출부에 ignition 전달 |
+| `development/backend/.../test/.../VendorTelemetryAdapterTests.java` | `sampleEvent` 생성자 인자 갱신 |
+| (신규) 백엔드 `TelemetryConnection`/ignition 단위 테스트 | 신규 |
+| (신규) 프론트 `route.ts` 단위 테스트 | 신규 |


### PR DESCRIPTION
## Summary
- 시동 파생을 5분 gap 휴리스틱 → OTOPLUG `accStatus`(0=OFF/≠0=ON) 명시 신호 기반으로 전환. 미수신(null) 시 직전 시동 상태 carry-forward, 이력 없으면 UNKNOWN.
- 연결(도달성) 판정을 시동 상태 종속 이중 임계값으로: 시동 ON=2분(주행 중 ~1~2분 주기), OFF/UNKNOWN=120분(주차 중 ~1시간 keep-alive). 수신이력 null → OFFLINE.
- NT 수신부(`route.ts`)에서 `readAccStatus`로 accStatus 안전 추출 — `Number(null)===0` 함정 방지(미전송/비숫자 → undefined → 백엔드 null → carry-forward).
- **DB 스키마·마이그레이션 변경 없음** (accStatus는 시동 파생용으로만 쓰고 버림, rawPayload에 원본 보존; 연결은 read-time 계산).

## 동작 변화 (운영 참고)
- **신규 차량 기본값 ON → UNKNOWN:** 기존 gap 휴리스틱은 첫 이벤트를 ON으로 기본 처리했으나, 이제 accStatus 없는 첫 수신은 UNKNOWN. 첫 `driving-detail` NT(accStatus 포함) 수신 시 즉시 ON/OFF로 확정됨. UNKNOWN은 연결 판정에서 느슨한 120분 임계값을 사용해 오탐을 피함 — 더 안전한 기본값.
- **시동 ON 2분 임계값:** 보고 주기(~1~2분)에 근접해, 보고 1회 지연 시 주행 차량이 잠깐 OFFLINE로 깜빡일 수 있음(의도된 "즉시 감지" 트레이드오프). 완화 필요 시 `TelemetryConnection.IGNITION_ON_OFFLINE_THRESHOLD`를 3분으로 상향.

## Test Plan
- [x] 백엔드: `TelemetryConnectionTests`(9, 경계 포함), `TelemetryIgnitionDerivationTests`(7, carry-forward ON/OFF/UNKNOWN 포함), `VendorTelemetryAdapterTests` 통과 (Docker 불필요 단위 테스트)
- [x] 백엔드: `compileJava` 성공 — 연결 호출부 3곳(Dashboard/Rider/BikeCurrentStateReadResponse) 시그니처 정합
- [x] 프론트: `otoplug-acc-status.test.mjs`(6, `Number(null)===0` 함정 케이스 포함) 통과, `typecheck`/`lint` clean

설계 스펙: `docs/superpowers/specs/2026-07-01-ignition-accstatus-connection-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)